### PR TITLE
dyninst/symdb: fix cross-CU inlined functions

### DIFF
--- a/pkg/dyninst/gosymname/BUILD.bazel
+++ b/pkg/dyninst/gosymname/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     srcs = [
         "benchmark_test.go",
         "comparison_test.go",
+        "escape_test.go",
         "fuzz_test.go",
         "generic_test.go",
         "symbol_test.go",

--- a/pkg/dyninst/gosymname/escape.go
+++ b/pkg/dyninst/gosymname/escape.go
@@ -37,6 +37,40 @@ func splitPkg(name string) (pkgpath, sym string) {
 	return "", name
 }
 
+// EscapePkg escapes a Go package import path the same way the Go toolchain
+// does when emitting linker symbol names. Specifically: control bytes,
+// space, '%', '"', non-7-bit-clean bytes, and '.' bytes that appear after
+// the last '/' are encoded as %XX (lowercase hex). Other bytes are left
+// untouched. This mirrors cmd/internal/objabi.PathToPrefix in the Go
+// source tree.
+func EscapePkg(s string) string {
+	slash := strings.LastIndex(s, "/")
+	n := 0
+	for i := 0; i < len(s); i++ {
+		if needsEscape(s[i], i, slash) {
+			n++
+		}
+	}
+	if n == 0 {
+		return s
+	}
+	const hex = "0123456789abcdef"
+	p := make([]byte, 0, len(s)+2*n)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if needsEscape(c, i, slash) {
+			p = append(p, '%', hex[c>>4], hex[c&0xF])
+		} else {
+			p = append(p, c)
+		}
+	}
+	return string(p)
+}
+
+func needsEscape(c byte, i, lastSlash int) bool {
+	return c <= ' ' || (c == '.' && i > lastSlash) || c == '%' || c == '"' || c >= 0x7F
+}
+
 // unescapePkg unescapes a package import path, replacing %XX escape sequences
 // with the original characters. Returns the unescaped path.
 func unescapePkg(s string) (string, error) {

--- a/pkg/dyninst/gosymname/escape_test.go
+++ b/pkg/dyninst/gosymname/escape_test.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package gosymname
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEscapePkg(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{"plain", "main", "main"},
+		{"single_dot_in_segment", "lib.v2", "lib%2ev2"},
+		{"slash_then_dot", "gopkg.in/ini.v1", "gopkg.in/ini%2ev1"},
+		{"multi_segment_no_dot_last", "github.com/DataDog/datadog-agent/pkg/foo", "github.com/DataDog/datadog-agent/pkg/foo"},
+		{"multi_segment_dot_last", "github.com/DataDog/datadog-agent/pkg/foo.v2", "github.com/DataDog/datadog-agent/pkg/foo%2ev2"},
+		{"multiple_dots_last", "a.b.c", "a%2eb%2ec"},
+		{"percent", "weird%name", "weird%25name"},
+		{"quote", `q"x`, `q%22x`},
+		{"empty", "", ""},
+		{"trailing_dot", "pkg.", "pkg%2e"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := EscapePkg(c.in)
+			require.Equal(t, c.out, got)
+			// Round-trip through unescapePkg.
+			back, err := unescapePkg(got)
+			require.NoError(t, err)
+			require.Equal(t, c.in, back)
+		})
+	}
+}
+
+// FuzzEscapePkg asserts that unescapePkg ∘ EscapePkg is the identity:
+// every input round-trips through escape and unescape unchanged. Seeds
+// cover the kinds of paths we observe in real Go binaries: plain import
+// paths, paths with dotted last segments, the corner cases EscapePkg
+// specifically handles (control bytes, quotes, percent, high bytes),
+// and a few empty/edge inputs.
+func FuzzEscapePkg(f *testing.F) {
+	seeds := []string{
+		"",
+		"main",
+		"lib.v2",
+		"gopkg.in/ini.v1",
+		"github.com/DataDog/datadog-agent/pkg/dyninst/symdb",
+		"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2",
+		"a.b.c",
+		"a/b.c",
+		"a/b.c/d",
+		"weird%name",
+		`q"x`,
+		"pkg.",
+		"\x00\x01 \x7f",
+		"\xc3\xa9",            // multi-byte UTF-8 (é)
+		"go.opencensus.io",    // dotted top-level
+		"k8s.io/api/core/v1",  // dotted top, plain last
+		"sigs.k8s.io/yaml.v1", // dotted top + dotted last
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		got := EscapePkg(s)
+		back, err := unescapePkg(got)
+		require.NoError(t, err, "unescapePkg failed on EscapePkg(%q)=%q", s, got)
+		require.Equal(t, s, back, "round-trip mismatch for %q (escaped=%q)", s, got)
+	})
+}

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,4 +1,4 @@
-- offset: "0x00101900"
+- offset: "0x00101980"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[float64] (exported)'
@@ -11,7 +11,7 @@
       type: func(float64)
   pointer:
     elem: lib.Box[float64]
-- offset: "0x00101680"
+- offset: "0x00101700"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[int] (exported)'
@@ -24,7 +24,7 @@
       type: func(int)
   pointer:
     elem: lib.Box[int]
-- offset: "0x00101700"
+- offset: "0x00101780"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[string] (exported)'
@@ -37,7 +37,7 @@
       type: func(string)
   pointer:
     elem: lib.Box[string]
-- offset: "0x00101880"
+- offset: "0x00101900"
   size: 8
   kind: ptr
   nameEntry: '*lib.ImmutableSet[string] (exported)'
@@ -50,7 +50,7 @@
       type: func(string) (*lib.ImmutableSet[string], bool)
   pointer:
     elem: lib.ImmutableSet[string]
-- offset: "0x000d73a0"
+- offset: "0x000d73c0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[bool,string] (exported)'
@@ -61,7 +61,7 @@
       type: func() lib.Pair[string,bool]
   pointer:
     elem: lib.Pair[bool,string]
-- offset: "0x000d8840"
+- offset: "0x000d8860"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[float64,float64] (exported)'
@@ -72,7 +72,7 @@
       type: func() lib.Pair[float64,float64]
   pointer:
     elem: lib.Pair[float64,float64]
-- offset: "0x000d7460"
+- offset: "0x000d7480"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[int,string] (exported)'
@@ -83,7 +83,7 @@
       type: func() lib.Pair[string,int]
   pointer:
     elem: lib.Pair[int,string]
-- offset: "0x000d7340"
+- offset: "0x000d7360"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[string,bool] (exported)'
@@ -94,7 +94,7 @@
       type: func() lib.Pair[bool,string]
   pointer:
     elem: lib.Pair[string,bool]
-- offset: "0x000d7400"
+- offset: "0x000d7420"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[string,int] (exported)'
@@ -105,13 +105,13 @@
       type: func() lib.Pair[int,string]
   pointer:
     elem: lib.Pair[string,int]
-- offset: "0x001376e0"
+- offset: "0x00137760"
   size: 8
   kind: struct
   nameEntry: lib.Box[float64] (exported)
   name: lib.Box[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x00101900"
+  ptrToThis: "0x00101980"
   methods:
     - name: Get (exported)
       type: func() float64
@@ -120,13 +120,13 @@
         - name: Value (exported)
           type: float64
           offset: 0
-- offset: "0x00137140"
+- offset: "0x001371c0"
   size: 8
   kind: struct
   nameEntry: lib.Box[int] (exported)
   name: lib.Box[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x00101680"
+  ptrToThis: "0x00101700"
   methods:
     - name: Get (exported)
       type: func() int
@@ -135,13 +135,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x001371e0"
+- offset: "0x00137260"
   size: 16
   kind: struct
   nameEntry: lib.Box[string] (exported)
   name: lib.Box[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x00101700"
+  ptrToThis: "0x00101780"
   methods:
     - name: Get (exported)
       type: func() string
@@ -150,37 +150,37 @@
         - name: Value (exported)
           type: string
           offset: 0
-- offset: "0x001220a0"
+- offset: "0x00122120"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[go.shape.string] (exported)
   name: lib.ImmutableSet[go.shape.string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0006dda0"
+  ptrToThis: "0x0006ddc0"
   struct:
     fields:
         - name: items
           type: map[go.shape.string]bool
           offset: 0
-- offset: "0x00121fa0"
+- offset: "0x00122020"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[string] (exported)
   name: lib.ImmutableSet[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x00101880"
+  ptrToThis: "0x00101900"
   struct:
     fields:
         - name: items
           type: map[string]bool
           offset: 0
-- offset: "0x0015b940"
+- offset: "0x0015ba60"
   size: 24
   kind: struct
   nameEntry: lib.Pair[bool,string] (exported)
   name: lib.Pair[bool,string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000d73a0"
+  ptrToThis: "0x000d73c0"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[string,bool]
@@ -192,13 +192,13 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x0015bc60"
+- offset: "0x0015bd80"
   size: 16
   kind: struct
   nameEntry: lib.Pair[float64,float64] (exported)
   name: lib.Pair[float64,float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000d8840"
+  ptrToThis: "0x000d8860"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[float64,float64]
@@ -210,13 +210,13 @@
         - name: Second (exported)
           type: float64
           offset: 8
-- offset: "0x0015ba80"
+- offset: "0x0015bba0"
   size: 24
   kind: struct
   nameEntry: lib.Pair[int,string] (exported)
   name: lib.Pair[int,string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000d7460"
+  ptrToThis: "0x000d7480"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[string,int]
@@ -228,13 +228,13 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x0015b8a0"
+- offset: "0x0015b9c0"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,bool] (exported)
   name: lib.Pair[string,bool]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000d7340"
+  ptrToThis: "0x000d7360"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[bool,string]
@@ -246,13 +246,13 @@
         - name: Second (exported)
           type: bool
           offset: 16
-- offset: "0x0015b9e0"
+- offset: "0x0015bb00"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,int] (exported)
   name: lib.Pair[string,int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000d7400"
+  ptrToThis: "0x000d7420"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[int,string]
@@ -264,7 +264,18 @@
         - name: Second (exported)
           type: int
           offset: 16
-- offset: "0x000ca4a0"
+- offset: "0x000d8920"
+  size: 8
+  kind: ptr
+  nameEntry: '*lib_v2.V2GenericBox[int] (exported)'
+  name: '*lib_v2.V2GenericBox[int]'
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  methods:
+    - name: Get (exported)
+      type: func() int
+  pointer:
+    elem: lib_v2.V2GenericBox[int]
+- offset: "0x000ca4c0"
   size: 8
   kind: ptr
   nameEntry: '*lib_v2.V2Type (exported)'
@@ -275,16 +286,31 @@
       type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000e84c0"
+- offset: "0x00137940"
+  size: 8
+  kind: struct
+  nameEntry: lib_v2.V2GenericBox[int] (exported)
+  name: lib_v2.V2GenericBox[int]
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  ptrToThis: "0x000d8920"
+  methods:
+    - name: Get (exported)
+      type: func() int
+  struct:
+    fields:
+        - name: Value (exported)
+          type: int
+          offset: 0
+- offset: "0x000e8540"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000ca4a0"
+  ptrToThis: "0x000ca4c0"
   struct:
     fields: []
-- offset: "0x00101980"
+- offset: "0x00101a00"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[float64] (exported)'
@@ -297,7 +323,7 @@
       type: func() float64
   pointer:
     elem: lib2.Wrapper[float64]
-- offset: "0x00101780"
+- offset: "0x00101800"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[int] (exported)'
@@ -310,7 +336,7 @@
       type: func() int
   pointer:
     elem: lib2.Wrapper[int]
-- offset: "0x00101800"
+- offset: "0x00101880"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[string] (exported)'
@@ -323,13 +349,13 @@
       type: func() string
   pointer:
     elem: lib2.Wrapper[string]
-- offset: "0x0015bd00"
+- offset: "0x0015be20"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[float64] (exported)
   name: lib2.Wrapper[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x00101980"
+  ptrToThis: "0x00101a00"
   methods:
     - name: Unwrap (exported)
       type: func() float64
@@ -341,13 +367,13 @@
         - name: Inner (exported)
           type: lib.Box[float64]
           offset: 16
-- offset: "0x0015bb20"
+- offset: "0x0015bc40"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[int] (exported)
   name: lib2.Wrapper[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x00101780"
+  ptrToThis: "0x00101800"
   methods:
     - name: Unwrap (exported)
       type: func() int
@@ -359,13 +385,13 @@
         - name: Inner (exported)
           type: lib.Box[int]
           offset: 16
-- offset: "0x0015bbc0"
+- offset: "0x0015bce0"
   size: 32
   kind: struct
   nameEntry: lib2.Wrapper[string] (exported)
   name: lib2.Wrapper[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x00101800"
+  ptrToThis: "0x00101880"
   methods:
     - name: Unwrap (exported)
       type: func() string
@@ -377,7 +403,7 @@
         - name: Inner (exported)
           type: lib.Box[string]
           offset: 16
-- offset: "0x000d74c0"
+- offset: "0x000d74e0"
   size: 8
   kind: ptr
   nameEntry: '*main.Pair[int,bool] (exported)'
@@ -388,7 +414,7 @@
       type: func(int, bool)
   pointer:
     elem: main.Pair[int,bool]
-- offset: "0x000d7520"
+- offset: "0x000d7540"
   size: 8
   kind: ptr
   nameEntry: '*main.Pair[string,int] (exported)'
@@ -399,7 +425,7 @@
       type: func(string, int)
   pointer:
     elem: main.Pair[string,int]
-- offset: "0x000c9fc0"
+- offset: "0x000c9fe0"
   size: 8
   kind: ptr
   nameEntry: '*main.firstBehavior'
@@ -410,7 +436,7 @@
       type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000d7580"
+- offset: "0x000d75a0"
   size: 8
   kind: ptr
   nameEntry: '*main.largeGenericType[int]'
@@ -421,7 +447,7 @@
       type: func() int
   pointer:
     elem: main.largeGenericType[int]
-- offset: "0x000d75e0"
+- offset: "0x000d7600"
   size: 8
   kind: ptr
   nameEntry: '*main.largeGenericType[string]'
@@ -432,7 +458,7 @@
       type: func() string
   pointer:
     elem: main.largeGenericType[string]
-- offset: "0x000ca020"
+- offset: "0x000ca040"
   size: 8
   kind: ptr
   nameEntry: '*main.secondBehavior'
@@ -443,7 +469,7 @@
       type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000ca080"
+- offset: "0x000ca0a0"
   size: 8
   kind: ptr
   nameEntry: '*main.somethingImpl'
@@ -454,7 +480,7 @@
       type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000d76a0"
+- offset: "0x000d76c0"
   size: 8
   kind: ptr
   nameEntry: '*main.typeWithGenerics[int]'
@@ -465,7 +491,7 @@
       type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000d7700"
+- offset: "0x000d7720"
   size: 8
   kind: ptr
   nameEntry: '*main.typeWithGenerics[string]'
@@ -476,13 +502,13 @@
       type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x0014b940"
+- offset: "0x0014ba60"
   size: 16
   kind: struct
   nameEntry: main.Pair[int,bool] (exported)
   name: main.Pair[int,bool]
   pkg: main
-  ptrToThis: "0x000d74c0"
+  ptrToThis: "0x000d74e0"
   struct:
     fields:
         - name: Key (exported)
@@ -491,13 +517,13 @@
         - name: Value (exported)
           type: bool
           offset: 8
-- offset: "0x0014b9e0"
+- offset: "0x0014bb00"
   size: 24
   kind: struct
   nameEntry: main.Pair[string,int] (exported)
   name: main.Pair[string,int]
   pkg: main
-  ptrToThis: "0x000d7520"
+  ptrToThis: "0x000d7540"
   struct:
     fields:
         - name: Key (exported)
@@ -506,23 +532,23 @@
         - name: Value (exported)
           type: int
           offset: 16
-- offset: "0x000f0400"
+- offset: "0x000f0480"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x00057160"
+  ptrToThis: "0x00057180"
   interfaceMethods:
     - name: DoSomething (exported)
       type: func() string
-- offset: "0x0015cc60"
+- offset: "0x0015cd80"
   size: 48
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x000571e0"
+  ptrToThis: "0x00057200"
   struct:
     fields:
         - name: x
@@ -534,344 +560,344 @@
         - name: writer
           type: io.Writer
           offset: 32
-- offset: "0x000822c0"
+- offset: "0x000822e0"
   size: 8
   kind: int
   nameEntry: main.celsius
   name: main.celsius
   pkg: main
-  ptrToThis: "0x00057220"
-- offset: "0x0010dea0"
+  ptrToThis: "0x00057240"
+- offset: "0x0010df20"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x00057620"
+  ptrToThis: "0x00057640"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap2
           offset: 0
-- offset: "0x0010de20"
+- offset: "0x0010dea0"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x000575e0"
+  ptrToThis: "0x00057600"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap3
           offset: 0
-- offset: "0x0010dda0"
+- offset: "0x0010de20"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x000575a0"
+  ptrToThis: "0x000575c0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap4
           offset: 0
-- offset: "0x0010dd20"
+- offset: "0x0010dda0"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x00057560"
+  ptrToThis: "0x00057580"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap5
           offset: 0
-- offset: "0x0010dca0"
+- offset: "0x0010dd20"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x00057520"
+  ptrToThis: "0x00057540"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap6
           offset: 0
-- offset: "0x0010dc20"
+- offset: "0x0010dca0"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x000574e0"
+  ptrToThis: "0x00057500"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap7
           offset: 0
-- offset: "0x0010dba0"
+- offset: "0x0010dc20"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x000574a0"
+  ptrToThis: "0x000574c0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap8
           offset: 0
-- offset: "0x0010db20"
+- offset: "0x0010dba0"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x00057460"
+  ptrToThis: "0x00057480"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap9
           offset: 0
-- offset: "0x0010daa0"
+- offset: "0x0010db20"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x00057420"
+  ptrToThis: "0x00057440"
   struct:
     fields:
         - name: a
           type: map[int]interface {}
           offset: 0
-- offset: "0x0010e320"
+- offset: "0x0010e3a0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x00057860"
+  ptrToThis: "0x00057880"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr2'
           offset: 0
-- offset: "0x0010e2a0"
+- offset: "0x0010e320"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x00057820"
+  ptrToThis: "0x00057840"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr3'
           offset: 0
-- offset: "0x0010e220"
+- offset: "0x0010e2a0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x000577e0"
+  ptrToThis: "0x00057800"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr4'
           offset: 0
-- offset: "0x0010e1a0"
+- offset: "0x0010e220"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x000577a0"
+  ptrToThis: "0x000577c0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr5'
           offset: 0
-- offset: "0x0010e120"
+- offset: "0x0010e1a0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x00057760"
+  ptrToThis: "0x00057780"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr6'
           offset: 0
-- offset: "0x0010e0a0"
+- offset: "0x0010e120"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x00057720"
+  ptrToThis: "0x00057740"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr7'
           offset: 0
-- offset: "0x0010e020"
+- offset: "0x0010e0a0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x000576e0"
+  ptrToThis: "0x00057700"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr8'
           offset: 0
-- offset: "0x0010dfa0"
+- offset: "0x0010e020"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x000576a0"
+  ptrToThis: "0x000576c0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr9'
           offset: 0
-- offset: "0x0010df20"
+- offset: "0x0010dfa0"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x00057660"
+  ptrToThis: "0x00057680"
   struct:
     fields:
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x0010e7a0"
+- offset: "0x0010e820"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x00057aa0"
+  ptrToThis: "0x00057ac0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice2'
           offset: 0
-- offset: "0x0010e720"
+- offset: "0x0010e7a0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x00057a60"
+  ptrToThis: "0x00057a80"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice3'
           offset: 0
-- offset: "0x0010e6a0"
+- offset: "0x0010e720"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x00057a20"
+  ptrToThis: "0x00057a40"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice4'
           offset: 0
-- offset: "0x0010e620"
+- offset: "0x0010e6a0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x000579e0"
+  ptrToThis: "0x00057a00"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice5'
           offset: 0
-- offset: "0x0010e5a0"
+- offset: "0x0010e620"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x000579a0"
+  ptrToThis: "0x000579c0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice6'
           offset: 0
-- offset: "0x0010e520"
+- offset: "0x0010e5a0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x00057960"
+  ptrToThis: "0x00057980"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice7'
           offset: 0
-- offset: "0x0010e4a0"
+- offset: "0x0010e520"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x00057920"
+  ptrToThis: "0x00057940"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice8'
           offset: 0
-- offset: "0x0010e420"
+- offset: "0x0010e4a0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x000578e0"
+  ptrToThis: "0x00057900"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice9'
           offset: 0
-- offset: "0x0010e3a0"
+- offset: "0x0010e420"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x000578a0"
+  ptrToThis: "0x000578c0"
   struct:
     fields:
         - name: a
           type: '[]interface {}'
           offset: 0
-- offset: "0x001a2400"
+- offset: "0x001a2520"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x00057ae0"
+  ptrToThis: "0x00057b00"
   struct:
     fields:
         - name: esotericStack (embedded)
@@ -889,13 +915,13 @@
         - name: a
           type: atomic.Int32
           offset: 104
-- offset: "0x001c1200"
+- offset: "0x001c1320"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x00057260"
+  ptrToThis: "0x00057280"
   struct:
     fields:
         - name: _
@@ -919,13 +945,13 @@
         - name: foo
           type: func()
           offset: 56
-- offset: "0x0012e180"
+- offset: "0x0012e200"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000c9fc0"
+  ptrToThis: "0x000c9fe0"
   methods:
     - name: DoSomething (exported)
       type: func() string
@@ -934,13 +960,13 @@
         - name: s
           type: string
           offset: 0
-- offset: "0x001e1a40"
+- offset: "0x001e1b60"
   size: 136
   kind: struct
   nameEntry: main.largeGenericType[int]
   name: main.largeGenericType[int]
   pkg: main
-  ptrToThis: "0x000d7580"
+  ptrToThis: "0x000d75a0"
   methods:
     - name: LargeGet (exported)
       type: func() int
@@ -973,13 +999,13 @@
         - name: Value (exported)
           type: int
           offset: 128
-- offset: "0x001e1ba0"
+- offset: "0x001e1cc0"
   size: 144
   kind: struct
   nameEntry: main.largeGenericType[string]
   name: main.largeGenericType[string]
   pkg: main
-  ptrToThis: "0x000d75e0"
+  ptrToThis: "0x000d7600"
   methods:
     - name: LargeGet (exported)
       type: func() string
@@ -1012,20 +1038,20 @@
         - name: Value (exported)
           type: string
           offset: 128
-- offset: "0x00082300"
+- offset: "0x00082320"
   size: 8
   kind: int
   nameEntry: main.namedInt
   name: main.namedInt
   pkg: main
-  ptrToThis: "0x000572a0"
-- offset: "0x0013a140"
+  ptrToThis: "0x000572c0"
+- offset: "0x0013a260"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x00057be0"
+  ptrToThis: "0x00057c00"
   struct:
     fields:
         - name: anotherInt
@@ -1034,13 +1060,13 @@
         - name: anotherString
           type: string
           offset: 8
-- offset: "0x0013a000"
+- offset: "0x0013a120"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x00057b20"
+  ptrToThis: "0x00057b40"
   struct:
     fields:
         - name: val
@@ -1049,44 +1075,44 @@
         - name: b
           type: '*main.node'
           offset: 8
-- offset: "0x0010d8a0"
+- offset: "0x0010d920"
   size: 16
   kind: struct
   nameEntry: main.otherFirstBehavior
   name: main.otherFirstBehavior
   pkg: main
-  ptrToThis: "0x000572e0"
+  ptrToThis: "0x00057300"
   struct:
     fields:
         - name: s
           type: string
           offset: 0
-- offset: "0x0010d920"
+- offset: "0x0010d9a0"
   size: 8
   kind: struct
   nameEntry: main.otherSecondBehavior
   name: main.otherSecondBehavior
   pkg: main
-  ptrToThis: "0x00057320"
+  ptrToThis: "0x00057340"
   struct:
     fields:
         - name: i
           type: int
           offset: 0
-- offset: "0x00082340"
+- offset: "0x00082360"
   size: 8
   kind: int
   nameEntry: main.score
   name: main.score
   pkg: main
-  ptrToThis: "0x00057360"
-- offset: "0x0012e220"
+  ptrToThis: "0x00057380"
+- offset: "0x0012e2a0"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000ca020"
+  ptrToThis: "0x000ca040"
   methods:
     - name: DoSomething (exported)
       type: func() string
@@ -1095,13 +1121,13 @@
         - name: i
           type: int
           offset: 0
-- offset: "0x0013a0a0"
+- offset: "0x0013a1c0"
   size: 16
   kind: struct
   nameEntry: main.smallStruct
   name: main.smallStruct
   pkg: main
-  ptrToThis: "0x00057b60"
+  ptrToThis: "0x00057b80"
   struct:
     fields:
         - name: X (exported)
@@ -1110,68 +1136,68 @@
         - name: Y (exported)
           type: int
           offset: 8
-- offset: "0x000f0480"
+- offset: "0x000f0500"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x000571a0"
+  ptrToThis: "0x000571c0"
   interfaceMethods:
     - name: Do (exported)
       type: func()
-- offset: "0x000e8340"
+- offset: "0x000e83c0"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000ca080"
+  ptrToThis: "0x000ca0a0"
   struct:
     fields: []
-- offset: "0x0010d9a0"
+- offset: "0x0010da20"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
   name: main.structWithAny
   pkg: main
-  ptrToThis: "0x000573a0"
+  ptrToThis: "0x000573c0"
   struct:
     fields:
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x0010da20"
+- offset: "0x0010daa0"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x000573e0"
+  ptrToThis: "0x00057400"
   struct:
     fields:
         - name: m
           type: map[int]int
           offset: 0
-- offset: "0x0010e820"
+- offset: "0x0010e8a0"
   size: 16
   kind: struct
   nameEntry: main.tinyStruct
   name: main.tinyStruct
   pkg: main
-  ptrToThis: "0x00057ba0"
+  ptrToThis: "0x00057bc0"
   struct:
     fields:
         - name: Name (exported)
           type: string
           offset: 0
-- offset: "0x00137280"
+- offset: "0x00137300"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000d76a0"
+  ptrToThis: "0x000d76c0"
   methods:
     - name: Guess (exported)
       type: func(int) bool
@@ -1180,13 +1206,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x00137320"
+- offset: "0x001373a0"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000d7700"
+  ptrToThis: "0x000d7720"
   methods:
     - name: Guess (exported)
       type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -1,4 +1,4 @@
-- offset: "0x0010ac60"
+- offset: "0x0010ace0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[float64] (exported)'
@@ -11,7 +11,7 @@
       type: func(float64)
   pointer:
     elem: lib.Box[float64]
-- offset: "0x0010a960"
+- offset: "0x0010a9e0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[int] (exported)'
@@ -24,7 +24,7 @@
       type: func(int)
   pointer:
     elem: lib.Box[int]
-- offset: "0x0010a9e0"
+- offset: "0x0010aa60"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[string] (exported)'
@@ -37,7 +37,7 @@
       type: func(string)
   pointer:
     elem: lib.Box[string]
-- offset: "0x0010ab60"
+- offset: "0x0010abe0"
   size: 8
   kind: ptr
   nameEntry: '*lib.ImmutableSet[string] (exported)'
@@ -50,7 +50,7 @@
       type: func(string) (*lib.ImmutableSet[string], bool)
   pointer:
     elem: lib.ImmutableSet[string]
-- offset: "0x000e8560"
+- offset: "0x000e8580"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[bool,string] (exported)'
@@ -61,7 +61,7 @@
       type: func() lib.Pair[string,bool]
   pointer:
     elem: lib.Pair[bool,string]
-- offset: "0x000e8e60"
+- offset: "0x000e8e80"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[float64,float64] (exported)'
@@ -72,7 +72,7 @@
       type: func() lib.Pair[float64,float64]
   pointer:
     elem: lib.Pair[float64,float64]
-- offset: "0x000e8620"
+- offset: "0x000e8640"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[int,string] (exported)'
@@ -83,7 +83,7 @@
       type: func() lib.Pair[string,int]
   pointer:
     elem: lib.Pair[int,string]
-- offset: "0x000e8500"
+- offset: "0x000e8520"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[string,bool] (exported)'
@@ -94,7 +94,7 @@
       type: func() lib.Pair[bool,string]
   pointer:
     elem: lib.Pair[string,bool]
-- offset: "0x000e85c0"
+- offset: "0x000e85e0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[string,int] (exported)'
@@ -105,13 +105,13 @@
       type: func() lib.Pair[int,string]
   pointer:
     elem: lib.Pair[string,int]
-- offset: "0x00163620"
+- offset: "0x001636a0"
   size: 8
   kind: struct
   nameEntry: lib.Box[float64] (exported)
   name: lib.Box[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010ac60"
+  ptrToThis: "0x0010ace0"
   methods:
     - name: Get (exported)
       type: func() float64
@@ -120,13 +120,13 @@
         - name: Value (exported)
           type: float64
           offset: 0
-- offset: "0x00162fe0"
+- offset: "0x00163060"
   size: 8
   kind: struct
   nameEntry: lib.Box[int] (exported)
   name: lib.Box[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010a960"
+  ptrToThis: "0x0010a9e0"
   methods:
     - name: Get (exported)
       type: func() int
@@ -135,13 +135,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x00163080"
+- offset: "0x00163100"
   size: 16
   kind: struct
   nameEntry: lib.Box[string] (exported)
   name: lib.Box[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010a9e0"
+  ptrToThis: "0x0010aa60"
   methods:
     - name: Get (exported)
       type: func() string
@@ -150,37 +150,37 @@
         - name: Value (exported)
           type: string
           offset: 0
-- offset: "0x00136800"
+- offset: "0x00136880"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[go.shape.string] (exported)
   name: lib.ImmutableSet[go.shape.string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x00074ee0"
+  ptrToThis: "0x00074f00"
   struct:
     fields:
         - name: items
           type: map[go.shape.string]bool
           offset: 0
-- offset: "0x00136700"
+- offset: "0x00136780"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[string] (exported)
   name: lib.ImmutableSet[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010ab60"
+  ptrToThis: "0x0010abe0"
   struct:
     fields:
         - name: items
           type: map[string]bool
           offset: 0
-- offset: "0x00189640"
+- offset: "0x00189760"
   size: 24
   kind: struct
   nameEntry: lib.Pair[bool,string] (exported)
   name: lib.Pair[bool,string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e8560"
+  ptrToThis: "0x000e8580"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[string,bool]
@@ -192,13 +192,13 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x00189960"
+- offset: "0x00189a80"
   size: 16
   kind: struct
   nameEntry: lib.Pair[float64,float64] (exported)
   name: lib.Pair[float64,float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e8e60"
+  ptrToThis: "0x000e8e80"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[float64,float64]
@@ -210,13 +210,13 @@
         - name: Second (exported)
           type: float64
           offset: 8
-- offset: "0x00189780"
+- offset: "0x001898a0"
   size: 24
   kind: struct
   nameEntry: lib.Pair[int,string] (exported)
   name: lib.Pair[int,string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e8620"
+  ptrToThis: "0x000e8640"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[string,int]
@@ -228,13 +228,13 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x001895a0"
+- offset: "0x001896c0"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,bool] (exported)
   name: lib.Pair[string,bool]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e8500"
+  ptrToThis: "0x000e8520"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[bool,string]
@@ -246,13 +246,13 @@
         - name: Second (exported)
           type: bool
           offset: 16
-- offset: "0x001896e0"
+- offset: "0x00189800"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,int] (exported)
   name: lib.Pair[string,int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e85c0"
+  ptrToThis: "0x000e85e0"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[int,string]
@@ -264,7 +264,18 @@
         - name: Second (exported)
           type: int
           offset: 16
-- offset: "0x000db1e0"
+- offset: "0x000e8ee0"
+  size: 8
+  kind: ptr
+  nameEntry: '*lib_v2.V2GenericBox[int] (exported)'
+  name: '*lib_v2.V2GenericBox[int]'
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  methods:
+    - name: Get (exported)
+      type: func() int
+  pointer:
+    elem: lib_v2.V2GenericBox[int]
+- offset: "0x000db200"
   size: 8
   kind: ptr
   nameEntry: '*lib_v2.V2Type (exported)'
@@ -275,16 +286,31 @@
       type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f18e0"
+- offset: "0x00163880"
+  size: 8
+  kind: struct
+  nameEntry: lib_v2.V2GenericBox[int] (exported)
+  name: lib_v2.V2GenericBox[int]
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  ptrToThis: "0x000e8ee0"
+  methods:
+    - name: Get (exported)
+      type: func() int
+  struct:
+    fields:
+        - name: Value (exported)
+          type: int
+          offset: 0
+- offset: "0x000f1960"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000db1e0"
+  ptrToThis: "0x000db200"
   struct:
     fields: []
-- offset: "0x0010ace0"
+- offset: "0x0010ad60"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[float64] (exported)'
@@ -297,7 +323,7 @@
       type: func() float64
   pointer:
     elem: lib2.Wrapper[float64]
-- offset: "0x0010aa60"
+- offset: "0x0010aae0"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[int] (exported)'
@@ -310,7 +336,7 @@
       type: func() int
   pointer:
     elem: lib2.Wrapper[int]
-- offset: "0x0010aae0"
+- offset: "0x0010ab60"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[string] (exported)'
@@ -323,13 +349,13 @@
       type: func() string
   pointer:
     elem: lib2.Wrapper[string]
-- offset: "0x00189a00"
+- offset: "0x00189b20"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[float64] (exported)
   name: lib2.Wrapper[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010ace0"
+  ptrToThis: "0x0010ad60"
   methods:
     - name: Unwrap (exported)
       type: func() float64
@@ -341,13 +367,13 @@
         - name: Inner (exported)
           type: lib.Box[float64]
           offset: 16
-- offset: "0x00189820"
+- offset: "0x00189940"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[int] (exported)
   name: lib2.Wrapper[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010aa60"
+  ptrToThis: "0x0010aae0"
   methods:
     - name: Unwrap (exported)
       type: func() int
@@ -359,13 +385,13 @@
         - name: Inner (exported)
           type: lib.Box[int]
           offset: 16
-- offset: "0x001898c0"
+- offset: "0x001899e0"
   size: 32
   kind: struct
   nameEntry: lib2.Wrapper[string] (exported)
   name: lib2.Wrapper[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010aae0"
+  ptrToThis: "0x0010ab60"
   methods:
     - name: Unwrap (exported)
       type: func() string
@@ -377,7 +403,7 @@
         - name: Inner (exported)
           type: lib.Box[string]
           offset: 16
-- offset: "0x000e8680"
+- offset: "0x000e86a0"
   size: 8
   kind: ptr
   nameEntry: '*main.Pair[int,bool] (exported)'
@@ -388,7 +414,7 @@
       type: func(int, bool)
   pointer:
     elem: main.Pair[int,bool]
-- offset: "0x000e86e0"
+- offset: "0x000e8700"
   size: 8
   kind: ptr
   nameEntry: '*main.Pair[string,int] (exported)'
@@ -399,7 +425,7 @@
       type: func(string, int)
   pointer:
     elem: main.Pair[string,int]
-- offset: "0x000dad00"
+- offset: "0x000dad20"
   size: 8
   kind: ptr
   nameEntry: '*main.firstBehavior'
@@ -410,7 +436,7 @@
       type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000e8740"
+- offset: "0x000e8760"
   size: 8
   kind: ptr
   nameEntry: '*main.largeGenericType[int]'
@@ -421,7 +447,7 @@
       type: func() int
   pointer:
     elem: main.largeGenericType[int]
-- offset: "0x000e87a0"
+- offset: "0x000e87c0"
   size: 8
   kind: ptr
   nameEntry: '*main.largeGenericType[string]'
@@ -432,7 +458,7 @@
       type: func() string
   pointer:
     elem: main.largeGenericType[string]
-- offset: "0x000dad60"
+- offset: "0x000dad80"
   size: 8
   kind: ptr
   nameEntry: '*main.secondBehavior'
@@ -443,7 +469,7 @@
       type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000dadc0"
+- offset: "0x000dade0"
   size: 8
   kind: ptr
   nameEntry: '*main.somethingImpl'
@@ -454,7 +480,7 @@
       type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e8800"
+- offset: "0x000e8820"
   size: 8
   kind: ptr
   nameEntry: '*main.typeWithGenerics[int]'
@@ -465,7 +491,7 @@
       type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e8860"
+- offset: "0x000e8880"
   size: 8
   kind: ptr
   nameEntry: '*main.typeWithGenerics[string]'
@@ -476,13 +502,13 @@
       type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x00178480"
+- offset: "0x001785a0"
   size: 16
   kind: struct
   nameEntry: main.Pair[int,bool] (exported)
   name: main.Pair[int,bool]
   pkg: main
-  ptrToThis: "0x000e8680"
+  ptrToThis: "0x000e86a0"
   struct:
     fields:
         - name: Key (exported)
@@ -491,13 +517,13 @@
         - name: Value (exported)
           type: bool
           offset: 8
-- offset: "0x00178520"
+- offset: "0x00178640"
   size: 24
   kind: struct
   nameEntry: main.Pair[string,int] (exported)
   name: main.Pair[string,int]
   pkg: main
-  ptrToThis: "0x000e86e0"
+  ptrToThis: "0x000e8700"
   struct:
     fields:
         - name: Key (exported)
@@ -506,23 +532,23 @@
         - name: Value (exported)
           type: int
           offset: 16
-- offset: "0x000f9de0"
+- offset: "0x000f9e60"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x0005dc60"
+  ptrToThis: "0x0005dc80"
   interfaceMethods:
     - name: DoSomething (exported)
       type: func() string
-- offset: "0x0018abe0"
+- offset: "0x0018ad00"
   size: 48
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x0005dce0"
+  ptrToThis: "0x0005dd00"
   struct:
     fields:
         - name: x
@@ -534,344 +560,344 @@
         - name: writer
           type: io.Writer
           offset: 32
-- offset: "0x0008e500"
+- offset: "0x0008e520"
   size: 8
   kind: int
   nameEntry: main.celsius
   name: main.celsius
   pkg: main
-  ptrToThis: "0x0005dd20"
-- offset: "0x00122480"
+  ptrToThis: "0x0005dd40"
+- offset: "0x00122500"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x0005e120"
+  ptrToThis: "0x0005e140"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap2
           offset: 0
-- offset: "0x00122400"
+- offset: "0x00122480"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x0005e0e0"
+  ptrToThis: "0x0005e100"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap3
           offset: 0
-- offset: "0x00122380"
+- offset: "0x00122400"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x0005e0a0"
+  ptrToThis: "0x0005e0c0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap4
           offset: 0
-- offset: "0x00122300"
+- offset: "0x00122380"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x0005e060"
+  ptrToThis: "0x0005e080"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap5
           offset: 0
-- offset: "0x00122280"
+- offset: "0x00122300"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x0005e020"
+  ptrToThis: "0x0005e040"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap6
           offset: 0
-- offset: "0x00122200"
+- offset: "0x00122280"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x0005dfe0"
+  ptrToThis: "0x0005e000"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap7
           offset: 0
-- offset: "0x00122180"
+- offset: "0x00122200"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x0005dfa0"
+  ptrToThis: "0x0005dfc0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap8
           offset: 0
-- offset: "0x00122100"
+- offset: "0x00122180"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x0005df60"
+  ptrToThis: "0x0005df80"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap9
           offset: 0
-- offset: "0x00122080"
+- offset: "0x00122100"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x0005df20"
+  ptrToThis: "0x0005df40"
   struct:
     fields:
         - name: a
           type: map[int]interface {}
           offset: 0
-- offset: "0x00122900"
+- offset: "0x00122980"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x0005e360"
+  ptrToThis: "0x0005e380"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr2'
           offset: 0
-- offset: "0x00122880"
+- offset: "0x00122900"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x0005e320"
+  ptrToThis: "0x0005e340"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr3'
           offset: 0
-- offset: "0x00122800"
+- offset: "0x00122880"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x0005e2e0"
+  ptrToThis: "0x0005e300"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr4'
           offset: 0
-- offset: "0x00122780"
+- offset: "0x00122800"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x0005e2a0"
+  ptrToThis: "0x0005e2c0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr5'
           offset: 0
-- offset: "0x00122700"
+- offset: "0x00122780"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x0005e260"
+  ptrToThis: "0x0005e280"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr6'
           offset: 0
-- offset: "0x00122680"
+- offset: "0x00122700"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x0005e220"
+  ptrToThis: "0x0005e240"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr7'
           offset: 0
-- offset: "0x00122600"
+- offset: "0x00122680"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x0005e1e0"
+  ptrToThis: "0x0005e200"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr8'
           offset: 0
-- offset: "0x00122580"
+- offset: "0x00122600"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x0005e1a0"
+  ptrToThis: "0x0005e1c0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr9'
           offset: 0
-- offset: "0x00122500"
+- offset: "0x00122580"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x0005e160"
+  ptrToThis: "0x0005e180"
   struct:
     fields:
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x00122d80"
+- offset: "0x00122e00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x0005e5a0"
+  ptrToThis: "0x0005e5c0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice2'
           offset: 0
-- offset: "0x00122d00"
+- offset: "0x00122d80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x0005e560"
+  ptrToThis: "0x0005e580"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice3'
           offset: 0
-- offset: "0x00122c80"
+- offset: "0x00122d00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x0005e520"
+  ptrToThis: "0x0005e540"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice4'
           offset: 0
-- offset: "0x00122c00"
+- offset: "0x00122c80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x0005e4e0"
+  ptrToThis: "0x0005e500"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice5'
           offset: 0
-- offset: "0x00122b80"
+- offset: "0x00122c00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x0005e4a0"
+  ptrToThis: "0x0005e4c0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice6'
           offset: 0
-- offset: "0x00122b00"
+- offset: "0x00122b80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x0005e460"
+  ptrToThis: "0x0005e480"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice7'
           offset: 0
-- offset: "0x00122a80"
+- offset: "0x00122b00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x0005e420"
+  ptrToThis: "0x0005e440"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice8'
           offset: 0
-- offset: "0x00122a00"
+- offset: "0x00122a80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x0005e3e0"
+  ptrToThis: "0x0005e400"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice9'
           offset: 0
-- offset: "0x00122980"
+- offset: "0x00122a00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x0005e3a0"
+  ptrToThis: "0x0005e3c0"
   struct:
     fields:
         - name: a
           type: '[]interface {}'
           offset: 0
-- offset: "0x001c0260"
+- offset: "0x001c0380"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005e5e0"
+  ptrToThis: "0x0005e600"
   struct:
     fields:
         - name: esotericStack (embedded)
@@ -889,13 +915,13 @@
         - name: a
           type: atomic.Int32
           offset: 104
-- offset: "0x001e0d20"
+- offset: "0x001e0e40"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x0005dd60"
+  ptrToThis: "0x0005dd80"
   struct:
     fields:
         - name: _
@@ -919,13 +945,13 @@
         - name: foo
           type: func()
           offset: 56
-- offset: "0x00159c60"
+- offset: "0x00159ce0"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000dad00"
+  ptrToThis: "0x000dad20"
   methods:
     - name: DoSomething (exported)
       type: func() string
@@ -934,13 +960,13 @@
         - name: s
           type: string
           offset: 0
-- offset: "0x00201780"
+- offset: "0x002018a0"
   size: 136
   kind: struct
   nameEntry: main.largeGenericType[int]
   name: main.largeGenericType[int]
   pkg: main
-  ptrToThis: "0x000e8740"
+  ptrToThis: "0x000e8760"
   methods:
     - name: LargeGet (exported)
       type: func() int
@@ -973,13 +999,13 @@
         - name: Value (exported)
           type: int
           offset: 128
-- offset: "0x002018e0"
+- offset: "0x00201a00"
   size: 144
   kind: struct
   nameEntry: main.largeGenericType[string]
   name: main.largeGenericType[string]
   pkg: main
-  ptrToThis: "0x000e87a0"
+  ptrToThis: "0x000e87c0"
   methods:
     - name: LargeGet (exported)
       type: func() string
@@ -1012,20 +1038,20 @@
         - name: Value (exported)
           type: string
           offset: 128
-- offset: "0x0008e540"
+- offset: "0x0008e560"
   size: 8
   kind: int
   nameEntry: main.namedInt
   name: main.namedInt
   pkg: main
-  ptrToThis: "0x0005dda0"
-- offset: "0x00165f60"
+  ptrToThis: "0x0005ddc0"
+- offset: "0x00166080"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005e6e0"
+  ptrToThis: "0x0005e700"
   struct:
     fields:
         - name: anotherInt
@@ -1034,13 +1060,13 @@
         - name: anotherString
           type: string
           offset: 8
-- offset: "0x00165e20"
+- offset: "0x00165f40"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005e620"
+  ptrToThis: "0x0005e640"
   struct:
     fields:
         - name: val
@@ -1049,44 +1075,44 @@
         - name: b
           type: '*main.node'
           offset: 8
-- offset: "0x00121e80"
+- offset: "0x00121f00"
   size: 16
   kind: struct
   nameEntry: main.otherFirstBehavior
   name: main.otherFirstBehavior
   pkg: main
-  ptrToThis: "0x0005dde0"
+  ptrToThis: "0x0005de00"
   struct:
     fields:
         - name: s
           type: string
           offset: 0
-- offset: "0x00121f00"
+- offset: "0x00121f80"
   size: 8
   kind: struct
   nameEntry: main.otherSecondBehavior
   name: main.otherSecondBehavior
   pkg: main
-  ptrToThis: "0x0005de20"
+  ptrToThis: "0x0005de40"
   struct:
     fields:
         - name: i
           type: int
           offset: 0
-- offset: "0x0008e580"
+- offset: "0x0008e5a0"
   size: 8
   kind: int
   nameEntry: main.score
   name: main.score
   pkg: main
-  ptrToThis: "0x0005de60"
-- offset: "0x00159d00"
+  ptrToThis: "0x0005de80"
+- offset: "0x00159d80"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000dad60"
+  ptrToThis: "0x000dad80"
   methods:
     - name: DoSomething (exported)
       type: func() string
@@ -1095,13 +1121,13 @@
         - name: i
           type: int
           offset: 0
-- offset: "0x00165ec0"
+- offset: "0x00165fe0"
   size: 16
   kind: struct
   nameEntry: main.smallStruct
   name: main.smallStruct
   pkg: main
-  ptrToThis: "0x0005e660"
+  ptrToThis: "0x0005e680"
   struct:
     fields:
         - name: X (exported)
@@ -1110,68 +1136,68 @@
         - name: Y (exported)
           type: int
           offset: 8
-- offset: "0x000f9e60"
+- offset: "0x000f9ee0"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x0005dca0"
+  ptrToThis: "0x0005dcc0"
   interfaceMethods:
     - name: Do (exported)
       type: func()
-- offset: "0x000f1760"
+- offset: "0x000f17e0"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000dadc0"
+  ptrToThis: "0x000dade0"
   struct:
     fields: []
-- offset: "0x00121f80"
+- offset: "0x00122000"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
   name: main.structWithAny
   pkg: main
-  ptrToThis: "0x0005dea0"
+  ptrToThis: "0x0005dec0"
   struct:
     fields:
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x00122000"
+- offset: "0x00122080"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005dee0"
+  ptrToThis: "0x0005df00"
   struct:
     fields:
         - name: m
           type: map[int]int
           offset: 0
-- offset: "0x00122e00"
+- offset: "0x00122e80"
   size: 16
   kind: struct
   nameEntry: main.tinyStruct
   name: main.tinyStruct
   pkg: main
-  ptrToThis: "0x0005e6a0"
+  ptrToThis: "0x0005e6c0"
   struct:
     fields:
         - name: Name (exported)
           type: string
           offset: 0
-- offset: "0x00163120"
+- offset: "0x001631a0"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e8800"
+  ptrToThis: "0x000e8820"
   methods:
     - name: Guess (exported)
       type: func(int) bool
@@ -1180,13 +1206,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x001631c0"
+- offset: "0x00163240"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e8860"
+  ptrToThis: "0x000e8880"
   methods:
     - name: Guess (exported)
       type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -1,4 +1,4 @@
-- offset: "0x0010be80"
+- offset: "0x0010bee0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[float64] (exported)'
@@ -11,7 +11,7 @@
       type: func(float64)
   pointer:
     elem: lib.Box[float64]
-- offset: "0x0010bb80"
+- offset: "0x0010bbe0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[int] (exported)'
@@ -24,7 +24,7 @@
       type: func(int)
   pointer:
     elem: lib.Box[int]
-- offset: "0x0010bc00"
+- offset: "0x0010bc60"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[string] (exported)'
@@ -37,7 +37,7 @@
       type: func(string)
   pointer:
     elem: lib.Box[string]
-- offset: "0x0010bd80"
+- offset: "0x0010bde0"
   size: 8
   kind: ptr
   nameEntry: '*lib.ImmutableSet[string] (exported)'
@@ -105,13 +105,13 @@
       type: func() lib.Pair[int,string]
   pointer:
     elem: lib.Pair[string,int]
-- offset: "0x00164700"
+- offset: "0x00164760"
   size: 8
   kind: struct
   nameEntry: lib.Box[float64] (exported)
   name: lib.Box[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010be80"
+  ptrToThis: "0x0010bee0"
   methods:
     - name: Get (exported)
       type: func() float64
@@ -120,13 +120,13 @@
         - name: Value (exported)
           type: float64
           offset: 0
-- offset: "0x001640c0"
+- offset: "0x00164120"
   size: 8
   kind: struct
   nameEntry: lib.Box[int] (exported)
   name: lib.Box[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010bb80"
+  ptrToThis: "0x0010bbe0"
   methods:
     - name: Get (exported)
       type: func() int
@@ -135,13 +135,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x00164160"
+- offset: "0x001641c0"
   size: 16
   kind: struct
   nameEntry: lib.Box[string] (exported)
   name: lib.Box[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010bc00"
+  ptrToThis: "0x0010bc60"
   methods:
     - name: Get (exported)
       type: func() string
@@ -150,7 +150,7 @@
         - name: Value (exported)
           type: string
           offset: 0
-- offset: "0x00137880"
+- offset: "0x001378e0"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[go.shape.string] (exported)
@@ -162,19 +162,19 @@
         - name: items
           type: map[go.shape.string]bool
           offset: 0
-- offset: "0x00137780"
+- offset: "0x001377e0"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[string] (exported)
   name: lib.ImmutableSet[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010bd80"
+  ptrToThis: "0x0010bde0"
   struct:
     fields:
         - name: items
           type: map[string]bool
           offset: 0
-- offset: "0x0018a8c0"
+- offset: "0x0018a9c0"
   size: 24
   kind: struct
   nameEntry: lib.Pair[bool,string] (exported)
@@ -192,7 +192,7 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x0018abe0"
+- offset: "0x0018ace0"
   size: 16
   kind: struct
   nameEntry: lib.Pair[float64,float64] (exported)
@@ -210,7 +210,7 @@
         - name: Second (exported)
           type: float64
           offset: 8
-- offset: "0x0018aa00"
+- offset: "0x0018ab00"
   size: 24
   kind: struct
   nameEntry: lib.Pair[int,string] (exported)
@@ -228,7 +228,7 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x0018a820"
+- offset: "0x0018a920"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,bool] (exported)
@@ -246,7 +246,7 @@
         - name: Second (exported)
           type: bool
           offset: 16
-- offset: "0x0018a960"
+- offset: "0x0018aa60"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,int] (exported)
@@ -264,6 +264,17 @@
         - name: Second (exported)
           type: int
           offset: 16
+- offset: "0x000ea140"
+  size: 8
+  kind: ptr
+  nameEntry: '*lib_v2.V2GenericBox[int] (exported)'
+  name: '*lib_v2.V2GenericBox[int]'
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  methods:
+    - name: Get (exported)
+      type: func() int
+  pointer:
+    elem: lib_v2.V2GenericBox[int]
 - offset: "0x000dc2e0"
   size: 8
   kind: ptr
@@ -275,7 +286,22 @@
       type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f2a00"
+- offset: "0x00164940"
+  size: 8
+  kind: struct
+  nameEntry: lib_v2.V2GenericBox[int] (exported)
+  name: lib_v2.V2GenericBox[int]
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  ptrToThis: "0x000ea140"
+  methods:
+    - name: Get (exported)
+      type: func() int
+  struct:
+    fields:
+        - name: Value (exported)
+          type: int
+          offset: 0
+- offset: "0x000f2a60"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
@@ -284,7 +310,7 @@
   ptrToThis: "0x000dc2e0"
   struct:
     fields: []
-- offset: "0x0010bf00"
+- offset: "0x0010bf60"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[float64] (exported)'
@@ -297,7 +323,7 @@
       type: func() float64
   pointer:
     elem: lib2.Wrapper[float64]
-- offset: "0x0010bc80"
+- offset: "0x0010bce0"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[int] (exported)'
@@ -310,7 +336,7 @@
       type: func() int
   pointer:
     elem: lib2.Wrapper[int]
-- offset: "0x0010bd00"
+- offset: "0x0010bd60"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[string] (exported)'
@@ -323,13 +349,13 @@
       type: func() string
   pointer:
     elem: lib2.Wrapper[string]
-- offset: "0x0018ac80"
+- offset: "0x0018ad80"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[float64] (exported)
   name: lib2.Wrapper[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010bf00"
+  ptrToThis: "0x0010bf60"
   methods:
     - name: Unwrap (exported)
       type: func() float64
@@ -341,13 +367,13 @@
         - name: Inner (exported)
           type: lib.Box[float64]
           offset: 16
-- offset: "0x0018aaa0"
+- offset: "0x0018aba0"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[int] (exported)
   name: lib2.Wrapper[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010bc80"
+  ptrToThis: "0x0010bce0"
   methods:
     - name: Unwrap (exported)
       type: func() int
@@ -359,13 +385,13 @@
         - name: Inner (exported)
           type: lib.Box[int]
           offset: 16
-- offset: "0x0018ab40"
+- offset: "0x0018ac40"
   size: 32
   kind: struct
   nameEntry: lib2.Wrapper[string] (exported)
   name: lib2.Wrapper[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010bd00"
+  ptrToThis: "0x0010bd60"
   methods:
     - name: Unwrap (exported)
       type: func() string
@@ -476,7 +502,7 @@
       type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x00179960"
+- offset: "0x00179a60"
   size: 16
   kind: struct
   nameEntry: main.Pair[int,bool] (exported)
@@ -491,7 +517,7 @@
         - name: Value (exported)
           type: bool
           offset: 8
-- offset: "0x00179a00"
+- offset: "0x00179b00"
   size: 24
   kind: struct
   nameEntry: main.Pair[string,int] (exported)
@@ -506,7 +532,7 @@
         - name: Value (exported)
           type: int
           offset: 16
-- offset: "0x000fae80"
+- offset: "0x000faee0"
   size: 16
   kind: interface
   nameEntry: main.behavior
@@ -516,7 +542,7 @@
   interfaceMethods:
     - name: DoSomething (exported)
       type: func() string
-- offset: "0x0018bf00"
+- offset: "0x0018c000"
   size: 48
   kind: struct
   nameEntry: main.bigStruct
@@ -541,7 +567,7 @@
   name: main.celsius
   pkg: main
   ptrToThis: "0x0005e820"
-- offset: "0x00123400"
+- offset: "0x00123460"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
@@ -553,7 +579,7 @@
         - name: a
           type: map[int]*main.deepMap2
           offset: 0
-- offset: "0x00123380"
+- offset: "0x001233e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
@@ -565,7 +591,7 @@
         - name: a
           type: map[int]*main.deepMap3
           offset: 0
-- offset: "0x00123300"
+- offset: "0x00123360"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
@@ -577,7 +603,7 @@
         - name: a
           type: map[int]*main.deepMap4
           offset: 0
-- offset: "0x00123280"
+- offset: "0x001232e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
@@ -589,7 +615,7 @@
         - name: a
           type: map[int]*main.deepMap5
           offset: 0
-- offset: "0x00123200"
+- offset: "0x00123260"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
@@ -601,7 +627,7 @@
         - name: a
           type: map[int]*main.deepMap6
           offset: 0
-- offset: "0x00123180"
+- offset: "0x001231e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
@@ -613,7 +639,7 @@
         - name: a
           type: map[int]*main.deepMap7
           offset: 0
-- offset: "0x00123100"
+- offset: "0x00123160"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
@@ -625,7 +651,7 @@
         - name: a
           type: map[int]*main.deepMap8
           offset: 0
-- offset: "0x00123080"
+- offset: "0x001230e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
@@ -637,7 +663,7 @@
         - name: a
           type: map[int]*main.deepMap9
           offset: 0
-- offset: "0x00123000"
+- offset: "0x00123060"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
@@ -649,7 +675,7 @@
         - name: a
           type: map[int]interface {}
           offset: 0
-- offset: "0x00123880"
+- offset: "0x001238e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
@@ -661,7 +687,7 @@
         - name: a
           type: '*main.deepPtr2'
           offset: 0
-- offset: "0x00123800"
+- offset: "0x00123860"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
@@ -673,7 +699,7 @@
         - name: a
           type: '*main.deepPtr3'
           offset: 0
-- offset: "0x00123780"
+- offset: "0x001237e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
@@ -685,7 +711,7 @@
         - name: a
           type: '*main.deepPtr4'
           offset: 0
-- offset: "0x00123700"
+- offset: "0x00123760"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
@@ -697,7 +723,7 @@
         - name: a
           type: '*main.deepPtr5'
           offset: 0
-- offset: "0x00123680"
+- offset: "0x001236e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
@@ -709,7 +735,7 @@
         - name: a
           type: '*main.deepPtr6'
           offset: 0
-- offset: "0x00123600"
+- offset: "0x00123660"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
@@ -721,7 +747,7 @@
         - name: a
           type: '*main.deepPtr7'
           offset: 0
-- offset: "0x00123580"
+- offset: "0x001235e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
@@ -733,7 +759,7 @@
         - name: a
           type: '*main.deepPtr8'
           offset: 0
-- offset: "0x00123500"
+- offset: "0x00123560"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
@@ -745,7 +771,7 @@
         - name: a
           type: '*main.deepPtr9'
           offset: 0
-- offset: "0x00123480"
+- offset: "0x001234e0"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
@@ -757,7 +783,7 @@
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x00123d00"
+- offset: "0x00123d60"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
@@ -769,7 +795,7 @@
         - name: a
           type: '[]*main.deepSlice2'
           offset: 0
-- offset: "0x00123c80"
+- offset: "0x00123ce0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
@@ -781,7 +807,7 @@
         - name: a
           type: '[]*main.deepSlice3'
           offset: 0
-- offset: "0x00123c00"
+- offset: "0x00123c60"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
@@ -793,7 +819,7 @@
         - name: a
           type: '[]*main.deepSlice4'
           offset: 0
-- offset: "0x00123b80"
+- offset: "0x00123be0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
@@ -805,7 +831,7 @@
         - name: a
           type: '[]*main.deepSlice5'
           offset: 0
-- offset: "0x00123b00"
+- offset: "0x00123b60"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
@@ -817,7 +843,7 @@
         - name: a
           type: '[]*main.deepSlice6'
           offset: 0
-- offset: "0x00123a80"
+- offset: "0x00123ae0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
@@ -829,7 +855,7 @@
         - name: a
           type: '[]*main.deepSlice7'
           offset: 0
-- offset: "0x00123a00"
+- offset: "0x00123a60"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
@@ -841,7 +867,7 @@
         - name: a
           type: '[]*main.deepSlice8'
           offset: 0
-- offset: "0x00123980"
+- offset: "0x001239e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
@@ -853,7 +879,7 @@
         - name: a
           type: '[]*main.deepSlice9'
           offset: 0
-- offset: "0x00123900"
+- offset: "0x00123960"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
@@ -865,7 +891,7 @@
         - name: a
           type: '[]interface {}'
           offset: 0
-- offset: "0x001c2680"
+- offset: "0x001c2780"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
@@ -889,7 +915,7 @@
         - name: a
           type: atomic.Int32
           offset: 104
-- offset: "0x001e2f40"
+- offset: "0x001e3040"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
@@ -919,7 +945,7 @@
         - name: foo
           type: func()
           offset: 56
-- offset: "0x0015ab60"
+- offset: "0x0015abc0"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
@@ -934,7 +960,7 @@
         - name: s
           type: string
           offset: 0
-- offset: "0x002037a0"
+- offset: "0x002038a0"
   size: 136
   kind: struct
   nameEntry: main.largeGenericType[int]
@@ -973,7 +999,7 @@
         - name: Value (exported)
           type: int
           offset: 128
-- offset: "0x00203900"
+- offset: "0x00203a00"
   size: 144
   kind: struct
   nameEntry: main.largeGenericType[string]
@@ -1019,7 +1045,7 @@
   name: main.namedInt
   pkg: main
   ptrToThis: "0x0005e8a0"
-- offset: "0x00167120"
+- offset: "0x00167220"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
@@ -1034,7 +1060,7 @@
         - name: anotherString
           type: string
           offset: 8
-- offset: "0x00166fe0"
+- offset: "0x001670e0"
   size: 16
   kind: struct
   nameEntry: main.node
@@ -1049,7 +1075,7 @@
         - name: b
           type: '*main.node'
           offset: 8
-- offset: "0x00122e00"
+- offset: "0x00122e60"
   size: 16
   kind: struct
   nameEntry: main.otherFirstBehavior
@@ -1061,7 +1087,7 @@
         - name: s
           type: string
           offset: 0
-- offset: "0x00122e80"
+- offset: "0x00122ee0"
   size: 8
   kind: struct
   nameEntry: main.otherSecondBehavior
@@ -1080,7 +1106,7 @@
   name: main.score
   pkg: main
   ptrToThis: "0x0005e960"
-- offset: "0x0015ac00"
+- offset: "0x0015ac60"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
@@ -1095,7 +1121,7 @@
         - name: i
           type: int
           offset: 0
-- offset: "0x00167080"
+- offset: "0x00167180"
   size: 16
   kind: struct
   nameEntry: main.smallStruct
@@ -1110,7 +1136,7 @@
         - name: Y (exported)
           type: int
           offset: 8
-- offset: "0x000faf00"
+- offset: "0x000faf60"
   size: 16
   kind: interface
   nameEntry: main.something
@@ -1120,7 +1146,7 @@
   interfaceMethods:
     - name: Do (exported)
       type: func()
-- offset: "0x000f2880"
+- offset: "0x000f28e0"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
@@ -1129,7 +1155,7 @@
   ptrToThis: "0x000dbec0"
   struct:
     fields: []
-- offset: "0x00122f00"
+- offset: "0x00122f60"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
@@ -1141,7 +1167,7 @@
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x00122f80"
+- offset: "0x00122fe0"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
@@ -1153,7 +1179,7 @@
         - name: m
           type: map[int]int
           offset: 0
-- offset: "0x00123d80"
+- offset: "0x00123de0"
   size: 16
   kind: struct
   nameEntry: main.tinyStruct
@@ -1165,7 +1191,7 @@
         - name: Name (exported)
           type: string
           offset: 0
-- offset: "0x00164200"
+- offset: "0x00164260"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
@@ -1180,7 +1206,7 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x001642a0"
+- offset: "0x00164300"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -1,4 +1,4 @@
-- offset: "0x0010dfa0"
+- offset: "0x0010e000"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[float64] (exported)'
@@ -11,7 +11,7 @@
       type: func(float64)
   pointer:
     elem: lib.Box[float64]
-- offset: "0x0010dca0"
+- offset: "0x0010dd00"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[int] (exported)'
@@ -24,7 +24,7 @@
       type: func(int)
   pointer:
     elem: lib.Box[int]
-- offset: "0x0010dd20"
+- offset: "0x0010dd80"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[string] (exported)'
@@ -37,7 +37,7 @@
       type: func(string)
   pointer:
     elem: lib.Box[string]
-- offset: "0x0010dea0"
+- offset: "0x0010df00"
   size: 8
   kind: ptr
   nameEntry: '*lib.ImmutableSet[string] (exported)'
@@ -105,13 +105,13 @@
       type: func() lib.Pair[int,string]
   pointer:
     elem: lib.Pair[string,int]
-- offset: "0x00167280"
+- offset: "0x001672e0"
   size: 8
   kind: struct
   nameEntry: lib.Box[float64] (exported)
   name: lib.Box[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010dfa0"
+  ptrToThis: "0x0010e000"
   methods:
     - name: Get (exported)
       type: func() float64
@@ -120,13 +120,13 @@
         - name: Value (exported)
           type: float64
           offset: 0
-- offset: "0x00166c40"
+- offset: "0x00166ca0"
   size: 8
   kind: struct
   nameEntry: lib.Box[int] (exported)
   name: lib.Box[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010dca0"
+  ptrToThis: "0x0010dd00"
   methods:
     - name: Get (exported)
       type: func() int
@@ -135,13 +135,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x00166ce0"
+- offset: "0x00166d40"
   size: 16
   kind: struct
   nameEntry: lib.Box[string] (exported)
   name: lib.Box[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010dd20"
+  ptrToThis: "0x0010dd80"
   methods:
     - name: Get (exported)
       type: func() string
@@ -150,7 +150,7 @@
         - name: Value (exported)
           type: string
           offset: 0
-- offset: "0x00139e20"
+- offset: "0x00139e80"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[go.shape.string] (exported)
@@ -162,19 +162,19 @@
         - name: items
           type: map[go.shape.string]bool
           offset: 0
-- offset: "0x00139d20"
+- offset: "0x00139d80"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[string] (exported)
   name: lib.ImmutableSet[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010dea0"
+  ptrToThis: "0x0010df00"
   struct:
     fields:
         - name: items
           type: map[string]bool
           offset: 0
-- offset: "0x0018e5a0"
+- offset: "0x0018e6a0"
   size: 24
   kind: struct
   nameEntry: lib.Pair[bool,string] (exported)
@@ -192,7 +192,7 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x0018e8c0"
+- offset: "0x0018e9c0"
   size: 16
   kind: struct
   nameEntry: lib.Pair[float64,float64] (exported)
@@ -210,7 +210,7 @@
         - name: Second (exported)
           type: float64
           offset: 8
-- offset: "0x0018e6e0"
+- offset: "0x0018e7e0"
   size: 24
   kind: struct
   nameEntry: lib.Pair[int,string] (exported)
@@ -228,7 +228,7 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x0018e500"
+- offset: "0x0018e600"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,bool] (exported)
@@ -246,7 +246,7 @@
         - name: Second (exported)
           type: bool
           offset: 16
-- offset: "0x0018e640"
+- offset: "0x0018e740"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,int] (exported)
@@ -264,6 +264,17 @@
         - name: Second (exported)
           type: int
           offset: 16
+- offset: "0x000ec560"
+  size: 8
+  kind: ptr
+  nameEntry: '*lib_v2.V2GenericBox[int] (exported)'
+  name: '*lib_v2.V2GenericBox[int]'
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  methods:
+    - name: Get (exported)
+      type: func() int
+  pointer:
+    elem: lib_v2.V2GenericBox[int]
 - offset: "0x000de340"
   size: 8
   kind: ptr
@@ -275,7 +286,22 @@
       type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f4d60"
+- offset: "0x001674c0"
+  size: 8
+  kind: struct
+  nameEntry: lib_v2.V2GenericBox[int] (exported)
+  name: lib_v2.V2GenericBox[int]
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  ptrToThis: "0x000ec560"
+  methods:
+    - name: Get (exported)
+      type: func() int
+  struct:
+    fields:
+        - name: Value (exported)
+          type: int
+          offset: 0
+- offset: "0x000f4dc0"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
@@ -284,7 +310,7 @@
   ptrToThis: "0x000de340"
   struct:
     fields: []
-- offset: "0x0010e020"
+- offset: "0x0010e080"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[float64] (exported)'
@@ -297,7 +323,7 @@
       type: func() float64
   pointer:
     elem: lib2.Wrapper[float64]
-- offset: "0x0010dda0"
+- offset: "0x0010de00"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[int] (exported)'
@@ -310,7 +336,7 @@
       type: func() int
   pointer:
     elem: lib2.Wrapper[int]
-- offset: "0x0010de20"
+- offset: "0x0010de80"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[string] (exported)'
@@ -323,13 +349,13 @@
       type: func() string
   pointer:
     elem: lib2.Wrapper[string]
-- offset: "0x0018e960"
+- offset: "0x0018ea60"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[float64] (exported)
   name: lib2.Wrapper[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010e020"
+  ptrToThis: "0x0010e080"
   methods:
     - name: Unwrap (exported)
       type: func() float64
@@ -341,13 +367,13 @@
         - name: Inner (exported)
           type: lib.Box[float64]
           offset: 16
-- offset: "0x0018e780"
+- offset: "0x0018e880"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[int] (exported)
   name: lib2.Wrapper[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010dda0"
+  ptrToThis: "0x0010de00"
   methods:
     - name: Unwrap (exported)
       type: func() int
@@ -359,13 +385,13 @@
         - name: Inner (exported)
           type: lib.Box[int]
           offset: 16
-- offset: "0x0018e820"
+- offset: "0x0018e920"
   size: 32
   kind: struct
   nameEntry: lib2.Wrapper[string] (exported)
   name: lib2.Wrapper[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010de20"
+  ptrToThis: "0x0010de80"
   methods:
     - name: Unwrap (exported)
       type: func() string
@@ -476,7 +502,7 @@
       type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x0017cec0"
+- offset: "0x0017cfc0"
   size: 16
   kind: struct
   nameEntry: main.Pair[int,bool] (exported)
@@ -491,7 +517,7 @@
         - name: Value (exported)
           type: bool
           offset: 8
-- offset: "0x0017cf60"
+- offset: "0x0017d060"
   size: 24
   kind: struct
   nameEntry: main.Pair[string,int] (exported)
@@ -506,7 +532,7 @@
         - name: Value (exported)
           type: int
           offset: 16
-- offset: "0x000fd120"
+- offset: "0x000fd180"
   size: 16
   kind: interface
   nameEntry: main.behavior
@@ -516,7 +542,7 @@
   interfaceMethods:
     - name: DoSomething (exported)
       type: func() string
-- offset: "0x0018fbe0"
+- offset: "0x0018fce0"
   size: 48
   kind: struct
   nameEntry: main.bigStruct
@@ -541,7 +567,7 @@
   name: main.celsius
   pkg: main
   ptrToThis: "0x0005fbc0"
-- offset: "0x001252a0"
+- offset: "0x00125300"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
@@ -553,7 +579,7 @@
         - name: a
           type: map[int]*main.deepMap2
           offset: 0
-- offset: "0x00125220"
+- offset: "0x00125280"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
@@ -565,7 +591,7 @@
         - name: a
           type: map[int]*main.deepMap3
           offset: 0
-- offset: "0x001251a0"
+- offset: "0x00125200"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
@@ -577,7 +603,7 @@
         - name: a
           type: map[int]*main.deepMap4
           offset: 0
-- offset: "0x00125120"
+- offset: "0x00125180"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
@@ -589,7 +615,7 @@
         - name: a
           type: map[int]*main.deepMap5
           offset: 0
-- offset: "0x001250a0"
+- offset: "0x00125100"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
@@ -601,7 +627,7 @@
         - name: a
           type: map[int]*main.deepMap6
           offset: 0
-- offset: "0x00125020"
+- offset: "0x00125080"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
@@ -613,7 +639,7 @@
         - name: a
           type: map[int]*main.deepMap7
           offset: 0
-- offset: "0x00124fa0"
+- offset: "0x00125000"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
@@ -625,7 +651,7 @@
         - name: a
           type: map[int]*main.deepMap8
           offset: 0
-- offset: "0x00124f20"
+- offset: "0x00124f80"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
@@ -637,7 +663,7 @@
         - name: a
           type: map[int]*main.deepMap9
           offset: 0
-- offset: "0x00124ea0"
+- offset: "0x00124f00"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
@@ -649,7 +675,7 @@
         - name: a
           type: map[int]interface {}
           offset: 0
-- offset: "0x00125720"
+- offset: "0x00125780"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
@@ -661,7 +687,7 @@
         - name: a
           type: '*main.deepPtr2'
           offset: 0
-- offset: "0x001256a0"
+- offset: "0x00125700"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
@@ -673,7 +699,7 @@
         - name: a
           type: '*main.deepPtr3'
           offset: 0
-- offset: "0x00125620"
+- offset: "0x00125680"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
@@ -685,7 +711,7 @@
         - name: a
           type: '*main.deepPtr4'
           offset: 0
-- offset: "0x001255a0"
+- offset: "0x00125600"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
@@ -697,7 +723,7 @@
         - name: a
           type: '*main.deepPtr5'
           offset: 0
-- offset: "0x00125520"
+- offset: "0x00125580"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
@@ -709,7 +735,7 @@
         - name: a
           type: '*main.deepPtr6'
           offset: 0
-- offset: "0x001254a0"
+- offset: "0x00125500"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
@@ -721,7 +747,7 @@
         - name: a
           type: '*main.deepPtr7'
           offset: 0
-- offset: "0x00125420"
+- offset: "0x00125480"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
@@ -733,7 +759,7 @@
         - name: a
           type: '*main.deepPtr8'
           offset: 0
-- offset: "0x001253a0"
+- offset: "0x00125400"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
@@ -745,7 +771,7 @@
         - name: a
           type: '*main.deepPtr9'
           offset: 0
-- offset: "0x00125320"
+- offset: "0x00125380"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
@@ -757,7 +783,7 @@
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x00125ba0"
+- offset: "0x00125c00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
@@ -769,7 +795,7 @@
         - name: a
           type: '[]*main.deepSlice2'
           offset: 0
-- offset: "0x00125b20"
+- offset: "0x00125b80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
@@ -781,7 +807,7 @@
         - name: a
           type: '[]*main.deepSlice3'
           offset: 0
-- offset: "0x00125aa0"
+- offset: "0x00125b00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
@@ -793,7 +819,7 @@
         - name: a
           type: '[]*main.deepSlice4'
           offset: 0
-- offset: "0x00125a20"
+- offset: "0x00125a80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
@@ -805,7 +831,7 @@
         - name: a
           type: '[]*main.deepSlice5'
           offset: 0
-- offset: "0x001259a0"
+- offset: "0x00125a00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
@@ -817,7 +843,7 @@
         - name: a
           type: '[]*main.deepSlice6'
           offset: 0
-- offset: "0x00125920"
+- offset: "0x00125980"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
@@ -829,7 +855,7 @@
         - name: a
           type: '[]*main.deepSlice7'
           offset: 0
-- offset: "0x001258a0"
+- offset: "0x00125900"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
@@ -841,7 +867,7 @@
         - name: a
           type: '[]*main.deepSlice8'
           offset: 0
-- offset: "0x00125820"
+- offset: "0x00125880"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
@@ -853,7 +879,7 @@
         - name: a
           type: '[]*main.deepSlice9'
           offset: 0
-- offset: "0x001257a0"
+- offset: "0x00125800"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
@@ -865,7 +891,7 @@
         - name: a
           type: '[]interface {}'
           offset: 0
-- offset: "0x001c6d00"
+- offset: "0x001c6e00"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
@@ -889,7 +915,7 @@
         - name: a
           type: atomic.Int32
           offset: 104
-- offset: "0x001e7f00"
+- offset: "0x001e8000"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
@@ -919,7 +945,7 @@
         - name: foo
           type: func()
           offset: 56
-- offset: "0x0015d500"
+- offset: "0x0015d560"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
@@ -934,7 +960,7 @@
         - name: s
           type: string
           offset: 0
-- offset: "0x00208b80"
+- offset: "0x00208c80"
   size: 136
   kind: struct
   nameEntry: main.largeGenericType[int]
@@ -973,7 +999,7 @@
         - name: Value (exported)
           type: int
           offset: 128
-- offset: "0x00208ce0"
+- offset: "0x00208de0"
   size: 144
   kind: struct
   nameEntry: main.largeGenericType[string]
@@ -1019,7 +1045,7 @@
   name: main.namedInt
   pkg: main
   ptrToThis: "0x0005fc40"
-- offset: "0x00169d20"
+- offset: "0x00169e20"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
@@ -1034,7 +1060,7 @@
         - name: anotherString
           type: string
           offset: 8
-- offset: "0x00169be0"
+- offset: "0x00169ce0"
   size: 16
   kind: struct
   nameEntry: main.node
@@ -1049,7 +1075,7 @@
         - name: b
           type: '*main.node'
           offset: 8
-- offset: "0x00124ca0"
+- offset: "0x00124d00"
   size: 16
   kind: struct
   nameEntry: main.otherFirstBehavior
@@ -1061,7 +1087,7 @@
         - name: s
           type: string
           offset: 0
-- offset: "0x00124d20"
+- offset: "0x00124d80"
   size: 8
   kind: struct
   nameEntry: main.otherSecondBehavior
@@ -1080,7 +1106,7 @@
   name: main.score
   pkg: main
   ptrToThis: "0x0005fd00"
-- offset: "0x0015d5a0"
+- offset: "0x0015d600"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
@@ -1095,7 +1121,7 @@
         - name: i
           type: int
           offset: 0
-- offset: "0x00169c80"
+- offset: "0x00169d80"
   size: 16
   kind: struct
   nameEntry: main.smallStruct
@@ -1110,7 +1136,7 @@
         - name: Y (exported)
           type: int
           offset: 8
-- offset: "0x000fd1a0"
+- offset: "0x000fd200"
   size: 16
   kind: interface
   nameEntry: main.something
@@ -1120,7 +1146,7 @@
   interfaceMethods:
     - name: Do (exported)
       type: func()
-- offset: "0x000f4be0"
+- offset: "0x000f4c40"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
@@ -1129,7 +1155,7 @@
   ptrToThis: "0x000ddf20"
   struct:
     fields: []
-- offset: "0x00124da0"
+- offset: "0x00124e00"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
@@ -1141,7 +1167,7 @@
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x00124e20"
+- offset: "0x00124e80"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
@@ -1153,7 +1179,7 @@
         - name: m
           type: map[int]int
           offset: 0
-- offset: "0x00125c20"
+- offset: "0x00125c80"
   size: 16
   kind: struct
   nameEntry: main.tinyStruct
@@ -1165,7 +1191,7 @@
         - name: Name (exported)
           type: string
           offset: 0
-- offset: "0x00166d80"
+- offset: "0x00166de0"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
@@ -1180,7 +1206,7 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x00166e20"
+- offset: "0x00166e80"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,4 +1,4 @@
-- offset: "0x001019c0"
+- offset: "0x00101a40"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[float64] (exported)'
@@ -11,7 +11,7 @@
       type: func(float64)
   pointer:
     elem: lib.Box[float64]
-- offset: "0x00101740"
+- offset: "0x001017c0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[int] (exported)'
@@ -24,7 +24,7 @@
       type: func(int)
   pointer:
     elem: lib.Box[int]
-- offset: "0x001017c0"
+- offset: "0x00101840"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[string] (exported)'
@@ -37,7 +37,7 @@
       type: func(string)
   pointer:
     elem: lib.Box[string]
-- offset: "0x00101940"
+- offset: "0x001019c0"
   size: 8
   kind: ptr
   nameEntry: '*lib.ImmutableSet[string] (exported)'
@@ -50,7 +50,7 @@
       type: func(string) (*lib.ImmutableSet[string], bool)
   pointer:
     elem: lib.ImmutableSet[string]
-- offset: "0x000d7400"
+- offset: "0x000d7420"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[bool,string] (exported)'
@@ -61,7 +61,7 @@
       type: func() lib.Pair[string,bool]
   pointer:
     elem: lib.Pair[bool,string]
-- offset: "0x000d88a0"
+- offset: "0x000d88c0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[float64,float64] (exported)'
@@ -72,7 +72,7 @@
       type: func() lib.Pair[float64,float64]
   pointer:
     elem: lib.Pair[float64,float64]
-- offset: "0x000d74c0"
+- offset: "0x000d74e0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[int,string] (exported)'
@@ -83,7 +83,7 @@
       type: func() lib.Pair[string,int]
   pointer:
     elem: lib.Pair[int,string]
-- offset: "0x000d73a0"
+- offset: "0x000d73c0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[string,bool] (exported)'
@@ -94,7 +94,7 @@
       type: func() lib.Pair[bool,string]
   pointer:
     elem: lib.Pair[string,bool]
-- offset: "0x000d7460"
+- offset: "0x000d7480"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[string,int] (exported)'
@@ -105,13 +105,13 @@
       type: func() lib.Pair[int,string]
   pointer:
     elem: lib.Pair[string,int]
-- offset: "0x001377a0"
+- offset: "0x00137820"
   size: 8
   kind: struct
   nameEntry: lib.Box[float64] (exported)
   name: lib.Box[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x001019c0"
+  ptrToThis: "0x00101a40"
   methods:
     - name: Get (exported)
       type: func() float64
@@ -120,13 +120,13 @@
         - name: Value (exported)
           type: float64
           offset: 0
-- offset: "0x00137200"
+- offset: "0x00137280"
   size: 8
   kind: struct
   nameEntry: lib.Box[int] (exported)
   name: lib.Box[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x00101740"
+  ptrToThis: "0x001017c0"
   methods:
     - name: Get (exported)
       type: func() int
@@ -135,13 +135,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x001372a0"
+- offset: "0x00137320"
   size: 16
   kind: struct
   nameEntry: lib.Box[string] (exported)
   name: lib.Box[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x001017c0"
+  ptrToThis: "0x00101840"
   methods:
     - name: Get (exported)
       type: func() string
@@ -150,37 +150,37 @@
         - name: Value (exported)
           type: string
           offset: 0
-- offset: "0x00122160"
+- offset: "0x001221e0"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[go.shape.string] (exported)
   name: lib.ImmutableSet[go.shape.string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0006de20"
+  ptrToThis: "0x0006de40"
   struct:
     fields:
         - name: items
           type: map[go.shape.string]bool
           offset: 0
-- offset: "0x00122060"
+- offset: "0x001220e0"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[string] (exported)
   name: lib.ImmutableSet[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x00101940"
+  ptrToThis: "0x001019c0"
   struct:
     fields:
         - name: items
           type: map[string]bool
           offset: 0
-- offset: "0x0015baa0"
+- offset: "0x0015bbc0"
   size: 24
   kind: struct
   nameEntry: lib.Pair[bool,string] (exported)
   name: lib.Pair[bool,string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000d7400"
+  ptrToThis: "0x000d7420"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[string,bool]
@@ -192,13 +192,13 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x0015bdc0"
+- offset: "0x0015bee0"
   size: 16
   kind: struct
   nameEntry: lib.Pair[float64,float64] (exported)
   name: lib.Pair[float64,float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000d88a0"
+  ptrToThis: "0x000d88c0"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[float64,float64]
@@ -210,13 +210,13 @@
         - name: Second (exported)
           type: float64
           offset: 8
-- offset: "0x0015bbe0"
+- offset: "0x0015bd00"
   size: 24
   kind: struct
   nameEntry: lib.Pair[int,string] (exported)
   name: lib.Pair[int,string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000d74c0"
+  ptrToThis: "0x000d74e0"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[string,int]
@@ -228,13 +228,13 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x0015ba00"
+- offset: "0x0015bb20"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,bool] (exported)
   name: lib.Pair[string,bool]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000d73a0"
+  ptrToThis: "0x000d73c0"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[bool,string]
@@ -246,13 +246,13 @@
         - name: Second (exported)
           type: bool
           offset: 16
-- offset: "0x0015bb40"
+- offset: "0x0015bc60"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,int] (exported)
   name: lib.Pair[string,int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000d7460"
+  ptrToThis: "0x000d7480"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[int,string]
@@ -264,7 +264,18 @@
         - name: Second (exported)
           type: int
           offset: 16
-- offset: "0x000ca500"
+- offset: "0x000d8980"
+  size: 8
+  kind: ptr
+  nameEntry: '*lib_v2.V2GenericBox[int] (exported)'
+  name: '*lib_v2.V2GenericBox[int]'
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  methods:
+    - name: Get (exported)
+      type: func() int
+  pointer:
+    elem: lib_v2.V2GenericBox[int]
+- offset: "0x000ca520"
   size: 8
   kind: ptr
   nameEntry: '*lib_v2.V2Type (exported)'
@@ -275,16 +286,31 @@
       type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000e8580"
+- offset: "0x00137a00"
+  size: 8
+  kind: struct
+  nameEntry: lib_v2.V2GenericBox[int] (exported)
+  name: lib_v2.V2GenericBox[int]
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  ptrToThis: "0x000d8980"
+  methods:
+    - name: Get (exported)
+      type: func() int
+  struct:
+    fields:
+        - name: Value (exported)
+          type: int
+          offset: 0
+- offset: "0x000e8600"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000ca500"
+  ptrToThis: "0x000ca520"
   struct:
     fields: []
-- offset: "0x00101a40"
+- offset: "0x00101ac0"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[float64] (exported)'
@@ -297,7 +323,7 @@
       type: func() float64
   pointer:
     elem: lib2.Wrapper[float64]
-- offset: "0x00101840"
+- offset: "0x001018c0"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[int] (exported)'
@@ -310,7 +336,7 @@
       type: func() int
   pointer:
     elem: lib2.Wrapper[int]
-- offset: "0x001018c0"
+- offset: "0x00101940"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[string] (exported)'
@@ -323,13 +349,13 @@
       type: func() string
   pointer:
     elem: lib2.Wrapper[string]
-- offset: "0x0015be60"
+- offset: "0x0015bf80"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[float64] (exported)
   name: lib2.Wrapper[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x00101a40"
+  ptrToThis: "0x00101ac0"
   methods:
     - name: Unwrap (exported)
       type: func() float64
@@ -341,13 +367,13 @@
         - name: Inner (exported)
           type: lib.Box[float64]
           offset: 16
-- offset: "0x0015bc80"
+- offset: "0x0015bda0"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[int] (exported)
   name: lib2.Wrapper[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x00101840"
+  ptrToThis: "0x001018c0"
   methods:
     - name: Unwrap (exported)
       type: func() int
@@ -359,13 +385,13 @@
         - name: Inner (exported)
           type: lib.Box[int]
           offset: 16
-- offset: "0x0015bd20"
+- offset: "0x0015be40"
   size: 32
   kind: struct
   nameEntry: lib2.Wrapper[string] (exported)
   name: lib2.Wrapper[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x001018c0"
+  ptrToThis: "0x00101940"
   methods:
     - name: Unwrap (exported)
       type: func() string
@@ -377,7 +403,7 @@
         - name: Inner (exported)
           type: lib.Box[string]
           offset: 16
-- offset: "0x000d7520"
+- offset: "0x000d7540"
   size: 8
   kind: ptr
   nameEntry: '*main.Pair[int,bool] (exported)'
@@ -388,7 +414,7 @@
       type: func(int, bool)
   pointer:
     elem: main.Pair[int,bool]
-- offset: "0x000d7580"
+- offset: "0x000d75a0"
   size: 8
   kind: ptr
   nameEntry: '*main.Pair[string,int] (exported)'
@@ -399,7 +425,7 @@
       type: func(string, int)
   pointer:
     elem: main.Pair[string,int]
-- offset: "0x000ca020"
+- offset: "0x000ca040"
   size: 8
   kind: ptr
   nameEntry: '*main.firstBehavior'
@@ -410,7 +436,7 @@
       type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000d75e0"
+- offset: "0x000d7600"
   size: 8
   kind: ptr
   nameEntry: '*main.largeGenericType[int]'
@@ -421,7 +447,7 @@
       type: func() int
   pointer:
     elem: main.largeGenericType[int]
-- offset: "0x000d7640"
+- offset: "0x000d7660"
   size: 8
   kind: ptr
   nameEntry: '*main.largeGenericType[string]'
@@ -432,7 +458,7 @@
       type: func() string
   pointer:
     elem: main.largeGenericType[string]
-- offset: "0x000ca080"
+- offset: "0x000ca0a0"
   size: 8
   kind: ptr
   nameEntry: '*main.secondBehavior'
@@ -443,7 +469,7 @@
       type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000ca0e0"
+- offset: "0x000ca100"
   size: 8
   kind: ptr
   nameEntry: '*main.somethingImpl'
@@ -454,7 +480,7 @@
       type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000d7700"
+- offset: "0x000d7720"
   size: 8
   kind: ptr
   nameEntry: '*main.typeWithGenerics[int]'
@@ -465,7 +491,7 @@
       type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000d7760"
+- offset: "0x000d7780"
   size: 8
   kind: ptr
   nameEntry: '*main.typeWithGenerics[string]'
@@ -476,13 +502,13 @@
       type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x0014baa0"
+- offset: "0x0014bbc0"
   size: 16
   kind: struct
   nameEntry: main.Pair[int,bool] (exported)
   name: main.Pair[int,bool]
   pkg: main
-  ptrToThis: "0x000d7520"
+  ptrToThis: "0x000d7540"
   struct:
     fields:
         - name: Key (exported)
@@ -491,13 +517,13 @@
         - name: Value (exported)
           type: bool
           offset: 8
-- offset: "0x0014bb40"
+- offset: "0x0014bc60"
   size: 24
   kind: struct
   nameEntry: main.Pair[string,int] (exported)
   name: main.Pair[string,int]
   pkg: main
-  ptrToThis: "0x000d7580"
+  ptrToThis: "0x000d75a0"
   struct:
     fields:
         - name: Key (exported)
@@ -506,23 +532,23 @@
         - name: Value (exported)
           type: int
           offset: 16
-- offset: "0x000f04c0"
+- offset: "0x000f0540"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x000571a0"
+  ptrToThis: "0x000571c0"
   interfaceMethods:
     - name: DoSomething (exported)
       type: func() string
-- offset: "0x0015cdc0"
+- offset: "0x0015cee0"
   size: 48
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00057220"
+  ptrToThis: "0x00057240"
   struct:
     fields:
         - name: x
@@ -534,344 +560,344 @@
         - name: writer
           type: io.Writer
           offset: 32
-- offset: "0x00082380"
+- offset: "0x000823a0"
   size: 8
   kind: int
   nameEntry: main.celsius
   name: main.celsius
   pkg: main
-  ptrToThis: "0x00057260"
-- offset: "0x0010df60"
+  ptrToThis: "0x00057280"
+- offset: "0x0010dfe0"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x00057660"
+  ptrToThis: "0x00057680"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap2
           offset: 0
-- offset: "0x0010dee0"
+- offset: "0x0010df60"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x00057620"
+  ptrToThis: "0x00057640"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap3
           offset: 0
-- offset: "0x0010de60"
+- offset: "0x0010dee0"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x000575e0"
+  ptrToThis: "0x00057600"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap4
           offset: 0
-- offset: "0x0010dde0"
+- offset: "0x0010de60"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x000575a0"
+  ptrToThis: "0x000575c0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap5
           offset: 0
-- offset: "0x0010dd60"
+- offset: "0x0010dde0"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x00057560"
+  ptrToThis: "0x00057580"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap6
           offset: 0
-- offset: "0x0010dce0"
+- offset: "0x0010dd60"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x00057520"
+  ptrToThis: "0x00057540"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap7
           offset: 0
-- offset: "0x0010dc60"
+- offset: "0x0010dce0"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x000574e0"
+  ptrToThis: "0x00057500"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap8
           offset: 0
-- offset: "0x0010dbe0"
+- offset: "0x0010dc60"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x000574a0"
+  ptrToThis: "0x000574c0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap9
           offset: 0
-- offset: "0x0010db60"
+- offset: "0x0010dbe0"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x00057460"
+  ptrToThis: "0x00057480"
   struct:
     fields:
         - name: a
           type: map[int]interface {}
           offset: 0
-- offset: "0x0010e3e0"
+- offset: "0x0010e460"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x000578a0"
+  ptrToThis: "0x000578c0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr2'
           offset: 0
-- offset: "0x0010e360"
+- offset: "0x0010e3e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x00057860"
+  ptrToThis: "0x00057880"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr3'
           offset: 0
-- offset: "0x0010e2e0"
+- offset: "0x0010e360"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x00057820"
+  ptrToThis: "0x00057840"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr4'
           offset: 0
-- offset: "0x0010e260"
+- offset: "0x0010e2e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x000577e0"
+  ptrToThis: "0x00057800"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr5'
           offset: 0
-- offset: "0x0010e1e0"
+- offset: "0x0010e260"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x000577a0"
+  ptrToThis: "0x000577c0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr6'
           offset: 0
-- offset: "0x0010e160"
+- offset: "0x0010e1e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x00057760"
+  ptrToThis: "0x00057780"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr7'
           offset: 0
-- offset: "0x0010e0e0"
+- offset: "0x0010e160"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x00057720"
+  ptrToThis: "0x00057740"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr8'
           offset: 0
-- offset: "0x0010e060"
+- offset: "0x0010e0e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x000576e0"
+  ptrToThis: "0x00057700"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr9'
           offset: 0
-- offset: "0x0010dfe0"
+- offset: "0x0010e060"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x000576a0"
+  ptrToThis: "0x000576c0"
   struct:
     fields:
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x0010e860"
+- offset: "0x0010e8e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x00057ae0"
+  ptrToThis: "0x00057b00"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice2'
           offset: 0
-- offset: "0x0010e7e0"
+- offset: "0x0010e860"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x00057aa0"
+  ptrToThis: "0x00057ac0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice3'
           offset: 0
-- offset: "0x0010e760"
+- offset: "0x0010e7e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x00057a60"
+  ptrToThis: "0x00057a80"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice4'
           offset: 0
-- offset: "0x0010e6e0"
+- offset: "0x0010e760"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x00057a20"
+  ptrToThis: "0x00057a40"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice5'
           offset: 0
-- offset: "0x0010e660"
+- offset: "0x0010e6e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x000579e0"
+  ptrToThis: "0x00057a00"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice6'
           offset: 0
-- offset: "0x0010e5e0"
+- offset: "0x0010e660"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x000579a0"
+  ptrToThis: "0x000579c0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice7'
           offset: 0
-- offset: "0x0010e560"
+- offset: "0x0010e5e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x00057960"
+  ptrToThis: "0x00057980"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice8'
           offset: 0
-- offset: "0x0010e4e0"
+- offset: "0x0010e560"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x00057920"
+  ptrToThis: "0x00057940"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice9'
           offset: 0
-- offset: "0x0010e460"
+- offset: "0x0010e4e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x000578e0"
+  ptrToThis: "0x00057900"
   struct:
     fields:
         - name: a
           type: '[]interface {}'
           offset: 0
-- offset: "0x001a2620"
+- offset: "0x001a2740"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x00057b20"
+  ptrToThis: "0x00057b40"
   struct:
     fields:
         - name: esotericStack (embedded)
@@ -889,13 +915,13 @@
         - name: a
           type: atomic.Int32
           offset: 104
-- offset: "0x001c1420"
+- offset: "0x001c1540"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x000572a0"
+  ptrToThis: "0x000572c0"
   struct:
     fields:
         - name: _
@@ -919,13 +945,13 @@
         - name: foo
           type: func()
           offset: 56
-- offset: "0x0012e240"
+- offset: "0x0012e2c0"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000ca020"
+  ptrToThis: "0x000ca040"
   methods:
     - name: DoSomething (exported)
       type: func() string
@@ -934,13 +960,13 @@
         - name: s
           type: string
           offset: 0
-- offset: "0x001e1c60"
+- offset: "0x001e1d80"
   size: 136
   kind: struct
   nameEntry: main.largeGenericType[int]
   name: main.largeGenericType[int]
   pkg: main
-  ptrToThis: "0x000d75e0"
+  ptrToThis: "0x000d7600"
   methods:
     - name: LargeGet (exported)
       type: func() int
@@ -973,13 +999,13 @@
         - name: Value (exported)
           type: int
           offset: 128
-- offset: "0x001e1dc0"
+- offset: "0x001e1ee0"
   size: 144
   kind: struct
   nameEntry: main.largeGenericType[string]
   name: main.largeGenericType[string]
   pkg: main
-  ptrToThis: "0x000d7640"
+  ptrToThis: "0x000d7660"
   methods:
     - name: LargeGet (exported)
       type: func() string
@@ -1012,20 +1038,20 @@
         - name: Value (exported)
           type: string
           offset: 128
-- offset: "0x000823c0"
+- offset: "0x000823e0"
   size: 8
   kind: int
   nameEntry: main.namedInt
   name: main.namedInt
   pkg: main
-  ptrToThis: "0x000572e0"
-- offset: "0x0013a200"
+  ptrToThis: "0x00057300"
+- offset: "0x0013a320"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x00057c20"
+  ptrToThis: "0x00057c40"
   struct:
     fields:
         - name: anotherInt
@@ -1034,13 +1060,13 @@
         - name: anotherString
           type: string
           offset: 8
-- offset: "0x0013a0c0"
+- offset: "0x0013a1e0"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x00057b60"
+  ptrToThis: "0x00057b80"
   struct:
     fields:
         - name: val
@@ -1049,44 +1075,44 @@
         - name: b
           type: '*main.node'
           offset: 8
-- offset: "0x0010d960"
+- offset: "0x0010d9e0"
   size: 16
   kind: struct
   nameEntry: main.otherFirstBehavior
   name: main.otherFirstBehavior
   pkg: main
-  ptrToThis: "0x00057320"
+  ptrToThis: "0x00057340"
   struct:
     fields:
         - name: s
           type: string
           offset: 0
-- offset: "0x0010d9e0"
+- offset: "0x0010da60"
   size: 8
   kind: struct
   nameEntry: main.otherSecondBehavior
   name: main.otherSecondBehavior
   pkg: main
-  ptrToThis: "0x00057360"
+  ptrToThis: "0x00057380"
   struct:
     fields:
         - name: i
           type: int
           offset: 0
-- offset: "0x00082400"
+- offset: "0x00082420"
   size: 8
   kind: int
   nameEntry: main.score
   name: main.score
   pkg: main
-  ptrToThis: "0x000573a0"
-- offset: "0x0012e2e0"
+  ptrToThis: "0x000573c0"
+- offset: "0x0012e360"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000ca080"
+  ptrToThis: "0x000ca0a0"
   methods:
     - name: DoSomething (exported)
       type: func() string
@@ -1095,13 +1121,13 @@
         - name: i
           type: int
           offset: 0
-- offset: "0x0013a160"
+- offset: "0x0013a280"
   size: 16
   kind: struct
   nameEntry: main.smallStruct
   name: main.smallStruct
   pkg: main
-  ptrToThis: "0x00057ba0"
+  ptrToThis: "0x00057bc0"
   struct:
     fields:
         - name: X (exported)
@@ -1110,68 +1136,68 @@
         - name: Y (exported)
           type: int
           offset: 8
-- offset: "0x000f0540"
+- offset: "0x000f05c0"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x000571e0"
+  ptrToThis: "0x00057200"
   interfaceMethods:
     - name: Do (exported)
       type: func()
-- offset: "0x000e8400"
+- offset: "0x000e8480"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000ca0e0"
+  ptrToThis: "0x000ca100"
   struct:
     fields: []
-- offset: "0x0010da60"
+- offset: "0x0010dae0"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
   name: main.structWithAny
   pkg: main
-  ptrToThis: "0x000573e0"
+  ptrToThis: "0x00057400"
   struct:
     fields:
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x0010dae0"
+- offset: "0x0010db60"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x00057420"
+  ptrToThis: "0x00057440"
   struct:
     fields:
         - name: m
           type: map[int]int
           offset: 0
-- offset: "0x0010e8e0"
+- offset: "0x0010e960"
   size: 16
   kind: struct
   nameEntry: main.tinyStruct
   name: main.tinyStruct
   pkg: main
-  ptrToThis: "0x00057be0"
+  ptrToThis: "0x00057c00"
   struct:
     fields:
         - name: Name (exported)
           type: string
           offset: 0
-- offset: "0x00137340"
+- offset: "0x001373c0"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000d7700"
+  ptrToThis: "0x000d7720"
   methods:
     - name: Guess (exported)
       type: func(int) bool
@@ -1180,13 +1206,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x001373e0"
+- offset: "0x00137460"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000d7760"
+  ptrToThis: "0x000d7780"
   methods:
     - name: Guess (exported)
       type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -1,4 +1,4 @@
-- offset: "0x0010a9c0"
+- offset: "0x0010aa40"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[float64] (exported)'
@@ -11,7 +11,7 @@
       type: func(float64)
   pointer:
     elem: lib.Box[float64]
-- offset: "0x0010a6c0"
+- offset: "0x0010a740"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[int] (exported)'
@@ -24,7 +24,7 @@
       type: func(int)
   pointer:
     elem: lib.Box[int]
-- offset: "0x0010a740"
+- offset: "0x0010a7c0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[string] (exported)'
@@ -37,7 +37,7 @@
       type: func(string)
   pointer:
     elem: lib.Box[string]
-- offset: "0x0010a8c0"
+- offset: "0x0010a940"
   size: 8
   kind: ptr
   nameEntry: '*lib.ImmutableSet[string] (exported)'
@@ -50,7 +50,7 @@
       type: func(string) (*lib.ImmutableSet[string], bool)
   pointer:
     elem: lib.ImmutableSet[string]
-- offset: "0x000e82c0"
+- offset: "0x000e82e0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[bool,string] (exported)'
@@ -61,7 +61,7 @@
       type: func() lib.Pair[string,bool]
   pointer:
     elem: lib.Pair[bool,string]
-- offset: "0x000e8bc0"
+- offset: "0x000e8be0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[float64,float64] (exported)'
@@ -72,7 +72,7 @@
       type: func() lib.Pair[float64,float64]
   pointer:
     elem: lib.Pair[float64,float64]
-- offset: "0x000e8380"
+- offset: "0x000e83a0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[int,string] (exported)'
@@ -83,7 +83,7 @@
       type: func() lib.Pair[string,int]
   pointer:
     elem: lib.Pair[int,string]
-- offset: "0x000e8260"
+- offset: "0x000e8280"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[string,bool] (exported)'
@@ -94,7 +94,7 @@
       type: func() lib.Pair[bool,string]
   pointer:
     elem: lib.Pair[string,bool]
-- offset: "0x000e8320"
+- offset: "0x000e8340"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[string,int] (exported)'
@@ -105,13 +105,13 @@
       type: func() lib.Pair[int,string]
   pointer:
     elem: lib.Pair[string,int]
-- offset: "0x00163380"
+- offset: "0x00163400"
   size: 8
   kind: struct
   nameEntry: lib.Box[float64] (exported)
   name: lib.Box[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010a9c0"
+  ptrToThis: "0x0010aa40"
   methods:
     - name: Get (exported)
       type: func() float64
@@ -120,13 +120,13 @@
         - name: Value (exported)
           type: float64
           offset: 0
-- offset: "0x00162d40"
+- offset: "0x00162dc0"
   size: 8
   kind: struct
   nameEntry: lib.Box[int] (exported)
   name: lib.Box[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010a6c0"
+  ptrToThis: "0x0010a740"
   methods:
     - name: Get (exported)
       type: func() int
@@ -135,13 +135,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x00162de0"
+- offset: "0x00162e60"
   size: 16
   kind: struct
   nameEntry: lib.Box[string] (exported)
   name: lib.Box[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010a740"
+  ptrToThis: "0x0010a7c0"
   methods:
     - name: Get (exported)
       type: func() string
@@ -150,37 +150,37 @@
         - name: Value (exported)
           type: string
           offset: 0
-- offset: "0x00136560"
+- offset: "0x001365e0"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[go.shape.string] (exported)
   name: lib.ImmutableSet[go.shape.string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x00074e60"
+  ptrToThis: "0x00074e80"
   struct:
     fields:
         - name: items
           type: map[go.shape.string]bool
           offset: 0
-- offset: "0x00136460"
+- offset: "0x001364e0"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[string] (exported)
   name: lib.ImmutableSet[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010a8c0"
+  ptrToThis: "0x0010a940"
   struct:
     fields:
         - name: items
           type: map[string]bool
           offset: 0
-- offset: "0x00189440"
+- offset: "0x00189560"
   size: 24
   kind: struct
   nameEntry: lib.Pair[bool,string] (exported)
   name: lib.Pair[bool,string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e82c0"
+  ptrToThis: "0x000e82e0"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[string,bool]
@@ -192,13 +192,13 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x00189760"
+- offset: "0x00189880"
   size: 16
   kind: struct
   nameEntry: lib.Pair[float64,float64] (exported)
   name: lib.Pair[float64,float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e8bc0"
+  ptrToThis: "0x000e8be0"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[float64,float64]
@@ -210,13 +210,13 @@
         - name: Second (exported)
           type: float64
           offset: 8
-- offset: "0x00189580"
+- offset: "0x001896a0"
   size: 24
   kind: struct
   nameEntry: lib.Pair[int,string] (exported)
   name: lib.Pair[int,string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e8380"
+  ptrToThis: "0x000e83a0"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[string,int]
@@ -228,13 +228,13 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x001893a0"
+- offset: "0x001894c0"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,bool] (exported)
   name: lib.Pair[string,bool]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e8260"
+  ptrToThis: "0x000e8280"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[bool,string]
@@ -246,13 +246,13 @@
         - name: Second (exported)
           type: bool
           offset: 16
-- offset: "0x001894e0"
+- offset: "0x00189600"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,int] (exported)
   name: lib.Pair[string,int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e8320"
+  ptrToThis: "0x000e8340"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[int,string]
@@ -264,7 +264,18 @@
         - name: Second (exported)
           type: int
           offset: 16
-- offset: "0x000dafa0"
+- offset: "0x000e8c40"
+  size: 8
+  kind: ptr
+  nameEntry: '*lib_v2.V2GenericBox[int] (exported)'
+  name: '*lib_v2.V2GenericBox[int]'
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  methods:
+    - name: Get (exported)
+      type: func() int
+  pointer:
+    elem: lib_v2.V2GenericBox[int]
+- offset: "0x000dafc0"
   size: 8
   kind: ptr
   nameEntry: '*lib_v2.V2Type (exported)'
@@ -275,16 +286,31 @@
       type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f1640"
+- offset: "0x001635e0"
+  size: 8
+  kind: struct
+  nameEntry: lib_v2.V2GenericBox[int] (exported)
+  name: lib_v2.V2GenericBox[int]
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  ptrToThis: "0x000e8c40"
+  methods:
+    - name: Get (exported)
+      type: func() int
+  struct:
+    fields:
+        - name: Value (exported)
+          type: int
+          offset: 0
+- offset: "0x000f16c0"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000dafa0"
+  ptrToThis: "0x000dafc0"
   struct:
     fields: []
-- offset: "0x0010aa40"
+- offset: "0x0010aac0"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[float64] (exported)'
@@ -297,7 +323,7 @@
       type: func() float64
   pointer:
     elem: lib2.Wrapper[float64]
-- offset: "0x0010a7c0"
+- offset: "0x0010a840"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[int] (exported)'
@@ -310,7 +336,7 @@
       type: func() int
   pointer:
     elem: lib2.Wrapper[int]
-- offset: "0x0010a840"
+- offset: "0x0010a8c0"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[string] (exported)'
@@ -323,13 +349,13 @@
       type: func() string
   pointer:
     elem: lib2.Wrapper[string]
-- offset: "0x00189800"
+- offset: "0x00189920"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[float64] (exported)
   name: lib2.Wrapper[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010aa40"
+  ptrToThis: "0x0010aac0"
   methods:
     - name: Unwrap (exported)
       type: func() float64
@@ -341,13 +367,13 @@
         - name: Inner (exported)
           type: lib.Box[float64]
           offset: 16
-- offset: "0x00189620"
+- offset: "0x00189740"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[int] (exported)
   name: lib2.Wrapper[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010a7c0"
+  ptrToThis: "0x0010a840"
   methods:
     - name: Unwrap (exported)
       type: func() int
@@ -359,13 +385,13 @@
         - name: Inner (exported)
           type: lib.Box[int]
           offset: 16
-- offset: "0x001896c0"
+- offset: "0x001897e0"
   size: 32
   kind: struct
   nameEntry: lib2.Wrapper[string] (exported)
   name: lib2.Wrapper[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010a840"
+  ptrToThis: "0x0010a8c0"
   methods:
     - name: Unwrap (exported)
       type: func() string
@@ -377,7 +403,7 @@
         - name: Inner (exported)
           type: lib.Box[string]
           offset: 16
-- offset: "0x000e83e0"
+- offset: "0x000e8400"
   size: 8
   kind: ptr
   nameEntry: '*main.Pair[int,bool] (exported)'
@@ -388,7 +414,7 @@
       type: func(int, bool)
   pointer:
     elem: main.Pair[int,bool]
-- offset: "0x000e8440"
+- offset: "0x000e8460"
   size: 8
   kind: ptr
   nameEntry: '*main.Pair[string,int] (exported)'
@@ -399,7 +425,7 @@
       type: func(string, int)
   pointer:
     elem: main.Pair[string,int]
-- offset: "0x000daac0"
+- offset: "0x000daae0"
   size: 8
   kind: ptr
   nameEntry: '*main.firstBehavior'
@@ -410,7 +436,7 @@
       type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000e84a0"
+- offset: "0x000e84c0"
   size: 8
   kind: ptr
   nameEntry: '*main.largeGenericType[int]'
@@ -421,7 +447,7 @@
       type: func() int
   pointer:
     elem: main.largeGenericType[int]
-- offset: "0x000e8500"
+- offset: "0x000e8520"
   size: 8
   kind: ptr
   nameEntry: '*main.largeGenericType[string]'
@@ -432,7 +458,7 @@
       type: func() string
   pointer:
     elem: main.largeGenericType[string]
-- offset: "0x000dab20"
+- offset: "0x000dab40"
   size: 8
   kind: ptr
   nameEntry: '*main.secondBehavior'
@@ -443,7 +469,7 @@
       type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000dab80"
+- offset: "0x000daba0"
   size: 8
   kind: ptr
   nameEntry: '*main.somethingImpl'
@@ -454,7 +480,7 @@
       type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e8560"
+- offset: "0x000e8580"
   size: 8
   kind: ptr
   nameEntry: '*main.typeWithGenerics[int]'
@@ -465,7 +491,7 @@
       type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e85c0"
+- offset: "0x000e85e0"
   size: 8
   kind: ptr
   nameEntry: '*main.typeWithGenerics[string]'
@@ -476,13 +502,13 @@
       type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x00178280"
+- offset: "0x001783a0"
   size: 16
   kind: struct
   nameEntry: main.Pair[int,bool] (exported)
   name: main.Pair[int,bool]
   pkg: main
-  ptrToThis: "0x000e83e0"
+  ptrToThis: "0x000e8400"
   struct:
     fields:
         - name: Key (exported)
@@ -491,13 +517,13 @@
         - name: Value (exported)
           type: bool
           offset: 8
-- offset: "0x00178320"
+- offset: "0x00178440"
   size: 24
   kind: struct
   nameEntry: main.Pair[string,int] (exported)
   name: main.Pair[string,int]
   pkg: main
-  ptrToThis: "0x000e8440"
+  ptrToThis: "0x000e8460"
   struct:
     fields:
         - name: Key (exported)
@@ -506,23 +532,23 @@
         - name: Value (exported)
           type: int
           offset: 16
-- offset: "0x000f9b40"
+- offset: "0x000f9bc0"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x0005dc20"
+  ptrToThis: "0x0005dc40"
   interfaceMethods:
     - name: DoSomething (exported)
       type: func() string
-- offset: "0x0018a9e0"
+- offset: "0x0018ab00"
   size: 48
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x0005dca0"
+  ptrToThis: "0x0005dcc0"
   struct:
     fields:
         - name: x
@@ -534,344 +560,344 @@
         - name: writer
           type: io.Writer
           offset: 32
-- offset: "0x0008e440"
+- offset: "0x0008e460"
   size: 8
   kind: int
   nameEntry: main.celsius
   name: main.celsius
   pkg: main
-  ptrToThis: "0x0005dce0"
-- offset: "0x001221e0"
+  ptrToThis: "0x0005dd00"
+- offset: "0x00122260"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x0005e0e0"
+  ptrToThis: "0x0005e100"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap2
           offset: 0
-- offset: "0x00122160"
+- offset: "0x001221e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x0005e0a0"
+  ptrToThis: "0x0005e0c0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap3
           offset: 0
-- offset: "0x001220e0"
+- offset: "0x00122160"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x0005e060"
+  ptrToThis: "0x0005e080"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap4
           offset: 0
-- offset: "0x00122060"
+- offset: "0x001220e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x0005e020"
+  ptrToThis: "0x0005e040"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap5
           offset: 0
-- offset: "0x00121fe0"
+- offset: "0x00122060"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x0005dfe0"
+  ptrToThis: "0x0005e000"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap6
           offset: 0
-- offset: "0x00121f60"
+- offset: "0x00121fe0"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x0005dfa0"
+  ptrToThis: "0x0005dfc0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap7
           offset: 0
-- offset: "0x00121ee0"
+- offset: "0x00121f60"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x0005df60"
+  ptrToThis: "0x0005df80"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap8
           offset: 0
-- offset: "0x00121e60"
+- offset: "0x00121ee0"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x0005df20"
+  ptrToThis: "0x0005df40"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap9
           offset: 0
-- offset: "0x00121de0"
+- offset: "0x00121e60"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x0005dee0"
+  ptrToThis: "0x0005df00"
   struct:
     fields:
         - name: a
           type: map[int]interface {}
           offset: 0
-- offset: "0x00122660"
+- offset: "0x001226e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x0005e320"
+  ptrToThis: "0x0005e340"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr2'
           offset: 0
-- offset: "0x001225e0"
+- offset: "0x00122660"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x0005e2e0"
+  ptrToThis: "0x0005e300"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr3'
           offset: 0
-- offset: "0x00122560"
+- offset: "0x001225e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x0005e2a0"
+  ptrToThis: "0x0005e2c0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr4'
           offset: 0
-- offset: "0x001224e0"
+- offset: "0x00122560"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x0005e260"
+  ptrToThis: "0x0005e280"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr5'
           offset: 0
-- offset: "0x00122460"
+- offset: "0x001224e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x0005e220"
+  ptrToThis: "0x0005e240"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr6'
           offset: 0
-- offset: "0x001223e0"
+- offset: "0x00122460"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x0005e1e0"
+  ptrToThis: "0x0005e200"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr7'
           offset: 0
-- offset: "0x00122360"
+- offset: "0x001223e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x0005e1a0"
+  ptrToThis: "0x0005e1c0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr8'
           offset: 0
-- offset: "0x001222e0"
+- offset: "0x00122360"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x0005e160"
+  ptrToThis: "0x0005e180"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr9'
           offset: 0
-- offset: "0x00122260"
+- offset: "0x001222e0"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x0005e120"
+  ptrToThis: "0x0005e140"
   struct:
     fields:
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x00122ae0"
+- offset: "0x00122b60"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x0005e560"
+  ptrToThis: "0x0005e580"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice2'
           offset: 0
-- offset: "0x00122a60"
+- offset: "0x00122ae0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x0005e520"
+  ptrToThis: "0x0005e540"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice3'
           offset: 0
-- offset: "0x001229e0"
+- offset: "0x00122a60"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x0005e4e0"
+  ptrToThis: "0x0005e500"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice4'
           offset: 0
-- offset: "0x00122960"
+- offset: "0x001229e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x0005e4a0"
+  ptrToThis: "0x0005e4c0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice5'
           offset: 0
-- offset: "0x001228e0"
+- offset: "0x00122960"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x0005e460"
+  ptrToThis: "0x0005e480"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice6'
           offset: 0
-- offset: "0x00122860"
+- offset: "0x001228e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x0005e420"
+  ptrToThis: "0x0005e440"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice7'
           offset: 0
-- offset: "0x001227e0"
+- offset: "0x00122860"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x0005e3e0"
+  ptrToThis: "0x0005e400"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice8'
           offset: 0
-- offset: "0x00122760"
+- offset: "0x001227e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x0005e3a0"
+  ptrToThis: "0x0005e3c0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice9'
           offset: 0
-- offset: "0x001226e0"
+- offset: "0x00122760"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x0005e360"
+  ptrToThis: "0x0005e380"
   struct:
     fields:
         - name: a
           type: '[]interface {}'
           offset: 0
-- offset: "0x001c0060"
+- offset: "0x001c0180"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005e5a0"
+  ptrToThis: "0x0005e5c0"
   struct:
     fields:
         - name: esotericStack (embedded)
@@ -889,13 +915,13 @@
         - name: a
           type: atomic.Int32
           offset: 104
-- offset: "0x001e0a40"
+- offset: "0x001e0b60"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x0005dd20"
+  ptrToThis: "0x0005dd40"
   struct:
     fields:
         - name: _
@@ -919,13 +945,13 @@
         - name: foo
           type: func()
           offset: 56
-- offset: "0x001599c0"
+- offset: "0x00159a40"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000daac0"
+  ptrToThis: "0x000daae0"
   methods:
     - name: DoSomething (exported)
       type: func() string
@@ -934,13 +960,13 @@
         - name: s
           type: string
           offset: 0
-- offset: "0x002014a0"
+- offset: "0x002015c0"
   size: 136
   kind: struct
   nameEntry: main.largeGenericType[int]
   name: main.largeGenericType[int]
   pkg: main
-  ptrToThis: "0x000e84a0"
+  ptrToThis: "0x000e84c0"
   methods:
     - name: LargeGet (exported)
       type: func() int
@@ -973,13 +999,13 @@
         - name: Value (exported)
           type: int
           offset: 128
-- offset: "0x00201600"
+- offset: "0x00201720"
   size: 144
   kind: struct
   nameEntry: main.largeGenericType[string]
   name: main.largeGenericType[string]
   pkg: main
-  ptrToThis: "0x000e8500"
+  ptrToThis: "0x000e8520"
   methods:
     - name: LargeGet (exported)
       type: func() string
@@ -1012,20 +1038,20 @@
         - name: Value (exported)
           type: string
           offset: 128
-- offset: "0x0008e480"
+- offset: "0x0008e4a0"
   size: 8
   kind: int
   nameEntry: main.namedInt
   name: main.namedInt
   pkg: main
-  ptrToThis: "0x0005dd60"
-- offset: "0x00165cc0"
+  ptrToThis: "0x0005dd80"
+- offset: "0x00165de0"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005e6a0"
+  ptrToThis: "0x0005e6c0"
   struct:
     fields:
         - name: anotherInt
@@ -1034,13 +1060,13 @@
         - name: anotherString
           type: string
           offset: 8
-- offset: "0x00165b80"
+- offset: "0x00165ca0"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005e5e0"
+  ptrToThis: "0x0005e600"
   struct:
     fields:
         - name: val
@@ -1049,44 +1075,44 @@
         - name: b
           type: '*main.node'
           offset: 8
-- offset: "0x00121be0"
+- offset: "0x00121c60"
   size: 16
   kind: struct
   nameEntry: main.otherFirstBehavior
   name: main.otherFirstBehavior
   pkg: main
-  ptrToThis: "0x0005dda0"
+  ptrToThis: "0x0005ddc0"
   struct:
     fields:
         - name: s
           type: string
           offset: 0
-- offset: "0x00121c60"
+- offset: "0x00121ce0"
   size: 8
   kind: struct
   nameEntry: main.otherSecondBehavior
   name: main.otherSecondBehavior
   pkg: main
-  ptrToThis: "0x0005dde0"
+  ptrToThis: "0x0005de00"
   struct:
     fields:
         - name: i
           type: int
           offset: 0
-- offset: "0x0008e4c0"
+- offset: "0x0008e4e0"
   size: 8
   kind: int
   nameEntry: main.score
   name: main.score
   pkg: main
-  ptrToThis: "0x0005de20"
-- offset: "0x00159a60"
+  ptrToThis: "0x0005de40"
+- offset: "0x00159ae0"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000dab20"
+  ptrToThis: "0x000dab40"
   methods:
     - name: DoSomething (exported)
       type: func() string
@@ -1095,13 +1121,13 @@
         - name: i
           type: int
           offset: 0
-- offset: "0x00165c20"
+- offset: "0x00165d40"
   size: 16
   kind: struct
   nameEntry: main.smallStruct
   name: main.smallStruct
   pkg: main
-  ptrToThis: "0x0005e620"
+  ptrToThis: "0x0005e640"
   struct:
     fields:
         - name: X (exported)
@@ -1110,68 +1136,68 @@
         - name: Y (exported)
           type: int
           offset: 8
-- offset: "0x000f9bc0"
+- offset: "0x000f9c40"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x0005dc60"
+  ptrToThis: "0x0005dc80"
   interfaceMethods:
     - name: Do (exported)
       type: func()
-- offset: "0x000f14c0"
+- offset: "0x000f1540"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000dab80"
+  ptrToThis: "0x000daba0"
   struct:
     fields: []
-- offset: "0x00121ce0"
+- offset: "0x00121d60"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
   name: main.structWithAny
   pkg: main
-  ptrToThis: "0x0005de60"
+  ptrToThis: "0x0005de80"
   struct:
     fields:
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x00121d60"
+- offset: "0x00121de0"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005dea0"
+  ptrToThis: "0x0005dec0"
   struct:
     fields:
         - name: m
           type: map[int]int
           offset: 0
-- offset: "0x00122b60"
+- offset: "0x00122be0"
   size: 16
   kind: struct
   nameEntry: main.tinyStruct
   name: main.tinyStruct
   pkg: main
-  ptrToThis: "0x0005e660"
+  ptrToThis: "0x0005e680"
   struct:
     fields:
         - name: Name (exported)
           type: string
           offset: 0
-- offset: "0x00162e80"
+- offset: "0x00162f00"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e8560"
+  ptrToThis: "0x000e8580"
   methods:
     - name: Guess (exported)
       type: func(int) bool
@@ -1180,13 +1206,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x00162f20"
+- offset: "0x00162fa0"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e85c0"
+  ptrToThis: "0x000e85e0"
   methods:
     - name: Guess (exported)
       type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -1,4 +1,4 @@
-- offset: "0x0010bbc0"
+- offset: "0x0010bc40"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[float64] (exported)'
@@ -11,7 +11,7 @@
       type: func(float64)
   pointer:
     elem: lib.Box[float64]
-- offset: "0x0010b8c0"
+- offset: "0x0010b940"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[int] (exported)'
@@ -24,7 +24,7 @@
       type: func(int)
   pointer:
     elem: lib.Box[int]
-- offset: "0x0010b940"
+- offset: "0x0010b9c0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[string] (exported)'
@@ -37,7 +37,7 @@
       type: func(string)
   pointer:
     elem: lib.Box[string]
-- offset: "0x0010bac0"
+- offset: "0x0010bb40"
   size: 8
   kind: ptr
   nameEntry: '*lib.ImmutableSet[string] (exported)'
@@ -50,7 +50,7 @@
       type: func(string) (*lib.ImmutableSet[string], bool)
   pointer:
     elem: lib.ImmutableSet[string]
-- offset: "0x000e9520"
+- offset: "0x000e9540"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[bool,string] (exported)'
@@ -61,7 +61,7 @@
       type: func() lib.Pair[string,bool]
   pointer:
     elem: lib.Pair[bool,string]
-- offset: "0x000e9e20"
+- offset: "0x000e9e40"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[float64,float64] (exported)'
@@ -72,7 +72,7 @@
       type: func() lib.Pair[float64,float64]
   pointer:
     elem: lib.Pair[float64,float64]
-- offset: "0x000e95e0"
+- offset: "0x000e9600"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[int,string] (exported)'
@@ -83,7 +83,7 @@
       type: func() lib.Pair[string,int]
   pointer:
     elem: lib.Pair[int,string]
-- offset: "0x000e94c0"
+- offset: "0x000e94e0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[string,bool] (exported)'
@@ -94,7 +94,7 @@
       type: func() lib.Pair[bool,string]
   pointer:
     elem: lib.Pair[string,bool]
-- offset: "0x000e9580"
+- offset: "0x000e95a0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[string,int] (exported)'
@@ -105,13 +105,13 @@
       type: func() lib.Pair[int,string]
   pointer:
     elem: lib.Pair[string,int]
-- offset: "0x00164440"
+- offset: "0x001644c0"
   size: 8
   kind: struct
   nameEntry: lib.Box[float64] (exported)
   name: lib.Box[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010bbc0"
+  ptrToThis: "0x0010bc40"
   methods:
     - name: Get (exported)
       type: func() float64
@@ -120,13 +120,13 @@
         - name: Value (exported)
           type: float64
           offset: 0
-- offset: "0x00163e00"
+- offset: "0x00163e80"
   size: 8
   kind: struct
   nameEntry: lib.Box[int] (exported)
   name: lib.Box[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010b8c0"
+  ptrToThis: "0x0010b940"
   methods:
     - name: Get (exported)
       type: func() int
@@ -135,13 +135,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x00163ea0"
+- offset: "0x00163f20"
   size: 16
   kind: struct
   nameEntry: lib.Box[string] (exported)
   name: lib.Box[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010b940"
+  ptrToThis: "0x0010b9c0"
   methods:
     - name: Get (exported)
       type: func() string
@@ -150,37 +150,37 @@
         - name: Value (exported)
           type: string
           offset: 0
-- offset: "0x001375c0"
+- offset: "0x00137640"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[go.shape.string] (exported)
   name: lib.ImmutableSet[go.shape.string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x00075980"
+  ptrToThis: "0x000759a0"
   struct:
     fields:
         - name: items
           type: map[go.shape.string]bool
           offset: 0
-- offset: "0x001374c0"
+- offset: "0x00137540"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[string] (exported)
   name: lib.ImmutableSet[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010bac0"
+  ptrToThis: "0x0010bb40"
   struct:
     fields:
         - name: items
           type: map[string]bool
           offset: 0
-- offset: "0x0018a6a0"
+- offset: "0x0018a7c0"
   size: 24
   kind: struct
   nameEntry: lib.Pair[bool,string] (exported)
   name: lib.Pair[bool,string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e9520"
+  ptrToThis: "0x000e9540"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[string,bool]
@@ -192,13 +192,13 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x0018a9c0"
+- offset: "0x0018aae0"
   size: 16
   kind: struct
   nameEntry: lib.Pair[float64,float64] (exported)
   name: lib.Pair[float64,float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e9e20"
+  ptrToThis: "0x000e9e40"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[float64,float64]
@@ -210,13 +210,13 @@
         - name: Second (exported)
           type: float64
           offset: 8
-- offset: "0x0018a7e0"
+- offset: "0x0018a900"
   size: 24
   kind: struct
   nameEntry: lib.Pair[int,string] (exported)
   name: lib.Pair[int,string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e95e0"
+  ptrToThis: "0x000e9600"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[string,int]
@@ -228,13 +228,13 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x0018a600"
+- offset: "0x0018a720"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,bool] (exported)
   name: lib.Pair[string,bool]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e94c0"
+  ptrToThis: "0x000e94e0"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[bool,string]
@@ -246,13 +246,13 @@
         - name: Second (exported)
           type: bool
           offset: 16
-- offset: "0x0018a740"
+- offset: "0x0018a860"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,int] (exported)
   name: lib.Pair[string,int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000e9580"
+  ptrToThis: "0x000e95a0"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[int,string]
@@ -264,7 +264,18 @@
         - name: Second (exported)
           type: int
           offset: 16
-- offset: "0x000dc080"
+- offset: "0x000e9ea0"
+  size: 8
+  kind: ptr
+  nameEntry: '*lib_v2.V2GenericBox[int] (exported)'
+  name: '*lib_v2.V2GenericBox[int]'
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  methods:
+    - name: Get (exported)
+      type: func() int
+  pointer:
+    elem: lib_v2.V2GenericBox[int]
+- offset: "0x000dc0a0"
   size: 8
   kind: ptr
   nameEntry: '*lib_v2.V2Type (exported)'
@@ -275,16 +286,31 @@
       type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f2740"
+- offset: "0x001646a0"
+  size: 8
+  kind: struct
+  nameEntry: lib_v2.V2GenericBox[int] (exported)
+  name: lib_v2.V2GenericBox[int]
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  ptrToThis: "0x000e9ea0"
+  methods:
+    - name: Get (exported)
+      type: func() int
+  struct:
+    fields:
+        - name: Value (exported)
+          type: int
+          offset: 0
+- offset: "0x000f27c0"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000dc080"
+  ptrToThis: "0x000dc0a0"
   struct:
     fields: []
-- offset: "0x0010bc40"
+- offset: "0x0010bcc0"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[float64] (exported)'
@@ -297,7 +323,7 @@
       type: func() float64
   pointer:
     elem: lib2.Wrapper[float64]
-- offset: "0x0010b9c0"
+- offset: "0x0010ba40"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[int] (exported)'
@@ -310,7 +336,7 @@
       type: func() int
   pointer:
     elem: lib2.Wrapper[int]
-- offset: "0x0010ba40"
+- offset: "0x0010bac0"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[string] (exported)'
@@ -323,13 +349,13 @@
       type: func() string
   pointer:
     elem: lib2.Wrapper[string]
-- offset: "0x0018aa60"
+- offset: "0x0018ab80"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[float64] (exported)
   name: lib2.Wrapper[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010bc40"
+  ptrToThis: "0x0010bcc0"
   methods:
     - name: Unwrap (exported)
       type: func() float64
@@ -341,13 +367,13 @@
         - name: Inner (exported)
           type: lib.Box[float64]
           offset: 16
-- offset: "0x0018a880"
+- offset: "0x0018a9a0"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[int] (exported)
   name: lib2.Wrapper[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010b9c0"
+  ptrToThis: "0x0010ba40"
   methods:
     - name: Unwrap (exported)
       type: func() int
@@ -359,13 +385,13 @@
         - name: Inner (exported)
           type: lib.Box[int]
           offset: 16
-- offset: "0x0018a920"
+- offset: "0x0018aa40"
   size: 32
   kind: struct
   nameEntry: lib2.Wrapper[string] (exported)
   name: lib2.Wrapper[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010ba40"
+  ptrToThis: "0x0010bac0"
   methods:
     - name: Unwrap (exported)
       type: func() string
@@ -377,7 +403,7 @@
         - name: Inner (exported)
           type: lib.Box[string]
           offset: 16
-- offset: "0x000e9640"
+- offset: "0x000e9660"
   size: 8
   kind: ptr
   nameEntry: '*main.Pair[int,bool] (exported)'
@@ -388,7 +414,7 @@
       type: func(int, bool)
   pointer:
     elem: main.Pair[int,bool]
-- offset: "0x000e96a0"
+- offset: "0x000e96c0"
   size: 8
   kind: ptr
   nameEntry: '*main.Pair[string,int] (exported)'
@@ -399,7 +425,7 @@
       type: func(string, int)
   pointer:
     elem: main.Pair[string,int]
-- offset: "0x000dbba0"
+- offset: "0x000dbbc0"
   size: 8
   kind: ptr
   nameEntry: '*main.firstBehavior'
@@ -410,7 +436,7 @@
       type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000e9700"
+- offset: "0x000e9720"
   size: 8
   kind: ptr
   nameEntry: '*main.largeGenericType[int]'
@@ -421,7 +447,7 @@
       type: func() int
   pointer:
     elem: main.largeGenericType[int]
-- offset: "0x000e9760"
+- offset: "0x000e9780"
   size: 8
   kind: ptr
   nameEntry: '*main.largeGenericType[string]'
@@ -432,7 +458,7 @@
       type: func() string
   pointer:
     elem: main.largeGenericType[string]
-- offset: "0x000dbc00"
+- offset: "0x000dbc20"
   size: 8
   kind: ptr
   nameEntry: '*main.secondBehavior'
@@ -443,7 +469,7 @@
       type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000dbc60"
+- offset: "0x000dbc80"
   size: 8
   kind: ptr
   nameEntry: '*main.somethingImpl'
@@ -454,7 +480,7 @@
       type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e97c0"
+- offset: "0x000e97e0"
   size: 8
   kind: ptr
   nameEntry: '*main.typeWithGenerics[int]'
@@ -465,7 +491,7 @@
       type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e9820"
+- offset: "0x000e9840"
   size: 8
   kind: ptr
   nameEntry: '*main.typeWithGenerics[string]'
@@ -476,13 +502,13 @@
       type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x00179740"
+- offset: "0x00179860"
   size: 16
   kind: struct
   nameEntry: main.Pair[int,bool] (exported)
   name: main.Pair[int,bool]
   pkg: main
-  ptrToThis: "0x000e9640"
+  ptrToThis: "0x000e9660"
   struct:
     fields:
         - name: Key (exported)
@@ -491,13 +517,13 @@
         - name: Value (exported)
           type: bool
           offset: 8
-- offset: "0x001797e0"
+- offset: "0x00179900"
   size: 24
   kind: struct
   nameEntry: main.Pair[string,int] (exported)
   name: main.Pair[string,int]
   pkg: main
-  ptrToThis: "0x000e96a0"
+  ptrToThis: "0x000e96c0"
   struct:
     fields:
         - name: Key (exported)
@@ -506,23 +532,23 @@
         - name: Value (exported)
           type: int
           offset: 16
-- offset: "0x000fabc0"
+- offset: "0x000fac40"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x0005e700"
+  ptrToThis: "0x0005e720"
   interfaceMethods:
     - name: DoSomething (exported)
       type: func() string
-- offset: "0x0018bce0"
+- offset: "0x0018be00"
   size: 48
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x0005e780"
+  ptrToThis: "0x0005e7a0"
   struct:
     fields:
         - name: x
@@ -534,344 +560,344 @@
         - name: writer
           type: io.Writer
           offset: 32
-- offset: "0x0008f320"
+- offset: "0x0008f340"
   size: 8
   kind: int
   nameEntry: main.celsius
   name: main.celsius
   pkg: main
-  ptrToThis: "0x0005e7c0"
-- offset: "0x00123140"
+  ptrToThis: "0x0005e7e0"
+- offset: "0x001231c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x0005ebc0"
+  ptrToThis: "0x0005ebe0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap2
           offset: 0
-- offset: "0x001230c0"
+- offset: "0x00123140"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x0005eb80"
+  ptrToThis: "0x0005eba0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap3
           offset: 0
-- offset: "0x00123040"
+- offset: "0x001230c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x0005eb40"
+  ptrToThis: "0x0005eb60"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap4
           offset: 0
-- offset: "0x00122fc0"
+- offset: "0x00123040"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x0005eb00"
+  ptrToThis: "0x0005eb20"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap5
           offset: 0
-- offset: "0x00122f40"
+- offset: "0x00122fc0"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x0005eac0"
+  ptrToThis: "0x0005eae0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap6
           offset: 0
-- offset: "0x00122ec0"
+- offset: "0x00122f40"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x0005ea80"
+  ptrToThis: "0x0005eaa0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap7
           offset: 0
-- offset: "0x00122e40"
+- offset: "0x00122ec0"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x0005ea40"
+  ptrToThis: "0x0005ea60"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap8
           offset: 0
-- offset: "0x00122dc0"
+- offset: "0x00122e40"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x0005ea00"
+  ptrToThis: "0x0005ea20"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap9
           offset: 0
-- offset: "0x00122d40"
+- offset: "0x00122dc0"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x0005e9c0"
+  ptrToThis: "0x0005e9e0"
   struct:
     fields:
         - name: a
           type: map[int]interface {}
           offset: 0
-- offset: "0x001235c0"
+- offset: "0x00123640"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x0005ee00"
+  ptrToThis: "0x0005ee20"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr2'
           offset: 0
-- offset: "0x00123540"
+- offset: "0x001235c0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x0005edc0"
+  ptrToThis: "0x0005ede0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr3'
           offset: 0
-- offset: "0x001234c0"
+- offset: "0x00123540"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x0005ed80"
+  ptrToThis: "0x0005eda0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr4'
           offset: 0
-- offset: "0x00123440"
+- offset: "0x001234c0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x0005ed40"
+  ptrToThis: "0x0005ed60"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr5'
           offset: 0
-- offset: "0x001233c0"
+- offset: "0x00123440"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x0005ed00"
+  ptrToThis: "0x0005ed20"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr6'
           offset: 0
-- offset: "0x00123340"
+- offset: "0x001233c0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x0005ecc0"
+  ptrToThis: "0x0005ece0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr7'
           offset: 0
-- offset: "0x001232c0"
+- offset: "0x00123340"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x0005ec80"
+  ptrToThis: "0x0005eca0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr8'
           offset: 0
-- offset: "0x00123240"
+- offset: "0x001232c0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x0005ec40"
+  ptrToThis: "0x0005ec60"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr9'
           offset: 0
-- offset: "0x001231c0"
+- offset: "0x00123240"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x0005ec00"
+  ptrToThis: "0x0005ec20"
   struct:
     fields:
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x00123a40"
+- offset: "0x00123ac0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x0005f040"
+  ptrToThis: "0x0005f060"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice2'
           offset: 0
-- offset: "0x001239c0"
+- offset: "0x00123a40"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x0005f000"
+  ptrToThis: "0x0005f020"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice3'
           offset: 0
-- offset: "0x00123940"
+- offset: "0x001239c0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x0005efc0"
+  ptrToThis: "0x0005efe0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice4'
           offset: 0
-- offset: "0x001238c0"
+- offset: "0x00123940"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x0005ef80"
+  ptrToThis: "0x0005efa0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice5'
           offset: 0
-- offset: "0x00123840"
+- offset: "0x001238c0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x0005ef40"
+  ptrToThis: "0x0005ef60"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice6'
           offset: 0
-- offset: "0x001237c0"
+- offset: "0x00123840"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x0005ef00"
+  ptrToThis: "0x0005ef20"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice7'
           offset: 0
-- offset: "0x00123740"
+- offset: "0x001237c0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x0005eec0"
+  ptrToThis: "0x0005eee0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice8'
           offset: 0
-- offset: "0x001236c0"
+- offset: "0x00123740"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x0005ee80"
+  ptrToThis: "0x0005eea0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice9'
           offset: 0
-- offset: "0x00123640"
+- offset: "0x001236c0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x0005ee40"
+  ptrToThis: "0x0005ee60"
   struct:
     fields:
         - name: a
           type: '[]interface {}'
           offset: 0
-- offset: "0x001c2460"
+- offset: "0x001c2580"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005f080"
+  ptrToThis: "0x0005f0a0"
   struct:
     fields:
         - name: esotericStack (embedded)
@@ -889,13 +915,13 @@
         - name: a
           type: atomic.Int32
           offset: 104
-- offset: "0x001e2c40"
+- offset: "0x001e2d60"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x0005e800"
+  ptrToThis: "0x0005e820"
   struct:
     fields:
         - name: _
@@ -919,13 +945,13 @@
         - name: foo
           type: func()
           offset: 56
-- offset: "0x0015a8a0"
+- offset: "0x0015a920"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000dbba0"
+  ptrToThis: "0x000dbbc0"
   methods:
     - name: DoSomething (exported)
       type: func() string
@@ -934,13 +960,13 @@
         - name: s
           type: string
           offset: 0
-- offset: "0x002034a0"
+- offset: "0x002035c0"
   size: 136
   kind: struct
   nameEntry: main.largeGenericType[int]
   name: main.largeGenericType[int]
   pkg: main
-  ptrToThis: "0x000e9700"
+  ptrToThis: "0x000e9720"
   methods:
     - name: LargeGet (exported)
       type: func() int
@@ -973,13 +999,13 @@
         - name: Value (exported)
           type: int
           offset: 128
-- offset: "0x00203600"
+- offset: "0x00203720"
   size: 144
   kind: struct
   nameEntry: main.largeGenericType[string]
   name: main.largeGenericType[string]
   pkg: main
-  ptrToThis: "0x000e9760"
+  ptrToThis: "0x000e9780"
   methods:
     - name: LargeGet (exported)
       type: func() string
@@ -1012,20 +1038,20 @@
         - name: Value (exported)
           type: string
           offset: 128
-- offset: "0x0008f360"
+- offset: "0x0008f380"
   size: 8
   kind: int
   nameEntry: main.namedInt
   name: main.namedInt
   pkg: main
-  ptrToThis: "0x0005e840"
-- offset: "0x00166e60"
+  ptrToThis: "0x0005e860"
+- offset: "0x00166f80"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005f180"
+  ptrToThis: "0x0005f1a0"
   struct:
     fields:
         - name: anotherInt
@@ -1034,13 +1060,13 @@
         - name: anotherString
           type: string
           offset: 8
-- offset: "0x00166d20"
+- offset: "0x00166e40"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005f0c0"
+  ptrToThis: "0x0005f0e0"
   struct:
     fields:
         - name: val
@@ -1049,44 +1075,44 @@
         - name: b
           type: '*main.node'
           offset: 8
-- offset: "0x00122b40"
+- offset: "0x00122bc0"
   size: 16
   kind: struct
   nameEntry: main.otherFirstBehavior
   name: main.otherFirstBehavior
   pkg: main
-  ptrToThis: "0x0005e880"
+  ptrToThis: "0x0005e8a0"
   struct:
     fields:
         - name: s
           type: string
           offset: 0
-- offset: "0x00122bc0"
+- offset: "0x00122c40"
   size: 8
   kind: struct
   nameEntry: main.otherSecondBehavior
   name: main.otherSecondBehavior
   pkg: main
-  ptrToThis: "0x0005e8c0"
+  ptrToThis: "0x0005e8e0"
   struct:
     fields:
         - name: i
           type: int
           offset: 0
-- offset: "0x0008f3a0"
+- offset: "0x0008f3c0"
   size: 8
   kind: int
   nameEntry: main.score
   name: main.score
   pkg: main
-  ptrToThis: "0x0005e900"
-- offset: "0x0015a940"
+  ptrToThis: "0x0005e920"
+- offset: "0x0015a9c0"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000dbc00"
+  ptrToThis: "0x000dbc20"
   methods:
     - name: DoSomething (exported)
       type: func() string
@@ -1095,13 +1121,13 @@
         - name: i
           type: int
           offset: 0
-- offset: "0x00166dc0"
+- offset: "0x00166ee0"
   size: 16
   kind: struct
   nameEntry: main.smallStruct
   name: main.smallStruct
   pkg: main
-  ptrToThis: "0x0005f100"
+  ptrToThis: "0x0005f120"
   struct:
     fields:
         - name: X (exported)
@@ -1110,68 +1136,68 @@
         - name: Y (exported)
           type: int
           offset: 8
-- offset: "0x000fac40"
+- offset: "0x000facc0"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x0005e740"
+  ptrToThis: "0x0005e760"
   interfaceMethods:
     - name: Do (exported)
       type: func()
-- offset: "0x000f25c0"
+- offset: "0x000f2640"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000dbc60"
+  ptrToThis: "0x000dbc80"
   struct:
     fields: []
-- offset: "0x00122c40"
+- offset: "0x00122cc0"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
   name: main.structWithAny
   pkg: main
-  ptrToThis: "0x0005e940"
+  ptrToThis: "0x0005e960"
   struct:
     fields:
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x00122cc0"
+- offset: "0x00122d40"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005e980"
+  ptrToThis: "0x0005e9a0"
   struct:
     fields:
         - name: m
           type: map[int]int
           offset: 0
-- offset: "0x00123ac0"
+- offset: "0x00123b40"
   size: 16
   kind: struct
   nameEntry: main.tinyStruct
   name: main.tinyStruct
   pkg: main
-  ptrToThis: "0x0005f140"
+  ptrToThis: "0x0005f160"
   struct:
     fields:
         - name: Name (exported)
           type: string
           offset: 0
-- offset: "0x00163f40"
+- offset: "0x00163fc0"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e97c0"
+  ptrToThis: "0x000e97e0"
   methods:
     - name: Guess (exported)
       type: func(int) bool
@@ -1180,13 +1206,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x00163fe0"
+- offset: "0x00164060"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e9820"
+  ptrToThis: "0x000e9840"
   methods:
     - name: Guess (exported)
       type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -1,4 +1,4 @@
-- offset: "0x0010dca0"
+- offset: "0x0010dd20"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[float64] (exported)'
@@ -11,7 +11,7 @@
       type: func(float64)
   pointer:
     elem: lib.Box[float64]
-- offset: "0x0010d9a0"
+- offset: "0x0010da20"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[int] (exported)'
@@ -24,7 +24,7 @@
       type: func(int)
   pointer:
     elem: lib.Box[int]
-- offset: "0x0010da20"
+- offset: "0x0010daa0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Box[string] (exported)'
@@ -37,7 +37,7 @@
       type: func(string)
   pointer:
     elem: lib.Box[string]
-- offset: "0x0010dba0"
+- offset: "0x0010dc20"
   size: 8
   kind: ptr
   nameEntry: '*lib.ImmutableSet[string] (exported)'
@@ -50,7 +50,7 @@
       type: func(string) (*lib.ImmutableSet[string], bool)
   pointer:
     elem: lib.ImmutableSet[string]
-- offset: "0x000eb900"
+- offset: "0x000eb920"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[bool,string] (exported)'
@@ -61,7 +61,7 @@
       type: func() lib.Pair[string,bool]
   pointer:
     elem: lib.Pair[bool,string]
-- offset: "0x000ec200"
+- offset: "0x000ec220"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[float64,float64] (exported)'
@@ -72,7 +72,7 @@
       type: func() lib.Pair[float64,float64]
   pointer:
     elem: lib.Pair[float64,float64]
-- offset: "0x000eb9c0"
+- offset: "0x000eb9e0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[int,string] (exported)'
@@ -83,7 +83,7 @@
       type: func() lib.Pair[string,int]
   pointer:
     elem: lib.Pair[int,string]
-- offset: "0x000eb8a0"
+- offset: "0x000eb8c0"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[string,bool] (exported)'
@@ -94,7 +94,7 @@
       type: func() lib.Pair[bool,string]
   pointer:
     elem: lib.Pair[string,bool]
-- offset: "0x000eb960"
+- offset: "0x000eb980"
   size: 8
   kind: ptr
   nameEntry: '*lib.Pair[string,int] (exported)'
@@ -105,13 +105,13 @@
       type: func() lib.Pair[int,string]
   pointer:
     elem: lib.Pair[string,int]
-- offset: "0x00166f80"
+- offset: "0x00167000"
   size: 8
   kind: struct
   nameEntry: lib.Box[float64] (exported)
   name: lib.Box[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010dca0"
+  ptrToThis: "0x0010dd20"
   methods:
     - name: Get (exported)
       type: func() float64
@@ -120,13 +120,13 @@
         - name: Value (exported)
           type: float64
           offset: 0
-- offset: "0x00166940"
+- offset: "0x001669c0"
   size: 8
   kind: struct
   nameEntry: lib.Box[int] (exported)
   name: lib.Box[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010d9a0"
+  ptrToThis: "0x0010da20"
   methods:
     - name: Get (exported)
       type: func() int
@@ -135,13 +135,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x001669e0"
+- offset: "0x00166a60"
   size: 16
   kind: struct
   nameEntry: lib.Box[string] (exported)
   name: lib.Box[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010da20"
+  ptrToThis: "0x0010daa0"
   methods:
     - name: Get (exported)
       type: func() string
@@ -150,37 +150,37 @@
         - name: Value (exported)
           type: string
           offset: 0
-- offset: "0x00139b20"
+- offset: "0x00139ba0"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[go.shape.string] (exported)
   name: lib.ImmutableSet[go.shape.string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x00076f20"
+  ptrToThis: "0x00076f40"
   struct:
     fields:
         - name: items
           type: map[go.shape.string]bool
           offset: 0
-- offset: "0x00139a20"
+- offset: "0x00139aa0"
   size: 8
   kind: struct
   nameEntry: lib.ImmutableSet[string] (exported)
   name: lib.ImmutableSet[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x0010dba0"
+  ptrToThis: "0x0010dc20"
   struct:
     fields:
         - name: items
           type: map[string]bool
           offset: 0
-- offset: "0x0018e340"
+- offset: "0x0018e460"
   size: 24
   kind: struct
   nameEntry: lib.Pair[bool,string] (exported)
   name: lib.Pair[bool,string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000eb900"
+  ptrToThis: "0x000eb920"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[string,bool]
@@ -192,13 +192,13 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x0018e660"
+- offset: "0x0018e780"
   size: 16
   kind: struct
   nameEntry: lib.Pair[float64,float64] (exported)
   name: lib.Pair[float64,float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000ec200"
+  ptrToThis: "0x000ec220"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[float64,float64]
@@ -210,13 +210,13 @@
         - name: Second (exported)
           type: float64
           offset: 8
-- offset: "0x0018e480"
+- offset: "0x0018e5a0"
   size: 24
   kind: struct
   nameEntry: lib.Pair[int,string] (exported)
   name: lib.Pair[int,string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000eb9c0"
+  ptrToThis: "0x000eb9e0"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[string,int]
@@ -228,13 +228,13 @@
         - name: Second (exported)
           type: string
           offset: 8
-- offset: "0x0018e2a0"
+- offset: "0x0018e3c0"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,bool] (exported)
   name: lib.Pair[string,bool]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000eb8a0"
+  ptrToThis: "0x000eb8c0"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[bool,string]
@@ -246,13 +246,13 @@
         - name: Second (exported)
           type: bool
           offset: 16
-- offset: "0x0018e3e0"
+- offset: "0x0018e500"
   size: 24
   kind: struct
   nameEntry: lib.Pair[string,int] (exported)
   name: lib.Pair[string,int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-  ptrToThis: "0x000eb960"
+  ptrToThis: "0x000eb980"
   methods:
     - name: Swap (exported)
       type: func() lib.Pair[int,string]
@@ -264,7 +264,18 @@
         - name: Second (exported)
           type: int
           offset: 16
-- offset: "0x000de0a0"
+- offset: "0x000ec280"
+  size: 8
+  kind: ptr
+  nameEntry: '*lib_v2.V2GenericBox[int] (exported)'
+  name: '*lib_v2.V2GenericBox[int]'
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  methods:
+    - name: Get (exported)
+      type: func() int
+  pointer:
+    elem: lib_v2.V2GenericBox[int]
+- offset: "0x000de0c0"
   size: 8
   kind: ptr
   nameEntry: '*lib_v2.V2Type (exported)'
@@ -275,16 +286,31 @@
       type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f4a60"
+- offset: "0x001671e0"
+  size: 8
+  kind: struct
+  nameEntry: lib_v2.V2GenericBox[int] (exported)
+  name: lib_v2.V2GenericBox[int]
+  pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+  ptrToThis: "0x000ec280"
+  methods:
+    - name: Get (exported)
+      type: func() int
+  struct:
+    fields:
+        - name: Value (exported)
+          type: int
+          offset: 0
+- offset: "0x000f4ae0"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000de0a0"
+  ptrToThis: "0x000de0c0"
   struct:
     fields: []
-- offset: "0x0010dd20"
+- offset: "0x0010dda0"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[float64] (exported)'
@@ -297,7 +323,7 @@
       type: func() float64
   pointer:
     elem: lib2.Wrapper[float64]
-- offset: "0x0010daa0"
+- offset: "0x0010db20"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[int] (exported)'
@@ -310,7 +336,7 @@
       type: func() int
   pointer:
     elem: lib2.Wrapper[int]
-- offset: "0x0010db20"
+- offset: "0x0010dba0"
   size: 8
   kind: ptr
   nameEntry: '*lib2.Wrapper[string] (exported)'
@@ -323,13 +349,13 @@
       type: func() string
   pointer:
     elem: lib2.Wrapper[string]
-- offset: "0x0018e700"
+- offset: "0x0018e820"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[float64] (exported)
   name: lib2.Wrapper[float64]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010dd20"
+  ptrToThis: "0x0010dda0"
   methods:
     - name: Unwrap (exported)
       type: func() float64
@@ -341,13 +367,13 @@
         - name: Inner (exported)
           type: lib.Box[float64]
           offset: 16
-- offset: "0x0018e520"
+- offset: "0x0018e640"
   size: 24
   kind: struct
   nameEntry: lib2.Wrapper[int] (exported)
   name: lib2.Wrapper[int]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010daa0"
+  ptrToThis: "0x0010db20"
   methods:
     - name: Unwrap (exported)
       type: func() int
@@ -359,13 +385,13 @@
         - name: Inner (exported)
           type: lib.Box[int]
           offset: 16
-- offset: "0x0018e5c0"
+- offset: "0x0018e6e0"
   size: 32
   kind: struct
   nameEntry: lib2.Wrapper[string] (exported)
   name: lib2.Wrapper[string]
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
-  ptrToThis: "0x0010db20"
+  ptrToThis: "0x0010dba0"
   methods:
     - name: Unwrap (exported)
       type: func() string
@@ -377,7 +403,7 @@
         - name: Inner (exported)
           type: lib.Box[string]
           offset: 16
-- offset: "0x000eba20"
+- offset: "0x000eba40"
   size: 8
   kind: ptr
   nameEntry: '*main.Pair[int,bool] (exported)'
@@ -388,7 +414,7 @@
       type: func(int, bool)
   pointer:
     elem: main.Pair[int,bool]
-- offset: "0x000eba80"
+- offset: "0x000ebaa0"
   size: 8
   kind: ptr
   nameEntry: '*main.Pair[string,int] (exported)'
@@ -399,7 +425,7 @@
       type: func(string, int)
   pointer:
     elem: main.Pair[string,int]
-- offset: "0x000ddbc0"
+- offset: "0x000ddbe0"
   size: 8
   kind: ptr
   nameEntry: '*main.firstBehavior'
@@ -410,7 +436,7 @@
       type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000ebae0"
+- offset: "0x000ebb00"
   size: 8
   kind: ptr
   nameEntry: '*main.largeGenericType[int]'
@@ -421,7 +447,7 @@
       type: func() int
   pointer:
     elem: main.largeGenericType[int]
-- offset: "0x000ebb40"
+- offset: "0x000ebb60"
   size: 8
   kind: ptr
   nameEntry: '*main.largeGenericType[string]'
@@ -432,7 +458,7 @@
       type: func() string
   pointer:
     elem: main.largeGenericType[string]
-- offset: "0x000ddc20"
+- offset: "0x000ddc40"
   size: 8
   kind: ptr
   nameEntry: '*main.secondBehavior'
@@ -443,7 +469,7 @@
       type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000ddc80"
+- offset: "0x000ddca0"
   size: 8
   kind: ptr
   nameEntry: '*main.somethingImpl'
@@ -454,7 +480,7 @@
       type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000ebba0"
+- offset: "0x000ebbc0"
   size: 8
   kind: ptr
   nameEntry: '*main.typeWithGenerics[int]'
@@ -465,7 +491,7 @@
       type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000ebc00"
+- offset: "0x000ebc20"
   size: 8
   kind: ptr
   nameEntry: '*main.typeWithGenerics[string]'
@@ -476,13 +502,13 @@
       type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x0017cc60"
+- offset: "0x0017cd80"
   size: 16
   kind: struct
   nameEntry: main.Pair[int,bool] (exported)
   name: main.Pair[int,bool]
   pkg: main
-  ptrToThis: "0x000eba20"
+  ptrToThis: "0x000eba40"
   struct:
     fields:
         - name: Key (exported)
@@ -491,13 +517,13 @@
         - name: Value (exported)
           type: bool
           offset: 8
-- offset: "0x0017cd00"
+- offset: "0x0017ce20"
   size: 24
   kind: struct
   nameEntry: main.Pair[string,int] (exported)
   name: main.Pair[string,int]
   pkg: main
-  ptrToThis: "0x000eba80"
+  ptrToThis: "0x000ebaa0"
   struct:
     fields:
         - name: Key (exported)
@@ -506,23 +532,23 @@
         - name: Value (exported)
           type: int
           offset: 16
-- offset: "0x000fce20"
+- offset: "0x000fcea0"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x0005fa60"
+  ptrToThis: "0x0005fa80"
   interfaceMethods:
     - name: DoSomething (exported)
       type: func() string
-- offset: "0x0018f980"
+- offset: "0x0018faa0"
   size: 48
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x0005fae0"
+  ptrToThis: "0x0005fb00"
   struct:
     fields:
         - name: x
@@ -534,344 +560,344 @@
         - name: writer
           type: io.Writer
           offset: 32
-- offset: "0x00090940"
+- offset: "0x00090960"
   size: 8
   kind: int
   nameEntry: main.celsius
   name: main.celsius
   pkg: main
-  ptrToThis: "0x0005fb20"
-- offset: "0x00124fa0"
+  ptrToThis: "0x0005fb40"
+- offset: "0x00125020"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x0005ff20"
+  ptrToThis: "0x0005ff40"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap2
           offset: 0
-- offset: "0x00124f20"
+- offset: "0x00124fa0"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x0005fee0"
+  ptrToThis: "0x0005ff00"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap3
           offset: 0
-- offset: "0x00124ea0"
+- offset: "0x00124f20"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x0005fea0"
+  ptrToThis: "0x0005fec0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap4
           offset: 0
-- offset: "0x00124e20"
+- offset: "0x00124ea0"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x0005fe60"
+  ptrToThis: "0x0005fe80"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap5
           offset: 0
-- offset: "0x00124da0"
+- offset: "0x00124e20"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x0005fe20"
+  ptrToThis: "0x0005fe40"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap6
           offset: 0
-- offset: "0x00124d20"
+- offset: "0x00124da0"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x0005fde0"
+  ptrToThis: "0x0005fe00"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap7
           offset: 0
-- offset: "0x00124ca0"
+- offset: "0x00124d20"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x0005fda0"
+  ptrToThis: "0x0005fdc0"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap8
           offset: 0
-- offset: "0x00124c20"
+- offset: "0x00124ca0"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x0005fd60"
+  ptrToThis: "0x0005fd80"
   struct:
     fields:
         - name: a
           type: map[int]*main.deepMap9
           offset: 0
-- offset: "0x00124ba0"
+- offset: "0x00124c20"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x0005fd20"
+  ptrToThis: "0x0005fd40"
   struct:
     fields:
         - name: a
           type: map[int]interface {}
           offset: 0
-- offset: "0x00125420"
+- offset: "0x001254a0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x00060160"
+  ptrToThis: "0x00060180"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr2'
           offset: 0
-- offset: "0x001253a0"
+- offset: "0x00125420"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x00060120"
+  ptrToThis: "0x00060140"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr3'
           offset: 0
-- offset: "0x00125320"
+- offset: "0x001253a0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x000600e0"
+  ptrToThis: "0x00060100"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr4'
           offset: 0
-- offset: "0x001252a0"
+- offset: "0x00125320"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x000600a0"
+  ptrToThis: "0x000600c0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr5'
           offset: 0
-- offset: "0x00125220"
+- offset: "0x001252a0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x00060060"
+  ptrToThis: "0x00060080"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr6'
           offset: 0
-- offset: "0x001251a0"
+- offset: "0x00125220"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x00060020"
+  ptrToThis: "0x00060040"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr7'
           offset: 0
-- offset: "0x00125120"
+- offset: "0x001251a0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x0005ffe0"
+  ptrToThis: "0x00060000"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr8'
           offset: 0
-- offset: "0x001250a0"
+- offset: "0x00125120"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x0005ffa0"
+  ptrToThis: "0x0005ffc0"
   struct:
     fields:
         - name: a
           type: '*main.deepPtr9'
           offset: 0
-- offset: "0x00125020"
+- offset: "0x001250a0"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x0005ff60"
+  ptrToThis: "0x0005ff80"
   struct:
     fields:
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x001258a0"
+- offset: "0x00125920"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x000603a0"
+  ptrToThis: "0x000603c0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice2'
           offset: 0
-- offset: "0x00125820"
+- offset: "0x001258a0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x00060360"
+  ptrToThis: "0x00060380"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice3'
           offset: 0
-- offset: "0x001257a0"
+- offset: "0x00125820"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x00060320"
+  ptrToThis: "0x00060340"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice4'
           offset: 0
-- offset: "0x00125720"
+- offset: "0x001257a0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x000602e0"
+  ptrToThis: "0x00060300"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice5'
           offset: 0
-- offset: "0x001256a0"
+- offset: "0x00125720"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x000602a0"
+  ptrToThis: "0x000602c0"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice6'
           offset: 0
-- offset: "0x00125620"
+- offset: "0x001256a0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x00060260"
+  ptrToThis: "0x00060280"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice7'
           offset: 0
-- offset: "0x001255a0"
+- offset: "0x00125620"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x00060220"
+  ptrToThis: "0x00060240"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice8'
           offset: 0
-- offset: "0x00125520"
+- offset: "0x001255a0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x000601e0"
+  ptrToThis: "0x00060200"
   struct:
     fields:
         - name: a
           type: '[]*main.deepSlice9'
           offset: 0
-- offset: "0x001254a0"
+- offset: "0x00125520"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x000601a0"
+  ptrToThis: "0x000601c0"
   struct:
     fields:
         - name: a
           type: '[]interface {}'
           offset: 0
-- offset: "0x001c6aa0"
+- offset: "0x001c6bc0"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x000603e0"
+  ptrToThis: "0x00060400"
   struct:
     fields:
         - name: esotericStack (embedded)
@@ -889,13 +915,13 @@
         - name: a
           type: atomic.Int32
           offset: 104
-- offset: "0x001e7bc0"
+- offset: "0x001e7ce0"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x0005fb60"
+  ptrToThis: "0x0005fb80"
   struct:
     fields:
         - name: _
@@ -919,13 +945,13 @@
         - name: foo
           type: func()
           offset: 56
-- offset: "0x0015d200"
+- offset: "0x0015d280"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000ddbc0"
+  ptrToThis: "0x000ddbe0"
   methods:
     - name: DoSomething (exported)
       type: func() string
@@ -934,13 +960,13 @@
         - name: s
           type: string
           offset: 0
-- offset: "0x00208840"
+- offset: "0x00208960"
   size: 136
   kind: struct
   nameEntry: main.largeGenericType[int]
   name: main.largeGenericType[int]
   pkg: main
-  ptrToThis: "0x000ebae0"
+  ptrToThis: "0x000ebb00"
   methods:
     - name: LargeGet (exported)
       type: func() int
@@ -973,13 +999,13 @@
         - name: Value (exported)
           type: int
           offset: 128
-- offset: "0x002089a0"
+- offset: "0x00208ac0"
   size: 144
   kind: struct
   nameEntry: main.largeGenericType[string]
   name: main.largeGenericType[string]
   pkg: main
-  ptrToThis: "0x000ebb40"
+  ptrToThis: "0x000ebb60"
   methods:
     - name: LargeGet (exported)
       type: func() string
@@ -1012,20 +1038,20 @@
         - name: Value (exported)
           type: string
           offset: 128
-- offset: "0x00090980"
+- offset: "0x000909a0"
   size: 8
   kind: int
   nameEntry: main.namedInt
   name: main.namedInt
   pkg: main
-  ptrToThis: "0x0005fba0"
-- offset: "0x00169a20"
+  ptrToThis: "0x0005fbc0"
+- offset: "0x00169b40"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x000604e0"
+  ptrToThis: "0x00060500"
   struct:
     fields:
         - name: anotherInt
@@ -1034,13 +1060,13 @@
         - name: anotherString
           type: string
           offset: 8
-- offset: "0x001698e0"
+- offset: "0x00169a00"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x00060420"
+  ptrToThis: "0x00060440"
   struct:
     fields:
         - name: val
@@ -1049,44 +1075,44 @@
         - name: b
           type: '*main.node'
           offset: 8
-- offset: "0x001249a0"
+- offset: "0x00124a20"
   size: 16
   kind: struct
   nameEntry: main.otherFirstBehavior
   name: main.otherFirstBehavior
   pkg: main
-  ptrToThis: "0x0005fbe0"
+  ptrToThis: "0x0005fc00"
   struct:
     fields:
         - name: s
           type: string
           offset: 0
-- offset: "0x00124a20"
+- offset: "0x00124aa0"
   size: 8
   kind: struct
   nameEntry: main.otherSecondBehavior
   name: main.otherSecondBehavior
   pkg: main
-  ptrToThis: "0x0005fc20"
+  ptrToThis: "0x0005fc40"
   struct:
     fields:
         - name: i
           type: int
           offset: 0
-- offset: "0x000909c0"
+- offset: "0x000909e0"
   size: 8
   kind: int
   nameEntry: main.score
   name: main.score
   pkg: main
-  ptrToThis: "0x0005fc60"
-- offset: "0x0015d2a0"
+  ptrToThis: "0x0005fc80"
+- offset: "0x0015d320"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000ddc20"
+  ptrToThis: "0x000ddc40"
   methods:
     - name: DoSomething (exported)
       type: func() string
@@ -1095,13 +1121,13 @@
         - name: i
           type: int
           offset: 0
-- offset: "0x00169980"
+- offset: "0x00169aa0"
   size: 16
   kind: struct
   nameEntry: main.smallStruct
   name: main.smallStruct
   pkg: main
-  ptrToThis: "0x00060460"
+  ptrToThis: "0x00060480"
   struct:
     fields:
         - name: X (exported)
@@ -1110,68 +1136,68 @@
         - name: Y (exported)
           type: int
           offset: 8
-- offset: "0x000fcea0"
+- offset: "0x000fcf20"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x0005faa0"
+  ptrToThis: "0x0005fac0"
   interfaceMethods:
     - name: Do (exported)
       type: func()
-- offset: "0x000f48e0"
+- offset: "0x000f4960"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000ddc80"
+  ptrToThis: "0x000ddca0"
   struct:
     fields: []
-- offset: "0x00124aa0"
+- offset: "0x00124b20"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
   name: main.structWithAny
   pkg: main
-  ptrToThis: "0x0005fca0"
+  ptrToThis: "0x0005fcc0"
   struct:
     fields:
         - name: a
           type: interface {}
           offset: 0
-- offset: "0x00124b20"
+- offset: "0x00124ba0"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005fce0"
+  ptrToThis: "0x0005fd00"
   struct:
     fields:
         - name: m
           type: map[int]int
           offset: 0
-- offset: "0x00125920"
+- offset: "0x001259a0"
   size: 16
   kind: struct
   nameEntry: main.tinyStruct
   name: main.tinyStruct
   pkg: main
-  ptrToThis: "0x000604a0"
+  ptrToThis: "0x000604c0"
   struct:
     fields:
         - name: Name (exported)
           type: string
           offset: 0
-- offset: "0x00166a80"
+- offset: "0x00166b00"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000ebba0"
+  ptrToThis: "0x000ebbc0"
   methods:
     - name: Guess (exported)
       type: func(int) bool
@@ -1180,13 +1206,13 @@
         - name: Value (exported)
           type: int
           offset: 0
-- offset: "0x00166b20"
+- offset: "0x00166ba0"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000ebc00"
+  ptrToThis: "0x000ebc20"
   methods:
     - name: Guess (exported)
       type: func(string) bool

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xd0c9aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0caca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1400 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xd0c9e5", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cb05", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1238 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0xd06e4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06f6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1239 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0xd06e85", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06fa5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1241 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0xd06eea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0700a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1242 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0xd06f1d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0703d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xd0b3ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b4ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1371 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0b482", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b5a2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1188 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0xd03d00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03e20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1184 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0xd03c80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03da0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1186 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0xd03cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1250 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xd07660", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1185 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0xd03ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03dc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1187 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0xd03ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1272 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xd09380", Frameless: true}]
+              InjectionPoints: [{PC: "0xd094a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1273 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xd09392", Frameless: true}]
+              InjectionPoints: [{PC: "0xd094b2", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1206 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0xd04400", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04520", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1207 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0xd0441e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0453e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1173 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0xd03b20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03c40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1170 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0xd03ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xd0cde0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cf00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1419 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xd0ce02", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cf22", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1479 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xd0666e"
+                - PC: "0xd0678e"
                   Frameless: false
-                - PC: "0xd066f1"
+                - PC: "0xd06811"
                   Frameless: false
-                - PC: "0xd06832"
+                - PC: "0xd06952"
                   Frameless: false
-                - PC: "0xd068bc"
+                - PC: "0xd069dc"
                   Frameless: false
-                - PC: "0xd0698f"
+                - PC: "0xd06aaf"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1480 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xd0666e"
+                - PC: "0xd0678e"
                   Frameless: false
-                - PC: "0xd066f1"
+                - PC: "0xd06811"
                   Frameless: false
-                - PC: "0xd06832"
+                - PC: "0xd06952"
                   Frameless: false
-                - PC: "0xd068bc"
+                - PC: "0xd069dc"
                   Frameless: false
-                - PC: "0xd0698f"
+                - PC: "0xd06aaf"
                   Frameless: false
               Condition:
                 Type: 4 BaseType bool
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 1481 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xd0666e"
+                - PC: "0xd0678e"
                   Frameless: false
-                - PC: "0xd066f1"
+                - PC: "0xd06811"
                   Frameless: false
-                - PC: "0xd06832"
+                - PC: "0xd06952"
                   Frameless: false
-                - PC: "0xd068bc"
+                - PC: "0xd069dc"
                   Frameless: false
-                - PC: "0xd0698f"
+                - PC: "0xd06aaf"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -474,7 +474,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1269 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xd08fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09100", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -493,7 +493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1270 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xd08fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -519,7 +519,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xd0cf00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0d020", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -554,7 +554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1274 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xd093a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd094c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -584,7 +584,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1268 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xd08fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd090c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -613,11 +613,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1335 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xd0a62e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a74e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1336 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xd0a6f4", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a814", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -639,7 +639,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1282 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xd09780", Frameless: true}]
+              InjectionPoints: [{PC: "0xd098a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -661,7 +661,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1213 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0xd04900", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -683,7 +683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1214 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0xd04920", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -705,7 +705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1209 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0xd045e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -727,7 +727,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1210 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0xd04600", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -749,7 +749,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1211 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0xd04780", Frameless: true}]
+              InjectionPoints: [{PC: "0xd048a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -771,7 +771,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1212 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0xd047a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd048c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -793,7 +793,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xd0c4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -820,7 +820,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xd0c520", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -848,7 +848,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1413 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xd0cae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cc00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -870,7 +870,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xd0cf60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0d080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -891,7 +891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xd0cf80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0d0a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -913,7 +913,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1240 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0xd06ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06fe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -947,7 +947,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1208 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0xd0449b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd045bb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -975,11 +975,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1222 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0xd0514a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0526a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1223 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0xd0518c", Frameless: false}]
+              InjectionPoints: [{PC: "0xd052ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1001,11 +1001,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1220 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0xd0502e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0514e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1221 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0xd050bb", Frameless: false}]
+              InjectionPoints: [{PC: "0xd051db", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1027,11 +1027,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1232 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0xd06b20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06c40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1233 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0xd06b25", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06c45", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1053,11 +1053,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1234 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0xd06b44", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06c64", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1235 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0xd06b7d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06c9d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1082,7 +1082,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1236 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0xd06b48", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06c68", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1104,11 +1104,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xd0fb80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0fca0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1466 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd0fb87", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0fca7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1122,11 +1122,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xd0fba4", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fcc4", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1468 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xd0fbf1", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fd11", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1149,11 +1149,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xd0faea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fc0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1462 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xd0faf9", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fc19", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1167,11 +1167,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xd0fb2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fc4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1464 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xd0fb42", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fc62", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1194,14 +1194,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xd0fc00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0fd20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1470 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xd0fc20"
+                - PC: "0xd0fd40"
                   Frameless: true
-                - PC: "0xd0fc23"
+                - PC: "0xd0fd43"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1216,14 +1216,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xd0fc4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fd6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1472 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xd0fcab"
+                - PC: "0xd0fdcb"
                   Frameless: false
-                - PC: "0xd0fcb3"
+                - PC: "0xd0fdd3"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1250,7 +1250,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1473 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xd0fc05", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0fd25", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1262,7 +1262,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1474 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xd0fc5f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fd7f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1283,11 +1283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xd0f7a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f8c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1450 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xd0f7b0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f8d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1301,11 +1301,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xd0f840", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f960", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1452 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xd0f848", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f968", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1329,11 +1329,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xd0f32e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f44e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1438 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd0f414", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f534", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1375,11 +1375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xd0f46a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f58a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1442 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd0f479", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f599", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1402,11 +1402,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xd0fd00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0fe20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1476 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xd0fd06", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0fe26", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1420,11 +1420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xd0fd8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0feaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1478 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xd0fdad", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fecd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1447,11 +1447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xd0f280", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f3a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1434 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd0f283", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f3a3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1465,11 +1465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xd0f2a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f3c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1436 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd0f2ab", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f3cb", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1492,11 +1492,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xd0f900", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0fa20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1454 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xd0f907", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0fa27", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1510,11 +1510,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xd0f9aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0faca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1456 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xd0f9d6", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0faf6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1537,11 +1537,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xd0f740", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f860", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1444 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd0f743", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f863", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1555,11 +1555,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xd0f760", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f880", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1446 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xd0f763", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f883", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1573,11 +1573,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xd0f780", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f8a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1448 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xd0f783", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f8a3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1600,11 +1600,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xd0faa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0fbc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1458 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xd0faa7", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0fbc7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1618,11 +1618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xd0fac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0fbe0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1460 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd0face", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0fbee", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1645,11 +1645,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xd0f240", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f360", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1430 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd0f243", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f363", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1663,11 +1663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xd0f260", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f380", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1432 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd0f26b", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f38b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1690,11 +1690,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1224 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0xd0680a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0692a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1225 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0xd0686e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0698e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1721,11 +1721,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1226 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0xd068ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd069ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1227 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0xd0693e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06a5e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1752,11 +1752,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1228 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0xd0698a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06aaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1229 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0xd069cb", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06aeb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1778,7 +1778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1485 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0xd06906", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06a26", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1796,11 +1796,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1230 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0xd06a0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06b2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1231 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0xd06afe", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06c1e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1818,7 +1818,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0xd06a13", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06b33", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1839,7 +1839,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1487 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0xd06a13", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06b33", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1857,7 +1857,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0xd06ac6", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06be6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1878,7 +1878,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1489 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0xd06ac6", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06be6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1899,7 +1899,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x51e6d2"
                   Frameless: true
-                - PC: "0xd074eb"
+                - PC: "0xd07610"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1920,20 +1920,20 @@ Probes:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0xd0666a"
+                - PC: "0xd0678a"
                   Frameless: false
-                - PC: "0xd066f1"
+                - PC: "0xd06811"
                   Frameless: false
-                - PC: "0xd06832"
+                - PC: "0xd06952"
                   Frameless: false
-                - PC: "0xd068bc"
+                - PC: "0xd069dc"
                   Frameless: false
-                - PC: "0xd0698f"
+                - PC: "0xd06aaf"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1483 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0xd066aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd067ca", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1959,15 +1959,15 @@ Probes:
             - Kind: Line
               Type: 1484 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xd0666e"
+                - PC: "0xd0678e"
                   Frameless: false
-                - PC: "0xd066f1"
+                - PC: "0xd06811"
                   Frameless: false
-                - PC: "0xd06832"
+                - PC: "0xd06952"
                   Frameless: false
-                - PC: "0xd068bc"
+                - PC: "0xd069dc"
                   Frameless: false
-                - PC: "0xd0698f"
+                - PC: "0xd06aaf"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1990,7 +1990,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0xd06b21", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06c41", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2015,7 +2015,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1491 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0xd06b21", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06c41", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2039,9 +2039,9 @@ Probes:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0xd06b65"
+                - PC: "0xd06c85"
                   Frameless: false
-                - PC: "0xd06c05"
+                - PC: "0xd06d25"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2064,7 +2064,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1176 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0xd03b80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03ca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2086,7 +2086,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1177 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0xd03ba0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03cc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2108,7 +2108,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1178 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0xd03bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03ce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2130,7 +2130,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1175 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0xd03b60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03c80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2152,7 +2152,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1174 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0xd03b40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03c60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2174,7 +2174,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1237 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0xd06e20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06f40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2195,11 +2195,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xd0b24e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b36e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1369 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0b393", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b4b3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2221,7 +2221,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1276 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xd095a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd096c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2246,7 +2246,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1217 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xd0499a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd04aba", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2268,7 +2268,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1218 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xd04a4d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd04b6d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2290,7 +2290,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1219 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xd04b14", Frameless: false}]
+              InjectionPoints: [{PC: "0xd04c34", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2333,11 +2333,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xd0b6f3", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b813", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1375 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xd0b902", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ba22", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2399,7 +2399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1248 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xd07620", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2421,7 +2421,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1255 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xd076e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2443,7 +2443,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1265 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xd07820", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2465,7 +2465,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1267 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xd07860", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2487,7 +2487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1266 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xd07840", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2509,7 +2509,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1252 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xd076a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd077c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2531,7 +2531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1264 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xd07800", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2553,7 +2553,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1263 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xd077e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2577,7 +2577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1253 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xd076c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd077e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2601,7 +2601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1254 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xd076c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd077e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2623,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1262 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xd077c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd078e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2645,7 +2645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1261 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xd077a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd078c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2667,7 +2667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1246 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xd075e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2689,7 +2689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1247 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xd07600", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2711,7 +2711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1245 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xd075c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd076e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2733,7 +2733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1256 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xd07700", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2755,7 +2755,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1259 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xd07760", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2777,7 +2777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1260 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xd07780", Frameless: true}]
+              InjectionPoints: [{PC: "0xd078a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2799,7 +2799,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1257 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xd07720", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2823,7 +2823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1258 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xd07740", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2845,7 +2845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xd0caa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cbc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2868,7 +2868,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1411 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xd0caa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cbc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2915,11 +2915,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xd0b993", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bab3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1377 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xd0bbcb", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bceb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2985,11 +2985,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xd0bd0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0be2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1381 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xd0bdd6", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bef6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3020,11 +3020,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xd0b4ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b5ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1373 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xd0b6ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b7ea", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3050,11 +3050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1313 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0a46e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a58e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1314 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a50f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a62f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3090,7 +3090,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1271 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xd09160", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3131,11 +3131,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1307 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xd0a3ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a4ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1308 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a435", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a555", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3159,11 +3159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1309 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xd0a3ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a4ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1310 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a435", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a555", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3182,11 +3182,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1315 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0a46e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a58e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1316 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a50f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a62f", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3206,11 +3206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1317 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0a46e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a58e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1318 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a50f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a62f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3243,11 +3243,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1311 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xd0a3ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a4ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1312 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a435", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a555", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3275,7 +3275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0cee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0d000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3300,7 +3300,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0cee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0d000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3331,7 +3331,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1424 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0cee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0d000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3356,7 +3356,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0cee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0d000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3383,7 +3383,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1281 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xd09740", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3410,7 +3410,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xd0c5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c6c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3437,7 +3437,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xd0c540", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3472,7 +3472,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xd0c580", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c6a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3504,7 +3504,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xd0ca80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3526,7 +3526,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1277 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xd095c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd096e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3548,7 +3548,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1251 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xd07680", Frameless: true}]
+              InjectionPoints: [{PC: "0xd077a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3570,7 +3570,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1275 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xd09580", Frameless: true}]
+              InjectionPoints: [{PC: "0xd096a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3594,11 +3594,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1283 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd09c8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09daa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1284 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd09cdb", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09dfb", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3618,11 +3618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1327 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0a54e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a66e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1328 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a5ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a70e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3663,11 +3663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1293 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xd09dae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09ece", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1294 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xd09e64", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09f84", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3705,11 +3705,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1285 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd09c8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09daa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1286 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd09cdb", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09dfb", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3750,11 +3750,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1295 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xd09dae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09ece", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1296 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xd09e64", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09f84", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3794,11 +3794,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1329 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0a54e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a66e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1330 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a5ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a70e", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3815,11 +3815,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1331 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0a54e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a66e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1332 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a5ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a70e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3841,11 +3841,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1287 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd09c8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09daa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1288 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd09cdb", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09dfb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3868,18 +3868,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1303 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xd0a04e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a16e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1304 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xd0a104"
+                - PC: "0xd0a224"
                   Frameless: false
-                - PC: "0xd0a13f"
+                - PC: "0xd0a25f"
                   Frameless: false
-                - PC: "0xd0a202"
+                - PC: "0xd0a322"
                   Frameless: false
-                - PC: "0xd0a20c"
+                - PC: "0xd0a32c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3907,18 +3907,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1301 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xd09eee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a00e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1302 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xd09f58"
+                - PC: "0xd0a078"
                   Frameless: false
-                - PC: "0xd09f93"
+                - PC: "0xd0a0b3"
                   Frameless: false
-                - PC: "0xd09fc7"
+                - PC: "0xd0a0e7"
                   Frameless: false
-                - PC: "0xd09ff9"
+                - PC: "0xd0a119"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3945,11 +3945,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1346 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xd0acea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ae0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1347 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xd0ad4d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ae6d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3966,11 +3966,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1348 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xd0ad6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ae8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1349 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xd0adab", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0aecb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3987,11 +3987,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1350 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xd0adca", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0aeea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1351 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xd0ae06", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0af26", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4008,11 +4008,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1354 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xd0aeae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0afce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1355 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xd0af2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b04a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4029,11 +4029,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xd0b1ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b30a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1367 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xd0b230", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b350", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4050,11 +4050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1342 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xd0abaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0acca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1343 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xd0ac06", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ad26", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4072,14 +4072,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1299 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xd09e8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09faa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1300 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xd09eba"
+                - PC: "0xd09fda"
                   Frameless: false
-                - PC: "0xd09ec5"
+                - PC: "0xd09fe5"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4101,11 +4101,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1289 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd09c8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09daa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1290 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd09cdb", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09dfb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4126,11 +4126,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1297 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xd09dae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09ece", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1298 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xd09e64", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09f84", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4151,11 +4151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1291 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xd09d0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09e2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1292 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xd09d7b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09e9b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4177,14 +4177,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1305 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xd0a24e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a36e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1306 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xd0a331"
+                - PC: "0xd0a451"
                   Frameless: false
-                - PC: "0xd0a33b"
+                - PC: "0xd0a45b"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4206,11 +4206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1344 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xd0ac2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ad4e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1345 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xd0acb3", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0add3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4227,11 +4227,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1340 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xd0aaae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0abce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1341 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xd0ab85", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0aca5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4248,11 +4248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1358 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xd0b00a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b12a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1359 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xd0b06c", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b18c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4269,11 +4269,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1352 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xd0ae2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0af4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1353 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xd0ae78", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0af98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4290,11 +4290,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1364 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xd0b16a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b28a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1365 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xd0b1b6", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b2d6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4314,7 +4314,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1337 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xd0a82f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a94f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4335,11 +4335,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1362 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xd0b10a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b22a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1363 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xd0b14e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b26e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4356,11 +4356,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1338 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xd0aa2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ab4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1339 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xd0aa91", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0abb1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4377,11 +4377,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1360 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xd0b08a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b1aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1361 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xd0b0ed", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b20d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4398,11 +4398,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1356 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xd0af4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b06e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1357 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xd0afd4", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b0f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4420,7 +4420,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1171 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0xd03ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1319 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0a46e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a58e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1320 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a50f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a62f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4505,7 +4505,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1192 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0xd04100", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4527,7 +4527,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1190 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0xd040c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd041e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4549,7 +4549,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1203 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0xd04260", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4567,7 +4567,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1204 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0xd04280", Frameless: true}]
+              InjectionPoints: [{PC: "0xd043a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1193 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0xd04120", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1195 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0xd04160", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4630,7 +4630,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1196 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0xd04180", Frameless: true}]
+              InjectionPoints: [{PC: "0xd042a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4652,7 +4652,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1197 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0xd041a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd042c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4681,7 +4681,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1194 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0xd04140", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4712,7 +4712,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1191 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0xd040e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4734,7 +4734,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xd0ca00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cb20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4756,7 +4756,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1198 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0xd041c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd042e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4778,7 +4778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1200 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0xd04200", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4800,7 +4800,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1201 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0xd04220", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4822,7 +4822,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1202 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0xd04240", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4844,7 +4844,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1199 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0xd041e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4866,7 +4866,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xd0c5e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4888,7 +4888,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xd0c4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4910,7 +4910,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1249 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xd07640", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4931,11 +4931,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1333 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0a54e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a66e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1334 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a5ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a70e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4956,11 +4956,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xd0bc6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bd8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1379 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xd0bcdc", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bdfc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4982,7 +4982,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1172 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0xd03b00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03c20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5004,7 +5004,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1280 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xd09700", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5026,7 +5026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xd0c560", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5048,7 +5048,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1215 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0xd04940", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5070,7 +5070,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1216 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0xd04960", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5092,11 +5092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xd0cde0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cf00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1421 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xd0ce02", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cf22", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5123,7 +5123,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xd0c500", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5150,7 +5150,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1243 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0xd06f40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5171,11 +5171,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xd0be0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bf2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1383 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xd0beba", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bfda", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5197,11 +5197,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xd0cca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cdc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xd0ccbe", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cdde", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5222,7 +5222,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xd0cc80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cda0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5249,7 +5249,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1244 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xd075a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd076c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5281,7 +5281,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xd0c600", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5321,7 +5321,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xd0cb00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cc20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5354,11 +5354,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1321 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0a46e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a58e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1322 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a50f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a62f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5379,11 +5379,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1323 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0a46e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a58e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1324 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a50f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a62f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5406,11 +5406,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1325 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0a46e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a58e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1326 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0a50f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0a62f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5439,7 +5439,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1402 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xd0ca20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cb40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5471,11 +5471,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xd0ca40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cb60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1404 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xd0ca5e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cb7e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5505,11 +5505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xd0ca40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cb60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1406 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xd0ca5e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cb7e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5541,7 +5541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1407 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xd0ca60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cb80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xd0ca60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cb80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1205 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0xd042a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd043c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5625,7 +5625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1181 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0xd03c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03d40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5647,7 +5647,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1182 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0xd03c40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5669,7 +5669,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1183 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0xd03c60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03d80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5691,7 +5691,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1180 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0xd03c00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03d20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5713,7 +5713,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1179 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0xd03be0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03d00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5735,7 +5735,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1279 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xd09620", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5757,7 +5757,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xd0c4a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5779,7 +5779,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xd0cac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0cbe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5801,7 +5801,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1278 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xd095e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5823,7 +5823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1189 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0xd03d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5845,7 +5845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xd0c5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c6e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5867,7 +5867,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xd0c5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c6e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5890,14 +5890,14 @@ Probes:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0xd06d4a"
+                - PC: "0xd06e6a"
                   Frameless: false
-                - PC: "0xd0fea3"
+                - PC: "0xd0ffc3"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1494 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0xd06d90", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06eb0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5919,11 +5919,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xd0beee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c00e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1385 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0bf6c", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c08c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5940,383 +5940,266 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0xd03ac0..0xd03ac1]
+      OutOfLinePCRanges: [0xd03be0..0xd03be1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 102 ArrayType [2]uint8
           Locations:
-            - Range: 0xd03ac0..0xd03ac1
+            - Range: 0xd03be0..0xd03be1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0xd03ae0..0xd03ae1]
+      OutOfLinePCRanges: [0xd03c00..0xd03c01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 ArrayType [2]int32
           Locations:
-            - Range: 0xd03ae0..0xd03ae1
+            - Range: 0xd03c00..0xd03c01
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0xd03b00..0xd03b01]
+      OutOfLinePCRanges: [0xd03c20..0xd03c21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 104 ArrayType [2]string
           Locations:
-            - Range: 0xd03b00..0xd03b01
+            - Range: 0xd03c20..0xd03c21
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0xd03b20..0xd03b21]
+      OutOfLinePCRanges: [0xd03c40..0xd03c41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 ArrayType [2]bool
           Locations:
-            - Range: 0xd03b20..0xd03b21
+            - Range: 0xd03c40..0xd03c41
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0xd03b40..0xd03b41]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 106 ArrayType [2]int
-          Locations:
-            - Range: 0xd03b40..0xd03b41
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 6
-      Name: main.testInt8Array
-      OutOfLinePCRanges: [0xd03b60..0xd03b61]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 107 ArrayType [2]int8
-          Locations:
-            - Range: 0xd03b60..0xd03b61
-              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 7
-      Name: main.testInt16Array
-      OutOfLinePCRanges: [0xd03b80..0xd03b81]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 108 ArrayType [2]int16
-          Locations:
-            - Range: 0xd03b80..0xd03b81
-              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 8
-      Name: main.testInt32Array
-      OutOfLinePCRanges: [0xd03ba0..0xd03ba1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 103 ArrayType [2]int32
-          Locations:
-            - Range: 0xd03ba0..0xd03ba1
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 9
-      Name: main.testInt64Array
-      OutOfLinePCRanges: [0xd03bc0..0xd03bc1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 109 ArrayType [2]int64
-          Locations:
-            - Range: 0xd03bc0..0xd03bc1
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 10
-      Name: main.testUintArray
-      OutOfLinePCRanges: [0xd03be0..0xd03be1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 110 ArrayType [2]uint
-          Locations:
-            - Range: 0xd03be0..0xd03be1
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 11
-      Name: main.testUint8Array
-      OutOfLinePCRanges: [0xd03c00..0xd03c01]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 102 ArrayType [2]uint8
-          Locations:
-            - Range: 0xd03c00..0xd03c01
-              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 12
-      Name: main.testUint16Array
-      OutOfLinePCRanges: [0xd03c20..0xd03c21]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 111 ArrayType [2]uint16
-          Locations:
-            - Range: 0xd03c20..0xd03c21
-              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 13
-      Name: main.testUint32Array
-      OutOfLinePCRanges: [0xd03c40..0xd03c41]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 112 ArrayType [2]uint32
-          Locations:
-            - Range: 0xd03c40..0xd03c41
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 14
-      Name: main.testUint64Array
       OutOfLinePCRanges: [0xd03c60..0xd03c61]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 52 ArrayType [2]uint64
+          Type: 106 ArrayType [2]int
           Locations:
             - Range: 0xd03c60..0xd03c61
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 6
+      Name: main.testInt8Array
+      OutOfLinePCRanges: [0xd03c80..0xd03c81]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 107 ArrayType [2]int8
+          Locations:
+            - Range: 0xd03c80..0xd03c81
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 7
+      Name: main.testInt16Array
+      OutOfLinePCRanges: [0xd03ca0..0xd03ca1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 108 ArrayType [2]int16
+          Locations:
+            - Range: 0xd03ca0..0xd03ca1
+              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 8
+      Name: main.testInt32Array
+      OutOfLinePCRanges: [0xd03cc0..0xd03cc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 103 ArrayType [2]int32
+          Locations:
+            - Range: 0xd03cc0..0xd03cc1
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 9
+      Name: main.testInt64Array
+      OutOfLinePCRanges: [0xd03ce0..0xd03ce1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 109 ArrayType [2]int64
+          Locations:
+            - Range: 0xd03ce0..0xd03ce1
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 10
+      Name: main.testUintArray
+      OutOfLinePCRanges: [0xd03d00..0xd03d01]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 110 ArrayType [2]uint
+          Locations:
+            - Range: 0xd03d00..0xd03d01
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 11
+      Name: main.testUint8Array
+      OutOfLinePCRanges: [0xd03d20..0xd03d21]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 102 ArrayType [2]uint8
+          Locations:
+            - Range: 0xd03d20..0xd03d21
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 12
+      Name: main.testUint16Array
+      OutOfLinePCRanges: [0xd03d40..0xd03d41]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 111 ArrayType [2]uint16
+          Locations:
+            - Range: 0xd03d40..0xd03d41
+              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 13
+      Name: main.testUint32Array
+      OutOfLinePCRanges: [0xd03d60..0xd03d61]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 112 ArrayType [2]uint32
+          Locations:
+            - Range: 0xd03d60..0xd03d61
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 14
+      Name: main.testUint64Array
+      OutOfLinePCRanges: [0xd03d80..0xd03d81]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 52 ArrayType [2]uint64
+          Locations:
+            - Range: 0xd03d80..0xd03d81
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0xd03c80..0xd03c81]
+      OutOfLinePCRanges: [0xd03da0..0xd03da1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 113 ArrayType [2][2]int
           Locations:
-            - Range: 0xd03c80..0xd03c81
+            - Range: 0xd03da0..0xd03da1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0xd03ca0..0xd03ca1]
+      OutOfLinePCRanges: [0xd03dc0..0xd03dc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 104 ArrayType [2]string
           Locations:
-            - Range: 0xd03ca0..0xd03ca1
+            - Range: 0xd03dc0..0xd03dc1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0xd03cc0..0xd03cc1]
+      OutOfLinePCRanges: [0xd03de0..0xd03de1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 114 ArrayType [2][2][2]int
           Locations:
-            - Range: 0xd03cc0..0xd03cc1
+            - Range: 0xd03de0..0xd03de1
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0xd03ce0..0xd03ce1]
+      OutOfLinePCRanges: [0xd03e00..0xd03e01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 115 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0xd03ce0..0xd03ce1
+            - Range: 0xd03e00..0xd03e01
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0xd03d00..0xd03d01]
+      OutOfLinePCRanges: [0xd03e20..0xd03e21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 117 ArrayType [2]struct {}
           Locations:
-            - Range: 0xd03d00..0xd03d01
+            - Range: 0xd03e20..0xd03e21
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0xd03d40..0xd03d41]
+      OutOfLinePCRanges: [0xd03e60..0xd03e61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [100]uint
           Locations:
-            - Range: 0xd03d40..0xd03d41
+            - Range: 0xd03e60..0xd03e61
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xd040c0..0xd040c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 3 BaseType uint8
-          Locations:
-            - Range: 0xd040c0..0xd040c1
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 22
-      Name: main.testSingleRune
-      OutOfLinePCRanges: [0xd040e0..0xd040e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 BaseType int32
-          Locations:
-            - Range: 0xd040e0..0xd040e1
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 23
-      Name: main.testSingleBool
-      OutOfLinePCRanges: [0xd04100..0xd04101]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 4 BaseType bool
-          Locations:
-            - Range: 0xd04100..0xd04101
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 24
-      Name: main.testSingleInt
-      OutOfLinePCRanges: [0xd04120..0xd04121]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd04120..0xd04121
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 25
-      Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xd04140..0xd04141]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 14 BaseType int8
-          Locations:
-            - Range: 0xd04140..0xd04141
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 26
-      Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xd04160..0xd04161]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 97 BaseType int16
-          Locations:
-            - Range: 0xd04160..0xd04161
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 27
-      Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xd04180..0xd04181]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 BaseType int32
-          Locations:
-            - Range: 0xd04180..0xd04181
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 28
-      Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xd041a0..0xd041a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 13 BaseType int64
-          Locations:
-            - Range: 0xd041a0..0xd041a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 29
-      Name: main.testSingleUint
-      OutOfLinePCRanges: [0xd041c0..0xd041c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 15 BaseType uint
-          Locations:
-            - Range: 0xd041c0..0xd041c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 30
-      Name: main.testSingleUint8
       OutOfLinePCRanges: [0xd041e0..0xd041e1]
       InlinePCRanges: []
       Variables:
@@ -6328,93 +6211,210 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 31
-      Name: main.testSingleUint16
+    - ID: 22
+      Name: main.testSingleRune
       OutOfLinePCRanges: [0xd04200..0xd04201]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 BaseType uint16
+          Type: 12 BaseType int32
           Locations:
             - Range: 0xd04200..0xd04201
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 32
-      Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xd04220..0xd04221]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 2 BaseType uint32
-          Locations:
-            - Range: 0xd04220..0xd04221
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 33
-      Name: main.testSingleUint64
+    - ID: 23
+      Name: main.testSingleBool
+      OutOfLinePCRanges: [0xd04220..0xd04221]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xd04220..0xd04221
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 24
+      Name: main.testSingleInt
       OutOfLinePCRanges: [0xd04240..0xd04241]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 BaseType uint64
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd04240..0xd04241
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 25
+      Name: main.testSingleInt8
+      OutOfLinePCRanges: [0xd04260..0xd04261]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 14 BaseType int8
+          Locations:
+            - Range: 0xd04260..0xd04261
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 26
+      Name: main.testSingleInt16
+      OutOfLinePCRanges: [0xd04280..0xd04281]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 97 BaseType int16
+          Locations:
+            - Range: 0xd04280..0xd04281
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 27
+      Name: main.testSingleInt32
+      OutOfLinePCRanges: [0xd042a0..0xd042a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 BaseType int32
+          Locations:
+            - Range: 0xd042a0..0xd042a1
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 28
+      Name: main.testSingleInt64
+      OutOfLinePCRanges: [0xd042c0..0xd042c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 13 BaseType int64
+          Locations:
+            - Range: 0xd042c0..0xd042c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 29
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0xd042e0..0xd042e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 15 BaseType uint
+          Locations:
+            - Range: 0xd042e0..0xd042e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 30
+      Name: main.testSingleUint8
+      OutOfLinePCRanges: [0xd04300..0xd04301]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0xd04300..0xd04301
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 31
+      Name: main.testSingleUint16
+      OutOfLinePCRanges: [0xd04320..0xd04321]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType uint16
+          Locations:
+            - Range: 0xd04320..0xd04321
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 32
+      Name: main.testSingleUint32
+      OutOfLinePCRanges: [0xd04340..0xd04341]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 2 BaseType uint32
+          Locations:
+            - Range: 0xd04340..0xd04341
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 33
+      Name: main.testSingleUint64
+      OutOfLinePCRanges: [0xd04360..0xd04361]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 BaseType uint64
+          Locations:
+            - Range: 0xd04360..0xd04361
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xd04260..0xd04261]
+      OutOfLinePCRanges: [0xd04380..0xd04381]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float32
           Locations:
-            - Range: 0xd04260..0xd04261
+            - Range: 0xd04380..0xd04381
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xd04280..0xd04281]
+      OutOfLinePCRanges: [0xd043a0..0xd043a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd04280..0xd04281
+            - Range: 0xd043a0..0xd043a1
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xd042a0..0xd042a1]
+      OutOfLinePCRanges: [0xd043c0..0xd043c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 120 BaseType main.typeAlias
           Locations:
-            - Range: 0xd042a0..0xd042a1
+            - Range: 0xd043c0..0xd043c1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xd04400..0xd0441f]
+      OutOfLinePCRanges: [0xd04520..0xd0453f]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 121 StructureType main.bigStruct
           Locations:
-            - Range: 0xd04400..0xd0441f
+            - Range: 0xd04520..0xd0453f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6433,48 +6433,48 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0xd04460..0xd04572]
+      OutOfLinePCRanges: [0xd04580..0xd04692]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd04460..0xd04478
+            - Range: 0xd04580..0xd04598
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xd04460..0xd04572, Pieces: []}]
+          Locations: [{Range: 0xd04580..0xd04692, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 9 BaseType int
-          Locations: [{Range: 0xd04460..0xd04572, Pieces: []}]
+          Locations: [{Range: 0xd04580..0xd04692, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0xd04489..0xd044a5
+            - Range: 0xd045a9..0xd045c5
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0xd044a5..0xd044de
+            - Range: 0xd045c5..0xd045fe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd044de..0xd044e5
+            - Range: 0xd045fe..0xd04605
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0xd044e5..0xd04572
+            - Range: 0xd04605..0xd04692
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -80}
@@ -6485,39 +6485,39 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xd045e0..0xd045e1]
+      OutOfLinePCRanges: [0xd04700..0xd04701]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 125 StructureType main.deepPtr1
           Locations:
-            - Range: 0xd045e0..0xd045e1
+            - Range: 0xd04700..0xd04701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xd04600..0xd04601]
+      OutOfLinePCRanges: [0xd04720..0xd04721]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 128 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xd04600..0xd04601
+            - Range: 0xd04720..0xd04721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xd04780..0xd04781]
+      OutOfLinePCRanges: [0xd048a0..0xd048a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 130 StructureType main.deepSlice1
           Locations:
-            - Range: 0xd04780..0xd04781
+            - Range: 0xd048a0..0xd048a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6530,129 +6530,129 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xd047a0..0xd047a1]
+      OutOfLinePCRanges: [0xd048c0..0xd048c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 134 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xd047a0..0xd047a1
+            - Range: 0xd048c0..0xd048c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xd04900..0xd04901]
+      OutOfLinePCRanges: [0xd04a20..0xd04a21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 136 StructureType main.deepMap1
           Locations:
-            - Range: 0xd04900..0xd04901
+            - Range: 0xd04a20..0xd04a21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xd04920..0xd04921]
+      OutOfLinePCRanges: [0xd04a40..0xd04a41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 PointerType *main.deepMap7
           Locations:
-            - Range: 0xd04920..0xd04921
+            - Range: 0xd04a40..0xd04a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xd04940..0xd04941]
+      OutOfLinePCRanges: [0xd04a60..0xd04a61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 146 PointerType *main.stringType1
           Locations:
-            - Range: 0xd04940..0xd04941
+            - Range: 0xd04a60..0xd04a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xd04960..0xd04961]
+      OutOfLinePCRanges: [0xd04a80..0xd04a81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 148 PointerType **main.stringType2
           Locations:
-            - Range: 0xd04960..0xd04961
+            - Range: 0xd04a80..0xd04a81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xd04980..0xd04bca]
+      OutOfLinePCRanges: [0xd04aa0..0xd04cea]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04a64..0xd04a85
+            - Range: 0xd04b84..0xd04ba5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd04b38..0xd04b4f
+            - Range: 0xd04c58..0xd04c6f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04a4d..0xd04a50
+            - Range: 0xd04b6d..0xd04b70
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd04a50..0xd04a85
+            - Range: 0xd04b70..0xd04ba5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd04a85..0xd04b2b
+            - Range: 0xd04ba5..0xd04c4b
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xd04b2b..0xd04b38
+            - Range: 0xd04c4b..0xd04c58
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xd04b38..0xd04bca
+            - Range: 0xd04c58..0xd04cea
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04a4a..0xd04a50
+            - Range: 0xd04b6a..0xd04b70
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd04a50..0xd04a50
+            - Range: 0xd04b70..0xd04b70
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd04a50..0xd04a85
+            - Range: 0xd04b70..0xd04ba5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd04a85..0xd04b2b
+            - Range: 0xd04ba5..0xd04c4b
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xd04b2b..0xd04b30
+            - Range: 0xd04c4b..0xd04c50
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xd04b30..0xd04b38
+            - Range: 0xd04c50..0xd04c58
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xd04b38..0xd04b4f
+            - Range: 0xd04c58..0xd04c6f
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xd04b4f..0xd04bca
+            - Range: 0xd04c6f..0xd04cea
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xd05020..0xd05125]
+      OutOfLinePCRanges: [0xd05140..0xd05245]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 150 StructureType main.esotericStack
           Locations:
-            - Range: 0xd05020..0xd05073
+            - Range: 0xd05140..0xd05193
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6672,7 +6672,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd05073..0xd05078
+            - Range: 0xd05193..0xd05198
               Pieces:
                 - Size: 4
                   Op: null
@@ -6692,7 +6692,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd05078..0xd0507d
+            - Range: 0xd05198..0xd0519d
               Pieces:
                 - Size: 4
                   Op: null
@@ -6717,253 +6717,153 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xd05140..0xd051a3]
+      OutOfLinePCRanges: [0xd05260..0xd052c3]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 154 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xd05140..0xd0516d
+            - Range: 0xd05260..0xd0528d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 50
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xd06800..0xd06888]
+      OutOfLinePCRanges: [0xd06920..0xd069a8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd06800..0xd06815
+            - Range: 0xd06920..0xd06935
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 51
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xd068a0..0xd06965]
+      OutOfLinePCRanges: [0xd069c0..0xd06a85]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd068a0..0xd068b6
+            - Range: 0xd069c0..0xd069d6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd068a0..0xd068c7
+            - Range: 0xd069c0..0xd069e7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd068b6..0xd068c7
+            - Range: 0xd069d6..0xd069e7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd068c7..0xd06965
+            - Range: 0xd069e7..0xd06a85
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xd06980..0xd069e2]
+      OutOfLinePCRanges: [0xd06aa0..0xd06b02]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd06980..0xd0699a
+            - Range: 0xd06aa0..0xd06aba
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xd06a00..0xd06b0e]
+      OutOfLinePCRanges: [0xd06b20..0xd06c2e]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd06a5b..0xd06a65
+            - Range: 0xd06b7b..0xd06b85
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd06a65..0xd06a80
+            - Range: 0xd06b85..0xd06ba0
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd06a80..0xd06a94
+            - Range: 0xd06ba0..0xd06bb4
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd06a56..0xd06a60
+            - Range: 0xd06b76..0xd06b80
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd06a60..0xd06a80
+            - Range: 0xd06b80..0xd06ba0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd06a80..0xd06a8f
+            - Range: 0xd06ba0..0xd06baf
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xd06b20..0xd06b26]
+      OutOfLinePCRanges: [0xd06c40..0xd06c46]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd06b20..0xd06b25
+            - Range: 0xd06c40..0xd06c45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd06b20..0xd06b25
+            - Range: 0xd06c40..0xd06c45
               Pieces: []
-            - Range: 0xd06b25..0xd06b26
+            - Range: 0xd06c45..0xd06c46
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xd06b40..0xd06b83]
+      OutOfLinePCRanges: [0xd06c60..0xd06ca3]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0xd06b40..0xd06b83
+            - Range: 0xd06c60..0xd06ca3
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd06b40..0xd06b7d
+            - Range: 0xd06c60..0xd06c9d
               Pieces: []
-            - Range: 0xd06b7d..0xd06b7e
+            - Range: 0xd06c9d..0xd06c9e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd06b7e..0xd06b83
+            - Range: 0xd06c9e..0xd06ca3
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0xd06e20..0xd06e21]
+      OutOfLinePCRanges: [0xd06f40..0xd06f41]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 157 GoInterfaceType main.behavior
-          Locations:
-            - Range: 0xd06e20..0xd06e21
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 57
-      Name: main.testAny
-      OutOfLinePCRanges: [0xd06e40..0xd06ea6]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 152 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xd06e40..0xd06e69
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd06e69..0xd06e6e
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0xd06e40..0xd06e85
-              Pieces: []
-            - Range: 0xd06e85..0xd06e86
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd06e86..0xd06ea6
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 58
-      Name: main.testError
-      OutOfLinePCRanges: [0xd06ec0..0xd06ec1]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 18 GoInterfaceType error
-          Locations:
-            - Range: 0xd06ec0..0xd06ec1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 59
-      Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xd06ee0..0xd06f34]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 158 PointerType *interface {}
-          Locations:
-            - Range: 0xd06ee0..0xd06f06
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0xd06ee0..0xd06f1d
-              Pieces: []
-            - Range: 0xd06f1d..0xd06f1e
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd06f1e..0xd06f34
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 60
-      Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xd06f40..0xd06f41]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 159 StructureType main.structWithAny
           Locations:
             - Range: 0xd06f40..0xd06f41
               Pieces:
@@ -6974,348 +6874,448 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 57
+      Name: main.testAny
+      OutOfLinePCRanges: [0xd06f60..0xd06fc6]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 152 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xd06f60..0xd06f89
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd06f89..0xd06f8e
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd06f60..0xd06fa5
+              Pieces: []
+            - Range: 0xd06fa5..0xd06fa6
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd06fa6..0xd06fc6
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 58
+      Name: main.testError
+      OutOfLinePCRanges: [0xd06fe0..0xd06fe1]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 18 GoInterfaceType error
+          Locations:
+            - Range: 0xd06fe0..0xd06fe1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 59
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0xd07000..0xd07054]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 158 PointerType *interface {}
+          Locations:
+            - Range: 0xd07000..0xd07026
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd07000..0xd0703d
+              Pieces: []
+            - Range: 0xd0703d..0xd0703e
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd0703e..0xd07054
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 60
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0xd07060..0xd07061]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 159 StructureType main.structWithAny
+          Locations:
+            - Range: 0xd07060..0xd07061
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xd075a0..0xd075a1]
+      OutOfLinePCRanges: [0xd076c0..0xd076c1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 160 StructureType main.structWithMap
-          Locations:
-            - Range: 0xd075a0..0xd075a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xd075c0..0xd075c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 166 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xd075c0..0xd075c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 63
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xd075e0..0xd075e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 171 GoMapType map[string]int
-          Locations:
-            - Range: 0xd075e0..0xd075e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xd07600..0xd07601]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 176 GoMapType map[string][]string
-          Locations:
-            - Range: 0xd07600..0xd07601
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xd07620..0xd07621]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 181 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xd07620..0xd07621
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 66
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xd07640..0xd07641]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 171 GoMapType map[string]int
-          Locations:
-            - Range: 0xd07640..0xd07641
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xd07660..0xd07661]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 186 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xd07660..0xd07661
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xd07680..0xd07681]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 187 PointerType *map[string]int
-          Locations:
-            - Range: 0xd07680..0xd07681
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xd076a0..0xd076a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 161 GoMapType map[int]int
-          Locations:
-            - Range: 0xd076a0..0xd076a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xd076c0..0xd076c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 188 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd076c0..0xd076c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 71
-      Name: main.testMapEmbeddedMaps
+    - ID: 62
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xd076e0..0xd076e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 188 GoMapType map[string][]main.structWithMap
+          Type: 166 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xd076e0..0xd076e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapWithLinkedList
+    - ID: 63
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xd07700..0xd07701]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 193 GoMapType map[bool]main.node
+          Type: 171 GoMapType map[string]int
           Locations:
             - Range: 0xd07700..0xd07701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapWithSmallValue
+    - ID: 64
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xd07720..0xd07721]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 198 GoMapType map[int]uint8
+          Type: 176 GoMapType map[string][]string
           Locations:
             - Range: 0xd07720..0xd07721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithSmallValueMassive
+    - ID: 65
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xd07740..0xd07741]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 198 GoMapType map[int]uint8
+        - Name: m
+          Type: 181 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xd07740..0xd07741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 66
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xd07760..0xd07761]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 203 GoMapType map[uint8]uint8
+          Type: 171 GoMapType map[string]int
           Locations:
             - Range: 0xd07760..0xd07761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 67
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xd07780..0xd07781]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 203 GoMapType map[uint8]uint8
+          Type: 186 ArrayType [2]map[string]int
           Locations:
             - Range: 0xd07780..0xd07781
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapSmallKeySmallValue
+    - ID: 68
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xd077a0..0xd077a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 203 GoMapType map[uint8]uint8
+          Type: 187 PointerType *map[string]int
           Locations:
             - Range: 0xd077a0..0xd077a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 69
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xd077c0..0xd077c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 208 GoMapType map[uint8][4]int
+          Type: 161 GoMapType map[int]int
           Locations:
             - Range: 0xd077c0..0xd077c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapLargeKeySmallValue
+    - ID: 70
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xd077e0..0xd077e1]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 213 GoMapType map[[4]int]uint8
+        - Name: redactMyEntries
+          Type: 188 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd077e0..0xd077e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 71
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xd07800..0xd07801]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 218 GoMapType map[[4]int][4]int
+          Type: 188 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd07800..0xd07801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapEmptyKey
+    - ID: 72
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xd07820..0xd07821]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 223 GoMapType map[struct {}]int
+          Type: 193 GoMapType map[bool]main.node
           Locations:
             - Range: 0xd07820..0xd07821
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapEmptyValue
+    - ID: 73
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xd07840..0xd07841]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 228 GoMapType map[int]struct {}
+          Type: 198 GoMapType map[int]uint8
           Locations:
             - Range: 0xd07840..0xd07841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 74
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xd07860..0xd07861]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 233 GoMapType map[struct {}]struct {}
+        - Name: redactMyEntries
+          Type: 198 GoMapType map[int]uint8
           Locations:
             - Range: 0xd07860..0xd07861
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 75
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xd07880..0xd07881]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 203 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd07880..0xd07881
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 76
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xd078a0..0xd078a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 203 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd078a0..0xd078a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xd078c0..0xd078c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 203 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd078c0..0xd078c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 78
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xd078e0..0xd078e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xd078e0..0xd078e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 79
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xd07900..0xd07901]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 213 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xd07900..0xd07901
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 80
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xd07920..0xd07921]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 218 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xd07920..0xd07921
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 81
+      Name: main.testMapEmptyKey
+      OutOfLinePCRanges: [0xd07940..0xd07941]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 223 GoMapType map[struct {}]int
+          Locations:
+            - Range: 0xd07940..0xd07941
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 82
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0xd07960..0xd07961]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 228 GoMapType map[int]struct {}
+          Locations:
+            - Range: 0xd07960..0xd07961
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0xd07980..0xd07981]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 233 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0xd07980..0xd07981
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xd08fa0..0xd08fa1]
+      OutOfLinePCRanges: [0xd090c0..0xd090c1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd08fa0..0xd08fa1
+            - Range: 0xd090c0..0xd090c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd08fa0..0xd08fa1
+            - Range: 0xd090c0..0xd090c1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0xd08fa0..0xd08fa1
+            - Range: 0xd090c0..0xd090c1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xd08fe0..0xd08fe1]
+      OutOfLinePCRanges: [0xd09100..0xd09101]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd08fe0..0xd08fe1
+            - Range: 0xd09100..0xd09101
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08fe0..0xd08fe1
+            - Range: 0xd09100..0xd09101
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7326,48 +7326,48 @@ Subprograms:
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0xd08fe0..0xd08fe1
+            - Range: 0xd09100..0xd09101
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xd09160..0xd09161]
+      OutOfLinePCRanges: [0xd09280..0xd09281]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd09160..0xd09161
+            - Range: 0xd09280..0xd09281
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd09160..0xd09161
+            - Range: 0xd09280..0xd09281
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xd09160..0xd09161
+            - Range: 0xd09280..0xd09281
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd09160..0xd09161
+            - Range: 0xd09280..0xd09281
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd09160..0xd09161
+            - Range: 0xd09280..0xd09281
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7378,61 +7378,61 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xd09380..0xd09393]
+      OutOfLinePCRanges: [0xd094a0..0xd094b3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xd09380..0xd09392
+            - Range: 0xd094a0..0xd094b2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xd09380..0xd09392
+            - Range: 0xd094a0..0xd094b2
               Pieces: []
-            - Range: 0xd09392..0xd09393
+            - Range: 0xd094b2..0xd094b3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0xd093a0..0xd093a1]
+      OutOfLinePCRanges: [0xd094c0..0xd094c1]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 238 GoChannelType chan bool
           Locations:
-            - Range: 0xd093a0..0xd093a1
+            - Range: 0xd094c0..0xd094c1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xd09580..0xd09581]
+      OutOfLinePCRanges: [0xd096a0..0xd096a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xd09580..0xd09581
+            - Range: 0xd096a0..0xd096a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xd095a0..0xd095a1]
+      OutOfLinePCRanges: [0xd096c0..0xd096c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 241 StructureType main.node
           Locations:
-            - Range: 0xd095a0..0xd095a1
+            - Range: 0xd096c0..0xd096c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7443,273 +7443,273 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xd095c0..0xd095c1]
+      OutOfLinePCRanges: [0xd096e0..0xd096e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.node
           Locations:
-            - Range: 0xd095c0..0xd095c1
+            - Range: 0xd096e0..0xd096e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xd095e0..0xd095e1]
+      OutOfLinePCRanges: [0xd09700..0xd09701]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
-          Locations:
-            - Range: 0xd095e0..0xd095e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 93
-      Name: main.testUintPointer
-      OutOfLinePCRanges: [0xd09620..0xd09621]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 100 PointerType *uint
-          Locations:
-            - Range: 0xd09620..0xd09621
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 94
-      Name: main.testStringPointer
-      OutOfLinePCRanges: [0xd09700..0xd09701]
-      InlinePCRanges: []
-      Variables:
-        - Name: z
-          Type: 88 PointerType *string
           Locations:
             - Range: 0xd09700..0xd09701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 93
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0xd09740..0xd09741]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 100 PointerType *uint
+          Locations:
+            - Range: 0xd09740..0xd09741
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 94
+      Name: main.testStringPointer
+      OutOfLinePCRanges: [0xd09820..0xd09821]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 88 PointerType *string
+          Locations:
+            - Range: 0xd09820..0xd09821
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xd09740..0xd09741]
+      OutOfLinePCRanges: [0xd09860..0xd09861]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0xd09740..0xd09741
+            - Range: 0xd09860..0xd09861
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd09740..0xd09741
+            - Range: 0xd09860..0xd09861
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0xd09780..0xd09781]
+      OutOfLinePCRanges: [0xd098a0..0xd098a1]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 243 PointerType *main.t
           Locations:
-            - Range: 0xd09780..0xd09781
+            - Range: 0xd098a0..0xd098a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xd09c80..0xd09cf2]
+      OutOfLinePCRanges: [0xd09da0..0xd09e12]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09c80..0xd09c92
+            - Range: 0xd09da0..0xd09db2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09c80..0xd09cdb
+            - Range: 0xd09da0..0xd09dfb
               Pieces: []
-            - Range: 0xd09cdb..0xd09cdc
+            - Range: 0xd09dfb..0xd09dfc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09cdc..0xd09cf2
+            - Range: 0xd09dfc..0xd09e12
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09c92..0xd09ca5
+            - Range: 0xd09db2..0xd09dc5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09ca5..0xd09cf2
+            - Range: 0xd09dc5..0xd09e12
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xd09d00..0xd09d95]
+      OutOfLinePCRanges: [0xd09e20..0xd09eb5]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09d00..0xd09d1a
+            - Range: 0xd09e20..0xd09e3a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09d1a..0xd09d95
+            - Range: 0xd09e3a..0xd09eb5
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 93 PointerType *int
           Locations:
-            - Range: 0xd09d00..0xd09d7b
+            - Range: 0xd09e20..0xd09e9b
               Pieces: []
-            - Range: 0xd09d7b..0xd09d7c
+            - Range: 0xd09e9b..0xd09e9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09d7c..0xd09d95
+            - Range: 0xd09e9c..0xd09eb5
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 93 PointerType *int
           Locations:
-            - Range: 0xd09d1f..0xd09d3c
+            - Range: 0xd09e3f..0xd09e5c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09d3c..0xd09d95
+            - Range: 0xd09e5c..0xd09eb5
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xd09da0..0xd09e7e]
+      OutOfLinePCRanges: [0xd09ec0..0xd09f9e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09da0..0xd09e02
+            - Range: 0xd09ec0..0xd09f22
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09da0..0xd09e64
+            - Range: 0xd09ec0..0xd09f84
               Pieces: []
-            - Range: 0xd09e64..0xd09e65
+            - Range: 0xd09f84..0xd09f85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09e65..0xd09e7e
+            - Range: 0xd09f85..0xd09f9e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd09da0..0xd09e7e, Pieces: []}]
+          Locations: [{Range: 0xd09ec0..0xd09f9e, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09db6..0xd09e07
+            - Range: 0xd09ed6..0xd09f27
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd09e07..0xd09e7e
+            - Range: 0xd09f27..0xd09f9e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd09dcf..0xd09e07
+            - Range: 0xd09eef..0xd09f27
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xd09e07..0xd09e7e
+            - Range: 0xd09f27..0xd09f9e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xd09e80..0xd09edb]
+      OutOfLinePCRanges: [0xd09fa0..0xd09ffb]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd09e80..0xd09e99
+            - Range: 0xd09fa0..0xd09fb9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0xd09e80..0xd09eba
+            - Range: 0xd09fa0..0xd09fda
               Pieces: []
-            - Range: 0xd09eba..0xd09ebb
+            - Range: 0xd09fda..0xd09fdb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd09ebb..0xd09ec5
+            - Range: 0xd09fdb..0xd09fe5
               Pieces: []
-            - Range: 0xd09ec5..0xd09ec6
+            - Range: 0xd09fe5..0xd09fe6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd09ec6..0xd09edb
+            - Range: 0xd09fe6..0xd09ffb
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xd09ee0..0xd0a026]
+      OutOfLinePCRanges: [0xd0a000..0xd0a146]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd09ee0..0xd09f31
+            - Range: 0xd0a000..0xd0a051
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd09f31..0xd09f34
+            - Range: 0xd0a051..0xd0a054
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd09f77..0xd09f85
+            - Range: 0xd0a097..0xd0a0a5
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd09fa0..0xd09fa5
+            - Range: 0xd0a0c0..0xd0a0c5
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd09fd4..0xd09fd9
+            - Range: 0xd0a0f4..0xd0a0f9
               Pieces:
                 - Size: 8
                   Op: null
@@ -7720,117 +7720,117 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd09ee0..0xd09f2f
+            - Range: 0xd0a000..0xd0a04f
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd09ee0..0xd09f58
+            - Range: 0xd0a000..0xd0a078
               Pieces: []
-            - Range: 0xd09f58..0xd09f59
+            - Range: 0xd0a078..0xd0a079
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd09f59..0xd09f93
+            - Range: 0xd0a079..0xd0a0b3
               Pieces: []
-            - Range: 0xd09f93..0xd09f94
+            - Range: 0xd0a0b3..0xd0a0b4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd09f94..0xd09fc7
+            - Range: 0xd0a0b4..0xd0a0e7
               Pieces: []
-            - Range: 0xd09fc7..0xd09fc8
+            - Range: 0xd0a0e7..0xd0a0e8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd09fc8..0xd09ff9
+            - Range: 0xd0a0e8..0xd0a119
               Pieces: []
-            - Range: 0xd09ff9..0xd09ffa
+            - Range: 0xd0a119..0xd0a11a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd09ffa..0xd0a026
+            - Range: 0xd0a11a..0xd0a146
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0xd09ee0..0xd09f58
+            - Range: 0xd0a000..0xd0a078
               Pieces: []
-            - Range: 0xd09f58..0xd09f59
+            - Range: 0xd0a078..0xd0a079
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd09f59..0xd09f93
+            - Range: 0xd0a079..0xd0a0b3
               Pieces: []
-            - Range: 0xd09f93..0xd09f94
+            - Range: 0xd0a0b3..0xd0a0b4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd09f94..0xd09fc7
+            - Range: 0xd0a0b4..0xd0a0e7
               Pieces: []
-            - Range: 0xd09fc7..0xd09fc8
+            - Range: 0xd0a0e7..0xd0a0e8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd09fc8..0xd09ff9
+            - Range: 0xd0a0e8..0xd0a119
               Pieces: []
-            - Range: 0xd09ff9..0xd09ffa
+            - Range: 0xd0a119..0xd0a11a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd09ffa..0xd0a026
+            - Range: 0xd0a11a..0xd0a146
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09f77..0xd09f80
+            - Range: 0xd0a097..0xd0a0a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xd0a040..0xd0a234]
+      OutOfLinePCRanges: [0xd0a160..0xd0a354]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0a040..0xd0a09f
+            - Range: 0xd0a160..0xd0a1bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0a09f..0xd0a0a2
+            - Range: 0xd0a1bf..0xd0a1c2
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0a0a2..0xd0a234
+            - Range: 0xd0a1c2..0xd0a354
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7841,1128 +7841,1128 @@ Subprograms:
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0a040..0xd0a104
+            - Range: 0xd0a160..0xd0a224
               Pieces: []
-            - Range: 0xd0a104..0xd0a105
+            - Range: 0xd0a224..0xd0a225
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0a105..0xd0a13f
+            - Range: 0xd0a225..0xd0a25f
               Pieces: []
-            - Range: 0xd0a13f..0xd0a140
+            - Range: 0xd0a25f..0xd0a260
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0a140..0xd0a202
+            - Range: 0xd0a260..0xd0a322
               Pieces: []
-            - Range: 0xd0a202..0xd0a203
+            - Range: 0xd0a322..0xd0a323
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0a203..0xd0a20c
+            - Range: 0xd0a323..0xd0a32c
               Pieces: []
-            - Range: 0xd0a20c..0xd0a20d
+            - Range: 0xd0a32c..0xd0a32d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0a20d..0xd0a234
+            - Range: 0xd0a32d..0xd0a354
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0a12a..0xd0a130
+            - Range: 0xd0a24a..0xd0a250
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 93 PointerType *int
           Locations:
-            - Range: 0xd0a0e5..0xd0a104
+            - Range: 0xd0a205..0xd0a224
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xd0a240..0xd0a3a5]
+      OutOfLinePCRanges: [0xd0a360..0xd0a4c5]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0a240..0xd0a280
+            - Range: 0xd0a360..0xd0a3a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0a280..0xd0a2e5
+            - Range: 0xd0a3a0..0xd0a405
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0a2e5..0xd0a341
+            - Range: 0xd0a405..0xd0a461
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0a341..0xd0a361
+            - Range: 0xd0a461..0xd0a481
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0a361..0xd0a368
+            - Range: 0xd0a481..0xd0a488
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0a368..0xd0a3a5
+            - Range: 0xd0a488..0xd0a4c5
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd0a240..0xd0a331
+            - Range: 0xd0a360..0xd0a451
               Pieces: []
-            - Range: 0xd0a331..0xd0a332
+            - Range: 0xd0a451..0xd0a452
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0a332..0xd0a33b
+            - Range: 0xd0a452..0xd0a45b
               Pieces: []
-            - Range: 0xd0a33b..0xd0a33c
+            - Range: 0xd0a45b..0xd0a45c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0a33c..0xd0a3a5
+            - Range: 0xd0a45c..0xd0a4c5
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd0a240..0xd0a280
+            - Range: 0xd0a360..0xd0a3a0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0a280..0xd0a2d5
+            - Range: 0xd0a3a0..0xd0a3f5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0a2d5..0xd0a2e5
+            - Range: 0xd0a3f5..0xd0a405
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0a2e5..0xd0a337
+            - Range: 0xd0a405..0xd0a457
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0a337..0xd0a339
+            - Range: 0xd0a457..0xd0a459
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0a339..0xd0a33b
+            - Range: 0xd0a459..0xd0a45b
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0a33b..0xd0a3a5
+            - Range: 0xd0a45b..0xd0a4c5
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xd0a3c0..0xd0a44f]
+      OutOfLinePCRanges: [0xd0a4e0..0xd0a56f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0a3c0..0xd0a3d1
+            - Range: 0xd0a4e0..0xd0a4f1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0a3c0..0xd0a435
+            - Range: 0xd0a4e0..0xd0a555
               Pieces: []
-            - Range: 0xd0a435..0xd0a436
+            - Range: 0xd0a555..0xd0a556
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0a436..0xd0a44f
+            - Range: 0xd0a556..0xd0a56f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xd0a460..0xd0a529]
+      OutOfLinePCRanges: [0xd0a580..0xd0a649]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0a460..0xd0a4b3
+            - Range: 0xd0a580..0xd0a5d3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0a460..0xd0a50f
+            - Range: 0xd0a580..0xd0a62f
               Pieces: []
-            - Range: 0xd0a50f..0xd0a510
+            - Range: 0xd0a62f..0xd0a630
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0a510..0xd0a529
+            - Range: 0xd0a630..0xd0a649
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0a460..0xd0a50f
+            - Range: 0xd0a580..0xd0a62f
               Pieces: []
-            - Range: 0xd0a50f..0xd0a510
+            - Range: 0xd0a62f..0xd0a630
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0a510..0xd0a529
+            - Range: 0xd0a630..0xd0a649
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xd0a540..0xd0a608]
+      OutOfLinePCRanges: [0xd0a660..0xd0a728]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0a540..0xd0a585
+            - Range: 0xd0a660..0xd0a6a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0a585..0xd0a608
+            - Range: 0xd0a6a5..0xd0a728
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0a540..0xd0a5ee
+            - Range: 0xd0a660..0xd0a70e
               Pieces: []
-            - Range: 0xd0a5ee..0xd0a5ef
+            - Range: 0xd0a70e..0xd0a70f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0a5ef..0xd0a608
+            - Range: 0xd0a70f..0xd0a728
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0a540..0xd0a5ee
+            - Range: 0xd0a660..0xd0a70e
               Pieces: []
-            - Range: 0xd0a5ee..0xd0a5ef
+            - Range: 0xd0a70e..0xd0a70f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0a5ef..0xd0a608
+            - Range: 0xd0a70f..0xd0a728
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0a540..0xd0a5ee
+            - Range: 0xd0a660..0xd0a70e
               Pieces: []
-            - Range: 0xd0a5ee..0xd0a5ef
+            - Range: 0xd0a70e..0xd0a70f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0a5ef..0xd0a608
+            - Range: 0xd0a70f..0xd0a728
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xd0a620..0xd0a70f]
+      OutOfLinePCRanges: [0xd0a740..0xd0a82f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0a620..0xd0a665
+            - Range: 0xd0a740..0xd0a785
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0a665..0xd0a70f
+            - Range: 0xd0a785..0xd0a82f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0a620..0xd0a6f4
+            - Range: 0xd0a740..0xd0a814
               Pieces: []
-            - Range: 0xd0a6f4..0xd0a6f5
+            - Range: 0xd0a814..0xd0a815
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0a6f5..0xd0a70f
+            - Range: 0xd0a815..0xd0a82f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a620..0xd0a6f4
+            - Range: 0xd0a740..0xd0a814
               Pieces: []
-            - Range: 0xd0a6f4..0xd0a6f5
+            - Range: 0xd0a814..0xd0a815
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd0a6f5..0xd0a70f
+            - Range: 0xd0a815..0xd0a82f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xd0a720..0xd0a92f]
+      OutOfLinePCRanges: [0xd0a840..0xd0aa4f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0a720..0xd0a7a6
+            - Range: 0xd0a840..0xd0a8c6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0a7a6..0xd0a92f
+            - Range: 0xd0a8c6..0xd0aa4f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a757..0xd0a92f
+            - Range: 0xd0a877..0xd0aa4f
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a75d..0xd0a92f
+            - Range: 0xd0a87d..0xd0aa4f
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xd0aa20..0xd0aa9e]
+      OutOfLinePCRanges: [0xd0ab40..0xd0abbe]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd0aa20..0xd0aa91
+            - Range: 0xd0ab40..0xd0abb1
               Pieces: []
-            - Range: 0xd0aa91..0xd0aa92
+            - Range: 0xd0abb1..0xd0abb2
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0aa92..0xd0aa9e
+            - Range: 0xd0abb2..0xd0abbe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 97 BaseType int16
           Locations:
-            - Range: 0xd0aa20..0xd0aa91
+            - Range: 0xd0ab40..0xd0abb1
               Pieces: []
-            - Range: 0xd0aa91..0xd0aa92
+            - Range: 0xd0abb1..0xd0abb2
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0aa92..0xd0aa9e
+            - Range: 0xd0abb2..0xd0abbe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xd0aa20..0xd0aa91
+            - Range: 0xd0ab40..0xd0abb1
               Pieces: []
-            - Range: 0xd0aa91..0xd0aa92
+            - Range: 0xd0abb1..0xd0abb2
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0aa92..0xd0aa9e
+            - Range: 0xd0abb2..0xd0abbe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xd0aa20..0xd0aa91
+            - Range: 0xd0ab40..0xd0abb1
               Pieces: []
-            - Range: 0xd0aa91..0xd0aa92
+            - Range: 0xd0abb1..0xd0abb2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0aa92..0xd0aa9e
+            - Range: 0xd0abb2..0xd0abbe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd0aa20..0xd0aa91
+            - Range: 0xd0ab40..0xd0abb1
               Pieces: []
-            - Range: 0xd0aa91..0xd0aa92
+            - Range: 0xd0abb1..0xd0abb2
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0aa92..0xd0aa9e
+            - Range: 0xd0abb2..0xd0abbe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xd0aa20..0xd0aa91
+            - Range: 0xd0ab40..0xd0abb1
               Pieces: []
-            - Range: 0xd0aa91..0xd0aa92
+            - Range: 0xd0abb1..0xd0abb2
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0aa92..0xd0aa9e
+            - Range: 0xd0abb2..0xd0abbe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xd0aa20..0xd0aa91
+            - Range: 0xd0ab40..0xd0abb1
               Pieces: []
-            - Range: 0xd0aa91..0xd0aa92
+            - Range: 0xd0abb1..0xd0abb2
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0aa92..0xd0aa9e
+            - Range: 0xd0abb2..0xd0abbe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xd0aa20..0xd0aa91
+            - Range: 0xd0ab40..0xd0abb1
               Pieces: []
-            - Range: 0xd0aa91..0xd0aa92
+            - Range: 0xd0abb1..0xd0abb2
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0aa92..0xd0aa9e
+            - Range: 0xd0abb2..0xd0abbe
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xd0aaa0..0xd0ab95]
+      OutOfLinePCRanges: [0xd0abc0..0xd0acb5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
+          Locations: [{Range: 0xd0abc0..0xd0acb5, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd0aaa0..0xd0ab85
+            - Range: 0xd0abc0..0xd0aca5
               Pieces: []
-            - Range: 0xd0ab85..0xd0ab86
+            - Range: 0xd0aca5..0xd0aca6
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd0ab86..0xd0ab95
+            - Range: 0xd0aca6..0xd0acb5
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd0aaa0..0xd0ab85
+            - Range: 0xd0abc0..0xd0aca5
               Pieces: []
-            - Range: 0xd0ab85..0xd0ab86
+            - Range: 0xd0aca5..0xd0aca6
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0ab86..0xd0ab95
+            - Range: 0xd0aca6..0xd0acb5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xd0aba0..0xd0ac13]
+      OutOfLinePCRanges: [0xd0acc0..0xd0ad33]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 89 BaseType complex64
-          Locations: [{Range: 0xd0aba0..0xd0ac13, Pieces: []}]
+          Locations: [{Range: 0xd0acc0..0xd0ad33, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 90 BaseType complex128
-          Locations: [{Range: 0xd0aba0..0xd0ac13, Pieces: []}]
+          Locations: [{Range: 0xd0acc0..0xd0ad33, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xd0ac20..0xd0acc5]
+      OutOfLinePCRanges: [0xd0ad40..0xd0ade5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0ac20..0xd0acb3
+            - Range: 0xd0ad40..0xd0add3
               Pieces: []
-            - Range: 0xd0acb3..0xd0acb4
+            - Range: 0xd0add3..0xd0add4
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xd0acb4..0xd0acc5
+            - Range: 0xd0add4..0xd0ade5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xd0ace0..0xd0ad5a]
+      OutOfLinePCRanges: [0xd0ae00..0xd0ae7a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd0ace0..0xd0ad4d
+            - Range: 0xd0ae00..0xd0ae6d
               Pieces: []
-            - Range: 0xd0ad4d..0xd0ad4e
+            - Range: 0xd0ae6d..0xd0ae6e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd0ad4e..0xd0ad5a
+            - Range: 0xd0ae6e..0xd0ae7a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xd0ad60..0xd0adb8]
+      OutOfLinePCRanges: [0xd0ae80..0xd0aed8]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 247 ArrayType [1]int
           Locations:
-            - Range: 0xd0ad60..0xd0adab
+            - Range: 0xd0ae80..0xd0aecb
               Pieces: []
-            - Range: 0xd0adab..0xd0adac
+            - Range: 0xd0aecb..0xd0aecc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0adac..0xd0adb8
+            - Range: 0xd0aecc..0xd0aed8
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xd0adc0..0xd0ae13]
+      OutOfLinePCRanges: [0xd0aee0..0xd0af33]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0xd0adc0..0xd0ae06
+            - Range: 0xd0aee0..0xd0af26
               Pieces: []
-            - Range: 0xd0ae06..0xd0ae07
+            - Range: 0xd0af26..0xd0af27
               Pieces: []
-            - Range: 0xd0ae07..0xd0ae13
+            - Range: 0xd0af27..0xd0af33
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xd0ae20..0xd0ae87]
+      OutOfLinePCRanges: [0xd0af40..0xd0afa7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 StructureType main.mixedStruct
-          Locations: [{Range: 0xd0ae20..0xd0ae87, Pieces: []}]
+          Locations: [{Range: 0xd0af40..0xd0afa7, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xd0aea0..0xd0af3a]
+      OutOfLinePCRanges: [0xd0afc0..0xd0b05a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aea0..0xd0af2a
+            - Range: 0xd0afc0..0xd0b04a
               Pieces: []
-            - Range: 0xd0af2a..0xd0af2b
+            - Range: 0xd0b04a..0xd0b04b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0af2b..0xd0af3a
+            - Range: 0xd0b04b..0xd0b05a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aea0..0xd0af2a
+            - Range: 0xd0afc0..0xd0b04a
               Pieces: []
-            - Range: 0xd0af2a..0xd0af2b
+            - Range: 0xd0b04a..0xd0b04b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0af2b..0xd0af3a
+            - Range: 0xd0b04b..0xd0b05a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aea0..0xd0af2a
+            - Range: 0xd0afc0..0xd0b04a
               Pieces: []
-            - Range: 0xd0af2a..0xd0af2b
+            - Range: 0xd0b04a..0xd0b04b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0af2b..0xd0af3a
+            - Range: 0xd0b04b..0xd0b05a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aea0..0xd0af2a
+            - Range: 0xd0afc0..0xd0b04a
               Pieces: []
-            - Range: 0xd0af2a..0xd0af2b
+            - Range: 0xd0b04a..0xd0b04b
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0af2b..0xd0af3a
+            - Range: 0xd0b04b..0xd0b05a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aea0..0xd0af2a
+            - Range: 0xd0afc0..0xd0b04a
               Pieces: []
-            - Range: 0xd0af2a..0xd0af2b
+            - Range: 0xd0b04a..0xd0b04b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0af2b..0xd0af3a
+            - Range: 0xd0b04b..0xd0b05a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aea0..0xd0af2a
+            - Range: 0xd0afc0..0xd0b04a
               Pieces: []
-            - Range: 0xd0af2a..0xd0af2b
+            - Range: 0xd0b04a..0xd0b04b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0af2b..0xd0af3a
+            - Range: 0xd0b04b..0xd0b05a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aea0..0xd0af2a
+            - Range: 0xd0afc0..0xd0b04a
               Pieces: []
-            - Range: 0xd0af2a..0xd0af2b
+            - Range: 0xd0b04a..0xd0b04b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0af2b..0xd0af3a
+            - Range: 0xd0b04b..0xd0b05a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aea0..0xd0af2a
+            - Range: 0xd0afc0..0xd0b04a
               Pieces: []
-            - Range: 0xd0af2a..0xd0af2b
+            - Range: 0xd0b04a..0xd0b04b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0af2b..0xd0af3a
+            - Range: 0xd0b04b..0xd0b05a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0aea0..0xd0af2a
+            - Range: 0xd0afc0..0xd0b04a
               Pieces: []
-            - Range: 0xd0af2a..0xd0af2b
+            - Range: 0xd0b04a..0xd0b04b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd0af2b..0xd0af3a
+            - Range: 0xd0b04b..0xd0b05a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xd0af40..0xd0afe5]
+      OutOfLinePCRanges: [0xd0b060..0xd0b105]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.wideStruct
           Locations:
-            - Range: 0xd0af40..0xd0afd4
+            - Range: 0xd0b060..0xd0b0f4
               Pieces: []
-            - Range: 0xd0afd4..0xd0afd5
+            - Range: 0xd0b0f4..0xd0b0f5
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xd0afd5..0xd0afe5
+            - Range: 0xd0b0f5..0xd0b105
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xd0b000..0xd0b079]
+      OutOfLinePCRanges: [0xd0b120..0xd0b199]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b000..0xd0b06c
+            - Range: 0xd0b120..0xd0b18c
               Pieces: []
-            - Range: 0xd0b06c..0xd0b06d
+            - Range: 0xd0b18c..0xd0b18d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0b06d..0xd0b079
+            - Range: 0xd0b18d..0xd0b199
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0b000..0xd0b079, Pieces: []}]
+          Locations: [{Range: 0xd0b120..0xd0b199, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b000..0xd0b06c
+            - Range: 0xd0b120..0xd0b18c
               Pieces: []
-            - Range: 0xd0b06c..0xd0b06d
+            - Range: 0xd0b18c..0xd0b18d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0b06d..0xd0b079
+            - Range: 0xd0b18d..0xd0b199
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0b000..0xd0b079, Pieces: []}]
+          Locations: [{Range: 0xd0b120..0xd0b199, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0b000..0xd0b06c
+            - Range: 0xd0b120..0xd0b18c
               Pieces: []
-            - Range: 0xd0b06c..0xd0b06d
+            - Range: 0xd0b18c..0xd0b18d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0b06d..0xd0b079
+            - Range: 0xd0b18d..0xd0b199
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xd0b080..0xd0b0fa]
+      OutOfLinePCRanges: [0xd0b1a0..0xd0b21a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0xd0b080..0xd0b0ed
+            - Range: 0xd0b1a0..0xd0b20d
               Pieces: []
-            - Range: 0xd0b0ed..0xd0b0ee
+            - Range: 0xd0b20d..0xd0b20e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd0b0ee..0xd0b0fa
+            - Range: 0xd0b20e..0xd0b21a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xd0b100..0xd0b15b]
+      OutOfLinePCRanges: [0xd0b220..0xd0b27b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0b100..0xd0b15b, Pieces: []}]
+          Locations: [{Range: 0xd0b220..0xd0b27b, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xd0b160..0xd0b1c7]
+      OutOfLinePCRanges: [0xd0b280..0xd0b2e7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float32
-          Locations: [{Range: 0xd0b160..0xd0b1c7, Pieces: []}]
+          Locations: [{Range: 0xd0b280..0xd0b2e7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0b160..0xd0b1c7, Pieces: []}]
+          Locations: [{Range: 0xd0b280..0xd0b2e7, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xd0b1e0..0xd0b23d]
+      OutOfLinePCRanges: [0xd0b300..0xd0b35d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd0b1e0..0xd0b230
+            - Range: 0xd0b300..0xd0b350
               Pieces: []
-            - Range: 0xd0b230..0xd0b231
+            - Range: 0xd0b350..0xd0b351
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0b231..0xd0b23d
+            - Range: 0xd0b351..0xd0b35d
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xd0b1e0..0xd0b230
+            - Range: 0xd0b300..0xd0b350
               Pieces: []
-            - Range: 0xd0b230..0xd0b231
+            - Range: 0xd0b350..0xd0b351
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0b231..0xd0b23d
+            - Range: 0xd0b351..0xd0b35d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xd0b240..0xd0b3a5]
+      OutOfLinePCRanges: [0xd0b360..0xd0b4c5]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0b240..0xd0b3a5
+            - Range: 0xd0b360..0xd0b4c5
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0b240..0xd0b393
+            - Range: 0xd0b360..0xd0b4b3
               Pieces: []
-            - Range: 0xd0b393..0xd0b394
+            - Range: 0xd0b4b3..0xd0b4b4
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xd0b394..0xd0b3a5
+            - Range: 0xd0b4b4..0xd0b4c5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xd0b3c0..0xd0b492]
+      OutOfLinePCRanges: [0xd0b4e0..0xd0b5b2]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd0b3c0..0xd0b492
+            - Range: 0xd0b4e0..0xd0b5b2
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd0b3c0..0xd0b482
+            - Range: 0xd0b4e0..0xd0b5a2
               Pieces: []
-            - Range: 0xd0b482..0xd0b483
+            - Range: 0xd0b5a2..0xd0b5a3
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd0b483..0xd0b492
+            - Range: 0xd0b5a3..0xd0b5b2
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xd0b4a0..0xd0b6da]
+      OutOfLinePCRanges: [0xd0b5c0..0xd0b7fa]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0b4a0..0xd0b6da
+            - Range: 0xd0b5c0..0xd0b7fa
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0b4a0..0xd0b6da
+            - Range: 0xd0b5c0..0xd0b7fa
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0b4a0..0xd0b6ca
+            - Range: 0xd0b5c0..0xd0b7ea
               Pieces: []
-            - Range: 0xd0b6ca..0xd0b6cb
+            - Range: 0xd0b7ea..0xd0b7eb
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xd0b6cb..0xd0b6da
+            - Range: 0xd0b7eb..0xd0b7fa
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xd0b6e0..0xd0b96f]
+      OutOfLinePCRanges: [0xd0b800..0xd0ba8f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b6e0..0xd0b790
+            - Range: 0xd0b800..0xd0b8b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0b790..0xd0b96f
+            - Range: 0xd0b8b0..0xd0ba8f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b6e0..0xd0b790
+            - Range: 0xd0b800..0xd0b8b0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0b790..0xd0b96f
+            - Range: 0xd0b8b0..0xd0ba8f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b6e0..0xd0b790
+            - Range: 0xd0b800..0xd0b8b0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0b790..0xd0b96f
+            - Range: 0xd0b8b0..0xd0ba8f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b6e0..0xd0b750
+            - Range: 0xd0b800..0xd0b870
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0b750..0xd0b96f
+            - Range: 0xd0b870..0xd0ba8f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b6e0..0xd0b790
+            - Range: 0xd0b800..0xd0b8b0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0b790..0xd0b96f
+            - Range: 0xd0b8b0..0xd0ba8f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b6e0..0xd0b790
+            - Range: 0xd0b800..0xd0b8b0
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0b790..0xd0b96f
+            - Range: 0xd0b8b0..0xd0ba8f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b6e0..0xd0b790
+            - Range: 0xd0b800..0xd0b8b0
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0b790..0xd0b96f
+            - Range: 0xd0b8b0..0xd0ba8f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b6e0..0xd0b790
+            - Range: 0xd0b800..0xd0b8b0
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0b790..0xd0b96f
+            - Range: 0xd0b8b0..0xd0ba8f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b6e0..0xd0b790
+            - Range: 0xd0b800..0xd0b8b0
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xd0b790..0xd0b96f
+            - Range: 0xd0b8b0..0xd0ba8f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0xd0b6e0..0xd0b902
+            - Range: 0xd0b800..0xd0ba22
               Pieces: []
-            - Range: 0xd0b902..0xd0b903
+            - Range: 0xd0ba22..0xd0ba23
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd0b903..0xd0b96f
+            - Range: 0xd0ba23..0xd0ba8f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xd0b980..0xd0bc4c]
+      OutOfLinePCRanges: [0xd0baa0..0xd0bd6c]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b980..0xd0ba2b
+            - Range: 0xd0baa0..0xd0bb4b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ba2b..0xd0bc4c
+            - Range: 0xd0bb4b..0xd0bd6c
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b980..0xd0ba2b
+            - Range: 0xd0baa0..0xd0bb4b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0ba2b..0xd0bc4c
+            - Range: 0xd0bb4b..0xd0bd6c
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b980..0xd0ba2b
+            - Range: 0xd0baa0..0xd0bb4b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0ba2b..0xd0bc4c
+            - Range: 0xd0bb4b..0xd0bd6c
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b980..0xd0b9e2
+            - Range: 0xd0baa0..0xd0bb02
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0b9e2..0xd0bc4c
+            - Range: 0xd0bb02..0xd0bd6c
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b980..0xd0ba2b
+            - Range: 0xd0baa0..0xd0bb4b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0ba2b..0xd0bc4c
+            - Range: 0xd0bb4b..0xd0bd6c
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b980..0xd0ba2b
+            - Range: 0xd0baa0..0xd0bb4b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0ba2b..0xd0bc4c
+            - Range: 0xd0bb4b..0xd0bd6c
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b980..0xd0ba2b
+            - Range: 0xd0baa0..0xd0bb4b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0ba2b..0xd0bc4c
+            - Range: 0xd0bb4b..0xd0bd6c
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b980..0xd0ba2b
+            - Range: 0xd0baa0..0xd0bb4b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0ba2b..0xd0bc4c
+            - Range: 0xd0bb4b..0xd0bd6c
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0b980..0xd0bc4c
+            - Range: 0xd0baa0..0xd0bd6c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -8973,403 +8973,197 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0b980..0xd0bbcb
+            - Range: 0xd0baa0..0xd0bceb
               Pieces: []
-            - Range: 0xd0bbcb..0xd0bbcc
+            - Range: 0xd0bceb..0xd0bcec
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xd0bbcc..0xd0bc4c
+            - Range: 0xd0bcec..0xd0bd6c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xd0bc60..0xd0bcec]
+      OutOfLinePCRanges: [0xd0bd80..0xd0be0c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0xd0bc60..0xd0bcec
+            - Range: 0xd0bd80..0xd0be0c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0bc60..0xd0bcdc
+            - Range: 0xd0bd80..0xd0bdfc
               Pieces: []
-            - Range: 0xd0bcdc..0xd0bcdd
+            - Range: 0xd0bdfc..0xd0bdfd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bcdd..0xd0bcec
+            - Range: 0xd0bdfd..0xd0be0c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0bc60..0xd0bcdc
+            - Range: 0xd0bd80..0xd0bdfc
               Pieces: []
-            - Range: 0xd0bcdc..0xd0bcdd
+            - Range: 0xd0bdfc..0xd0bdfd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0bcdd..0xd0bcec
+            - Range: 0xd0bdfd..0xd0be0c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0bc60..0xd0bcdc
+            - Range: 0xd0bd80..0xd0bdfc
               Pieces: []
-            - Range: 0xd0bcdc..0xd0bcdd
+            - Range: 0xd0bdfc..0xd0bdfd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0bcdd..0xd0bcec
+            - Range: 0xd0bdfd..0xd0be0c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xd0bd00..0xd0bdea]
+      OutOfLinePCRanges: [0xd0be20..0xd0bf0a]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0xd0bd00..0xd0bdea
+            - Range: 0xd0be20..0xd0bf0a
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd0bd00..0xd0bdea
+            - Range: 0xd0be20..0xd0bf0a
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0bd00..0xd0bdd6
+            - Range: 0xd0be20..0xd0bef6
               Pieces: []
-            - Range: 0xd0bdd6..0xd0bdd7
+            - Range: 0xd0bef6..0xd0bef7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bdd7..0xd0bdea
+            - Range: 0xd0bef7..0xd0bf0a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0xd0bd00..0xd0bdd6
+            - Range: 0xd0be20..0xd0bef6
               Pieces: []
-            - Range: 0xd0bdd6..0xd0bdd7
+            - Range: 0xd0bef6..0xd0bef7
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xd0bdd7..0xd0bdea
+            - Range: 0xd0bef7..0xd0bf0a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xd0be00..0xd0becb]
+      OutOfLinePCRanges: [0xd0bf20..0xd0bfeb]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0xd0be00..0xd0becb
+            - Range: 0xd0bf20..0xd0bfeb
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0be00..0xd0beba
+            - Range: 0xd0bf20..0xd0bfda
               Pieces: []
-            - Range: 0xd0beba..0xd0bebb
+            - Range: 0xd0bfda..0xd0bfdb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bebb..0xd0becb
+            - Range: 0xd0bfdb..0xd0bfeb
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0xd0be00..0xd0beba
+            - Range: 0xd0bf20..0xd0bfda
               Pieces: []
-            - Range: 0xd0beba..0xd0bebb
+            - Range: 0xd0bfda..0xd0bfdb
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd0bebb..0xd0becb
+            - Range: 0xd0bfdb..0xd0bfeb
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0be86..0xd0becb
+            - Range: 0xd0bfa6..0xd0bfeb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xd0bee0..0xd0bf86]
+      OutOfLinePCRanges: [0xd0c000..0xd0c0a6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 248 ArrayType [0]int
-          Locations: [{Range: 0xd0bee0..0xd0bf86, Pieces: []}]
+          Locations: [{Range: 0xd0c000..0xd0c0a6, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0bee0..0xd0bf25
+            - Range: 0xd0c000..0xd0c045
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bf25..0xd0bf47
+            - Range: 0xd0c045..0xd0c067
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd0bf47..0xd0bf62
+            - Range: 0xd0c067..0xd0c082
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd0bf62..0xd0bf86
+            - Range: 0xd0c082..0xd0c0a6
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0bee0..0xd0bf6c
+            - Range: 0xd0c000..0xd0c08c
               Pieces: []
-            - Range: 0xd0bf6c..0xd0bf6d
+            - Range: 0xd0c08c..0xd0c08d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bf6d..0xd0bf86
+            - Range: 0xd0c08d..0xd0c0a6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0xd0bee0..0xd0bf6c
+            - Range: 0xd0c000..0xd0c08c
               Pieces: []
-            - Range: 0xd0bf6c..0xd0bf6d
+            - Range: 0xd0c08c..0xd0c08d
               Pieces: []
-            - Range: 0xd0bf6d..0xd0bf86
+            - Range: 0xd0c08d..0xd0c0a6
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd0c4a0..0xd0c4a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd0c4a0..0xd0c4a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 134
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xd0c4c0..0xd0c4c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd0c4c0..0xd0c4c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 135
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xd0c4e0..0xd0c4e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 253 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xd0c4e0..0xd0c4e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 136
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xd0c500..0xd0c501]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd0c500..0xd0c501
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd0c500..0xd0c501
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 137
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xd0c520..0xd0c521]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd0c520..0xd0c521
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd0c520..0xd0c521
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 138
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xd0c540..0xd0c541]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd0c540..0xd0c541
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd0c540..0xd0c541
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 139
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xd0c560..0xd0c561]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 258 GoSliceHeaderType []string
-          Locations:
-            - Range: 0xd0c560..0xd0c561
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 140
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xd0c580..0xd0c581]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 14 BaseType int8
-          Locations:
-            - Range: 0xd0c580..0xd0c581
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: s
-          Type: 259 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0xd0c580..0xd0c581
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: x
-          Type: 15 BaseType uint
-          Locations:
-            - Range: 0xd0c580..0xd0c581
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 141
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd0c5a0..0xd0c5a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xd0c5a0..0xd0c5a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 142
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xd0c5c0..0xd0c5c1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
+        - Name: u
           Type: 252 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd0c5c0..0xd0c5c1
@@ -9383,13 +9177,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 143
-      Name: main.testSliceEmptyStructs
+    - ID: 134
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xd0c5e0..0xd0c5e1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 261 GoSliceHeaderType []struct {}
+        - Name: u
+          Type: 252 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd0c5e0..0xd0c5e1
               Pieces:
@@ -9402,15 +9196,221 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 135
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xd0c600..0xd0c601]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 253 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xd0c600..0xd0c601
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 136
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xd0c620..0xd0c621]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd0c620..0xd0c621
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd0c620..0xd0c621
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 137
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xd0c640..0xd0c641]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd0c640..0xd0c641
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd0c640..0xd0c641
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xd0c660..0xd0c661]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd0c660..0xd0c661
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd0c660..0xd0c661
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 139
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xd0c680..0xd0c681]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 258 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xd0c680..0xd0c681
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 140
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xd0c6a0..0xd0c6a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 14 BaseType int8
+          Locations:
+            - Range: 0xd0c6a0..0xd0c6a1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: s
+          Type: 259 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0xd0c6a0..0xd0c6a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 15 BaseType uint
+          Locations:
+            - Range: 0xd0c6a0..0xd0c6a1
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 141
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xd0c6c0..0xd0c6c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0xd0c6c0..0xd0c6c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 142
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xd0c6e0..0xd0c6e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 252 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xd0c6e0..0xd0c6e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xd0c700..0xd0c701]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 261 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xd0c700..0xd0c701
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xd0c600..0xd0c601]
+      OutOfLinePCRanges: [0xd0c720..0xd0c721]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0c600..0xd0c601
+            - Range: 0xd0c720..0xd0c721
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9423,7 +9423,7 @@ Subprograms:
         - Name: bs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0c600..0xd0c601
+            - Range: 0xd0c720..0xd0c721
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9436,7 +9436,7 @@ Subprograms:
         - Name: cs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0c600..0xd0c601
+            - Range: 0xd0c720..0xd0c721
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9449,34 +9449,34 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0xd0c9a0..0xd0c9f2]
+      OutOfLinePCRanges: [0xd0cac0..0xd0cb12]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c9a0..0xd0c9e5
+            - Range: 0xd0cac0..0xd0cb05
               Pieces: []
-            - Range: 0xd0c9e5..0xd0c9e6
+            - Range: 0xd0cb05..0xd0cb06
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c9e6..0xd0c9f2
+            - Range: 0xd0cb06..0xd0cb12
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xd0ca00..0xd0ca01]
+      OutOfLinePCRanges: [0xd0cb20..0xd0cb21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0ca00..0xd0ca01
+            - Range: 0xd0cb20..0xd0cb21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9487,13 +9487,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xd0ca20..0xd0ca21]
+      OutOfLinePCRanges: [0xd0cb40..0xd0cb41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0ca20..0xd0ca21
+            - Range: 0xd0cb40..0xd0cb41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9504,7 +9504,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0ca20..0xd0ca21
+            - Range: 0xd0cb40..0xd0cb41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9515,7 +9515,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0ca20..0xd0ca21
+            - Range: 0xd0cb40..0xd0cb41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9526,13 +9526,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd0ca40..0xd0ca5f]
+      OutOfLinePCRanges: [0xd0cb60..0xd0cb7f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 263 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xd0ca40..0xd0ca5f
+            - Range: 0xd0cb60..0xd0cb7f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9551,39 +9551,39 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd0ca60..0xd0ca61]
+      OutOfLinePCRanges: [0xd0cb80..0xd0cb81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xd0ca60..0xd0ca61
+            - Range: 0xd0cb80..0xd0cb81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xd0ca80..0xd0ca81]
+      OutOfLinePCRanges: [0xd0cba0..0xd0cba1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 265 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xd0ca80..0xd0ca81
+            - Range: 0xd0cba0..0xd0cba1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xd0caa0..0xd0caa1]
+      OutOfLinePCRanges: [0xd0cbc0..0xd0cbc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0caa0..0xd0caa1
+            - Range: 0xd0cbc0..0xd0cbc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9594,13 +9594,13 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xd0cac0..0xd0cac1]
+      OutOfLinePCRanges: [0xd0cbe0..0xd0cbe1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0cac0..0xd0cac1
+            - Range: 0xd0cbe0..0xd0cbe1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9611,13 +9611,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xd0cae0..0xd0cae1]
+      OutOfLinePCRanges: [0xd0cc00..0xd0cc01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0cae0..0xd0cae1
+            - Range: 0xd0cc00..0xd0cc01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9628,13 +9628,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xd0cb00..0xd0cb01]
+      OutOfLinePCRanges: [0xd0cc20..0xd0cc21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0cb00..0xd0cb01
+            - Range: 0xd0cc20..0xd0cc21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9645,7 +9645,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0cb00..0xd0cb01
+            - Range: 0xd0cc20..0xd0cc21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9656,7 +9656,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0cb00..0xd0cb01
+            - Range: 0xd0cc20..0xd0cc21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9667,26 +9667,26 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xd0cc80..0xd0cc81]
+      OutOfLinePCRanges: [0xd0cda0..0xd0cda1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xd0cc80..0xd0cc81
+            - Range: 0xd0cda0..0xd0cda1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xd0cca0..0xd0ccbf]
+      OutOfLinePCRanges: [0xd0cdc0..0xd0cddf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xd0cca0..0xd0ccbf
+            - Range: 0xd0cdc0..0xd0cddf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9705,13 +9705,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0xd0cde0..0xd0ce03]
+      OutOfLinePCRanges: [0xd0cf00..0xd0cf23]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 311 StructureType main.aStruct
           Locations:
-            - Range: 0xd0cde0..0xd0ce03
+            - Range: 0xd0cf00..0xd0cf23
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9732,91 +9732,91 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xd0cee0..0xd0cee1]
+      OutOfLinePCRanges: [0xd0d000..0xd0d001]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 312 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xd0cee0..0xd0cee1
+            - Range: 0xd0d000..0xd0d001
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xd0cf00..0xd0cf01]
+      OutOfLinePCRanges: [0xd0d020..0xd0d021]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.tenStrings
           Locations:
-            - Range: 0xd0cf00..0xd0cf01
+            - Range: 0xd0d020..0xd0d021
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd0cf60..0xd0cf61]
+      OutOfLinePCRanges: [0xd0d080..0xd0d081]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 315 StructureType main.emptyStruct
-          Locations: [{Range: 0xd0cf60..0xd0cf61, Pieces: []}]
+          Locations: [{Range: 0xd0d080..0xd0d081, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xd0cf80..0xd0cf81]
+      OutOfLinePCRanges: [0xd0d0a0..0xd0d0a1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 316 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xd0cf80..0xd0cf81
+            - Range: 0xd0d0a0..0xd0d0a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xd0f240..0xd0f244]
+      OutOfLinePCRanges: [0xd0f360..0xd0f364]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0f240..0xd0f244
+            - Range: 0xd0f360..0xd0f364
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd0f240..0xd0f243
+            - Range: 0xd0f360..0xd0f363
               Pieces: []
-            - Range: 0xd0f243..0xd0f244
+            - Range: 0xd0f363..0xd0f364
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xd0f260..0xd0f26c]
+      OutOfLinePCRanges: [0xd0f380..0xd0f38c]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0f260..0xd0f26b
+            - Range: 0xd0f380..0xd0f38b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd0f26b..0xd0f26c
+            - Range: 0xd0f38b..0xd0f38c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9827,9 +9827,9 @@ Subprograms:
         - Name: ~r0
           Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd0f260..0xd0f26b
+            - Range: 0xd0f380..0xd0f38b
               Pieces: []
-            - Range: 0xd0f26b..0xd0f26c
+            - Range: 0xd0f38b..0xd0f38c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9840,41 +9840,41 @@ Subprograms:
       DictRegister: 0
     - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xd0f280..0xd0f284]
+      OutOfLinePCRanges: [0xd0f3a0..0xd0f3a4]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd0f280..0xd0f284
+            - Range: 0xd0f3a0..0xd0f3a4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0f280..0xd0f283
+            - Range: 0xd0f3a0..0xd0f3a3
               Pieces: []
-            - Range: 0xd0f283..0xd0f284
+            - Range: 0xd0f3a3..0xd0f3a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xd0f2a0..0xd0f2ac]
+      OutOfLinePCRanges: [0xd0f3c0..0xd0f3cc]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd0f2a0..0xd0f2ab
+            - Range: 0xd0f3c0..0xd0f3cb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd0f2ab..0xd0f2ac
+            - Range: 0xd0f3cb..0xd0f3cc
               Pieces:
                 - Size: 8
                   Op: null
@@ -9885,9 +9885,9 @@ Subprograms:
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0f2a0..0xd0f2ab
+            - Range: 0xd0f3c0..0xd0f3cb
               Pieces: []
-            - Range: 0xd0f2ab..0xd0f2ac
+            - Range: 0xd0f3cb..0xd0f3cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9898,13 +9898,13 @@ Subprograms:
       DictRegister: 0
     - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xd0f320..0xd0f456]
+      OutOfLinePCRanges: [0xd0f440..0xd0f576]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd0f320..0xd0f353
+            - Range: 0xd0f440..0xd0f473
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9912,7 +9912,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0f353..0xd0f35b
+            - Range: 0xd0f473..0xd0f47b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9920,7 +9920,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xd0f35b..0xd0f456
+            - Range: 0xd0f47b..0xd0f576
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9933,18 +9933,18 @@ Subprograms:
         - Name: pred
           Type: 323 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xd0f320..0xd0f35b
+            - Range: 0xd0f440..0xd0f47b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0f35b..0xd0f456
+            - Range: 0xd0f47b..0xd0f576
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd0f320..0xd0f414
+            - Range: 0xd0f440..0xd0f534
               Pieces: []
-            - Range: 0xd0f414..0xd0f415
+            - Range: 0xd0f534..0xd0f535
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9952,14 +9952,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd0f415..0xd0f456
+            - Range: 0xd0f535..0xd0f576
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd0f35b..0xd0f379
+            - Range: 0xd0f47b..0xd0f499
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9967,7 +9967,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd0f379..0xd0f381
+            - Range: 0xd0f499..0xd0f4a1
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9975,7 +9975,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd0f381..0xd0f389
+            - Range: 0xd0f4a1..0xd0f4a9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9983,7 +9983,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd0f389..0xd0f389
+            - Range: 0xd0f4a9..0xd0f4a9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9991,7 +9991,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd0f389..0xd0f3b3
+            - Range: 0xd0f4a9..0xd0f4d3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -9999,7 +9999,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0f3b3..0xd0f40b
+            - Range: 0xd0f4d3..0xd0f52b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10007,7 +10007,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd0f40b..0xd0f456
+            - Range: 0xd0f52b..0xd0f576
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10020,132 +10020,132 @@ Subprograms:
         - Name: item
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0f3a6..0xd0f3b3
+            - Range: 0xd0f4c6..0xd0f4d3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0f3b3..0xd0f40b
+            - Range: 0xd0f4d3..0xd0f52b
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xd0f460..0xd0f4a4]
+      OutOfLinePCRanges: [0xd0f580..0xd0f5c4]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd0f460..0xd0f479
+            - Range: 0xd0f580..0xd0f599
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 324 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xd0f460..0xd0f479
+            - Range: 0xd0f580..0xd0f599
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd0f460..0xd0f479
+            - Range: 0xd0f580..0xd0f599
               Pieces: []
-            - Range: 0xd0f479..0xd0f47a
+            - Range: 0xd0f599..0xd0f59a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0f47a..0xd0f4a4
+            - Range: 0xd0f59a..0xd0f5c4
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 168
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xd0f740..0xd0f744]
+      OutOfLinePCRanges: [0xd0f860..0xd0f864]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 322 PointerType *go.shape.int
           Locations:
-            - Range: 0xd0f740..0xd0f744
+            - Range: 0xd0f860..0xd0f864
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 PointerType *go.shape.int
           Locations:
-            - Range: 0xd0f740..0xd0f743
+            - Range: 0xd0f860..0xd0f863
               Pieces: []
-            - Range: 0xd0f743..0xd0f744
+            - Range: 0xd0f863..0xd0f864
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xd0f760..0xd0f764]
+      OutOfLinePCRanges: [0xd0f880..0xd0f884]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 325 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xd0f760..0xd0f764
+            - Range: 0xd0f880..0xd0f884
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 325 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xd0f760..0xd0f763
+            - Range: 0xd0f880..0xd0f883
               Pieces: []
-            - Range: 0xd0f763..0xd0f764
+            - Range: 0xd0f883..0xd0f884
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xd0f780..0xd0f784]
+      OutOfLinePCRanges: [0xd0f8a0..0xd0f8a4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 327 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xd0f780..0xd0f784
+            - Range: 0xd0f8a0..0xd0f8a4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 327 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xd0f780..0xd0f783
+            - Range: 0xd0f8a0..0xd0f8a3
               Pieces: []
-            - Range: 0xd0f783..0xd0f784
+            - Range: 0xd0f8a3..0xd0f8a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xd0f7a0..0xd0f7b1]
+      OutOfLinePCRanges: [0xd0f8c0..0xd0f8d1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xd0f7a0..0xd0f7b1
+            - Range: 0xd0f8c0..0xd0f8d1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0f7a0..0xd0f7b0
+            - Range: 0xd0f8c0..0xd0f8d0
               Pieces: []
-            - Range: 0xd0f7b0..0xd0f7b1
+            - Range: 0xd0f8d0..0xd0f8d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10156,69 +10156,69 @@ Subprograms:
       DictRegister: 0
     - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xd0f840..0xd0f849]
+      OutOfLinePCRanges: [0xd0f960..0xd0f969]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 331 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xd0f840..0xd0f849
+            - Range: 0xd0f960..0xd0f969
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0f840..0xd0f848
+            - Range: 0xd0f960..0xd0f968
               Pieces: []
-            - Range: 0xd0f848..0xd0f849
+            - Range: 0xd0f968..0xd0f969
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xd0f900..0xd0f908]
+      OutOfLinePCRanges: [0xd0fa20..0xd0fa28]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xd0f900..0xd0f908
+            - Range: 0xd0fa20..0xd0fa28
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0f900..0xd0f908
+            - Range: 0xd0fa20..0xd0fa28
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0xd0f900..0xd0f908
+            - Range: 0xd0fa20..0xd0fa28
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xd0f9a0..0xd0fa11]
+      OutOfLinePCRanges: [0xd0fac0..0xd0fb31]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xd0f9a0..0xd0fa11
+            - Range: 0xd0fac0..0xd0fb31
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0f9a0..0xd0fa11
+            - Range: 0xd0fac0..0xd0fb31
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10229,20 +10229,20 @@ Subprograms:
         - Name: v
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0f9a0..0xd0fa11
+            - Range: 0xd0fac0..0xd0fb31
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xd0faa0..0xd0faa8]
+      OutOfLinePCRanges: [0xd0fbc0..0xd0fbc8]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0faa0..0xd0faa8
+            - Range: 0xd0fbc0..0xd0fbc8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10253,25 +10253,25 @@ Subprograms:
         - Name: b
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0xd0faa0..0xd0faa8
+            - Range: 0xd0fbc0..0xd0fbc8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0xd0faa0..0xd0faa7
+            - Range: 0xd0fbc0..0xd0fbc7
               Pieces: []
-            - Range: 0xd0faa7..0xd0faa8
+            - Range: 0xd0fbc7..0xd0fbc8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0faa0..0xd0faa7
+            - Range: 0xd0fbc0..0xd0fbc7
               Pieces: []
-            - Range: 0xd0faa7..0xd0faa8
+            - Range: 0xd0fbc7..0xd0fbc8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10282,26 +10282,26 @@ Subprograms:
       DictRegister: 0
     - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xd0fac0..0xd0facf]
+      OutOfLinePCRanges: [0xd0fbe0..0xd0fbef]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0fac0..0xd0face
+            - Range: 0xd0fbe0..0xd0fbee
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0fac0..0xd0facb
+            - Range: 0xd0fbe0..0xd0fbeb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0facb..0xd0facf
+            - Range: 0xd0fbeb..0xd0fbef
               Pieces:
                 - Size: 8
                   Op: null
@@ -10312,9 +10312,9 @@ Subprograms:
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0fac0..0xd0face
+            - Range: 0xd0fbe0..0xd0fbee
               Pieces: []
-            - Range: 0xd0face..0xd0facf
+            - Range: 0xd0fbee..0xd0fbef
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10325,56 +10325,56 @@ Subprograms:
         - Name: ~r1
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0fac0..0xd0face
+            - Range: 0xd0fbe0..0xd0fbee
               Pieces: []
-            - Range: 0xd0face..0xd0facf
+            - Range: 0xd0fbee..0xd0fbef
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xd0fae0..0xd0fb1a]
+      OutOfLinePCRanges: [0xd0fc00..0xd0fc3a]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 337 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xd0fae0..0xd0faf9
+            - Range: 0xd0fc00..0xd0fc19
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0fae0..0xd0faf9
+            - Range: 0xd0fc00..0xd0fc19
               Pieces: []
-            - Range: 0xd0faf9..0xd0fafa
+            - Range: 0xd0fc19..0xd0fc1a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0fafa..0xd0fb1a
+            - Range: 0xd0fc1a..0xd0fc3a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xd0fb20..0xd0fb6d]
+      OutOfLinePCRanges: [0xd0fc40..0xd0fc8d]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 338 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xd0fb20..0xd0fb3f
+            - Range: 0xd0fc40..0xd0fc5f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd0fb3f..0xd0fb42
+            - Range: 0xd0fc5f..0xd0fc62
               Pieces:
                 - Size: 8
                   Op: null
@@ -10385,37 +10385,37 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0fb20..0xd0fb42
+            - Range: 0xd0fc40..0xd0fc62
               Pieces: []
-            - Range: 0xd0fb42..0xd0fb43
+            - Range: 0xd0fc62..0xd0fc63
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0fb43..0xd0fb6d
+            - Range: 0xd0fc63..0xd0fc8d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xd0fb80..0xd0fb88]
+      OutOfLinePCRanges: [0xd0fca0..0xd0fca8]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 339 PointerType *go.shape.string
           Locations:
-            - Range: 0xd0fb80..0xd0fb87
+            - Range: 0xd0fca0..0xd0fca7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0fb80..0xd0fb87
+            - Range: 0xd0fca0..0xd0fca7
               Pieces: []
-            - Range: 0xd0fb87..0xd0fb88
+            - Range: 0xd0fca7..0xd0fca8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10426,22 +10426,22 @@ Subprograms:
       DictRegister: 0
     - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xd0fba0..0xd0fbf7]
+      OutOfLinePCRanges: [0xd0fcc0..0xd0fd17]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 340 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xd0fba0..0xd0fbdd
+            - Range: 0xd0fcc0..0xd0fcfd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 341 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xd0fba0..0xd0fbf1
+            - Range: 0xd0fcc0..0xd0fd11
               Pieces: []
-            - Range: 0xd0fbf1..0xd0fbf2
+            - Range: 0xd0fd11..0xd0fd12
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10455,20 +10455,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xd0fbf2..0xd0fbf7
+            - Range: 0xd0fd12..0xd0fd17
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xd0fc00..0xd0fc24]
+      OutOfLinePCRanges: [0xd0fd20..0xd0fd44]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd0fc00..0xd0fc24
+            - Range: 0xd0fd20..0xd0fd44
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10481,33 +10481,33 @@ Subprograms:
         - Name: needle
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0fc00..0xd0fc24
+            - Range: 0xd0fd20..0xd0fd44
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd0fc00..0xd0fc20
+            - Range: 0xd0fd20..0xd0fd40
               Pieces: []
-            - Range: 0xd0fc20..0xd0fc21
+            - Range: 0xd0fd40..0xd0fd41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0fc21..0xd0fc23
+            - Range: 0xd0fd41..0xd0fd43
               Pieces: []
-            - Range: 0xd0fc23..0xd0fc24
+            - Range: 0xd0fd43..0xd0fd44
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xd0fc40..0xd0fcff]
+      OutOfLinePCRanges: [0xd0fd60..0xd0fe1f]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 342 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xd0fc40..0xd0fc5d
+            - Range: 0xd0fd60..0xd0fd7d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10515,7 +10515,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0fc5d..0xd0fc5f
+            - Range: 0xd0fd7d..0xd0fd7f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10528,13 +10528,13 @@ Subprograms:
         - Name: needle
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0fc40..0xd0fc8c
+            - Range: 0xd0fd60..0xd0fdac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xd0fc8c..0xd0fcff
+            - Range: 0xd0fdac..0xd0fe1f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10545,28 +10545,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd0fc40..0xd0fcab
+            - Range: 0xd0fd60..0xd0fdcb
               Pieces: []
-            - Range: 0xd0fcab..0xd0fcac
+            - Range: 0xd0fdcb..0xd0fdcc
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0fcac..0xd0fcb3
+            - Range: 0xd0fdcc..0xd0fdd3
               Pieces: []
-            - Range: 0xd0fcb3..0xd0fcb4
+            - Range: 0xd0fdd3..0xd0fdd4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0fcb4..0xd0fcff
+            - Range: 0xd0fdd4..0xd0fe1f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0fc6f..0xd0fc81
+            - Range: 0xd0fd8f..0xd0fda1
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xd0fc81..0xd0fc8c
+            - Range: 0xd0fda1..0xd0fdac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10577,54 +10577,54 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xd0fd00..0xd0fd07]
+      OutOfLinePCRanges: [0xd0fe20..0xd0fe27]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 343 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xd0fd00..0xd0fd06
+            - Range: 0xd0fe20..0xd0fe26
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0fd00..0xd0fd07
+            - Range: 0xd0fe20..0xd0fe27
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd0fd00..0xd0fd06
+            - Range: 0xd0fe20..0xd0fe26
               Pieces: []
-            - Range: 0xd0fd06..0xd0fd07
+            - Range: 0xd0fe26..0xd0fe27
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
     - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xd0fd80..0xd0fdec]
+      OutOfLinePCRanges: [0xd0fea0..0xd0ff0c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 344 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xd0fd80..0xd0fda0
+            - Range: 0xd0fea0..0xd0fec0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0fda0..0xd0fda8
+            - Range: 0xd0fec0..0xd0fec8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0fda8..0xd0fdad
+            - Range: 0xd0fec8..0xd0fecd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10635,7 +10635,7 @@ Subprograms:
         - Name: value
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0fd80..0xd0fdad
+            - Range: 0xd0fea0..0xd0fecd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10646,11 +10646,11 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd0fd80..0xd0fdad
+            - Range: 0xd0fea0..0xd0fecd
               Pieces: []
-            - Range: 0xd0fdad..0xd0fdae
+            - Range: 0xd0fecd..0xd0fece
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0fdae..0xd0fdec
+            - Range: 0xd0fece..0xd0ff0c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10788,31 +10788,31 @@ Subprograms:
       DictRegister: 0
     - ID: 186
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xd06660..0xd066c2]
+      OutOfLinePCRanges: [0xd06780..0xd067e2]
       InlinePCRanges:
-        - Ranges: [0xd066f1..0xd0672d]
-          RootRanges: [0xd066e0..0xd06751]
-        - Ranges: [0xd06832..0xd0686e]
-          RootRanges: [0xd06800..0xd06888]
-        - Ranges: [0xd068bc..0xd068f8]
-          RootRanges: [0xd068a0..0xd06965]
-        - Ranges: [0xd0698f..0xd069cb]
-          RootRanges: [0xd06980..0xd069e2]
+        - Ranges: [0xd06811..0xd0684d]
+          RootRanges: [0xd06800..0xd06871]
+        - Ranges: [0xd06952..0xd0698e]
+          RootRanges: [0xd06920..0xd069a8]
+        - Ranges: [0xd069dc..0xd06a18]
+          RootRanges: [0xd069c0..0xd06a85]
+        - Ranges: [0xd06aaf..0xd06aeb]
+          RootRanges: [0xd06aa0..0xd06b02]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd06660..0xd06679
+            - Range: 0xd06780..0xd06799
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd066f1..0xd066fc
+            - Range: 0xd06811..0xd0681c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd06832..0xd0683d
+            - Range: 0xd06952..0xd0695d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd068b6..0xd068c7
+            - Range: 0xd069d6..0xd069e7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd068c7..0xd06965
+            - Range: 0xd069e7..0xd06a85
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd06980..0xd0699a
+            - Range: 0xd06aa0..0xd06aba
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10821,37 +10821,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd06906..0xd0693e]
-          RootRanges: [0xd068a0..0xd06965]
+        - Ranges: [0xd06a26..0xd06a5e]
+          RootRanges: [0xd069c0..0xd06a85]
       Variables: []
       DictRegister: null
     - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd06a13..0xd06a51]
-          RootRanges: [0xd06a00..0xd06b0e]
+        - Ranges: [0xd06b33..0xd06b71]
+          RootRanges: [0xd06b20..0xd06c2e]
       Variables: []
       DictRegister: null
     - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd06ac6..0xd06afe]
-          RootRanges: [0xd06a00..0xd06b0e]
+        - Ranges: [0xd06be6..0xd06c1e]
+          RootRanges: [0xd06b20..0xd06c2e]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd06b21..0xd06b25]
-          RootRanges: [0xd06b20..0xd06b26]
+        - Ranges: [0xd06c41..0xd06c45]
+          RootRanges: [0xd06c40..0xd06c46]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd06b20..0xd06b25
+            - Range: 0xd06c40..0xd06c45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10860,38 +10860,38 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd06b65..0xd06b7d]
-          RootRanges: [0xd06b40..0xd06b83]
-        - Ranges: [0xd06c05..0xd06c23]
-          RootRanges: [0xd06ba0..0xd06d25]
+        - Ranges: [0xd06c85..0xd06c9d]
+          RootRanges: [0xd06c60..0xd06ca3]
+        - Ranges: [0xd06d25..0xd06d43]
+          RootRanges: [0xd06cc0..0xd06e45]
       Variables:
         - Name: a
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0xd06b4d..0xd06b83
+            - Range: 0xd06c6d..0xd06ca3
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xd06bec..0xd06d25
+            - Range: 0xd06d0c..0xd06e45
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 192
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xd06d40..0xd06db1]
+      OutOfLinePCRanges: [0xd06e60..0xd06ed1]
       InlinePCRanges:
-        - Ranges: [0xd0fea3..0xd0fee5]
-          RootRanges: [0xd0fe80..0xd0ff16]
+        - Ranges: [0xd0ffc3..0xd10005]
+          RootRanges: [0xd0ffa0..0xd10036]
       Variables:
         - Name: b
           Type: 349 StructureType main.firstBehavior
           Locations:
-            - Range: 0xd06d40..0xd06d68
+            - Range: 0xd06e60..0xd06e88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd06d68..0xd06d6d
+            - Range: 0xd06e88..0xd06e8d
               Pieces:
                 - Size: 8
                   Op: null
@@ -10902,15 +10902,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd06d40..0xd06d90
+            - Range: 0xd06e60..0xd06eb0
               Pieces: []
-            - Range: 0xd06d90..0xd06d91
+            - Range: 0xd06eb0..0xd06eb1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd06d91..0xd06db1
+            - Range: 0xd06eb1..0xd06ed1
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10919,8 +10919,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd074eb..0xd074f2]
-          RootRanges: [0xd073a0..0xd07538]
+        - Ranges: [0xd07610..0xd07617]
+          RootRanges: [0xd074c0..0xd07658]
         - Ranges: [0x51e6d2..0x51e6d6, 0x51e6d7..0x51e6de]
           RootRanges: [0x51e6c0..0x51e6df]
       Variables: []
@@ -10961,7 +10961,7 @@ Types:
       ID: 123
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 492672
+      GoRuntimeType: 492704
       GoKind: 22
       Pointee: 88 PointerType *string
     - __kind: PointerType
@@ -11093,7 +11093,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 458272
+      GoRuntimeType: 458304
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11135,14 +11135,14 @@ Types:
       ID: 1022
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.857472e+06
+      GoRuntimeType: 1.85776e+06
       GoKind: 22
       Pointee: 1023 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
       ID: 674
       Name: '*archive/tar.headerError'
       ByteSize: 8
-      GoRuntimeType: 861696
+      GoRuntimeType: 861728
       GoKind: 22
       Pointee: 675 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
@@ -11154,49 +11154,49 @@ Types:
       ID: 962
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.258816e+06
+      GoRuntimeType: 1.258944e+06
       GoKind: 22
       Pointee: 963 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
       ID: 910
       Name: '*archive/zip.countWriter'
       ByteSize: 8
-      GoRuntimeType: 861888
+      GoRuntimeType: 861920
       GoKind: 22
       Pointee: 911 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
       ID: 912
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
-      GoRuntimeType: 861984
+      GoRuntimeType: 862016
       GoKind: 22
       Pointee: 913 StructureType archive/zip.dirWriter
     - __kind: PointerType
       ID: 1009
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.78176e+06
+      GoRuntimeType: 1.782048e+06
       GoKind: 22
       Pointee: 1010 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 938
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.021056e+06
+      GoRuntimeType: 1.021184e+06
       GoKind: 22
       Pointee: 939 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 940
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.021312e+06
+      GoRuntimeType: 1.02144e+06
       GoKind: 22
       Pointee: 941 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 365472
+      GoRuntimeType: 365504
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
@@ -11338,35 +11338,35 @@ Types:
       ID: 986
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.038656e+06
+      GoRuntimeType: 2.038944e+06
       GoKind: 22
       Pointee: 987 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1013
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.823712e+06
+      GoRuntimeType: 1.824e+06
       GoKind: 22
       Pointee: 1014 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1058
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.131616e+06
+      GoRuntimeType: 2.131904e+06
       GoKind: 22
       Pointee: 1059 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
       ID: 587
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 844320
+      GoRuntimeType: 844352
       GoKind: 22
       Pointee: 482 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
       ID: 588
       Name: '*compress/flate.InternalError'
       ByteSize: 8
-      GoRuntimeType: 844416
+      GoRuntimeType: 844448
       GoKind: 22
       Pointee: 483 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
@@ -11378,329 +11378,329 @@ Types:
       ID: 960
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.249056e+06
+      GoRuntimeType: 1.249184e+06
       GoKind: 22
       Pointee: 961 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
       ID: 906
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
-      GoRuntimeType: 844512
+      GoRuntimeType: 844544
       GoKind: 22
       Pointee: 907 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
       ID: 982
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.608384e+06
+      GoRuntimeType: 1.608672e+06
       GoKind: 22
       Pointee: 983 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 818
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.123232e+06
+      GoRuntimeType: 1.12336e+06
       GoKind: 22
       Pointee: 819 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 667
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 856608
+      GoRuntimeType: 856640
       GoKind: 22
       Pointee: 496 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
       ID: 668
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 856800
+      GoRuntimeType: 856832
       GoKind: 22
       Pointee: 497 BaseType crypto/des.KeySizeError
     - __kind: PointerType
       ID: 972
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
-      GoRuntimeType: 1.380288e+06
+      GoRuntimeType: 1.380576e+06
       GoKind: 22
       Pointee: 973 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
       ID: 997
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.687392e+06
+      GoRuntimeType: 1.68768e+06
       GoKind: 22
       Pointee: 998 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
       ID: 669
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 857088
+      GoRuntimeType: 857120
       GoKind: 22
       Pointee: 498 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
       ID: 1005
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 1.778944e+06
+      GoRuntimeType: 1.779232e+06
       GoKind: 22
       Pointee: 1006 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 999
       Name: '*crypto/sha256.digest'
       ByteSize: 8
-      GoRuntimeType: 1.68784e+06
+      GoRuntimeType: 1.688128e+06
       GoKind: 22
       Pointee: 1000 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
       ID: 1001
       Name: '*crypto/sha512.digest'
       ByteSize: 8
-      GoRuntimeType: 1.688288e+06
+      GoRuntimeType: 1.688576e+06
       GoKind: 22
       Pointee: 1002 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
       ID: 593
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
-      GoRuntimeType: 845952
+      GoRuntimeType: 845984
       GoKind: 22
       Pointee: 486 BaseType crypto/tls.AlertError
     - __kind: PointerType
       ID: 758
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.008896e+06
+      GoRuntimeType: 1.009024e+06
       GoKind: 22
       Pointee: 759 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1084
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.240736e+06
+      GoRuntimeType: 2.241024e+06
       GoKind: 22
       Pointee: 1085 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
       ID: 591
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
-      GoRuntimeType: 845760
+      GoRuntimeType: 845792
       GoKind: 22
       Pointee: 592 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
       ID: 589
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
-      GoRuntimeType: 845664
+      GoRuntimeType: 845696
       GoKind: 22
       Pointee: 590 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
       ID: 757
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.007232e+06
+      GoRuntimeType: 1.00736e+06
       GoKind: 22
       Pointee: 714 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 970
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.377408e+06
+      GoRuntimeType: 1.377696e+06
       GoKind: 22
       Pointee: 971 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
       ID: 977
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.457952e+06
+      GoRuntimeType: 1.45824e+06
       GoKind: 22
       Pointee: 978 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 853
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.249376e+06
+      GoRuntimeType: 1.249504e+06
       GoKind: 22
       Pointee: 854 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 868
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 1.914624e+06
+      GoRuntimeType: 1.914912e+06
       GoKind: 22
       Pointee: 869 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
       ID: 663
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
-      GoRuntimeType: 855552
+      GoRuntimeType: 855584
       GoKind: 22
       Pointee: 664 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
       ID: 657
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
-      GoRuntimeType: 855072
+      GoRuntimeType: 855104
       GoKind: 22
       Pointee: 658 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
       ID: 659
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
-      GoRuntimeType: 855168
+      GoRuntimeType: 855200
       GoKind: 22
       Pointee: 660 StructureType crypto/x509.HostnameError
     - __kind: PointerType
       ID: 656
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
-      GoRuntimeType: 854976
+      GoRuntimeType: 855008
       GoKind: 22
       Pointee: 495 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
       ID: 763
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.014784e+06
+      GoRuntimeType: 1.014912e+06
       GoKind: 22
       Pointee: 764 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
       ID: 665
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
-      GoRuntimeType: 855648
+      GoRuntimeType: 855680
       GoKind: 22
       Pointee: 666 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
       ID: 661
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
-      GoRuntimeType: 855456
+      GoRuntimeType: 855488
       GoKind: 22
       Pointee: 662 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
       ID: 678
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
-      GoRuntimeType: 862176
+      GoRuntimeType: 862208
       GoKind: 22
       Pointee: 679 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
       ID: 682
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 862368
+      GoRuntimeType: 862400
       GoKind: 22
       Pointee: 683 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
       ID: 680
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 862272
+      GoRuntimeType: 862304
       GoKind: 22
       Pointee: 681 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
       ID: 579
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 842880
+      GoRuntimeType: 842912
       GoKind: 22
       Pointee: 480 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 928
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.004416e+06
+      GoRuntimeType: 1.004544e+06
       GoKind: 22
       Pointee: 929 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
       ID: 582
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
-      GoRuntimeType: 843744
+      GoRuntimeType: 843776
       GoKind: 22
       Pointee: 481 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
       ID: 550
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 837600
+      GoRuntimeType: 837632
       GoKind: 22
       Pointee: 551 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 749
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.000064e+06
+      GoRuntimeType: 1.000192e+06
       GoKind: 22
       Pointee: 750 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 542
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 837216
+      GoRuntimeType: 837248
       GoKind: 22
       Pointee: 543 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 548
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 837504
+      GoRuntimeType: 837536
       GoKind: 22
       Pointee: 549 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 546
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
-      GoRuntimeType: 837408
+      GoRuntimeType: 837440
       GoKind: 22
       Pointee: 547 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
       ID: 544
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 837312
+      GoRuntimeType: 837344
       GoKind: 22
       Pointee: 545 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1064
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.157184e+06
+      GoRuntimeType: 2.157472e+06
       GoKind: 22
       Pointee: 1065 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
       ID: 552
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 837984
+      GoRuntimeType: 838016
       GoKind: 22
       Pointee: 553 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 936
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.0176e+06
+      GoRuntimeType: 1.017728e+06
       GoKind: 22
       Pointee: 937 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
       ID: 651
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 854016
+      GoRuntimeType: 854048
       GoKind: 22
       Pointee: 652 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 649
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
-      GoRuntimeType: 853920
+      GoRuntimeType: 853952
       GoKind: 22
       Pointee: 650 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
       ID: 653
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 854112
+      GoRuntimeType: 854144
       GoKind: 22
       Pointee: 492 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
@@ -11712,119 +11712,119 @@ Types:
       ID: 654
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
-      GoRuntimeType: 854208
+      GoRuntimeType: 854240
       GoKind: 22
       Pointee: 655 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 1042
       Name: '*encoding/xml.printer'
       ByteSize: 8
-      GoRuntimeType: 2.027136e+06
+      GoRuntimeType: 2.027424e+06
       GoKind: 22
       Pointee: 1043 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 99
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 364384
+      GoRuntimeType: 364416
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 520
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 827616
+      GoRuntimeType: 827648
       GoKind: 22
       Pointee: 521 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 716
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 984320
+      GoRuntimeType: 984448
       GoKind: 22
       Pointee: 717 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 101
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 365344
+      GoRuntimeType: 365376
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 91
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 365408
+      GoRuntimeType: 365440
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
       ID: 1052
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.122912e+06
+      GoRuntimeType: 2.1232e+06
       GoKind: 22
       Pointee: 1053 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 718
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 984448
+      GoRuntimeType: 984576
       GoKind: 22
       Pointee: 719 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 720
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 984576
+      GoRuntimeType: 984704
       GoKind: 22
       Pointee: 721 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
       ID: 580
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 843264
+      GoRuntimeType: 843296
       GoKind: 22
       Pointee: 581 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 561
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 840384
+      GoRuntimeType: 840416
       GoKind: 22
       Pointee: 562 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
       ID: 563
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 840480
+      GoRuntimeType: 840512
       GoKind: 22
       Pointee: 564 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 880
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 840192
+      GoRuntimeType: 840224
       GoKind: 22
       Pointee: 881 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
       ID: 567
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 840768
+      GoRuntimeType: 840800
       GoKind: 22
       Pointee: 568 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 882
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 840288
+      GoRuntimeType: 840320
       GoKind: 22
       Pointee: 883 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
       ID: 565
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 840576
+      GoRuntimeType: 840608
       GoKind: 22
       Pointee: 474 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -11836,7 +11836,7 @@ Types:
       ID: 560
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 840096
+      GoRuntimeType: 840128
       GoKind: 22
       Pointee: 471 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -11848,7 +11848,7 @@ Types:
       ID: 566
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 840672
+      GoRuntimeType: 840704
       GoKind: 22
       Pointee: 477 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -11860,98 +11860,98 @@ Types:
       ID: 950
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.128992e+06
+      GoRuntimeType: 1.12912e+06
       GoKind: 22
       Pointee: 951 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1030
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 1.929952e+06
+      GoRuntimeType: 1.93024e+06
       GoKind: 22
       Pointee: 1031 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
       ID: 672
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
-      GoRuntimeType: 860640
+      GoRuntimeType: 860672
       GoKind: 22
       Pointee: 673 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 827
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.13232e+06
+      GoRuntimeType: 1.132448e+06
       GoKind: 22
       Pointee: 828 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1060
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.133152e+06
+      GoRuntimeType: 2.13344e+06
       GoKind: 22
       Pointee: 1061 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
       ID: 600
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
-      GoRuntimeType: 849504
+      GoRuntimeType: 849536
       GoKind: 22
       Pointee: 601 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
       ID: 607
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
-      GoRuntimeType: 850560
+      GoRuntimeType: 850592
       GoKind: 22
       Pointee: 608 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
       ID: 602
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
-      GoRuntimeType: 850272
+      GoRuntimeType: 850304
       GoKind: 22
       Pointee: 491 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
       ID: 605
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
-      GoRuntimeType: 850464
+      GoRuntimeType: 850496
       GoKind: 22
       Pointee: 606 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
       ID: 603
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
-      GoRuntimeType: 850368
+      GoRuntimeType: 850400
       GoKind: 22
       Pointee: 604 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
       ID: 623
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
-      GoRuntimeType: 852480
+      GoRuntimeType: 852512
       GoKind: 22
       Pointee: 624 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
       ID: 627
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
-      GoRuntimeType: 852672
+      GoRuntimeType: 852704
       GoKind: 22
       Pointee: 628 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
       ID: 625
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
-      GoRuntimeType: 852576
+      GoRuntimeType: 852608
       GoKind: 22
       Pointee: 626 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
       ID: 621
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
-      GoRuntimeType: 852384
+      GoRuntimeType: 852416
       GoKind: 22
       Pointee: 622 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
@@ -11963,357 +11963,357 @@ Types:
       ID: 635
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
-      GoRuntimeType: 853056
+      GoRuntimeType: 853088
       GoKind: 22
       Pointee: 636 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
       ID: 629
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
-      GoRuntimeType: 852768
+      GoRuntimeType: 852800
       GoKind: 22
       Pointee: 630 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
       ID: 633
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
-      GoRuntimeType: 852960
+      GoRuntimeType: 852992
       GoKind: 22
       Pointee: 634 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
       ID: 631
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
-      GoRuntimeType: 852864
+      GoRuntimeType: 852896
       GoKind: 22
       Pointee: 632 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
       ID: 637
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
-      GoRuntimeType: 853152
+      GoRuntimeType: 853184
       GoKind: 22
       Pointee: 638 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
       ID: 643
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
-      GoRuntimeType: 853440
+      GoRuntimeType: 853472
       GoKind: 22
       Pointee: 644 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
       ID: 645
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
-      GoRuntimeType: 853536
+      GoRuntimeType: 853568
       GoKind: 22
       Pointee: 646 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
       ID: 641
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
-      GoRuntimeType: 853344
+      GoRuntimeType: 853376
       GoKind: 22
       Pointee: 642 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
       ID: 639
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
-      GoRuntimeType: 853248
+      GoRuntimeType: 853280
       GoKind: 22
       Pointee: 640 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
       ID: 647
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
-      GoRuntimeType: 853728
+      GoRuntimeType: 853760
       GoKind: 22
       Pointee: 648 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 569
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 841920
+      GoRuntimeType: 841952
       GoKind: 22
       Pointee: 570 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 989
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.68448e+06
+      GoRuntimeType: 1.684768e+06
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
       ID: 571
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 842016
+      GoRuntimeType: 842048
       GoKind: 22
       Pointee: 572 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 968
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.376288e+06
+      GoRuntimeType: 1.376576e+06
       GoKind: 22
       Pointee: 969 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 924
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.003392e+06
+      GoRuntimeType: 1.00352e+06
       GoKind: 22
       Pointee: 925 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 958
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.247136e+06
+      GoRuntimeType: 1.247264e+06
       GoKind: 22
       Pointee: 959 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 575
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 842208
+      GoRuntimeType: 842240
       GoKind: 22
       Pointee: 576 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1020
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.847968e+06
+      GoRuntimeType: 1.848256e+06
       GoKind: 22
       Pointee: 1021 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1035
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.002176e+06
+      GoRuntimeType: 2.002464e+06
       GoKind: 22
       Pointee: 1032 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1034
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.001792e+06
+      GoRuntimeType: 2.00208e+06
       GoKind: 22
       Pointee: 1033 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 926
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.00352e+06
+      GoRuntimeType: 1.003648e+06
       GoKind: 22
       Pointee: 927 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 573
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 842112
+      GoRuntimeType: 842144
       GoKind: 22
       Pointee: 574 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
       ID: 577
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 842304
+      GoRuntimeType: 842336
       GoKind: 22
       Pointee: 578 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 993
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.686048e+06
+      GoRuntimeType: 1.686336e+06
       GoKind: 22
       Pointee: 994 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1026
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.883552e+06
+      GoRuntimeType: 1.88384e+06
       GoKind: 22
       Pointee: 1027 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1028
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.914304e+06
+      GoRuntimeType: 1.914592e+06
       GoKind: 22
       Pointee: 1029 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 858
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.261216e+06
+      GoRuntimeType: 1.261344e+06
       GoKind: 22
       Pointee: 859 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 771
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.028992e+06
+      GoRuntimeType: 1.02912e+06
       GoKind: 22
       Pointee: 772 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 769
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.028864e+06
+      GoRuntimeType: 1.028992e+06
       GoKind: 22
       Pointee: 770 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 773
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.03296e+06
+      GoRuntimeType: 1.033088e+06
       GoKind: 22
       Pointee: 774 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 775
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.033088e+06
+      GoRuntimeType: 1.033216e+06
       GoKind: 22
       Pointee: 776 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 979
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.4856e+06
+      GoRuntimeType: 1.485888e+06
       GoKind: 22
       Pointee: 980 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 765
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.015552e+06
+      GoRuntimeType: 1.01568e+06
       GoKind: 22
       Pointee: 766 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 583
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
-      GoRuntimeType: 843936
+      GoRuntimeType: 843968
       GoKind: 22
       Pointee: 584 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
       ID: 1076
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.21984e+06
+      GoRuntimeType: 2.220128e+06
       GoKind: 22
       Pointee: 1077 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 829
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.140512e+06
+      GoRuntimeType: 1.14064e+06
       GoKind: 22
       Pointee: 830 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 802
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.119392e+06
+      GoRuntimeType: 1.11952e+06
       GoKind: 22
       Pointee: 803 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 796
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.119008e+06
+      GoRuntimeType: 1.119136e+06
       GoKind: 22
       Pointee: 797 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 735
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 993920
+      GoRuntimeType: 994048
       GoKind: 22
       Pointee: 736 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 808
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.119776e+06
+      GoRuntimeType: 1.119904e+06
       GoKind: 22
       Pointee: 809 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 734
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 993792
+      GoRuntimeType: 993920
       GoKind: 22
       Pointee: 713 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 800
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.119264e+06
+      GoRuntimeType: 1.119392e+06
       GoKind: 22
       Pointee: 801 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 798
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.119136e+06
+      GoRuntimeType: 1.119264e+06
       GoKind: 22
       Pointee: 799 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 806
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.119648e+06
+      GoRuntimeType: 1.119776e+06
       GoKind: 22
       Pointee: 807 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 804
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.11952e+06
+      GoRuntimeType: 1.119648e+06
       GoKind: 22
       Pointee: 805 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1080
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.23088e+06
+      GoRuntimeType: 2.231168e+06
       GoKind: 22
       Pointee: 1081 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 812
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.12016e+06
+      GoRuntimeType: 1.120288e+06
       GoKind: 22
       Pointee: 813 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 739
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 994176
+      GoRuntimeType: 994304
       GoKind: 22
       Pointee: 740 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 737
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 994048
+      GoRuntimeType: 994176
       GoKind: 22
       Pointee: 738 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 810
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.120032e+06
+      GoRuntimeType: 1.12016e+06
       GoKind: 22
       Pointee: 811 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
       ID: 694
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
-      GoRuntimeType: 874272
+      GoRuntimeType: 874304
       GoKind: 22
       Pointee: 503 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
@@ -12325,21 +12325,21 @@ Types:
       ID: 346
       Name: '*go.shape.float64'
       ByteSize: 8
-      GoRuntimeType: 450208
+      GoRuntimeType: 450240
       GoKind: 22
       Pointee: 347 BaseType go.shape.float64
     - __kind: PointerType
       ID: 322
       Name: '*go.shape.int'
       ByteSize: 8
-      GoRuntimeType: 449824
+      GoRuntimeType: 449856
       GoKind: 22
       Pointee: 317 BaseType go.shape.int
     - __kind: PointerType
       ID: 339
       Name: '*go.shape.string'
       ByteSize: 8
-      GoRuntimeType: 449888
+      GoRuntimeType: 449920
       GoKind: 22
       Pointee: 319 GoStringHeaderType go.shape.string
     - __kind: PointerType
@@ -12369,63 +12369,63 @@ Types:
       ID: 871
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.484064e+06
+      GoRuntimeType: 1.484352e+06
       GoKind: 22
       Pointee: 872 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 779
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.047936e+06
+      GoRuntimeType: 1.048064e+06
       GoKind: 22
       Pointee: 780 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 956
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.179424e+06
+      GoRuntimeType: 1.179552e+06
       GoKind: 22
       Pointee: 957 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1040
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.016768e+06
+      GoRuntimeType: 2.017056e+06
       GoKind: 22
       Pointee: 1041 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 942
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.05024e+06
+      GoRuntimeType: 1.050368e+06
       GoKind: 22
       Pointee: 943 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
       ID: 695
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 875520
+      GoRuntimeType: 875552
       GoKind: 22
       Pointee: 506 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
       ID: 837
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.181088e+06
+      GoRuntimeType: 1.181216e+06
       GoKind: 22
       Pointee: 838 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
       ID: 698
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
-      GoRuntimeType: 875808
+      GoRuntimeType: 875840
       GoKind: 22
       Pointee: 699 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
       ID: 697
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 875712
+      GoRuntimeType: 875744
       GoKind: 22
       Pointee: 510 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
@@ -12437,7 +12437,7 @@ Types:
       ID: 701
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 876000
+      GoRuntimeType: 876032
       GoKind: 22
       Pointee: 516 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
@@ -12449,7 +12449,7 @@ Types:
       ID: 700
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 875904
+      GoRuntimeType: 875936
       GoKind: 22
       Pointee: 513 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
@@ -12461,7 +12461,7 @@ Types:
       ID: 696
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 875616
+      GoRuntimeType: 875648
       GoKind: 22
       Pointee: 507 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
@@ -12473,133 +12473,133 @@ Types:
       ID: 1038
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.014848e+06
+      GoRuntimeType: 2.015136e+06
       GoKind: 22
       Pointee: 1039 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
       ID: 702
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
-      GoRuntimeType: 876096
+      GoRuntimeType: 876128
       GoKind: 22
       Pointee: 703 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
       ID: 704
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
-      GoRuntimeType: 876192
+      GoRuntimeType: 876224
       GoKind: 22
       Pointee: 519 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
       ID: 690
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
-      GoRuntimeType: 869664
+      GoRuntimeType: 869696
       GoKind: 22
       Pointee: 691 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
       ID: 835
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.178016e+06
+      GoRuntimeType: 1.178144e+06
       GoKind: 22
       Pointee: 836 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 860
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.268576e+06
+      GoRuntimeType: 1.268704e+06
       GoKind: 22
       Pointee: 861 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
       ID: 692
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
-      GoRuntimeType: 872544
+      GoRuntimeType: 872576
       GoKind: 22
       Pointee: 693 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 1003
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.692768e+06
+      GoRuntimeType: 1.693056e+06
       GoKind: 22
       Pointee: 1004 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 954
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.17456e+06
+      GoRuntimeType: 1.174688e+06
       GoKind: 22
       Pointee: 955 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 777
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.042176e+06
+      GoRuntimeType: 1.042304e+06
       GoKind: 22
       Pointee: 778 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 914
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
-      GoRuntimeType: 872640
+      GoRuntimeType: 872672
       GoKind: 22
       Pointee: 915 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
       ID: 670
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
-      GoRuntimeType: 858528
+      GoRuntimeType: 858560
       GoKind: 22
       Pointee: 671 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
       ID: 767
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.019008e+06
+      GoRuntimeType: 1.019136e+06
       GoKind: 22
       Pointee: 768 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 833
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.146272e+06
+      GoRuntimeType: 1.1464e+06
       GoKind: 22
       Pointee: 834 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 831
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.146016e+06
+      GoRuntimeType: 1.146144e+06
       GoKind: 22
       Pointee: 832 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
       ID: 684
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
-      GoRuntimeType: 863232
+      GoRuntimeType: 863264
       GoKind: 22
       Pointee: 685 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
       ID: 686
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
-      GoRuntimeType: 863328
+      GoRuntimeType: 863360
       GoKind: 22
       Pointee: 687 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
       ID: 615
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
-      GoRuntimeType: 850944
+      GoRuntimeType: 850976
       GoKind: 22
       Pointee: 616 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
       ID: 991
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.685152e+06
+      GoRuntimeType: 1.68544e+06
       GoKind: 22
       Pointee: 992 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
@@ -12741,126 +12741,126 @@ Types:
       ID: 705
       Name: '*html/template.Error'
       ByteSize: 8
-      GoRuntimeType: 876960
+      GoRuntimeType: 876992
       GoKind: 22
       Pointee: 706 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 93
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 365024
+      GoRuntimeType: 365056
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 96
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 364640
+      GoRuntimeType: 364672
       GoKind: 22
       Pointee: 97 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 364768
+      GoRuntimeType: 364800
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 92
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 364896
+      GoRuntimeType: 364928
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 98
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 364512
+      GoRuntimeType: 364544
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
       ID: 158
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 365600
+      GoRuntimeType: 365632
       GoKind: 22
       Pointee: 152 GoEmptyInterfaceType interface {}
     - __kind: PointerType
       ID: 585
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 844032
+      GoRuntimeType: 844064
       GoKind: 22
       Pointee: 586 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 900
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 832512
+      GoRuntimeType: 832544
       GoKind: 22
       Pointee: 901 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
       ID: 794
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.11824e+06
+      GoRuntimeType: 1.118368e+06
       GoKind: 22
       Pointee: 795 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1082
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.235552e+06
+      GoRuntimeType: 2.23584e+06
       GoKind: 22
       Pointee: 1083 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 792
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.118112e+06
+      GoRuntimeType: 1.11824e+06
       GoKind: 22
       Pointee: 793 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 522
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 831360
+      GoRuntimeType: 831392
       GoKind: 22
       Pointee: 523 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 946
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.109536e+06
+      GoRuntimeType: 1.109664e+06
       GoKind: 22
       Pointee: 947 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 944
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.109152e+06
+      GoRuntimeType: 1.10928e+06
       GoKind: 22
       Pointee: 945 StructureType io.discard
     - __kind: PointerType
       ID: 918
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 985344
+      GoRuntimeType: 985472
       GoKind: 22
       Pointee: 919 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 790
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.117856e+06
+      GoRuntimeType: 1.117984e+06
       GoKind: 22
       Pointee: 791 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 995
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.686272e+06
+      GoRuntimeType: 1.68656e+06
       GoKind: 22
       Pointee: 996 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -12885,105 +12885,105 @@ Types:
       ID: 364
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 357856
+      GoRuntimeType: 357888
       GoKind: 22
       Pointee: 365 StructureType main.deepMap2
     - __kind: PointerType
       ID: 1120
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 357792
+      GoRuntimeType: 357824
       GoKind: 22
       Pointee: 1121 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 144
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 357536
+      GoRuntimeType: 357568
       GoKind: 22
       Pointee: 145 StructureType main.deepMap7
     - __kind: PointerType
       ID: 1148
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 357472
+      GoRuntimeType: 357504
       GoKind: 22
       Pointee: 1149 StructureType main.deepMap8
     - __kind: PointerType
       ID: 1157
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 357408
+      GoRuntimeType: 357440
       GoKind: 22
       Pointee: 1158 StructureType main.deepMap9
     - __kind: PointerType
       ID: 126
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 358432
+      GoRuntimeType: 358464
       GoKind: 22
       Pointee: 127 StructureType main.deepPtr2
     - __kind: PointerType
       ID: 1086
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 358368
+      GoRuntimeType: 358400
       GoKind: 22
       Pointee: 1087 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 128
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 358112
+      GoRuntimeType: 358144
       GoKind: 22
       Pointee: 129 StructureType main.deepPtr7
     - __kind: PointerType
       ID: 1123
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 358048
+      GoRuntimeType: 358080
       GoKind: 22
       Pointee: 1124 StructureType main.deepPtr8
     - __kind: PointerType
       ID: 1125
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 357984
+      GoRuntimeType: 358016
       GoKind: 22
       Pointee: 1126 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 133
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 359008
+      GoRuntimeType: 359040
       GoKind: 22
       Pointee: 358 StructureType main.deepSlice2
     - __kind: PointerType
       ID: 1110
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 358944
+      GoRuntimeType: 358976
       GoKind: 22
       Pointee: 1111 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 134
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 358688
+      GoRuntimeType: 358720
       GoKind: 22
       Pointee: 135 StructureType main.deepSlice7
     - __kind: PointerType
       ID: 1129
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 358624
+      GoRuntimeType: 358656
       GoKind: 22
       Pointee: 1130 StructureType main.deepSlice8
     - __kind: PointerType
       ID: 1135
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 358560
+      GoRuntimeType: 358592
       GoKind: 22
       Pointee: 1136 StructureType main.deepSlice9
     - __kind: PointerType
@@ -12996,28 +12996,28 @@ Types:
       ID: 154
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 359136
+      GoRuntimeType: 359168
       GoKind: 22
       Pointee: 155 StructureType main.esotericHeap
     - __kind: PointerType
       ID: 1102
       Name: '*main.firstBehavior'
       ByteSize: 8
-      GoRuntimeType: 827328
+      GoRuntimeType: 827360
       GoKind: 22
       Pointee: 349 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 1167
       Name: '*main.nestedStruct'
       ByteSize: 8
-      GoRuntimeType: 359392
+      GoRuntimeType: 359424
       GoKind: 22
       Pointee: 116 StructureType main.nestedStruct
     - __kind: PointerType
       ID: 242
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 359200
+      GoRuntimeType: 359232
       GoKind: 22
       Pointee: 241 StructureType main.node
     - __kind: PointerType
@@ -13030,14 +13030,14 @@ Types:
       ID: 1103
       Name: '*main.secondBehavior'
       ByteSize: 8
-      GoRuntimeType: 827424
+      GoRuntimeType: 827456
       GoKind: 22
       Pointee: 1104 StructureType main.secondBehavior
     - __kind: PointerType
       ID: 1091
       Name: '*main.somethingImpl'
       ByteSize: 8
-      GoRuntimeType: 827520
+      GoRuntimeType: 827552
       GoKind: 22
       Pointee: 1092 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
@@ -13071,7 +13071,7 @@ Types:
       ID: 381
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 357344
+      GoRuntimeType: 357376
       GoKind: 22
       Pointee: 160 StructureType main.structWithMap
     - __kind: PointerType
@@ -13112,77 +13112,77 @@ Types:
       ID: 619
       Name: '*math/big.ErrNaN'
       ByteSize: 8
-      GoRuntimeType: 851808
+      GoRuntimeType: 851840
       GoKind: 22
       Pointee: 620 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 908
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
-      GoRuntimeType: 846432
+      GoRuntimeType: 846464
       GoKind: 22
       Pointee: 909 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
       ID: 821
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.12656e+06
+      GoRuntimeType: 1.126688e+06
       GoKind: 22
       Pointee: 822 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 847
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.245376e+06
+      GoRuntimeType: 1.245504e+06
       GoKind: 22
       Pointee: 848 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1046
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.095584e+06
+      GoRuntimeType: 2.095872e+06
       GoKind: 22
       Pointee: 1047 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 845
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.245056e+06
+      GoRuntimeType: 1.245184e+06
       GoKind: 22
       Pointee: 846 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 823
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.126688e+06
+      GoRuntimeType: 1.126816e+06
       GoKind: 22
       Pointee: 824 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1056
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.12496e+06
+      GoRuntimeType: 2.125248e+06
       GoKind: 22
       Pointee: 1057 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1066
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.16992e+06
+      GoRuntimeType: 2.170208e+06
       GoKind: 22
       Pointee: 1067 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1054
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.124448e+06
+      GoRuntimeType: 2.124736e+06
       GoKind: 22
       Pointee: 1055 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 820
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.125792e+06
+      GoRuntimeType: 1.12592e+06
       GoKind: 22
       Pointee: 783 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13194,126 +13194,126 @@ Types:
       ID: 751
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.000832e+06
+      GoRuntimeType: 1.00096e+06
       GoKind: 22
       Pointee: 752 StructureType net.canceledError
     - __kind: PointerType
       ID: 1024
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 1.881248e+06
+      GoRuntimeType: 1.881536e+06
       GoKind: 22
       Pointee: 1025 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 889
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.72592e+06
+      GoRuntimeType: 1.726208e+06
       GoKind: 22
       Pointee: 890 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1068
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.174176e+06
+      GoRuntimeType: 2.174464e+06
       GoKind: 22
       Pointee: 1069 UnresolvedPointeeType net.netFD
     - __kind: PointerType
       ID: 554
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 838944
+      GoRuntimeType: 838976
       GoKind: 22
       Pointee: 555 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 556
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 839616
+      GoRuntimeType: 839648
       GoKind: 22
       Pointee: 557 StructureType net.result·2
     - __kind: PointerType
       ID: 1050
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.109952e+06
+      GoRuntimeType: 2.11024e+06
       GoKind: 22
       Pointee: 1051 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1048
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.109472e+06
+      GoRuntimeType: 2.10976e+06
       GoKind: 22
       Pointee: 1049 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 825
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.127328e+06
+      GoRuntimeType: 1.127456e+06
       GoKind: 22
       Pointee: 826 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 849
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.245536e+06
+      GoRuntimeType: 1.245664e+06
       GoKind: 22
       Pointee: 850 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 741
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 996608
+      GoRuntimeType: 996736
       GoKind: 22
       Pointee: 742 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 902
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 834816
+      GoRuntimeType: 834848
       GoKind: 22
       Pointee: 903 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 531
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 835488
+      GoRuntimeType: 835520
       GoKind: 22
       Pointee: 452 BaseType net/http.http2ConnectionError
     - __kind: PointerType
       ID: 532
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 835584
+      GoRuntimeType: 835616
       GoKind: 22
       Pointee: 533 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 841
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.241216e+06
+      GoRuntimeType: 1.241344e+06
       GoKind: 22
       Pointee: 842 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 536
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 836064
+      GoRuntimeType: 836096
       GoKind: 22
       Pointee: 537 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 964
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.372928e+06
+      GoRuntimeType: 1.373216e+06
       GoKind: 22
       Pointee: 965 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
       ID: 535
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 835968
+      GoRuntimeType: 836000
       GoKind: 22
       Pointee: 456 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -13325,7 +13325,7 @@ Types:
       ID: 539
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 836256
+      GoRuntimeType: 836288
       GoKind: 22
       Pointee: 462 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -13337,7 +13337,7 @@ Types:
       ID: 538
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 836160
+      GoRuntimeType: 836192
       GoKind: 22
       Pointee: 459 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -13349,28 +13349,28 @@ Types:
       ID: 816
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.122336e+06
+      GoRuntimeType: 1.122464e+06
       GoKind: 22
       Pointee: 817 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 747
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 997248
+      GoRuntimeType: 997376
       GoKind: 22
       Pointee: 748 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1015
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.825248e+06
+      GoRuntimeType: 1.825536e+06
       GoKind: 22
       Pointee: 1016 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
       ID: 534
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 835872
+      GoRuntimeType: 835904
       GoKind: 22
       Pointee: 453 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -13382,126 +13382,126 @@ Types:
       ID: 904
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 836352
+      GoRuntimeType: 836384
       GoKind: 22
       Pointee: 905 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 743
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 996864
+      GoRuntimeType: 996992
       GoKind: 22
       Pointee: 744 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 966
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.04032e+06
+      GoRuntimeType: 2.040608e+06
       GoKind: 22
       Pointee: 967 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 922
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 996736
+      GoRuntimeType: 996864
       GoKind: 22
       Pointee: 923 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 948
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.121312e+06
+      GoRuntimeType: 1.12144e+06
       GoKind: 22
       Pointee: 949 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
       ID: 540
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 836448
+      GoRuntimeType: 836480
       GoKind: 22
       Pointee: 541 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 843
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.242336e+06
+      GoRuntimeType: 1.242464e+06
       GoKind: 22
       Pointee: 844 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 814
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.122208e+06
+      GoRuntimeType: 1.122336e+06
       GoKind: 22
       Pointee: 815 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 745
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 996992
+      GoRuntimeType: 997120
       GoKind: 22
       Pointee: 746 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 529
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 834720
+      GoRuntimeType: 834752
       GoKind: 22
       Pointee: 530 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 1017
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.826784e+06
+      GoRuntimeType: 1.827072e+06
       GoKind: 22
       Pointee: 1018 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 932
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.00992e+06
+      GoRuntimeType: 1.010048e+06
       GoKind: 22
       Pointee: 933 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
       ID: 611
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
-      GoRuntimeType: 850752
+      GoRuntimeType: 850784
       GoKind: 22
       Pointee: 612 StructureType net/netip.parseAddrError
     - __kind: PointerType
       ID: 609
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
-      GoRuntimeType: 850656
+      GoRuntimeType: 850688
       GoKind: 22
       Pointee: 610 StructureType net/netip.parsePrefixError
     - __kind: PointerType
       ID: 974
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 1.989568e+06
+      GoRuntimeType: 1.989856e+06
       GoKind: 22
       Pointee: 975 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 934
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.01504e+06
+      GoRuntimeType: 1.015168e+06
       GoKind: 22
       Pointee: 935 StructureType net/smtp.dataCloser
     - __kind: PointerType
       ID: 595
       Name: '*net/textproto.Error'
       ByteSize: 8
-      GoRuntimeType: 846624
+      GoRuntimeType: 846656
       GoKind: 22
       Pointee: 596 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
       ID: 594
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 846528
+      GoRuntimeType: 846560
       GoKind: 22
       Pointee: 487 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
@@ -13513,21 +13513,21 @@ Types:
       ID: 930
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.00928e+06
+      GoRuntimeType: 1.009408e+06
       GoKind: 22
       Pointee: 931 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 851
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.245856e+06
+      GoRuntimeType: 1.245984e+06
       GoKind: 22
       Pointee: 852 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
       ID: 558
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 839712
+      GoRuntimeType: 839744
       GoKind: 22
       Pointee: 465 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -13539,7 +13539,7 @@ Types:
       ID: 559
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 839808
+      GoRuntimeType: 839840
       GoKind: 22
       Pointee: 468 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -13551,70 +13551,70 @@ Types:
       ID: 1074
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.211424e+06
+      GoRuntimeType: 2.211712e+06
       GoKind: 22
       Pointee: 1075 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 724
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 988032
+      GoRuntimeType: 988160
       GoKind: 22
       Pointee: 725 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 786
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.110944e+06
+      GoRuntimeType: 1.111072e+06
       GoKind: 22
       Pointee: 787 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1072
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.20848e+06
+      GoRuntimeType: 2.208768e+06
       GoKind: 22
       Pointee: 1073 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1070
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.207744e+06
+      GoRuntimeType: 2.208032e+06
       GoKind: 22
       Pointee: 1071 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 753
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.005952e+06
+      GoRuntimeType: 1.00608e+06
       GoKind: 22
       Pointee: 754 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 892
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 1.960832e+06
+      GoRuntimeType: 1.96112e+06
       GoKind: 22
       Pointee: 893 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 952
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.133344e+06
+      GoRuntimeType: 1.133472e+06
       GoKind: 22
       Pointee: 953 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 755
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.00608e+06
+      GoRuntimeType: 1.006208e+06
       GoKind: 22
       Pointee: 756 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 689
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
-      GoRuntimeType: 867744
+      GoRuntimeType: 867776
       GoKind: 22
       Pointee: 500 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
@@ -13626,84 +13626,84 @@ Types:
       ID: 688
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
-      GoRuntimeType: 867648
+      GoRuntimeType: 867680
       GoKind: 22
       Pointee: 499 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
       ID: 524
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 832128
+      GoRuntimeType: 832160
       GoKind: 22
       Pointee: 525 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 617
       Name: '*regexp/syntax.Error'
       ByteSize: 8
-      GoRuntimeType: 851424
+      GoRuntimeType: 851456
       GoKind: 22
       Pointee: 618 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
       ID: 727
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 989568
+      GoRuntimeType: 989696
       GoKind: 22
       Pointee: 728 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 732
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 991488
+      GoRuntimeType: 991616
       GoKind: 22
       Pointee: 733 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 365664
+      GoRuntimeType: 365696
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.239456e+06
+      GoRuntimeType: 1.239584e+06
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 729
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 989696
+      GoRuntimeType: 989824
       GoKind: 22
       Pointee: 730 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 366304
+      GoRuntimeType: 366336
       GoKind: 22
       Pointee: 61 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 366368
+      GoRuntimeType: 366400
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 788
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.11632e+06
+      GoRuntimeType: 1.116448e+06
       GoKind: 22
       Pointee: 789 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 726
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 989312
+      GoRuntimeType: 989440
       GoKind: 22
       Pointee: 707 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -13715,28 +13715,28 @@ Types:
       ID: 53
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 830592
+      GoRuntimeType: 830624
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 990848
+      GoRuntimeType: 990976
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 142
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 368352
+      GoRuntimeType: 368384
       GoKind: 22
       Pointee: 143 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 731
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 991232
+      GoRuntimeType: 991360
       GoKind: 22
       Pointee: 710 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -13748,35 +13748,35 @@ Types:
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 367072
+      GoRuntimeType: 367104
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 1.926112e+06
+      GoRuntimeType: 1.9264e+06
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.435296e+06
+      GoRuntimeType: 1.435584e+06
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 722
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 987392
+      GoRuntimeType: 987520
       GoKind: 22
       Pointee: 723 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 88
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 364448
+      GoRuntimeType: 364480
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
@@ -13788,21 +13788,21 @@ Types:
       ID: 1011
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.8232e+06
+      GoRuntimeType: 1.823488e+06
       GoKind: 22
       Pointee: 1012 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 920
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 987520
+      GoRuntimeType: 987648
       GoKind: 22
       Pointee: 921 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
       ID: 916
       Name: '*struct { io.Writer }'
       ByteSize: 8
-      GoRuntimeType: 924512
+      GoRuntimeType: 924640
       GoKind: 22
       Pointee: 917 StructureType struct { io.Writer }
     - __kind: PointerType
@@ -13814,42 +13814,42 @@ Types:
       ID: 840
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.240576e+06
+      GoRuntimeType: 1.240704e+06
       GoKind: 22
       Pointee: 839 BaseType syscall.Errno
     - __kind: PointerType
       ID: 1044
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.02752e+06
+      GoRuntimeType: 2.027808e+06
       GoKind: 22
       Pointee: 1045 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 781
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.051776e+06
+      GoRuntimeType: 1.051904e+06
       GoKind: 22
       Pointee: 782 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 856
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.440864e+06
+      GoRuntimeType: 1.441152e+06
       GoKind: 22
       Pointee: 857 UnresolvedPointeeType time.Location
     - __kind: PointerType
       ID: 527
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 833280
+      GoRuntimeType: 833312
       GoKind: 22
       Pointee: 528 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 526
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 833184
+      GoRuntimeType: 833216
       GoKind: 22
       Pointee: 449 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -13861,91 +13861,91 @@ Types:
       ID: 100
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 365088
+      GoRuntimeType: 365120
       GoKind: 22
       Pointee: 15 BaseType uint
     - __kind: PointerType
       ID: 95
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 364704
+      GoRuntimeType: 364736
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 364832
+      GoRuntimeType: 364864
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 94
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 364960
+      GoRuntimeType: 364992
       GoKind: 22
       Pointee: 10 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 364576
+      GoRuntimeType: 364608
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 365152
+      GoRuntimeType: 365184
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
       ID: 1007
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
-      GoRuntimeType: 1.780224e+06
+      GoRuntimeType: 1.780512e+06
       GoKind: 22
       Pointee: 1008 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
       ID: 613
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
-      GoRuntimeType: 850848
+      GoRuntimeType: 850880
       GoKind: 22
       Pointee: 614 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
       ID: 1036
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.004096e+06
+      GoRuntimeType: 2.004384e+06
       GoKind: 22
       Pointee: 1037 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
       ID: 597
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
-      GoRuntimeType: 847008
+      GoRuntimeType: 847040
       GoKind: 22
       Pointee: 598 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
       ID: 599
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
-      GoRuntimeType: 847104
+      GoRuntimeType: 847136
       GoKind: 22
       Pointee: 490 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
       ID: 760
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.009664e+06
+      GoRuntimeType: 1.009792e+06
       GoKind: 22
       Pointee: 761 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 762
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.009792e+06
+      GoRuntimeType: 1.00992e+06
       GoKind: 22
       Pointee: 715 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -22955,7 +22955,7 @@ Types:
       ID: 85
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 642336
+      GoRuntimeType: 642368
       GoKind: 17
       Count: 10
       HasCount: true
@@ -22964,7 +22964,7 @@ Types:
       ID: 330
       Name: '[16]uint8'
       ByteSize: 16
-      GoRuntimeType: 622880
+      GoRuntimeType: 622912
       GoKind: 17
       Count: 16
       HasCount: true
@@ -22973,7 +22973,7 @@ Types:
       ID: 247
       Name: '[1]int'
       ByteSize: 8
-      GoRuntimeType: 628928
+      GoRuntimeType: 628960
       GoKind: 17
       Count: 1
       HasCount: true
@@ -22982,7 +22982,7 @@ Types:
       ID: 71
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 642048
+      GoRuntimeType: 642080
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23007,7 +23007,7 @@ Types:
       ID: 77
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 642240
+      GoRuntimeType: 642272
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23024,7 +23024,7 @@ Types:
       ID: 106
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 626144
+      GoRuntimeType: 626176
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23041,7 +23041,7 @@ Types:
       ID: 103
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 627296
+      GoRuntimeType: 627328
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23082,7 +23082,7 @@ Types:
       ID: 104
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 627392
+      GoRuntimeType: 627424
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23122,7 +23122,7 @@ Types:
       ID: 52
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 627488
+      GoRuntimeType: 627520
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23131,7 +23131,7 @@ Types:
       ID: 102
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 627200
+      GoRuntimeType: 627232
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23140,7 +23140,7 @@ Types:
       ID: 83
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 675232
+      GoRuntimeType: 675264
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23149,7 +23149,7 @@ Types:
       ID: 63
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 641856
+      GoRuntimeType: 641888
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23158,7 +23158,7 @@ Types:
       ID: 246
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 627584
+      GoRuntimeType: 627616
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23167,7 +23167,7 @@ Types:
       ID: 51
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 641568
+      GoRuntimeType: 641600
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23176,7 +23176,7 @@ Types:
       ID: 391
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 625760
+      GoRuntimeType: 625792
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23185,7 +23185,7 @@ Types:
       ID: 376
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 626048
+      GoRuntimeType: 626080
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23194,7 +23194,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 634016
+      GoRuntimeType: 634048
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23211,7 +23211,7 @@ Types:
       ID: 884
       Name: '[5]uint8'
       ByteSize: 5
-      GoRuntimeType: 627104
+      GoRuntimeType: 627136
       GoKind: 17
       Count: 5
       HasCount: true
@@ -23220,7 +23220,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 628448
+      GoRuntimeType: 628480
       GoKind: 17
       Count: 6
       HasCount: true
@@ -23229,7 +23229,7 @@ Types:
       ID: 78
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 642144
+      GoRuntimeType: 642176
       GoKind: 17
       Count: 8
       HasCount: true
@@ -23238,7 +23238,7 @@ Types:
       ID: 361
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 622976
+      GoRuntimeType: 623008
       GoKind: 17
       Count: 8
       HasCount: true
@@ -23247,7 +23247,7 @@ Types:
       ID: 131
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 448672
+      GoRuntimeType: 448704
       GoKind: 23
       RawFields:
         - Name: array
@@ -23270,7 +23270,7 @@ Types:
       ID: 1108
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 448608
+      GoRuntimeType: 448640
       GoKind: 23
       RawFields:
         - Name: array
@@ -23293,7 +23293,7 @@ Types:
       ID: 1127
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 448288
+      GoRuntimeType: 448320
       GoKind: 23
       RawFields:
         - Name: array
@@ -23316,7 +23316,7 @@ Types:
       ID: 1133
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 448224
+      GoRuntimeType: 448256
       GoKind: 23
       RawFields:
         - Name: array
@@ -23339,7 +23339,7 @@ Types:
       ID: 122
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 447200
+      GoRuntimeType: 447232
       GoKind: 23
       RawFields:
         - Name: array
@@ -23494,7 +23494,7 @@ Types:
       ID: 259
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 456480
+      GoRuntimeType: 456512
       GoKind: 23
       RawFields:
         - Name: array
@@ -23679,7 +23679,7 @@ Types:
       ID: 879
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 456352
+      GoRuntimeType: 456384
       GoKind: 23
       RawFields:
         - Name: array
@@ -23702,7 +23702,7 @@ Types:
       ID: 345
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 452000
+      GoRuntimeType: 452032
       GoKind: 23
       RawFields:
         - Name: array
@@ -23747,7 +23747,7 @@ Types:
       ID: 342
       Name: '[]go.shape.string'
       ByteSize: 24
-      GoRuntimeType: 450016
+      GoRuntimeType: 450048
       GoKind: 23
       RawFields:
         - Name: array
@@ -23770,7 +23770,7 @@ Types:
       ID: 1139
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 456800
+      GoRuntimeType: 456832
       GoKind: 23
       RawFields:
         - Name: array
@@ -23863,7 +23863,7 @@ Types:
       ID: 380
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 449248
+      GoRuntimeType: 449280
       GoKind: 23
       RawFields:
         - Name: array
@@ -23912,7 +23912,7 @@ Types:
       ID: 258
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 456608
+      GoRuntimeType: 456640
       GoKind: 23
       RawFields:
         - Name: array
@@ -23935,7 +23935,7 @@ Types:
       ID: 261
       Name: '[]struct {}'
       ByteSize: 24
-      GoRuntimeType: 449568
+      GoRuntimeType: 449600
       GoKind: 23
       RawFields:
         - Name: array
@@ -23957,7 +23957,7 @@ Types:
       ID: 252
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 456096
+      GoRuntimeType: 456128
       GoKind: 23
       RawFields:
         - Name: array
@@ -23980,7 +23980,7 @@ Types:
       ID: 260
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 455456
+      GoRuntimeType: 455488
       GoKind: 23
       RawFields:
         - Name: array
@@ -24003,7 +24003,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 455328
+      GoRuntimeType: 455360
       GoKind: 23
       RawFields:
         - Name: array
@@ -24026,7 +24026,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 456160
+      GoRuntimeType: 456192
       GoKind: 23
       RawFields:
         - Name: array
@@ -24199,7 +24199,7 @@ Types:
       ID: 675
       Name: archive/tar.headerError
       ByteSize: 24
-      GoRuntimeType: 861792
+      GoRuntimeType: 861824
       GoKind: 23
       RawFields:
         - Name: array
@@ -24229,7 +24229,7 @@ Types:
     - __kind: StructureType
       ID: 913
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.083776e+06
+      GoRuntimeType: 1.083904e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24240,7 +24240,7 @@ Types:
       ID: 939
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.383008e+06
+      GoRuntimeType: 1.383296e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -24254,7 +24254,7 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 534720
+      GoRuntimeType: 534752
       GoKind: 1
     - __kind: GoHMapBucketType
       ID: 222
@@ -24784,36 +24784,36 @@ Types:
     - __kind: GoChannelType
       ID: 238
       Name: chan bool
-      GoRuntimeType: 546304
+      GoRuntimeType: 546336
       GoKind: 18
     - __kind: GoChannelType
       ID: 151
       Name: chan struct {}
-      GoRuntimeType: 545344
+      GoRuntimeType: 545376
       GoKind: 18
     - __kind: BaseType
       ID: 90
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 534528
+      GoRuntimeType: 534560
       GoKind: 16
     - __kind: BaseType
       ID: 89
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 534464
+      GoRuntimeType: 534496
       GoKind: 15
     - __kind: BaseType
       ID: 482
       Name: compress/flate.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 767616
+      GoRuntimeType: 767648
       GoKind: 6
     - __kind: GoStringHeaderType
       ID: 483
       Name: compress/flate.InternalError
       ByteSize: 16
-      GoRuntimeType: 767712
+      GoRuntimeType: 767744
       GoKind: 24
       RawFields:
         - Name: str
@@ -24843,20 +24843,20 @@ Types:
     - __kind: StructureType
       ID: 819
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.303104e+06
+      GoRuntimeType: 1.303392e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 496
       Name: crypto/aes.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 770208
+      GoRuntimeType: 770240
       GoKind: 2
     - __kind: BaseType
       ID: 497
       Name: crypto/des.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 770304
+      GoRuntimeType: 770336
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 973
@@ -24870,7 +24870,7 @@ Types:
       ID: 498
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 770400
+      GoRuntimeType: 770432
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1006
@@ -24888,7 +24888,7 @@ Types:
       ID: 486
       Name: crypto/tls.AlertError
       ByteSize: 1
-      GoRuntimeType: 768192
+      GoRuntimeType: 768224
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 759
@@ -24906,7 +24906,7 @@ Types:
       ID: 590
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.613568e+06
+      GoRuntimeType: 1.613856e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24922,7 +24922,7 @@ Types:
       ID: 714
       Name: crypto/tls.alert
       ByteSize: 1
-      GoRuntimeType: 955904
+      GoRuntimeType: 956032
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 971
@@ -24944,7 +24944,7 @@ Types:
       ID: 664
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.61664e+06
+      GoRuntimeType: 1.616928e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -24959,14 +24959,14 @@ Types:
     - __kind: StructureType
       ID: 658
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.081088e+06
+      GoRuntimeType: 1.081216e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 660
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.41536e+06
+      GoRuntimeType: 1.415648e+06
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -24979,19 +24979,19 @@ Types:
       ID: 495
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
-      GoRuntimeType: 769824
+      GoRuntimeType: 769856
       GoKind: 2
     - __kind: BaseType
       ID: 887
       Name: crypto/x509.InvalidReason
       ByteSize: 8
-      GoRuntimeType: 539968
+      GoRuntimeType: 540000
       GoKind: 2
     - __kind: StructureType
       ID: 764
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.379328e+06
+      GoRuntimeType: 1.379616e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -25000,14 +25000,14 @@ Types:
     - __kind: StructureType
       ID: 666
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.081344e+06
+      GoRuntimeType: 1.081472e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 662
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.616448e+06
+      GoRuntimeType: 1.616736e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25023,7 +25023,7 @@ Types:
       ID: 679
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.259456e+06
+      GoRuntimeType: 1.259584e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25033,7 +25033,7 @@ Types:
       ID: 683
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.259616e+06
+      GoRuntimeType: 1.259744e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25047,7 +25047,7 @@ Types:
       ID: 480
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 767328
+      GoRuntimeType: 767360
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 929
@@ -25057,7 +25057,7 @@ Types:
       ID: 481
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
-      GoRuntimeType: 767520
+      GoRuntimeType: 767552
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 551
@@ -25091,7 +25091,7 @@ Types:
       ID: 553
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.244096e+06
+      GoRuntimeType: 1.244224e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -25113,7 +25113,7 @@ Types:
       ID: 492
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
-      GoRuntimeType: 769728
+      GoRuntimeType: 769760
       GoKind: 24
       RawFields:
         - Name: str
@@ -25140,7 +25140,7 @@ Types:
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 989184
+      GoRuntimeType: 989312
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25161,13 +25161,13 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 534592
+      GoRuntimeType: 534624
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 534656
+      GoRuntimeType: 534688
       GoKind: 14
     - __kind: UnresolvedPointeeType
       ID: 1053
@@ -25185,13 +25185,13 @@ Types:
       ID: 57
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 446944
+      GoRuntimeType: 446976
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 67
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 781440
+      GoRuntimeType: 781472
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 348
@@ -25234,7 +25234,7 @@ Types:
       ID: 562
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.61184e+06
+      GoRuntimeType: 1.612128e+06
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25257,7 +25257,7 @@ Types:
     - __kind: StructureType
       ID: 568
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.077504e+06
+      GoRuntimeType: 1.077632e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25268,7 +25268,7 @@ Types:
       ID: 474
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 766752
+      GoRuntimeType: 766784
       GoKind: 24
       RawFields:
         - Name: str
@@ -25287,7 +25287,7 @@ Types:
       ID: 877
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.08336e+06
+      GoRuntimeType: 2.083648e+06
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25336,13 +25336,13 @@ Types:
       ID: 878
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 536960
+      GoRuntimeType: 536992
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 471
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 766656
+      GoRuntimeType: 766688
       GoKind: 24
       RawFields:
         - Name: str
@@ -25361,7 +25361,7 @@ Types:
       ID: 477
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 766848
+      GoRuntimeType: 766880
       GoKind: 24
       RawFields:
         - Name: str
@@ -25403,26 +25403,26 @@ Types:
     - __kind: StructureType
       ID: 608
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.08032e+06
+      GoRuntimeType: 1.080448e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 491
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
-      GoRuntimeType: 768864
+      GoRuntimeType: 768896
       GoKind: 2
     - __kind: StructureType
       ID: 606
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.080192e+06
+      GoRuntimeType: 1.08032e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 604
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.41344e+06
+      GoRuntimeType: 1.413728e+06
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25435,7 +25435,7 @@ Types:
       ID: 624
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.41424e+06
+      GoRuntimeType: 1.414528e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25448,7 +25448,7 @@ Types:
       ID: 628
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.615872e+06
+      GoRuntimeType: 1.61616e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25464,7 +25464,7 @@ Types:
       ID: 626
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.253856e+06
+      GoRuntimeType: 1.253984e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25474,7 +25474,7 @@ Types:
       ID: 622
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.253536e+06
+      GoRuntimeType: 1.253664e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25484,14 +25484,14 @@ Types:
       ID: 863
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.140768e+06
+      GoRuntimeType: 1.140896e+06
       GoKind: 21
       HeaderType: 865 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 886
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.013376e+06
+      GoRuntimeType: 1.013504e+06
       GoKind: 23
       RawFields:
         - Name: array
@@ -25514,7 +25514,7 @@ Types:
       ID: 636
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.41456e+06
+      GoRuntimeType: 1.414848e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25527,7 +25527,7 @@ Types:
       ID: 630
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.254016e+06
+      GoRuntimeType: 1.254144e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25537,7 +25537,7 @@ Types:
       ID: 634
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.616064e+06
+      GoRuntimeType: 1.616352e+06
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25553,7 +25553,7 @@ Types:
       ID: 632
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.4144e+06
+      GoRuntimeType: 1.414688e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25566,7 +25566,7 @@ Types:
       ID: 638
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.254176e+06
+      GoRuntimeType: 1.254304e+06
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25576,7 +25576,7 @@ Types:
       ID: 644
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.41488e+06
+      GoRuntimeType: 1.415168e+06
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25589,7 +25589,7 @@ Types:
       ID: 646
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.254496e+06
+      GoRuntimeType: 1.254624e+06
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25599,7 +25599,7 @@ Types:
       ID: 642
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.41472e+06
+      GoRuntimeType: 1.415008e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25612,7 +25612,7 @@ Types:
       ID: 640
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.254336e+06
+      GoRuntimeType: 1.254464e+06
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25622,7 +25622,7 @@ Types:
       ID: 648
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.41504e+06
+      GoRuntimeType: 1.415328e+06
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25635,7 +25635,7 @@ Types:
       ID: 570
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.246336e+06
+      GoRuntimeType: 1.246464e+06
       GoKind: 25
       RawFields:
         - Name: message
@@ -25649,7 +25649,7 @@ Types:
       ID: 572
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.246496e+06
+      GoRuntimeType: 1.246624e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25671,7 +25671,7 @@ Types:
       ID: 576
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.246816e+06
+      GoRuntimeType: 1.246944e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25685,7 +25685,7 @@ Types:
       ID: 1032
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 1.977632e+06
+      GoRuntimeType: 1.97792e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25698,7 +25698,7 @@ Types:
       ID: 1033
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.001408e+06
+      GoRuntimeType: 2.001696e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25718,7 +25718,7 @@ Types:
       ID: 574
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.246656e+06
+      GoRuntimeType: 1.246784e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25728,7 +25728,7 @@ Types:
       ID: 578
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.246976e+06
+      GoRuntimeType: 1.247104e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25778,7 +25778,7 @@ Types:
       ID: 584
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.247936e+06
+      GoRuntimeType: 1.248064e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -25793,7 +25793,7 @@ Types:
       ID: 803
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.720992e+06
+      GoRuntimeType: 1.72128e+06
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -25813,7 +25813,7 @@ Types:
       ID: 736
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.517568e+06
+      GoRuntimeType: 1.517856e+06
       GoKind: 25
       RawFields:
         - Name: Got
@@ -25826,7 +25826,7 @@ Types:
       ID: 809
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.72144e+06
+      GoRuntimeType: 1.721728e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25842,13 +25842,13 @@ Types:
       ID: 713
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 953312
+      GoRuntimeType: 953440
       GoKind: 8
     - __kind: StructureType
       ID: 801
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.720768e+06
+      GoRuntimeType: 1.721056e+06
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -25864,13 +25864,13 @@ Types:
       ID: 888
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 764928
+      GoRuntimeType: 764960
       GoKind: 8
     - __kind: StructureType
       ID: 799
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.720544e+06
+      GoRuntimeType: 1.720832e+06
       GoKind: 25
       RawFields:
         - Name: Method
@@ -25886,7 +25886,7 @@ Types:
       ID: 807
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.639456e+06
+      GoRuntimeType: 1.639744e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25899,7 +25899,7 @@ Types:
       ID: 805
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.721216e+06
+      GoRuntimeType: 1.721504e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25919,7 +25919,7 @@ Types:
       ID: 813
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.441824e+06
+      GoRuntimeType: 1.442112e+06
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -25928,20 +25928,20 @@ Types:
     - __kind: StructureType
       ID: 740
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.200864e+06
+      GoRuntimeType: 1.200992e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 738
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.200736e+06
+      GoRuntimeType: 1.200864e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 811
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.639648e+06
+      GoRuntimeType: 1.639936e+06
       GoKind: 25
       RawFields:
         - Name: cause
@@ -25954,7 +25954,7 @@ Types:
       ID: 503
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
-      GoRuntimeType: 772224
+      GoRuntimeType: 772256
       GoKind: 24
       RawFields:
         - Name: str
@@ -25973,25 +25973,25 @@ Types:
       ID: 334
       Name: go.shape.bool
       ByteSize: 1
-      GoRuntimeType: 546496
+      GoRuntimeType: 546528
       GoKind: 1
     - __kind: BaseType
       ID: 347
       Name: go.shape.float64
       ByteSize: 8
-      GoRuntimeType: 546560
+      GoRuntimeType: 546592
       GoKind: 14
     - __kind: BaseType
       ID: 317
       Name: go.shape.int
       ByteSize: 8
-      GoRuntimeType: 546368
+      GoRuntimeType: 546400
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 319
       Name: go.shape.string
       ByteSize: 16
-      GoRuntimeType: 546432
+      GoRuntimeType: 546464
       GoKind: 24
       RawFields:
         - Name: str
@@ -26065,7 +26065,7 @@ Types:
       ID: 780
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.271296e+06
+      GoRuntimeType: 1.271424e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26075,7 +26075,7 @@ Types:
       ID: 957
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.494432e+06
+      GoRuntimeType: 1.49472e+06
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -26089,7 +26089,7 @@ Types:
       ID: 981
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.0912e+06
+      GoRuntimeType: 1.091328e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26102,7 +26102,7 @@ Types:
       ID: 943
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.387808e+06
+      GoRuntimeType: 1.388096e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -26112,19 +26112,19 @@ Types:
       ID: 506
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
-      GoRuntimeType: 772800
+      GoRuntimeType: 772832
       GoKind: 10
     - __kind: BaseType
       ID: 870
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 966560
+      GoRuntimeType: 966688
       GoKind: 10
     - __kind: StructureType
       ID: 838
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.759072e+06
+      GoRuntimeType: 1.75936e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26140,7 +26140,7 @@ Types:
       ID: 699
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.42224e+06
+      GoRuntimeType: 1.422528e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26153,7 +26153,7 @@ Types:
       ID: 510
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 772992
+      GoRuntimeType: 773024
       GoKind: 24
       RawFields:
         - Name: str
@@ -26172,7 +26172,7 @@ Types:
       ID: 516
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 773184
+      GoRuntimeType: 773216
       GoKind: 24
       RawFields:
         - Name: str
@@ -26191,7 +26191,7 @@ Types:
       ID: 513
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 773088
+      GoRuntimeType: 773120
       GoKind: 24
       RawFields:
         - Name: str
@@ -26210,7 +26210,7 @@ Types:
       ID: 507
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 772896
+      GoRuntimeType: 772928
       GoKind: 24
       RawFields:
         - Name: str
@@ -26233,7 +26233,7 @@ Types:
       ID: 703
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.271936e+06
+      GoRuntimeType: 1.272064e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26243,13 +26243,13 @@ Types:
       ID: 519
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
-      GoRuntimeType: 773280
+      GoRuntimeType: 773312
       GoKind: 2
     - __kind: StructureType
       ID: 691
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.266976e+06
+      GoRuntimeType: 1.267104e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26263,7 +26263,7 @@ Types:
       ID: 861
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.784832e+06
+      GoRuntimeType: 1.78512e+06
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26279,7 +26279,7 @@ Types:
       ID: 693
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.42176e+06
+      GoRuntimeType: 1.422048e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26292,7 +26292,7 @@ Types:
       ID: 1004
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.838304e+06
+      GoRuntimeType: 1.838592e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26309,7 +26309,7 @@ Types:
       ID: 778
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.385408e+06
+      GoRuntimeType: 1.385696e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26334,14 +26334,14 @@ Types:
     - __kind: StructureType
       ID: 832
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.332224e+06
+      GoRuntimeType: 1.332512e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 685
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.260256e+06
+      GoRuntimeType: 1.260384e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26351,7 +26351,7 @@ Types:
       ID: 687
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.260416e+06
+      GoRuntimeType: 1.260544e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -27291,37 +27291,37 @@ Types:
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 534272
+      GoRuntimeType: 534304
       GoKind: 2
     - __kind: BaseType
       ID: 97
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 533888
+      GoRuntimeType: 533920
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 534016
+      GoRuntimeType: 534048
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 534144
+      GoRuntimeType: 534176
       GoKind: 6
     - __kind: BaseType
       ID: 14
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 533760
+      GoRuntimeType: 533792
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 152
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 781152
+      GoRuntimeType: 781184
       GoKind: 20
       RawFields:
         - Name: _type
@@ -27338,7 +27338,7 @@ Types:
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.729056e+06
+      GoRuntimeType: 1.729344e+06
       GoKind: 25
       RawFields:
         - Name: buf
@@ -27371,7 +27371,7 @@ Types:
     - __kind: StructureType
       ID: 793
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.300064e+06
+      GoRuntimeType: 1.300352e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27382,7 +27382,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.13296e+06
+      GoRuntimeType: 1.133088e+06
       GoKind: 25
       RawFields:
         - Name: u
@@ -27392,7 +27392,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.456032e+06
+      GoRuntimeType: 1.45632e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27408,7 +27408,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.313344e+06
+      GoRuntimeType: 1.313632e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27421,7 +27421,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.313184e+06
+      GoRuntimeType: 1.313472e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27434,7 +27434,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.313504e+06
+      GoRuntimeType: 1.313792e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27446,13 +27446,13 @@ Types:
     - __kind: StructureType
       ID: 66
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 955616
+      GoRuntimeType: 955744
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 955520
+      GoRuntimeType: 955648
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27463,7 +27463,7 @@ Types:
       ID: 988
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.10928e+06
+      GoRuntimeType: 1.109408e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27476,7 +27476,7 @@ Types:
       ID: 1019
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 985472
+      GoRuntimeType: 985600
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27489,7 +27489,7 @@ Types:
       ID: 976
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.07392e+06
+      GoRuntimeType: 1.074048e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27502,7 +27502,7 @@ Types:
       ID: 124
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 985216
+      GoRuntimeType: 985344
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27514,7 +27514,7 @@ Types:
     - __kind: StructureType
       ID: 945
       Name: io.discard
-      GoRuntimeType: 1.287424e+06
+      GoRuntimeType: 1.287712e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27584,7 +27584,7 @@ Types:
       ID: 157
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 984064
+      GoRuntimeType: 984192
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27597,7 +27597,7 @@ Types:
       ID: 121
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.428576e+06
+      GoRuntimeType: 1.428864e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -27613,7 +27613,7 @@ Types:
       ID: 136
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.105568e+06
+      GoRuntimeType: 1.105696e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27623,7 +27623,7 @@ Types:
       ID: 365
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.10544e+06
+      GoRuntimeType: 1.105568e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27637,7 +27637,7 @@ Types:
       ID: 145
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.1048e+06
+      GoRuntimeType: 1.104928e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27647,7 +27647,7 @@ Types:
       ID: 1149
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.104672e+06
+      GoRuntimeType: 1.1048e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27657,7 +27657,7 @@ Types:
       ID: 1158
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.104544e+06
+      GoRuntimeType: 1.104672e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27667,7 +27667,7 @@ Types:
       ID: 125
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.10672e+06
+      GoRuntimeType: 1.106848e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27677,7 +27677,7 @@ Types:
       ID: 127
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.106592e+06
+      GoRuntimeType: 1.10672e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27691,7 +27691,7 @@ Types:
       ID: 129
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.105952e+06
+      GoRuntimeType: 1.10608e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27701,7 +27701,7 @@ Types:
       ID: 1124
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.105824e+06
+      GoRuntimeType: 1.105952e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27711,7 +27711,7 @@ Types:
       ID: 1126
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.105696e+06
+      GoRuntimeType: 1.105824e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27721,7 +27721,7 @@ Types:
       ID: 130
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.107872e+06
+      GoRuntimeType: 1.108e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27731,7 +27731,7 @@ Types:
       ID: 358
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.107744e+06
+      GoRuntimeType: 1.107872e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27745,7 +27745,7 @@ Types:
       ID: 135
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.107104e+06
+      GoRuntimeType: 1.107232e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27755,7 +27755,7 @@ Types:
       ID: 1130
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.106976e+06
+      GoRuntimeType: 1.107104e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27765,7 +27765,7 @@ Types:
       ID: 1136
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.106848e+06
+      GoRuntimeType: 1.106976e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27780,7 +27780,7 @@ Types:
       ID: 155
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.713152e+06
+      GoRuntimeType: 1.71344e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27802,7 +27802,7 @@ Types:
       ID: 150
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.839616e+06
+      GoRuntimeType: 1.839904e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -27830,7 +27830,7 @@ Types:
       ID: 349
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.237376e+06
+      GoRuntimeType: 1.237504e+06
       GoKind: 25
       RawFields:
         - Name: s
@@ -27957,7 +27957,7 @@ Types:
       ID: 116
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.286464e+06
+      GoRuntimeType: 1.286752e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -27970,7 +27970,7 @@ Types:
       ID: 241
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.286144e+06
+      GoRuntimeType: 1.286432e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -27992,14 +27992,14 @@ Types:
       ID: 1104
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.237536e+06
+      GoRuntimeType: 1.237664e+06
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 9 BaseType int}]
     - __kind: GoInterfaceType
       ID: 153
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 984192
+      GoRuntimeType: 984320
       GoKind: 20
       RawFields:
         - Name: tab
@@ -28052,7 +28052,7 @@ Types:
       ID: 159
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.104288e+06
+      GoRuntimeType: 1.104416e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -28122,7 +28122,7 @@ Types:
       ID: 160
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.104416e+06
+      GoRuntimeType: 1.104544e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -28291,119 +28291,119 @@ Types:
       ID: 218
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 884160
+      GoRuntimeType: 884192
       GoKind: 21
       HeaderType: 220 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
       ID: 213
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 884256
+      GoRuntimeType: 884288
       GoKind: 21
       HeaderType: 215 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
       ID: 181
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 884352
+      GoRuntimeType: 884384
       GoKind: 21
       HeaderType: 183 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoMapType
       ID: 193
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 884448
+      GoRuntimeType: 884480
       GoKind: 21
       HeaderType: 195 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
       ID: 137
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 884064
+      GoRuntimeType: 884096
       GoKind: 21
       HeaderType: 139 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1114
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 883968
+      GoRuntimeType: 884000
       GoKind: 21
       HeaderType: 1116 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1142
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 883488
+      GoRuntimeType: 883520
       GoKind: 21
       HeaderType: 1144 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1151
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 883392
+      GoRuntimeType: 883424
       GoKind: 21
       HeaderType: 1153 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 161
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 882240
+      GoRuntimeType: 882272
       GoKind: 21
       HeaderType: 163 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
       ID: 1160
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 883296
+      GoRuntimeType: 883328
       GoKind: 21
       HeaderType: 1162 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 228
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 884544
+      GoRuntimeType: 884576
       GoKind: 21
       HeaderType: 230 GoHMapHeaderType hash<int,struct {}>
     - __kind: GoMapType
       ID: 198
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 884640
+      GoRuntimeType: 884672
       GoKind: 21
       HeaderType: 200 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
       ID: 188
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 884736
+      GoRuntimeType: 884768
       GoKind: 21
       HeaderType: 190 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 176
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 884832
+      GoRuntimeType: 884864
       GoKind: 21
       HeaderType: 178 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
       ID: 171
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 884928
+      GoRuntimeType: 884960
       GoKind: 21
       HeaderType: 173 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 166
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 885024
+      GoRuntimeType: 885056
       GoKind: 21
       HeaderType: 168 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 223
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 885120
+      GoRuntimeType: 885152
       GoKind: 21
       HeaderType: 225 GoHMapHeaderType hash<struct {},int>
     - __kind: GoMapType
@@ -28446,28 +28446,28 @@ Types:
       ID: 233
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 885216
+      GoRuntimeType: 885248
       GoKind: 21
       HeaderType: 235 GoHMapHeaderType hash<struct {},struct {}>
     - __kind: GoMapType
       ID: 208
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 885312
+      GoRuntimeType: 885344
       GoKind: 21
       HeaderType: 210 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoMapType
       ID: 203
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 885408
+      GoRuntimeType: 885440
       GoKind: 21
       HeaderType: 205 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
       ID: 620
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.253216e+06
+      GoRuntimeType: 1.253344e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -28477,7 +28477,7 @@ Types:
       ID: 909
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.250016e+06
+      GoRuntimeType: 1.250144e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -28491,7 +28491,7 @@ Types:
       ID: 885
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.41216e+06
+      GoRuntimeType: 1.412448e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -28532,7 +28532,7 @@ Types:
       ID: 783
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.07712e+06
+      GoRuntimeType: 1.077248e+06
       GoKind: 24
       RawFields:
         - Name: str
@@ -28550,7 +28550,7 @@ Types:
     - __kind: StructureType
       ID: 752
       Name: net.canceledError
-      GoRuntimeType: 1.20176e+06
+      GoRuntimeType: 1.201888e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28561,7 +28561,7 @@ Types:
       ID: 890
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 1.976928e+06
+      GoRuntimeType: 1.977216e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -28583,13 +28583,13 @@ Types:
     - __kind: StructureType
       ID: 1063
       Name: net.noReadFrom
-      GoRuntimeType: 1.077376e+06
+      GoRuntimeType: 1.077504e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1062
       Name: net.noWriteTo
-      GoRuntimeType: 1.077248e+06
+      GoRuntimeType: 1.077376e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28600,7 +28600,7 @@ Types:
       ID: 557
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.611648e+06
+      GoRuntimeType: 1.611936e+06
       GoKind: 25
       RawFields:
         - Name: p
@@ -28616,7 +28616,7 @@ Types:
       ID: 1051
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.153248e+06
+      GoRuntimeType: 2.153536e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -28629,7 +28629,7 @@ Types:
       ID: 1049
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.152704e+06
+      GoRuntimeType: 2.152992e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -28654,7 +28654,7 @@ Types:
       ID: 903
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.241536e+06
+      GoRuntimeType: 1.241664e+06
       GoKind: 25
       RawFields:
         - Name: w
@@ -28664,19 +28664,19 @@ Types:
       ID: 452
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 765408
+      GoRuntimeType: 765440
       GoKind: 10
     - __kind: BaseType
       ID: 862
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 953408
+      GoRuntimeType: 953536
       GoKind: 10
     - __kind: StructureType
       ID: 533
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.609728e+06
+      GoRuntimeType: 1.610016e+06
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -28692,7 +28692,7 @@ Types:
       ID: 842
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.775104e+06
+      GoRuntimeType: 1.775392e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -28708,7 +28708,7 @@ Types:
       ID: 537
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.41168e+06
+      GoRuntimeType: 1.411968e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -28725,7 +28725,7 @@ Types:
       ID: 456
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 765600
+      GoRuntimeType: 765632
       GoKind: 24
       RawFields:
         - Name: str
@@ -28744,7 +28744,7 @@ Types:
       ID: 462
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 765792
+      GoRuntimeType: 765824
       GoKind: 24
       RawFields:
         - Name: str
@@ -28763,7 +28763,7 @@ Types:
       ID: 459
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 765696
+      GoRuntimeType: 765728
       GoKind: 24
       RawFields:
         - Name: str
@@ -28785,7 +28785,7 @@ Types:
     - __kind: StructureType
       ID: 748
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.20112e+06
+      GoRuntimeType: 1.201248e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28796,7 +28796,7 @@ Types:
       ID: 453
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 765504
+      GoRuntimeType: 765536
       GoKind: 24
       RawFields:
         - Name: str
@@ -28815,7 +28815,7 @@ Types:
       ID: 905
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
-      GoRuntimeType: 1.610496e+06
+      GoRuntimeType: 1.610784e+06
       GoKind: 25
       RawFields:
         - Name: conn
@@ -28830,7 +28830,7 @@ Types:
     - __kind: ArrayType
       ID: 985
       Name: net/http.incomparable
-      GoRuntimeType: 834528
+      GoRuntimeType: 834560
       GoKind: 17
       HasCount: true
       Element: 57 GoSubroutineType func()
@@ -28838,7 +28838,7 @@ Types:
       ID: 744
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.373568e+06
+      GoRuntimeType: 1.373856e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -28852,7 +28852,7 @@ Types:
       ID: 923
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.373408e+06
+      GoRuntimeType: 1.373696e+06
       GoKind: 25
       RawFields:
         - Name: pc
@@ -28862,7 +28862,7 @@ Types:
       ID: 949
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.681792e+06
+      GoRuntimeType: 1.68208e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -28878,7 +28878,7 @@ Types:
       ID: 541
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.242496e+06
+      GoRuntimeType: 1.242624e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -28891,14 +28891,14 @@ Types:
     - __kind: StructureType
       ID: 815
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.302784e+06
+      GoRuntimeType: 1.303072e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 746
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.373728e+06
+      GoRuntimeType: 1.374016e+06
       GoKind: 25
       RawFields:
         - Name: err
@@ -28912,7 +28912,7 @@ Types:
       ID: 1018
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 1.913344e+06
+      GoRuntimeType: 1.913632e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -28926,7 +28926,7 @@ Types:
       ID: 612
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.615488e+06
+      GoRuntimeType: 1.615776e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -28942,7 +28942,7 @@ Types:
       ID: 610
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.4136e+06
+      GoRuntimeType: 1.413888e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -28959,7 +28959,7 @@ Types:
       ID: 935
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.41552e+06
+      GoRuntimeType: 1.415808e+06
       GoKind: 25
       RawFields:
         - Name: c
@@ -28976,7 +28976,7 @@ Types:
       ID: 487
       Name: net/textproto.ProtocolError
       ByteSize: 16
-      GoRuntimeType: 768288
+      GoRuntimeType: 768320
       GoKind: 24
       RawFields:
         - Name: str
@@ -29003,7 +29003,7 @@ Types:
       ID: 465
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 766368
+      GoRuntimeType: 766400
       GoKind: 24
       RawFields:
         - Name: str
@@ -29022,7 +29022,7 @@ Types:
       ID: 468
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 766464
+      GoRuntimeType: 766496
       GoKind: 24
       RawFields:
         - Name: str
@@ -29053,7 +29053,7 @@ Types:
       ID: 1073
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.22144e+06
+      GoRuntimeType: 2.221728e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29066,7 +29066,7 @@ Types:
       ID: 1071
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.22064e+06
+      GoRuntimeType: 2.220928e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29078,13 +29078,13 @@ Types:
     - __kind: StructureType
       ID: 1079
       Name: os.noReadFrom
-      GoRuntimeType: 1.074944e+06
+      GoRuntimeType: 1.075072e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1078
       Name: os.noWriteTo
-      GoRuntimeType: 1.074816e+06
+      GoRuntimeType: 1.074944e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29103,7 +29103,7 @@ Types:
       ID: 756
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.518144e+06
+      GoRuntimeType: 1.518432e+06
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -29116,7 +29116,7 @@ Types:
       ID: 500
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
-      GoRuntimeType: 771456
+      GoRuntimeType: 771488
       GoKind: 24
       RawFields:
         - Name: str
@@ -29135,7 +29135,7 @@ Types:
       ID: 499
       Name: os/user.UnknownUserIdError
       ByteSize: 8
-      GoRuntimeType: 771360
+      GoRuntimeType: 771392
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 525
@@ -29165,7 +29165,7 @@ Types:
       ID: 730
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.764672e+06
+      GoRuntimeType: 1.76496e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -29184,7 +29184,7 @@ Types:
       ID: 891
       Name: runtime.boundsErrorCode
       ByteSize: 1
-      GoRuntimeType: 534848
+      GoRuntimeType: 534880
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 61
@@ -29197,14 +29197,14 @@ Types:
     - __kind: StructureType
       ID: 80
       Name: runtime.dlogPerM
-      GoRuntimeType: 952640
+      GoRuntimeType: 952768
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 789
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.635616e+06
+      GoRuntimeType: 1.635904e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -29217,7 +29217,7 @@ Types:
       ID: 707
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 952256
+      GoRuntimeType: 952384
       GoKind: 24
       RawFields:
         - Name: str
@@ -29236,7 +29236,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 2.264672e+06
+      GoRuntimeType: 2.26496e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -29411,7 +29411,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.116064e+06
+      GoRuntimeType: 1.116192e+06
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -29421,7 +29421,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.84192e+06
+      GoRuntimeType: 1.842208e+06
       GoKind: 25
       RawFields:
         - Name: sp
@@ -29449,7 +29449,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.295104e+06
+      GoRuntimeType: 1.295392e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -29462,7 +29462,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.634656e+06
+      GoRuntimeType: 1.634944e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -29481,13 +29481,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 764160
+      GoRuntimeType: 764192
       GoKind: 12
     - __kind: StructureType
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.294944e+06
+      GoRuntimeType: 1.295232e+06
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -29500,7 +29500,7 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.790176e+06
+      GoRuntimeType: 1.790464e+06
       GoKind: 25
       RawFields:
         - Name: fn
@@ -29525,13 +29525,13 @@ Types:
       ID: 87
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 764064
+      GoRuntimeType: 764096
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 2.270784e+06
+      GoRuntimeType: 2.271072e+06
       GoKind: 25
       RawFields:
         - Name: g0
@@ -29751,7 +29751,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.78992e+06
+      GoRuntimeType: 1.790208e+06
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -29776,7 +29776,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 1.43568e+06
+      GoRuntimeType: 1.435968e+06
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -29792,7 +29792,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 1.435488e+06
+      GoRuntimeType: 1.435776e+06
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -29812,20 +29812,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 763776
+      GoRuntimeType: 763808
       GoKind: 12
     - __kind: StructureType
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.11568e+06
+      GoRuntimeType: 1.115808e+06
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.294784e+06
+      GoRuntimeType: 1.295072e+06
       GoKind: 25
       RawFields:
         - Name: entries
@@ -29838,7 +29838,7 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.635424e+06
+      GoRuntimeType: 1.635712e+06
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -29857,7 +29857,7 @@ Types:
       ID: 710
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 952832
+      GoRuntimeType: 952960
       GoKind: 24
       RawFields:
         - Name: str
@@ -29876,13 +29876,13 @@ Types:
       ID: 58
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 763968
+      GoRuntimeType: 764000
       GoKind: 12
     - __kind: ArrayType
       ID: 55
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 830208
+      GoRuntimeType: 830240
       GoKind: 17
       Count: 2
       HasCount: true
@@ -29891,7 +29891,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.293184e+06
+      GoRuntimeType: 1.293472e+06
       GoKind: 25
       RawFields:
         - Name: lo
@@ -29908,7 +29908,7 @@ Types:
       ID: 59
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 534976
+      GoRuntimeType: 535008
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -29918,7 +29918,7 @@ Types:
       ID: 68
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 535040
+      GoRuntimeType: 535072
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 73
@@ -29928,7 +29928,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.294144e+06
+      GoRuntimeType: 1.294432e+06
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -29941,12 +29941,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.075328e+06
+      GoRuntimeType: 1.075456e+06
       GoKind: 8
     - __kind: StructureType
       ID: 75
       Name: runtime.winlibcall
-      GoRuntimeType: 952544
+      GoRuntimeType: 952672
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29957,7 +29957,7 @@ Types:
       ID: 11
       Name: string
       ByteSize: 16
-      GoRuntimeType: 533696
+      GoRuntimeType: 533728
       GoKind: 24
       RawFields:
         - Name: str
@@ -29984,7 +29984,7 @@ Types:
       ID: 917
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.278944e+06
+      GoRuntimeType: 1.279232e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29993,14 +29993,14 @@ Types:
     - __kind: StructureType
       ID: 118
       Name: struct {}
-      GoRuntimeType: 775104
+      GoRuntimeType: 775136
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1093
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.287744e+06
+      GoRuntimeType: 1.288032e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -30013,7 +30013,7 @@ Types:
       ID: 1094
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.288864e+06
+      GoRuntimeType: 1.289152e+06
       GoKind: 25
       RawFields:
         - Name: done
@@ -30026,7 +30026,7 @@ Types:
       ID: 1097
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.429344e+06
+      GoRuntimeType: 1.429632e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -30041,14 +30041,14 @@ Types:
     - __kind: StructureType
       ID: 1098
       Name: sync.noCopy
-      GoRuntimeType: 951200
+      GoRuntimeType: 951328
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1101
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.289184e+06
+      GoRuntimeType: 1.289472e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -30061,7 +30061,7 @@ Types:
       ID: 1095
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.289344e+06
+      GoRuntimeType: 1.289632e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -30074,7 +30074,7 @@ Types:
       ID: 1099
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.429728e+06
+      GoRuntimeType: 1.430016e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -30089,20 +30089,20 @@ Types:
     - __kind: StructureType
       ID: 1100
       Name: sync/atomic.align64
-      GoRuntimeType: 951392
+      GoRuntimeType: 951520
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1096
       Name: sync/atomic.noCopy
-      GoRuntimeType: 951296
+      GoRuntimeType: 951424
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 839
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.200352e+06
+      GoRuntimeType: 1.20048e+06
       GoKind: 12
     - __kind: UnresolvedPointeeType
       ID: 1045
@@ -30112,7 +30112,7 @@ Types:
       ID: 782
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.52256e+06
+      GoRuntimeType: 1.522848e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -30125,7 +30125,7 @@ Types:
       ID: 984
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.790944e+06
+      GoRuntimeType: 1.791232e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 857
@@ -30139,7 +30139,7 @@ Types:
       ID: 855
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.233664e+06
+      GoRuntimeType: 2.233952e+06
       GoKind: 25
       RawFields:
         - Name: wall
@@ -30155,7 +30155,7 @@ Types:
       ID: 449
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 764544
+      GoRuntimeType: 764576
       GoKind: 24
       RawFields:
         - Name: str
@@ -30174,43 +30174,43 @@ Types:
       ID: 15
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 534336
+      GoRuntimeType: 534368
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 533952
+      GoRuntimeType: 533984
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 534080
+      GoRuntimeType: 534112
       GoKind: 10
     - __kind: BaseType
       ID: 10
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 534208
+      GoRuntimeType: 534240
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 533824
+      GoRuntimeType: 533856
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 534400
+      GoRuntimeType: 534432
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 534784
+      GoRuntimeType: 534816
       GoKind: 26
     - __kind: UnresolvedPointeeType
       ID: 1008
@@ -30220,7 +30220,7 @@ Types:
       ID: 873
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 1.935072e+06
+      GoRuntimeType: 1.93536e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30254,13 +30254,13 @@ Types:
       ID: 876
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
-      GoRuntimeType: 957536
+      GoRuntimeType: 957664
       GoKind: 9
     - __kind: StructureType
       ID: 874
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.80144e+06
+      GoRuntimeType: 1.801728e+06
       GoKind: 25
       RawFields:
         - Name: id
@@ -30289,7 +30289,7 @@ Types:
       ID: 875
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
-      GoRuntimeType: 538432
+      GoRuntimeType: 538464
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1037
@@ -30299,7 +30299,7 @@ Types:
       ID: 598
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.250336e+06
+      GoRuntimeType: 1.250464e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -30309,13 +30309,13 @@ Types:
       ID: 490
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
-      GoRuntimeType: 768384
+      GoRuntimeType: 768416
       GoKind: 2
     - __kind: StructureType
       ID: 761
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.518336e+06
+      GoRuntimeType: 1.518624e+06
       GoKind: 25
       RawFields:
         - Name: label
@@ -30328,7 +30328,7 @@ Types:
       ID: 715
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
-      GoRuntimeType: 956384
+      GoRuntimeType: 956512
       GoKind: 5
 MaxTypeID: 1495
 Issues:
@@ -30362,10 +30362,10 @@ Issues:
       issue:
         Kind: 7
         Message: return value selector (e.g., @return.r0) must be used for multi-value returns
-GoModuledataInfo: {FirstModuledataAddr: "0x1769760", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x176a760", TypesOffset: 296}
 GoMapHashInfo:
-    UseAeshashAddr: "0x184298b"
-    AeskeyschedAddr: "0x1843b20"
+    UseAeshashAddr: "0x184398b"
+    AeskeyschedAddr: "0x1844b20"
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1574 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xcdddea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcddf0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1575 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xcdde25", Frameless: false}]
+              InjectionPoints: [{PC: "0xcddf45", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1413 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0xcd816a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd828a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1414 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0xcd81a5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd82c5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0xcd820a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd832a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0xcd823d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd835d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1545 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xcdc80e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc92e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1546 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcdc8c2", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc9e2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1363 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0xcd5020", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1359 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0xcd4fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd50c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1361 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0xcd4fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xcd8980", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1360 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0xcd4fc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd50e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1362 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0xcd5000", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xcda860", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda980", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1448 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xcda872", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda992", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0xcd5720", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5840", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1382 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0xcd573e", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd585e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1348 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0xcd4e40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd4f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1345 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0xcd4de0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd4f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcde220", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde340", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1594 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xcde242", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde362", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1654 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcd798e"
+                - PC: "0xcd7aae"
                   Frameless: false
-                - PC: "0xcd7a11"
+                - PC: "0xcd7b31"
                   Frameless: false
-                - PC: "0xcd7b52"
+                - PC: "0xcd7c72"
                   Frameless: false
-                - PC: "0xcd7bdc"
+                - PC: "0xcd7cfc"
                   Frameless: false
-                - PC: "0xcd7caf"
+                - PC: "0xcd7dcf"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1655 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcd798e"
+                - PC: "0xcd7aae"
                   Frameless: false
-                - PC: "0xcd7a11"
+                - PC: "0xcd7b31"
                   Frameless: false
-                - PC: "0xcd7b52"
+                - PC: "0xcd7c72"
                   Frameless: false
-                - PC: "0xcd7bdc"
+                - PC: "0xcd7cfc"
                   Frameless: false
-                - PC: "0xcd7caf"
+                - PC: "0xcd7dcf"
                   Frameless: false
               Condition:
                 Type: 4 BaseType bool
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 1656 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcd798e"
+                - PC: "0xcd7aae"
                   Frameless: false
-                - PC: "0xcd7a11"
+                - PC: "0xcd7b31"
                   Frameless: false
-                - PC: "0xcd7b52"
+                - PC: "0xcd7c72"
                   Frameless: false
-                - PC: "0xcd7bdc"
+                - PC: "0xcd7cfc"
                   Frameless: false
-                - PC: "0xcd7caf"
+                - PC: "0xcd7dcf"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -474,7 +474,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcda4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda5e0", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -493,7 +493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcda4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -519,7 +519,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1601 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xcde340", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde460", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -554,7 +554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xcda880", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda9a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -584,7 +584,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xcda480", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -613,11 +613,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1510 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xcdba4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdbb6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1511 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xcdbb11", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdbc31", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -639,7 +639,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xcdac60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdad80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -661,7 +661,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0xcd5c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5d40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -683,7 +683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0xcd5c40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -705,7 +705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0xcd5900", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -727,7 +727,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0xcd5920", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -749,7 +749,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0xcd5aa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5bc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -771,7 +771,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0xcd5ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -793,7 +793,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1562 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xcdd900", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdda20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -820,7 +820,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1565 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xcdd960", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdda80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -848,7 +848,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xcddf20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -870,7 +870,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xcde3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -891,7 +891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xcde3c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -913,7 +913,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0xcd81e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -947,7 +947,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1383 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0xcd57bb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd58db", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -975,11 +975,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0xcd646a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd658a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1398 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0xcd64ac", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd65cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1001,11 +1001,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0xcd634e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd646e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1396 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0xcd63db", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd64fb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1027,11 +1027,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1407 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0xcd7e40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7f60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1408 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0xcd7e45", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7f65", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1053,11 +1053,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0xcd7e64", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7f84", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1410 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0xcd7e9d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7fbd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1082,7 +1082,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1411 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0xcd7e68", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7f88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1104,11 +1104,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1640 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xce0fc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce10e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1641 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce0fc7", Frameless: true}]
+              InjectionPoints: [{PC: "0xce10e7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1122,11 +1122,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1642 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xce0fe4", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1104", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1643 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xce1031", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1151", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1149,11 +1149,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1636 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xce0f2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce104a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1637 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xce0f39", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1059", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1167,11 +1167,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1638 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xce0f6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce108a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1639 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xce0f82", Frameless: false}]
+              InjectionPoints: [{PC: "0xce10a2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1194,14 +1194,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1644 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xce1040", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1160", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1645 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xce1060"
+                - PC: "0xce1180"
                   Frameless: true
-                - PC: "0xce1063"
+                - PC: "0xce1183"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1216,14 +1216,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1646 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xce108a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce11aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1647 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xce10eb"
+                - PC: "0xce120b"
                   Frameless: false
-                - PC: "0xce10f3"
+                - PC: "0xce1213"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1250,7 +1250,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1648 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xce1045", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1165", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1262,7 +1262,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1649 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xce109f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce11bf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1283,11 +1283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xce0be0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0d00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1625 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xce0bf0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0d10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1301,11 +1301,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1626 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xce0c80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0da0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1627 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xce0c88", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0da8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1329,11 +1329,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xce076e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce088e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1613 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce0854", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0974", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1375,11 +1375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce08aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce09ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1617 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce08b9", Frameless: false}]
+              InjectionPoints: [{PC: "0xce09d9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1402,11 +1402,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1650 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xce1140", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1260", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1651 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xce1146", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1266", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1420,11 +1420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1652 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xce11ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce12ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1653 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xce11ed", Frameless: false}]
+              InjectionPoints: [{PC: "0xce130d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1447,11 +1447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce07e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1609 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce06c3", Frameless: true}]
+              InjectionPoints: [{PC: "0xce07e3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1465,11 +1465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xce06e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0800", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1611 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce06eb", Frameless: true}]
+              InjectionPoints: [{PC: "0xce080b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1492,11 +1492,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1628 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xce0d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0e60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1629 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xce0d47", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0e67", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1510,11 +1510,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1630 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xce0dea", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0f0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1631 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xce0e16", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0f36", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1537,11 +1537,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1618 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xce0b80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0ca0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1619 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce0b83", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0ca3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1555,11 +1555,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1620 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xce0ba0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0cc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1621 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xce0ba3", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0cc3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1573,11 +1573,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1622 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xce0bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0ce0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1623 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xce0bc3", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0ce3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1600,11 +1600,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1632 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xce0ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1000", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1633 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xce0ee7", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1007", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1618,11 +1618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1634 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce0f00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1020", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1635 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce0f0e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce102e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1645,11 +1645,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xce0680", Frameless: true}]
+              InjectionPoints: [{PC: "0xce07a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1605 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce0683", Frameless: true}]
+              InjectionPoints: [{PC: "0xce07a3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1663,11 +1663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xce06a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce07c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1607 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce06ab", Frameless: true}]
+              InjectionPoints: [{PC: "0xce07cb", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1690,11 +1690,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0xcd7b2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7c4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1400 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0xcd7b8e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7cae", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1721,11 +1721,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0xcd7bce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7cee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1402 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0xcd7c5e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7d7e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1752,11 +1752,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0xcd7caa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7dca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1404 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0xcd7ceb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7e0b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1778,7 +1778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1660 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0xcd7c26", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7d46", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1796,11 +1796,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0xcd7d2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7e4e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1406 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0xcd7e1e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7f3e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1818,7 +1818,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1661 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0xcd7d33", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7e53", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1839,7 +1839,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1662 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0xcd7d33", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7e53", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1857,7 +1857,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1663 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0xcd7de6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7f06", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1878,7 +1878,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1664 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0xcd7de6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7f06", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1899,7 +1899,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x5230a1"
                   Frameless: true
-                - PC: "0xcd880b"
+                - PC: "0xcd8930"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1920,20 +1920,20 @@ Probes:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0xcd798a"
+                - PC: "0xcd7aaa"
                   Frameless: false
-                - PC: "0xcd7a11"
+                - PC: "0xcd7b31"
                   Frameless: false
-                - PC: "0xcd7b52"
+                - PC: "0xcd7c72"
                   Frameless: false
-                - PC: "0xcd7bdc"
+                - PC: "0xcd7cfc"
                   Frameless: false
-                - PC: "0xcd7caf"
+                - PC: "0xcd7dcf"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0xcd79ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7aea", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1959,15 +1959,15 @@ Probes:
             - Kind: Line
               Type: 1659 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcd798e"
+                - PC: "0xcd7aae"
                   Frameless: false
-                - PC: "0xcd7a11"
+                - PC: "0xcd7b31"
                   Frameless: false
-                - PC: "0xcd7b52"
+                - PC: "0xcd7c72"
                   Frameless: false
-                - PC: "0xcd7bdc"
+                - PC: "0xcd7cfc"
                   Frameless: false
-                - PC: "0xcd7caf"
+                - PC: "0xcd7dcf"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1990,7 +1990,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1665 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0xcd7e41", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7f61", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2015,7 +2015,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1666 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0xcd7e41", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7f61", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2039,9 +2039,9 @@ Probes:
             - Kind: Entry
               Type: 1667 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0xcd7e85"
+                - PC: "0xcd7fa5"
                   Frameless: false
-                - PC: "0xcd7f25"
+                - PC: "0xcd8045"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2064,7 +2064,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1351 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0xcd4ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd4fc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2086,7 +2086,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1352 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0xcd4ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd4fe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2108,7 +2108,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1353 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0xcd4ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2130,7 +2130,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1350 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0xcd4e80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd4fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2152,7 +2152,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1349 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0xcd4e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd4f80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2174,7 +2174,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0xcd8140", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2195,11 +2195,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1543 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xcdc66e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc78e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1544 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcdc7d3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc8f3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2221,7 +2221,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xcdaa80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2246,7 +2246,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1392 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcd5cba", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd5dda", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2268,7 +2268,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1393 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcd5d6d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd5e8d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2290,7 +2290,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1394 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcd5e34", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd5f54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2333,11 +2333,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1549 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xcdcb33", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcc53", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1550 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xcdcd42", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdce62", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2399,7 +2399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xcd8940", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2421,7 +2421,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1430 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8b20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2443,7 +2443,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2465,7 +2465,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8ca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2487,7 +2487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8c80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2509,7 +2509,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xcd89c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2531,7 +2531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xcd8b20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8c40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2553,7 +2553,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8c20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2577,7 +2577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcd89e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2601,7 +2601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcd89e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2623,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2645,7 +2645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1436 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2667,7 +2667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1421 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xcd8900", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2689,7 +2689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xcd8920", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2711,7 +2711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xcd88e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2733,7 +2733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2755,7 +2755,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2777,7 +2777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2799,7 +2799,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2823,7 +2823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2845,7 +2845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcddee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2868,7 +2868,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1586 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcddee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2915,11 +2915,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1551 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xcdcdd3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcef3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1552 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xcdd00b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd12b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2985,11 +2985,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1555 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xcdd14e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd26e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1556 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xcdd21e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd33e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3020,11 +3020,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1547 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xcdc8ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdca0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1548 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xcdcb0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcc2a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3050,11 +3050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdb88e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb9ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1489 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdb92f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdba4f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3090,7 +3090,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xcda640", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3131,11 +3131,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcdb7ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb90a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1483 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdb855", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb975", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3159,11 +3159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcdb7ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb90a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdb855", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb975", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3182,11 +3182,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdb88e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb9ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1491 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdb92f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdba4f", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3206,11 +3206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdb88e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb9ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1493 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdb92f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdba4f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3243,11 +3243,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcdb7ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb90a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1487 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdb855", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb975", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3275,7 +3275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcde320", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3300,7 +3300,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcde320", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3331,7 +3331,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcde320", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3356,7 +3356,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcde320", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3383,7 +3383,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xcdac20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdad40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3410,7 +3410,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xcdd9e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddb00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3437,7 +3437,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1566 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xcdd980", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddaa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3472,7 +3472,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1568 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xcdd9c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3504,7 +3504,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1584 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xcddec0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddfe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3526,7 +3526,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xcdaaa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdabc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3548,7 +3548,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xcd89a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3570,7 +3570,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xcdaa60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdab80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3594,11 +3594,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdb0ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb1ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1459 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdb11b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb23b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3618,11 +3618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1502 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcdb96e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdba8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1503 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdba0b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdbb2b", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3663,11 +3663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdb1ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb30e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1469 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdb2a4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb3c4", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3705,11 +3705,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdb0ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb1ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1461 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdb11b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb23b", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3750,11 +3750,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdb1ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb30e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1471 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdb2a4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb3c4", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3794,11 +3794,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1504 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcdb96e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdba8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1505 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdba0b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdbb2b", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3815,11 +3815,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1506 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcdb96e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdba8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1507 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdba0b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdbb2b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3841,11 +3841,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdb0ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb1ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1463 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdb11b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb23b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3868,18 +3868,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xcdb48e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb5ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1479 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xcdb544"
+                - PC: "0xcdb664"
                   Frameless: false
-                - PC: "0xcdb57f"
+                - PC: "0xcdb69f"
                   Frameless: false
-                - PC: "0xcdb642"
+                - PC: "0xcdb762"
                   Frameless: false
-                - PC: "0xcdb64c"
+                - PC: "0xcdb76c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3907,18 +3907,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xcdb32e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb44e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1477 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xcdb384"
+                - PC: "0xcdb4a4"
                   Frameless: false
-                - PC: "0xcdb3d3"
+                - PC: "0xcdb4f3"
                   Frameless: false
-                - PC: "0xcdb407"
+                - PC: "0xcdb527"
                   Frameless: false
-                - PC: "0xcdb439"
+                - PC: "0xcdb559"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3945,11 +3945,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1521 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xcdc10a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc22a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1522 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xcdc16d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc28d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3966,11 +3966,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1523 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xcdc18a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc2aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1524 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xcdc1cb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc2eb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3987,11 +3987,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1525 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xcdc1ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc30a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1526 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xcdc226", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc346", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4008,11 +4008,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1529 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xcdc2ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc3ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1530 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xcdc34a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc46a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4029,11 +4029,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1541 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xcdc60a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc72a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1542 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xcdc650", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc770", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4050,11 +4050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1517 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xcdbfca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc0ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1518 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xcdc026", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc146", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4072,14 +4072,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1474 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xcdb2ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb3ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1475 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xcdb2fa"
+                - PC: "0xcdb41a"
                   Frameless: false
-                - PC: "0xcdb305"
+                - PC: "0xcdb425"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4101,11 +4101,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdb0ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb1ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1465 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdb11b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb23b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4126,11 +4126,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdb1ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb30e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1473 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdb2a4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb3c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4151,11 +4151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xcdb14a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb26a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1467 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xcdb1b4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb2d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4177,14 +4177,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1480 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xcdb68e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb7ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1481 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xcdb76f"
+                - PC: "0xcdb88f"
                   Frameless: false
-                - PC: "0xcdb779"
+                - PC: "0xcdb899"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4206,11 +4206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1519 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xcdc04e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc16e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1520 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xcdc0d3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc1f3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4227,11 +4227,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1515 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xcdbece", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdbfee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1516 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xcdbfa7", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc0c7", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4248,11 +4248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1533 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xcdc42a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc54a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1534 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xcdc48c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc5ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4269,11 +4269,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1527 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xcdc24a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc36a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1528 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xcdc298", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc3b8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4290,11 +4290,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1539 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xcdc58a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc6aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1540 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xcdc5d6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc6f6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4314,7 +4314,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1512 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xcdbc4f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdbd6f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4335,11 +4335,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1537 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xcdc52a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc64a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1538 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xcdc56e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc68e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4356,11 +4356,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1513 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xcdbe4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdbf6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1514 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xcdbeb1", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdbfd1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4377,11 +4377,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1535 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xcdc4aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc5ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1536 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xcdc50d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc62d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4398,11 +4398,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1531 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xcdc36e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc48e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1532 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xcdc3f4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc514", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4420,7 +4420,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1346 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0xcd4e00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd4f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1494 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdb88e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb9ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1495 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdb92f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdba4f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4505,7 +4505,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0xcd5420", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4527,7 +4527,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0xcd53e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4549,7 +4549,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0xcd5580", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd56a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4567,7 +4567,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0xcd55a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd56c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0xcd5440", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0xcd5480", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd55a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4630,7 +4630,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0xcd54a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd55c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4652,7 +4652,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0xcd54c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd55e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4681,7 +4681,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0xcd5460", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4712,7 +4712,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0xcd5400", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4734,7 +4734,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1576 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xcdde40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddf60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4756,7 +4756,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0xcd54e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4778,7 +4778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0xcd5520", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4800,7 +4800,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0xcd5540", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4822,7 +4822,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0xcd5560", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4844,7 +4844,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0xcd5500", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4866,7 +4866,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1572 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xcdda20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddb40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4888,7 +4888,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1563 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xcdd920", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdda40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4910,7 +4910,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1424 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xcd8960", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4931,11 +4931,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1508 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcdb96e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdba8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1509 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdba0b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdbb2b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4956,11 +4956,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1553 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xcdd0aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd1ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1554 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xcdd11c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd23c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4982,7 +4982,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1347 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0xcd4e20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd4f40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5004,7 +5004,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xcdabe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdad00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5026,7 +5026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1567 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xcdd9a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5048,7 +5048,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0xcd5c60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5d80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5070,7 +5070,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0xcd5c80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5da0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5092,11 +5092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcde220", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde340", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1596 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xcde242", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde362", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5123,7 +5123,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1564 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xcdd940", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdda60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5150,7 +5150,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0xcd8260", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5171,11 +5171,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1557 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xcdd24e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd36e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1558 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xcdd2fa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd41a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5197,11 +5197,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xcde0e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde200", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1592 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xcde0fe", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde21e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5222,7 +5222,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xcde0c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde1e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5249,7 +5249,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1419 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xcd88c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd89e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5281,7 +5281,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xcdda40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddb60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5321,7 +5321,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xcddf40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5354,11 +5354,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1496 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdb88e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb9ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1497 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdb92f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdba4f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5379,11 +5379,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1498 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdb88e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb9ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1499 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdb92f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdba4f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5406,11 +5406,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1500 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdb88e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb9ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1501 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdb92f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdba4f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5439,7 +5439,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xcdde60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddf80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5471,11 +5471,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1578 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcdde80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddfa0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1579 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xcdde9e", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddfbe", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5505,11 +5505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1580 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcdde80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddfa0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1581 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xcdde9e", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddfbe", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5541,7 +5541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1582 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcddea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddfc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcddea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddfc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0xcd55c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd56e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5625,7 +5625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1356 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0xcd4f40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5647,7 +5647,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1357 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0xcd4f60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5669,7 +5669,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1358 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0xcd4f80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd50a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5691,7 +5691,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1355 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0xcd4f20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5713,7 +5713,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1354 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0xcd4f00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5735,7 +5735,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xcdab00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdac20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5757,7 +5757,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1561 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xcdd8e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdda00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5779,7 +5779,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xcddf00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5801,7 +5801,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xcdaac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdabe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5823,7 +5823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1364 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0xcd5060", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5845,7 +5845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1570 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcdda00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddb20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5867,7 +5867,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcdda00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcddb20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5890,14 +5890,14 @@ Probes:
             - Kind: Entry
               Type: 1668 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0xcd806a"
+                - PC: "0xcd818a"
                   Frameless: false
-                - PC: "0xce12e3"
+                - PC: "0xce1403"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1669 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0xcd80b0", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd81d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5919,11 +5919,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1559 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xcdd32e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd44e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1560 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcdd3ac", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd4cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5940,383 +5940,266 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0xcd4de0..0xcd4de1]
+      OutOfLinePCRanges: [0xcd4f00..0xcd4f01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 ArrayType [2]uint8
           Locations:
-            - Range: 0xcd4de0..0xcd4de1
+            - Range: 0xcd4f00..0xcd4f01
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0xcd4e00..0xcd4e01]
+      OutOfLinePCRanges: [0xcd4f20..0xcd4f21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]int32
           Locations:
-            - Range: 0xcd4e00..0xcd4e01
+            - Range: 0xcd4f20..0xcd4f21
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0xcd4e20..0xcd4e21]
+      OutOfLinePCRanges: [0xcd4f40..0xcd4f41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]string
           Locations:
-            - Range: 0xcd4e20..0xcd4e21
+            - Range: 0xcd4f40..0xcd4f41
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0xcd4e40..0xcd4e41]
+      OutOfLinePCRanges: [0xcd4f60..0xcd4f61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]bool
           Locations:
-            - Range: 0xcd4e40..0xcd4e41
+            - Range: 0xcd4f60..0xcd4f61
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0xcd4e60..0xcd4e61]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 111 ArrayType [2]int
-          Locations:
-            - Range: 0xcd4e60..0xcd4e61
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 6
-      Name: main.testInt8Array
-      OutOfLinePCRanges: [0xcd4e80..0xcd4e81]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 112 ArrayType [2]int8
-          Locations:
-            - Range: 0xcd4e80..0xcd4e81
-              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 7
-      Name: main.testInt16Array
-      OutOfLinePCRanges: [0xcd4ea0..0xcd4ea1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 113 ArrayType [2]int16
-          Locations:
-            - Range: 0xcd4ea0..0xcd4ea1
-              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 8
-      Name: main.testInt32Array
-      OutOfLinePCRanges: [0xcd4ec0..0xcd4ec1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 108 ArrayType [2]int32
-          Locations:
-            - Range: 0xcd4ec0..0xcd4ec1
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 9
-      Name: main.testInt64Array
-      OutOfLinePCRanges: [0xcd4ee0..0xcd4ee1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 114 ArrayType [2]int64
-          Locations:
-            - Range: 0xcd4ee0..0xcd4ee1
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 10
-      Name: main.testUintArray
-      OutOfLinePCRanges: [0xcd4f00..0xcd4f01]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 115 ArrayType [2]uint
-          Locations:
-            - Range: 0xcd4f00..0xcd4f01
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 11
-      Name: main.testUint8Array
-      OutOfLinePCRanges: [0xcd4f20..0xcd4f21]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 107 ArrayType [2]uint8
-          Locations:
-            - Range: 0xcd4f20..0xcd4f21
-              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 12
-      Name: main.testUint16Array
-      OutOfLinePCRanges: [0xcd4f40..0xcd4f41]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 116 ArrayType [2]uint16
-          Locations:
-            - Range: 0xcd4f40..0xcd4f41
-              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 13
-      Name: main.testUint32Array
-      OutOfLinePCRanges: [0xcd4f60..0xcd4f61]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 117 ArrayType [2]uint32
-          Locations:
-            - Range: 0xcd4f60..0xcd4f61
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 14
-      Name: main.testUint64Array
       OutOfLinePCRanges: [0xcd4f80..0xcd4f81]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 54 ArrayType [2]uint64
+          Type: 111 ArrayType [2]int
           Locations:
             - Range: 0xcd4f80..0xcd4f81
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 6
+      Name: main.testInt8Array
+      OutOfLinePCRanges: [0xcd4fa0..0xcd4fa1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 112 ArrayType [2]int8
+          Locations:
+            - Range: 0xcd4fa0..0xcd4fa1
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 7
+      Name: main.testInt16Array
+      OutOfLinePCRanges: [0xcd4fc0..0xcd4fc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 113 ArrayType [2]int16
+          Locations:
+            - Range: 0xcd4fc0..0xcd4fc1
+              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 8
+      Name: main.testInt32Array
+      OutOfLinePCRanges: [0xcd4fe0..0xcd4fe1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 108 ArrayType [2]int32
+          Locations:
+            - Range: 0xcd4fe0..0xcd4fe1
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 9
+      Name: main.testInt64Array
+      OutOfLinePCRanges: [0xcd5000..0xcd5001]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 114 ArrayType [2]int64
+          Locations:
+            - Range: 0xcd5000..0xcd5001
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 10
+      Name: main.testUintArray
+      OutOfLinePCRanges: [0xcd5020..0xcd5021]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 115 ArrayType [2]uint
+          Locations:
+            - Range: 0xcd5020..0xcd5021
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 11
+      Name: main.testUint8Array
+      OutOfLinePCRanges: [0xcd5040..0xcd5041]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 107 ArrayType [2]uint8
+          Locations:
+            - Range: 0xcd5040..0xcd5041
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 12
+      Name: main.testUint16Array
+      OutOfLinePCRanges: [0xcd5060..0xcd5061]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 116 ArrayType [2]uint16
+          Locations:
+            - Range: 0xcd5060..0xcd5061
+              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 13
+      Name: main.testUint32Array
+      OutOfLinePCRanges: [0xcd5080..0xcd5081]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 117 ArrayType [2]uint32
+          Locations:
+            - Range: 0xcd5080..0xcd5081
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 14
+      Name: main.testUint64Array
+      OutOfLinePCRanges: [0xcd50a0..0xcd50a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 54 ArrayType [2]uint64
+          Locations:
+            - Range: 0xcd50a0..0xcd50a1
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0xcd4fa0..0xcd4fa1]
+      OutOfLinePCRanges: [0xcd50c0..0xcd50c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 118 ArrayType [2][2]int
           Locations:
-            - Range: 0xcd4fa0..0xcd4fa1
+            - Range: 0xcd50c0..0xcd50c1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0xcd4fc0..0xcd4fc1]
+      OutOfLinePCRanges: [0xcd50e0..0xcd50e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 109 ArrayType [2]string
           Locations:
-            - Range: 0xcd4fc0..0xcd4fc1
+            - Range: 0xcd50e0..0xcd50e1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0xcd4fe0..0xcd4fe1]
+      OutOfLinePCRanges: [0xcd5100..0xcd5101]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 119 ArrayType [2][2][2]int
           Locations:
-            - Range: 0xcd4fe0..0xcd4fe1
+            - Range: 0xcd5100..0xcd5101
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0xcd5000..0xcd5001]
+      OutOfLinePCRanges: [0xcd5120..0xcd5121]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 120 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0xcd5000..0xcd5001
+            - Range: 0xcd5120..0xcd5121
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0xcd5020..0xcd5021]
+      OutOfLinePCRanges: [0xcd5140..0xcd5141]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 122 ArrayType [2]struct {}
           Locations:
-            - Range: 0xcd5020..0xcd5021
+            - Range: 0xcd5140..0xcd5141
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0xcd5060..0xcd5061]
+      OutOfLinePCRanges: [0xcd5180..0xcd5181]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 124 ArrayType [100]uint
           Locations:
-            - Range: 0xcd5060..0xcd5061
+            - Range: 0xcd5180..0xcd5181
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xcd53e0..0xcd53e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 3 BaseType uint8
-          Locations:
-            - Range: 0xcd53e0..0xcd53e1
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 22
-      Name: main.testSingleRune
-      OutOfLinePCRanges: [0xcd5400..0xcd5401]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 BaseType int32
-          Locations:
-            - Range: 0xcd5400..0xcd5401
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 23
-      Name: main.testSingleBool
-      OutOfLinePCRanges: [0xcd5420..0xcd5421]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 4 BaseType bool
-          Locations:
-            - Range: 0xcd5420..0xcd5421
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 24
-      Name: main.testSingleInt
-      OutOfLinePCRanges: [0xcd5440..0xcd5441]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd5440..0xcd5441
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 25
-      Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xcd5460..0xcd5461]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 15 BaseType int8
-          Locations:
-            - Range: 0xcd5460..0xcd5461
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 26
-      Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xcd5480..0xcd5481]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 102 BaseType int16
-          Locations:
-            - Range: 0xcd5480..0xcd5481
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 27
-      Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xcd54a0..0xcd54a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 BaseType int32
-          Locations:
-            - Range: 0xcd54a0..0xcd54a1
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 28
-      Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xcd54c0..0xcd54c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 BaseType int64
-          Locations:
-            - Range: 0xcd54c0..0xcd54c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 29
-      Name: main.testSingleUint
-      OutOfLinePCRanges: [0xcd54e0..0xcd54e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 16 BaseType uint
-          Locations:
-            - Range: 0xcd54e0..0xcd54e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 30
-      Name: main.testSingleUint8
       OutOfLinePCRanges: [0xcd5500..0xcd5501]
       InlinePCRanges: []
       Variables:
@@ -6328,93 +6211,210 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 31
-      Name: main.testSingleUint16
+    - ID: 22
+      Name: main.testSingleRune
       OutOfLinePCRanges: [0xcd5520..0xcd5521]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType uint16
+          Type: 10 BaseType int32
           Locations:
             - Range: 0xcd5520..0xcd5521
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 32
-      Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xcd5540..0xcd5541]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 2 BaseType uint32
-          Locations:
-            - Range: 0xcd5540..0xcd5541
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 33
-      Name: main.testSingleUint64
+    - ID: 23
+      Name: main.testSingleBool
+      OutOfLinePCRanges: [0xcd5540..0xcd5541]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xcd5540..0xcd5541
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 24
+      Name: main.testSingleInt
       OutOfLinePCRanges: [0xcd5560..0xcd5561]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 BaseType uint64
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd5560..0xcd5561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 25
+      Name: main.testSingleInt8
+      OutOfLinePCRanges: [0xcd5580..0xcd5581]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 15 BaseType int8
+          Locations:
+            - Range: 0xcd5580..0xcd5581
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 26
+      Name: main.testSingleInt16
+      OutOfLinePCRanges: [0xcd55a0..0xcd55a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 102 BaseType int16
+          Locations:
+            - Range: 0xcd55a0..0xcd55a1
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 27
+      Name: main.testSingleInt32
+      OutOfLinePCRanges: [0xcd55c0..0xcd55c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 BaseType int32
+          Locations:
+            - Range: 0xcd55c0..0xcd55c1
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 28
+      Name: main.testSingleInt64
+      OutOfLinePCRanges: [0xcd55e0..0xcd55e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 BaseType int64
+          Locations:
+            - Range: 0xcd55e0..0xcd55e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 29
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0xcd5600..0xcd5601]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 16 BaseType uint
+          Locations:
+            - Range: 0xcd5600..0xcd5601
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 30
+      Name: main.testSingleUint8
+      OutOfLinePCRanges: [0xcd5620..0xcd5621]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0xcd5620..0xcd5621
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 31
+      Name: main.testSingleUint16
+      OutOfLinePCRanges: [0xcd5640..0xcd5641]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 6 BaseType uint16
+          Locations:
+            - Range: 0xcd5640..0xcd5641
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 32
+      Name: main.testSingleUint32
+      OutOfLinePCRanges: [0xcd5660..0xcd5661]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 2 BaseType uint32
+          Locations:
+            - Range: 0xcd5660..0xcd5661
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 33
+      Name: main.testSingleUint64
+      OutOfLinePCRanges: [0xcd5680..0xcd5681]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0xcd5680..0xcd5681
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xcd5580..0xcd5581]
+      OutOfLinePCRanges: [0xcd56a0..0xcd56a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xcd5580..0xcd5581
+            - Range: 0xcd56a0..0xcd56a1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xcd55a0..0xcd55a1]
+      OutOfLinePCRanges: [0xcd56c0..0xcd56c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcd55a0..0xcd55a1
+            - Range: 0xcd56c0..0xcd56c1
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xcd55c0..0xcd55c1]
+      OutOfLinePCRanges: [0xcd56e0..0xcd56e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 125 BaseType main.typeAlias
           Locations:
-            - Range: 0xcd55c0..0xcd55c1
+            - Range: 0xcd56e0..0xcd56e1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xcd5720..0xcd573f]
+      OutOfLinePCRanges: [0xcd5840..0xcd585f]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 126 StructureType main.bigStruct
           Locations:
-            - Range: 0xcd5720..0xcd573f
+            - Range: 0xcd5840..0xcd585f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6433,48 +6433,48 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0xcd5780..0xcd5892]
+      OutOfLinePCRanges: [0xcd58a0..0xcd59b2]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd5780..0xcd5798
+            - Range: 0xcd58a0..0xcd58b8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd5780..0xcd5892, Pieces: []}]
+          Locations: [{Range: 0xcd58a0..0xcd59b2, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd5780..0xcd5892, Pieces: []}]
+          Locations: [{Range: 0xcd58a0..0xcd59b2, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcd57a9..0xcd57c5
+            - Range: 0xcd58c9..0xcd58e5
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0xcd57c5..0xcd57e8
+            - Range: 0xcd58e5..0xcd5908
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcd57e8..0xcd57fe
+            - Range: 0xcd5908..0xcd591e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0xcd57fe..0xcd5892
+            - Range: 0xcd591e..0xcd59b2
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -80}
@@ -6485,39 +6485,39 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xcd5900..0xcd5901]
+      OutOfLinePCRanges: [0xcd5a20..0xcd5a21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 130 StructureType main.deepPtr1
           Locations:
-            - Range: 0xcd5900..0xcd5901
+            - Range: 0xcd5a20..0xcd5a21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xcd5920..0xcd5921]
+      OutOfLinePCRanges: [0xcd5a40..0xcd5a41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 133 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xcd5920..0xcd5921
+            - Range: 0xcd5a40..0xcd5a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xcd5aa0..0xcd5aa1]
+      OutOfLinePCRanges: [0xcd5bc0..0xcd5bc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 135 StructureType main.deepSlice1
           Locations:
-            - Range: 0xcd5aa0..0xcd5aa1
+            - Range: 0xcd5bc0..0xcd5bc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6530,129 +6530,129 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xcd5ac0..0xcd5ac1]
+      OutOfLinePCRanges: [0xcd5be0..0xcd5be1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 139 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xcd5ac0..0xcd5ac1
+            - Range: 0xcd5be0..0xcd5be1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xcd5c20..0xcd5c21]
+      OutOfLinePCRanges: [0xcd5d40..0xcd5d41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 141 StructureType main.deepMap1
           Locations:
-            - Range: 0xcd5c20..0xcd5c21
+            - Range: 0xcd5d40..0xcd5d41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xcd5c40..0xcd5c41]
+      OutOfLinePCRanges: [0xcd5d60..0xcd5d61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 147 PointerType *main.deepMap7
           Locations:
-            - Range: 0xcd5c40..0xcd5c41
+            - Range: 0xcd5d60..0xcd5d61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xcd5c60..0xcd5c61]
+      OutOfLinePCRanges: [0xcd5d80..0xcd5d81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 PointerType *main.stringType1
           Locations:
-            - Range: 0xcd5c60..0xcd5c61
+            - Range: 0xcd5d80..0xcd5d81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xcd5c80..0xcd5c81]
+      OutOfLinePCRanges: [0xcd5da0..0xcd5da1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 151 PointerType **main.stringType2
           Locations:
-            - Range: 0xcd5c80..0xcd5c81
+            - Range: 0xcd5da0..0xcd5da1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xcd5ca0..0xcd5eea]
+      OutOfLinePCRanges: [0xcd5dc0..0xcd600a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5d84..0xcd5da5
+            - Range: 0xcd5ea4..0xcd5ec5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd5e58..0xcd5e6f
+            - Range: 0xcd5f78..0xcd5f8f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5d6d..0xcd5d70
+            - Range: 0xcd5e8d..0xcd5e90
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd5d70..0xcd5da5
+            - Range: 0xcd5e90..0xcd5ec5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd5da5..0xcd5e4b
+            - Range: 0xcd5ec5..0xcd5f6b
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xcd5e4b..0xcd5e58
+            - Range: 0xcd5f6b..0xcd5f78
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcd5e58..0xcd5eea
+            - Range: 0xcd5f78..0xcd600a
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5d6a..0xcd5d70
+            - Range: 0xcd5e8a..0xcd5e90
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd5d70..0xcd5d70
+            - Range: 0xcd5e90..0xcd5e90
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd5d70..0xcd5da5
+            - Range: 0xcd5e90..0xcd5ec5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd5da5..0xcd5e4b
+            - Range: 0xcd5ec5..0xcd5f6b
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xcd5e4b..0xcd5e50
+            - Range: 0xcd5f6b..0xcd5f70
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcd5e50..0xcd5e58
+            - Range: 0xcd5f70..0xcd5f78
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcd5e58..0xcd5e6f
+            - Range: 0xcd5f78..0xcd5f8f
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcd5e6f..0xcd5eea
+            - Range: 0xcd5f8f..0xcd600a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xcd6340..0xcd6445]
+      OutOfLinePCRanges: [0xcd6460..0xcd6565]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 153 StructureType main.esotericStack
           Locations:
-            - Range: 0xcd6340..0xcd6393
+            - Range: 0xcd6460..0xcd64b3
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6672,7 +6672,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd6393..0xcd6398
+            - Range: 0xcd64b3..0xcd64b8
               Pieces:
                 - Size: 4
                   Op: null
@@ -6692,7 +6692,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd6398..0xcd639d
+            - Range: 0xcd64b8..0xcd64bd
               Pieces:
                 - Size: 4
                   Op: null
@@ -6717,253 +6717,153 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xcd6460..0xcd64c3]
+      OutOfLinePCRanges: [0xcd6580..0xcd65e3]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 157 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xcd6460..0xcd648d
+            - Range: 0xcd6580..0xcd65ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 50
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcd7b20..0xcd7ba8]
+      OutOfLinePCRanges: [0xcd7c40..0xcd7cc8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd7b20..0xcd7b35
+            - Range: 0xcd7c40..0xcd7c55
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 51
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xcd7bc0..0xcd7c85]
+      OutOfLinePCRanges: [0xcd7ce0..0xcd7da5]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd7bc0..0xcd7bd6
+            - Range: 0xcd7ce0..0xcd7cf6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd7bc0..0xcd7be7
+            - Range: 0xcd7ce0..0xcd7d07
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd7bd6..0xcd7be7
+            - Range: 0xcd7cf6..0xcd7d07
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd7be7..0xcd7c85
+            - Range: 0xcd7d07..0xcd7da5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xcd7ca0..0xcd7d02]
+      OutOfLinePCRanges: [0xcd7dc0..0xcd7e22]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd7ca0..0xcd7cba
+            - Range: 0xcd7dc0..0xcd7dda
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xcd7d20..0xcd7e2e]
+      OutOfLinePCRanges: [0xcd7e40..0xcd7f4e]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd7d7b..0xcd7d85
+            - Range: 0xcd7e9b..0xcd7ea5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd7d85..0xcd7da0
+            - Range: 0xcd7ea5..0xcd7ec0
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd7da0..0xcd7db4
+            - Range: 0xcd7ec0..0xcd7ed4
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd7d76..0xcd7d80
+            - Range: 0xcd7e96..0xcd7ea0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd7d80..0xcd7da0
+            - Range: 0xcd7ea0..0xcd7ec0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd7da0..0xcd7daf
+            - Range: 0xcd7ec0..0xcd7ecf
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xcd7e40..0xcd7e46]
+      OutOfLinePCRanges: [0xcd7f60..0xcd7f66]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd7e40..0xcd7e45
+            - Range: 0xcd7f60..0xcd7f65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd7e40..0xcd7e45
+            - Range: 0xcd7f60..0xcd7f65
               Pieces: []
-            - Range: 0xcd7e45..0xcd7e46
+            - Range: 0xcd7f65..0xcd7f66
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xcd7e60..0xcd7ea3]
+      OutOfLinePCRanges: [0xcd7f80..0xcd7fc3]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0xcd7e60..0xcd7ea3
+            - Range: 0xcd7f80..0xcd7fc3
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd7e60..0xcd7e9d
+            - Range: 0xcd7f80..0xcd7fbd
               Pieces: []
-            - Range: 0xcd7e9d..0xcd7e9e
+            - Range: 0xcd7fbd..0xcd7fbe
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd7e9e..0xcd7ea3
+            - Range: 0xcd7fbe..0xcd7fc3
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcd8140..0xcd8141]
+      OutOfLinePCRanges: [0xcd8260..0xcd8261]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 160 GoInterfaceType main.behavior
-          Locations:
-            - Range: 0xcd8140..0xcd8141
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 57
-      Name: main.testAny
-      OutOfLinePCRanges: [0xcd8160..0xcd81c6]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 155 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xcd8160..0xcd8189
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd8189..0xcd818e
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd8160..0xcd81a5
-              Pieces: []
-            - Range: 0xcd81a5..0xcd81a6
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd81a6..0xcd81c6
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 58
-      Name: main.testError
-      OutOfLinePCRanges: [0xcd81e0..0xcd81e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 13 GoInterfaceType error
-          Locations:
-            - Range: 0xcd81e0..0xcd81e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 59
-      Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xcd8200..0xcd8254]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 161 PointerType *interface {}
-          Locations:
-            - Range: 0xcd8200..0xcd8226
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd8200..0xcd823d
-              Pieces: []
-            - Range: 0xcd823d..0xcd823e
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd823e..0xcd8254
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 60
-      Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xcd8260..0xcd8261]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 162 StructureType main.structWithAny
           Locations:
             - Range: 0xcd8260..0xcd8261
               Pieces:
@@ -6974,348 +6874,448 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 57
+      Name: main.testAny
+      OutOfLinePCRanges: [0xcd8280..0xcd82e6]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 155 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xcd8280..0xcd82a9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd82a9..0xcd82ae
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd8280..0xcd82c5
+              Pieces: []
+            - Range: 0xcd82c5..0xcd82c6
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd82c6..0xcd82e6
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 58
+      Name: main.testError
+      OutOfLinePCRanges: [0xcd8300..0xcd8301]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 13 GoInterfaceType error
+          Locations:
+            - Range: 0xcd8300..0xcd8301
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 59
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0xcd8320..0xcd8374]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 161 PointerType *interface {}
+          Locations:
+            - Range: 0xcd8320..0xcd8346
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd8320..0xcd835d
+              Pieces: []
+            - Range: 0xcd835d..0xcd835e
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd835e..0xcd8374
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 60
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0xcd8380..0xcd8381]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 162 StructureType main.structWithAny
+          Locations:
+            - Range: 0xcd8380..0xcd8381
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcd88c0..0xcd88c1]
+      OutOfLinePCRanges: [0xcd89e0..0xcd89e1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 163 StructureType main.structWithMap
-          Locations:
-            - Range: 0xcd88c0..0xcd88c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcd88e0..0xcd88e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 169 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xcd88e0..0xcd88e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 63
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcd8900..0xcd8901]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 174 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd8900..0xcd8901
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcd8920..0xcd8921]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 179 GoMapType map[string][]string
-          Locations:
-            - Range: 0xcd8920..0xcd8921
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcd8940..0xcd8941]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 184 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xcd8940..0xcd8941
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 66
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcd8960..0xcd8961]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 174 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd8960..0xcd8961
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcd8980..0xcd8981]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 189 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xcd8980..0xcd8981
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcd89a0..0xcd89a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 190 PointerType *map[string]int
-          Locations:
-            - Range: 0xcd89a0..0xcd89a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcd89c0..0xcd89c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 164 GoMapType map[int]int
-          Locations:
-            - Range: 0xcd89c0..0xcd89c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcd89e0..0xcd89e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 191 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd89e0..0xcd89e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 71
-      Name: main.testMapEmbeddedMaps
+    - ID: 62
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcd8a00..0xcd8a01]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 191 GoMapType map[string][]main.structWithMap
+          Type: 169 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcd8a00..0xcd8a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapWithLinkedList
+    - ID: 63
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcd8a20..0xcd8a21]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 196 GoMapType map[bool]main.node
+          Type: 174 GoMapType map[string]int
           Locations:
             - Range: 0xcd8a20..0xcd8a21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapWithSmallValue
+    - ID: 64
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcd8a40..0xcd8a41]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 201 GoMapType map[int]uint8
+          Type: 179 GoMapType map[string][]string
           Locations:
             - Range: 0xcd8a40..0xcd8a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithSmallValueMassive
+    - ID: 65
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcd8a60..0xcd8a61]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 201 GoMapType map[int]uint8
+        - Name: m
+          Type: 184 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcd8a60..0xcd8a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 66
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xcd8a80..0xcd8a81]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 206 GoMapType map[uint8]uint8
+          Type: 174 GoMapType map[string]int
           Locations:
             - Range: 0xcd8a80..0xcd8a81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 67
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcd8aa0..0xcd8aa1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 206 GoMapType map[uint8]uint8
+          Type: 189 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcd8aa0..0xcd8aa1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapSmallKeySmallValue
+    - ID: 68
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcd8ac0..0xcd8ac1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 206 GoMapType map[uint8]uint8
+          Type: 190 PointerType *map[string]int
           Locations:
             - Range: 0xcd8ac0..0xcd8ac1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 69
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcd8ae0..0xcd8ae1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 211 GoMapType map[uint8][4]int
+          Type: 164 GoMapType map[int]int
           Locations:
             - Range: 0xcd8ae0..0xcd8ae1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapLargeKeySmallValue
+    - ID: 70
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xcd8b00..0xcd8b01]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 216 GoMapType map[[4]int]uint8
+        - Name: redactMyEntries
+          Type: 191 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd8b00..0xcd8b01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 71
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xcd8b20..0xcd8b21]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 221 GoMapType map[[4]int][4]int
+          Type: 191 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd8b20..0xcd8b21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapEmptyKey
+    - ID: 72
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xcd8b40..0xcd8b41]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 226 GoMapType map[struct {}]int
+          Type: 196 GoMapType map[bool]main.node
           Locations:
             - Range: 0xcd8b40..0xcd8b41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapEmptyValue
+    - ID: 73
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xcd8b60..0xcd8b61]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 231 GoMapType map[int]struct {}
+          Type: 201 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd8b60..0xcd8b61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 74
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xcd8b80..0xcd8b81]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 236 GoMapType map[struct {}]struct {}
+        - Name: redactMyEntries
+          Type: 201 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd8b80..0xcd8b81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 75
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcd8ba0..0xcd8ba1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 206 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcd8ba0..0xcd8ba1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 76
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcd8bc0..0xcd8bc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 206 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcd8bc0..0xcd8bc1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcd8be0..0xcd8be1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 206 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcd8be0..0xcd8be1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 78
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xcd8c00..0xcd8c01]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 211 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xcd8c00..0xcd8c01
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 79
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xcd8c20..0xcd8c21]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 216 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xcd8c20..0xcd8c21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 80
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xcd8c40..0xcd8c41]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 221 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xcd8c40..0xcd8c41
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 81
+      Name: main.testMapEmptyKey
+      OutOfLinePCRanges: [0xcd8c60..0xcd8c61]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 226 GoMapType map[struct {}]int
+          Locations:
+            - Range: 0xcd8c60..0xcd8c61
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 82
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0xcd8c80..0xcd8c81]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 231 GoMapType map[int]struct {}
+          Locations:
+            - Range: 0xcd8c80..0xcd8c81
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0xcd8ca0..0xcd8ca1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 236 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0xcd8ca0..0xcd8ca1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcda480..0xcda481]
+      OutOfLinePCRanges: [0xcda5a0..0xcda5a1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcda480..0xcda481
+            - Range: 0xcda5a0..0xcda5a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcda480..0xcda481
+            - Range: 0xcda5a0..0xcda5a1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xcda480..0xcda481
+            - Range: 0xcda5a0..0xcda5a1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xcda4c0..0xcda4c1]
+      OutOfLinePCRanges: [0xcda5e0..0xcda5e1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcda4c0..0xcda4c1
+            - Range: 0xcda5e0..0xcda5e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcda4c0..0xcda4c1
+            - Range: 0xcda5e0..0xcda5e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7326,48 +7326,48 @@ Subprograms:
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xcda4c0..0xcda4c1
+            - Range: 0xcda5e0..0xcda5e1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcda640..0xcda641]
+      OutOfLinePCRanges: [0xcda760..0xcda761]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcda640..0xcda641
+            - Range: 0xcda760..0xcda761
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcda640..0xcda641
+            - Range: 0xcda760..0xcda761
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcda640..0xcda641
+            - Range: 0xcda760..0xcda761
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcda640..0xcda641
+            - Range: 0xcda760..0xcda761
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcda640..0xcda641
+            - Range: 0xcda760..0xcda761
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7378,61 +7378,61 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xcda860..0xcda873]
+      OutOfLinePCRanges: [0xcda980..0xcda993]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcda860..0xcda872
+            - Range: 0xcda980..0xcda992
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcda860..0xcda872
+            - Range: 0xcda980..0xcda992
               Pieces: []
-            - Range: 0xcda872..0xcda873
+            - Range: 0xcda992..0xcda993
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcda880..0xcda881]
+      OutOfLinePCRanges: [0xcda9a0..0xcda9a1]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 241 GoChannelType chan bool
           Locations:
-            - Range: 0xcda880..0xcda881
+            - Range: 0xcda9a0..0xcda9a1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcdaa60..0xcdaa61]
+      OutOfLinePCRanges: [0xcdab80..0xcdab81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcdaa60..0xcdaa61
+            - Range: 0xcdab80..0xcdab81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcdaa80..0xcdaa81]
+      OutOfLinePCRanges: [0xcdaba0..0xcdaba1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 StructureType main.node
           Locations:
-            - Range: 0xcdaa80..0xcdaa81
+            - Range: 0xcdaba0..0xcdaba1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7443,273 +7443,273 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcdaaa0..0xcdaaa1]
+      OutOfLinePCRanges: [0xcdabc0..0xcdabc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 245 PointerType *main.node
           Locations:
-            - Range: 0xcdaaa0..0xcdaaa1
+            - Range: 0xcdabc0..0xcdabc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcdaac0..0xcdaac1]
+      OutOfLinePCRanges: [0xcdabe0..0xcdabe1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
-          Locations:
-            - Range: 0xcdaac0..0xcdaac1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 93
-      Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcdab00..0xcdab01]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 105 PointerType *uint
-          Locations:
-            - Range: 0xcdab00..0xcdab01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 94
-      Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcdabe0..0xcdabe1]
-      InlinePCRanges: []
-      Variables:
-        - Name: z
-          Type: 93 PointerType *string
           Locations:
             - Range: 0xcdabe0..0xcdabe1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 93
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0xcdac20..0xcdac21]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 105 PointerType *uint
+          Locations:
+            - Range: 0xcdac20..0xcdac21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 94
+      Name: main.testStringPointer
+      OutOfLinePCRanges: [0xcdad00..0xcdad01]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 93 PointerType *string
+          Locations:
+            - Range: 0xcdad00..0xcdad01
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcdac20..0xcdac21]
+      OutOfLinePCRanges: [0xcdad40..0xcdad41]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcdac20..0xcdac21
+            - Range: 0xcdad40..0xcdad41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcdac20..0xcdac21
+            - Range: 0xcdad40..0xcdad41
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcdac60..0xcdac61]
+      OutOfLinePCRanges: [0xcdad80..0xcdad81]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 246 PointerType *main.t
           Locations:
-            - Range: 0xcdac60..0xcdac61
+            - Range: 0xcdad80..0xcdad81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcdb0c0..0xcdb132]
+      OutOfLinePCRanges: [0xcdb1e0..0xcdb252]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb0c0..0xcdb0d2
+            - Range: 0xcdb1e0..0xcdb1f2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb0c0..0xcdb11b
+            - Range: 0xcdb1e0..0xcdb23b
               Pieces: []
-            - Range: 0xcdb11b..0xcdb11c
+            - Range: 0xcdb23b..0xcdb23c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdb11c..0xcdb132
+            - Range: 0xcdb23c..0xcdb252
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb0d2..0xcdb0e5
+            - Range: 0xcdb1f2..0xcdb205
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdb0e5..0xcdb132
+            - Range: 0xcdb205..0xcdb252
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcdb140..0xcdb1cf]
+      OutOfLinePCRanges: [0xcdb260..0xcdb2ef]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb140..0xcdb15a
+            - Range: 0xcdb260..0xcdb27a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdb15a..0xcdb1cf
+            - Range: 0xcdb27a..0xcdb2ef
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 98 PointerType *int
           Locations:
-            - Range: 0xcdb140..0xcdb1b4
+            - Range: 0xcdb260..0xcdb2d4
               Pieces: []
-            - Range: 0xcdb1b4..0xcdb1b5
+            - Range: 0xcdb2d4..0xcdb2d5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdb1b5..0xcdb1cf
+            - Range: 0xcdb2d5..0xcdb2ef
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 98 PointerType *int
           Locations:
-            - Range: 0xcdb15f..0xcdb179
+            - Range: 0xcdb27f..0xcdb299
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdb179..0xcdb1cf
+            - Range: 0xcdb299..0xcdb2ef
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcdb1e0..0xcdb2be]
+      OutOfLinePCRanges: [0xcdb300..0xcdb3de]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb1e0..0xcdb242
+            - Range: 0xcdb300..0xcdb362
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb1e0..0xcdb2a4
+            - Range: 0xcdb300..0xcdb3c4
               Pieces: []
-            - Range: 0xcdb2a4..0xcdb2a5
+            - Range: 0xcdb3c4..0xcdb3c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdb2a5..0xcdb2be
+            - Range: 0xcdb3c5..0xcdb3de
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdb1e0..0xcdb2be, Pieces: []}]
+          Locations: [{Range: 0xcdb300..0xcdb3de, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb1f6..0xcdb247
+            - Range: 0xcdb316..0xcdb367
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdb247..0xcdb2be
+            - Range: 0xcdb367..0xcdb3de
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcdb20f..0xcdb247
+            - Range: 0xcdb32f..0xcdb367
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcdb247..0xcdb2be
+            - Range: 0xcdb367..0xcdb3de
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcdb2c0..0xcdb31b]
+      OutOfLinePCRanges: [0xcdb3e0..0xcdb43b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdb2c0..0xcdb2d9
+            - Range: 0xcdb3e0..0xcdb3f9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcdb2c0..0xcdb2fa
+            - Range: 0xcdb3e0..0xcdb41a
               Pieces: []
-            - Range: 0xcdb2fa..0xcdb2fb
+            - Range: 0xcdb41a..0xcdb41b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb2fb..0xcdb305
+            - Range: 0xcdb41b..0xcdb425
               Pieces: []
-            - Range: 0xcdb305..0xcdb306
+            - Range: 0xcdb425..0xcdb426
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb306..0xcdb31b
+            - Range: 0xcdb426..0xcdb43b
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcdb320..0xcdb466]
+      OutOfLinePCRanges: [0xcdb440..0xcdb586]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdb320..0xcdb36b
+            - Range: 0xcdb440..0xcdb48b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb36b..0xcdb376
+            - Range: 0xcdb48b..0xcdb496
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb3a7..0xcdb3aa
+            - Range: 0xcdb4c7..0xcdb4ca
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb3e0..0xcdb3e5
+            - Range: 0xcdb500..0xcdb505
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb414..0xcdb419
+            - Range: 0xcdb534..0xcdb539
               Pieces:
                 - Size: 8
                   Op: null
@@ -7720,117 +7720,117 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdb320..0xcdb363
+            - Range: 0xcdb440..0xcdb483
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdb320..0xcdb384
+            - Range: 0xcdb440..0xcdb4a4
               Pieces: []
-            - Range: 0xcdb384..0xcdb385
+            - Range: 0xcdb4a4..0xcdb4a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb385..0xcdb3d3
+            - Range: 0xcdb4a5..0xcdb4f3
               Pieces: []
-            - Range: 0xcdb3d3..0xcdb3d4
+            - Range: 0xcdb4f3..0xcdb4f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb3d4..0xcdb407
+            - Range: 0xcdb4f4..0xcdb527
               Pieces: []
-            - Range: 0xcdb407..0xcdb408
+            - Range: 0xcdb527..0xcdb528
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb408..0xcdb439
+            - Range: 0xcdb528..0xcdb559
               Pieces: []
-            - Range: 0xcdb439..0xcdb43a
+            - Range: 0xcdb559..0xcdb55a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb43a..0xcdb466
+            - Range: 0xcdb55a..0xcdb586
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcdb320..0xcdb384
+            - Range: 0xcdb440..0xcdb4a4
               Pieces: []
-            - Range: 0xcdb384..0xcdb385
+            - Range: 0xcdb4a4..0xcdb4a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdb385..0xcdb3d3
+            - Range: 0xcdb4a5..0xcdb4f3
               Pieces: []
-            - Range: 0xcdb3d3..0xcdb3d4
+            - Range: 0xcdb4f3..0xcdb4f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdb3d4..0xcdb407
+            - Range: 0xcdb4f4..0xcdb527
               Pieces: []
-            - Range: 0xcdb407..0xcdb408
+            - Range: 0xcdb527..0xcdb528
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdb408..0xcdb439
+            - Range: 0xcdb528..0xcdb559
               Pieces: []
-            - Range: 0xcdb439..0xcdb43a
+            - Range: 0xcdb559..0xcdb55a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdb43a..0xcdb466
+            - Range: 0xcdb55a..0xcdb586
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb36b..0xcdb371
+            - Range: 0xcdb48b..0xcdb491
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcdb480..0xcdb674]
+      OutOfLinePCRanges: [0xcdb5a0..0xcdb794]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdb480..0xcdb4cb
+            - Range: 0xcdb5a0..0xcdb5eb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb4cb..0xcdb4d2
+            - Range: 0xcdb5eb..0xcdb5f2
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdb4d2..0xcdb674
+            - Range: 0xcdb5f2..0xcdb794
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7841,1128 +7841,1128 @@ Subprograms:
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdb480..0xcdb544
+            - Range: 0xcdb5a0..0xcdb664
               Pieces: []
-            - Range: 0xcdb544..0xcdb545
+            - Range: 0xcdb664..0xcdb665
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb545..0xcdb57f
+            - Range: 0xcdb665..0xcdb69f
               Pieces: []
-            - Range: 0xcdb57f..0xcdb580
+            - Range: 0xcdb69f..0xcdb6a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb580..0xcdb642
+            - Range: 0xcdb6a0..0xcdb762
               Pieces: []
-            - Range: 0xcdb642..0xcdb643
+            - Range: 0xcdb762..0xcdb763
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb643..0xcdb64c
+            - Range: 0xcdb763..0xcdb76c
               Pieces: []
-            - Range: 0xcdb64c..0xcdb64d
+            - Range: 0xcdb76c..0xcdb76d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb64d..0xcdb674
+            - Range: 0xcdb76d..0xcdb794
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb56a..0xcdb570
+            - Range: 0xcdb68a..0xcdb690
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 98 PointerType *int
           Locations:
-            - Range: 0xcdb525..0xcdb544
+            - Range: 0xcdb645..0xcdb664
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcdb680..0xcdb7dd]
+      OutOfLinePCRanges: [0xcdb7a0..0xcdb8fd]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdb680..0xcdb6c0
+            - Range: 0xcdb7a0..0xcdb7e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb6c0..0xcdb70e
+            - Range: 0xcdb7e0..0xcdb82e
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdb70e..0xcdb77f
+            - Range: 0xcdb82e..0xcdb89f
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdb77f..0xcdb79f
+            - Range: 0xcdb89f..0xcdb8bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdb79f..0xcdb7a6
+            - Range: 0xcdb8bf..0xcdb8c6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdb7a6..0xcdb7dd
+            - Range: 0xcdb8c6..0xcdb8fd
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdb680..0xcdb76f
+            - Range: 0xcdb7a0..0xcdb88f
               Pieces: []
-            - Range: 0xcdb76f..0xcdb770
+            - Range: 0xcdb88f..0xcdb890
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb770..0xcdb779
+            - Range: 0xcdb890..0xcdb899
               Pieces: []
-            - Range: 0xcdb779..0xcdb77a
+            - Range: 0xcdb899..0xcdb89a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb77a..0xcdb7dd
+            - Range: 0xcdb89a..0xcdb8fd
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdb680..0xcdb6c0
+            - Range: 0xcdb7a0..0xcdb7e0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb6c0..0xcdb70e
+            - Range: 0xcdb7e0..0xcdb82e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdb70e..0xcdb715
+            - Range: 0xcdb82e..0xcdb835
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdb715..0xcdb775
+            - Range: 0xcdb835..0xcdb895
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdb775..0xcdb777
+            - Range: 0xcdb895..0xcdb897
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdb777..0xcdb779
+            - Range: 0xcdb897..0xcdb899
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdb779..0xcdb7dd
+            - Range: 0xcdb899..0xcdb8fd
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcdb7e0..0xcdb86f]
+      OutOfLinePCRanges: [0xcdb900..0xcdb98f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb7e0..0xcdb7f1
+            - Range: 0xcdb900..0xcdb911
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb7e0..0xcdb855
+            - Range: 0xcdb900..0xcdb975
               Pieces: []
-            - Range: 0xcdb855..0xcdb856
+            - Range: 0xcdb975..0xcdb976
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdb856..0xcdb86f
+            - Range: 0xcdb976..0xcdb98f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcdb880..0xcdb949]
+      OutOfLinePCRanges: [0xcdb9a0..0xcdba69]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb880..0xcdb8d3
+            - Range: 0xcdb9a0..0xcdb9f3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb880..0xcdb92f
+            - Range: 0xcdb9a0..0xcdba4f
               Pieces: []
-            - Range: 0xcdb92f..0xcdb930
+            - Range: 0xcdba4f..0xcdba50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdb930..0xcdb949
+            - Range: 0xcdba50..0xcdba69
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb880..0xcdb92f
+            - Range: 0xcdb9a0..0xcdba4f
               Pieces: []
-            - Range: 0xcdb92f..0xcdb930
+            - Range: 0xcdba4f..0xcdba50
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdb930..0xcdb949
+            - Range: 0xcdba50..0xcdba69
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcdb960..0xcdba25]
+      OutOfLinePCRanges: [0xcdba80..0xcdbb45]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb960..0xcdb9a5
+            - Range: 0xcdba80..0xcdbac5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdb9a5..0xcdba25
+            - Range: 0xcdbac5..0xcdbb45
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb960..0xcdba0b
+            - Range: 0xcdba80..0xcdbb2b
               Pieces: []
-            - Range: 0xcdba0b..0xcdba0c
+            - Range: 0xcdbb2b..0xcdbb2c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdba0c..0xcdba25
+            - Range: 0xcdbb2c..0xcdbb45
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb960..0xcdba0b
+            - Range: 0xcdba80..0xcdbb2b
               Pieces: []
-            - Range: 0xcdba0b..0xcdba0c
+            - Range: 0xcdbb2b..0xcdbb2c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdba0c..0xcdba25
+            - Range: 0xcdbb2c..0xcdbb45
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdb960..0xcdba0b
+            - Range: 0xcdba80..0xcdbb2b
               Pieces: []
-            - Range: 0xcdba0b..0xcdba0c
+            - Range: 0xcdbb2b..0xcdbb2c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdba0c..0xcdba25
+            - Range: 0xcdbb2c..0xcdbb45
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xcdba40..0xcdbb2f]
+      OutOfLinePCRanges: [0xcdbb60..0xcdbc4f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdba40..0xcdba85
+            - Range: 0xcdbb60..0xcdbba5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdba85..0xcdbb2f
+            - Range: 0xcdbba5..0xcdbc4f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdba40..0xcdbb11
+            - Range: 0xcdbb60..0xcdbc31
               Pieces: []
-            - Range: 0xcdbb11..0xcdbb12
+            - Range: 0xcdbc31..0xcdbc32
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdbb12..0xcdbb2f
+            - Range: 0xcdbc32..0xcdbc4f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdba40..0xcdbb11
+            - Range: 0xcdbb60..0xcdbc31
               Pieces: []
-            - Range: 0xcdbb11..0xcdbb12
+            - Range: 0xcdbc31..0xcdbc32
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcdbb12..0xcdbb2f
+            - Range: 0xcdbc32..0xcdbc4f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xcdbb40..0xcdbd4f]
+      OutOfLinePCRanges: [0xcdbc60..0xcdbe6f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdbb40..0xcdbbc6
+            - Range: 0xcdbc60..0xcdbce6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdbbc6..0xcdbd4f
+            - Range: 0xcdbce6..0xcdbe6f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdbb77..0xcdbd4f
+            - Range: 0xcdbc97..0xcdbe6f
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdbb7d..0xcdbd4f
+            - Range: 0xcdbc9d..0xcdbe6f
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcdbe40..0xcdbebe]
+      OutOfLinePCRanges: [0xcdbf60..0xcdbfde]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xcdbe40..0xcdbeb1
+            - Range: 0xcdbf60..0xcdbfd1
               Pieces: []
-            - Range: 0xcdbeb1..0xcdbeb2
+            - Range: 0xcdbfd1..0xcdbfd2
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdbeb2..0xcdbebe
+            - Range: 0xcdbfd2..0xcdbfde
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 102 BaseType int16
           Locations:
-            - Range: 0xcdbe40..0xcdbeb1
+            - Range: 0xcdbf60..0xcdbfd1
               Pieces: []
-            - Range: 0xcdbeb1..0xcdbeb2
+            - Range: 0xcdbfd1..0xcdbfd2
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdbeb2..0xcdbebe
+            - Range: 0xcdbfd2..0xcdbfde
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcdbe40..0xcdbeb1
+            - Range: 0xcdbf60..0xcdbfd1
               Pieces: []
-            - Range: 0xcdbeb1..0xcdbeb2
+            - Range: 0xcdbfd1..0xcdbfd2
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdbeb2..0xcdbebe
+            - Range: 0xcdbfd2..0xcdbfde
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 12 BaseType int64
           Locations:
-            - Range: 0xcdbe40..0xcdbeb1
+            - Range: 0xcdbf60..0xcdbfd1
               Pieces: []
-            - Range: 0xcdbeb1..0xcdbeb2
+            - Range: 0xcdbfd1..0xcdbfd2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdbeb2..0xcdbebe
+            - Range: 0xcdbfd2..0xcdbfde
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdbe40..0xcdbeb1
+            - Range: 0xcdbf60..0xcdbfd1
               Pieces: []
-            - Range: 0xcdbeb1..0xcdbeb2
+            - Range: 0xcdbfd1..0xcdbfd2
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdbeb2..0xcdbebe
+            - Range: 0xcdbfd2..0xcdbfde
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xcdbe40..0xcdbeb1
+            - Range: 0xcdbf60..0xcdbfd1
               Pieces: []
-            - Range: 0xcdbeb1..0xcdbeb2
+            - Range: 0xcdbfd1..0xcdbfd2
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdbeb2..0xcdbebe
+            - Range: 0xcdbfd2..0xcdbfde
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xcdbe40..0xcdbeb1
+            - Range: 0xcdbf60..0xcdbfd1
               Pieces: []
-            - Range: 0xcdbeb1..0xcdbeb2
+            - Range: 0xcdbfd1..0xcdbfd2
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdbeb2..0xcdbebe
+            - Range: 0xcdbfd2..0xcdbfde
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcdbe40..0xcdbeb1
+            - Range: 0xcdbf60..0xcdbfd1
               Pieces: []
-            - Range: 0xcdbeb1..0xcdbeb2
+            - Range: 0xcdbfd1..0xcdbfd2
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdbeb2..0xcdbebe
+            - Range: 0xcdbfd2..0xcdbfde
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcdbec0..0xcdbfb7]
+      OutOfLinePCRanges: [0xcdbfe0..0xcdc0d7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
+          Locations: [{Range: 0xcdbfe0..0xcdc0d7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcdbec0..0xcdbfa7
+            - Range: 0xcdbfe0..0xcdc0c7
               Pieces: []
-            - Range: 0xcdbfa7..0xcdbfa8
+            - Range: 0xcdc0c7..0xcdc0c8
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcdbfa8..0xcdbfb7
+            - Range: 0xcdc0c8..0xcdc0d7
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcdbec0..0xcdbfa7
+            - Range: 0xcdbfe0..0xcdc0c7
               Pieces: []
-            - Range: 0xcdbfa7..0xcdbfa8
+            - Range: 0xcdc0c7..0xcdc0c8
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdbfa8..0xcdbfb7
+            - Range: 0xcdc0c8..0xcdc0d7
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xcdbfc0..0xcdc033]
+      OutOfLinePCRanges: [0xcdc0e0..0xcdc153]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 94 BaseType complex64
-          Locations: [{Range: 0xcdbfc0..0xcdc033, Pieces: []}]
+          Locations: [{Range: 0xcdc0e0..0xcdc153, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 95 BaseType complex128
-          Locations: [{Range: 0xcdbfc0..0xcdc033, Pieces: []}]
+          Locations: [{Range: 0xcdc0e0..0xcdc153, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xcdc040..0xcdc0e5]
+      OutOfLinePCRanges: [0xcdc160..0xcdc205]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdc040..0xcdc0d3
+            - Range: 0xcdc160..0xcdc1f3
               Pieces: []
-            - Range: 0xcdc0d3..0xcdc0d4
+            - Range: 0xcdc1f3..0xcdc1f4
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xcdc0d4..0xcdc0e5
+            - Range: 0xcdc1f4..0xcdc205
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xcdc100..0xcdc17a]
+      OutOfLinePCRanges: [0xcdc220..0xcdc29a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcdc100..0xcdc16d
+            - Range: 0xcdc220..0xcdc28d
               Pieces: []
-            - Range: 0xcdc16d..0xcdc16e
+            - Range: 0xcdc28d..0xcdc28e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcdc16e..0xcdc17a
+            - Range: 0xcdc28e..0xcdc29a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xcdc180..0xcdc1d8]
+      OutOfLinePCRanges: [0xcdc2a0..0xcdc2f8]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 ArrayType [1]int
           Locations:
-            - Range: 0xcdc180..0xcdc1cb
+            - Range: 0xcdc2a0..0xcdc2eb
               Pieces: []
-            - Range: 0xcdc1cb..0xcdc1cc
+            - Range: 0xcdc2eb..0xcdc2ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc1cc..0xcdc1d8
+            - Range: 0xcdc2ec..0xcdc2f8
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xcdc1e0..0xcdc233]
+      OutOfLinePCRanges: [0xcdc300..0xcdc353]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0xcdc1e0..0xcdc226
+            - Range: 0xcdc300..0xcdc346
               Pieces: []
-            - Range: 0xcdc226..0xcdc227
+            - Range: 0xcdc346..0xcdc347
               Pieces: []
-            - Range: 0xcdc227..0xcdc233
+            - Range: 0xcdc347..0xcdc353
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xcdc240..0xcdc2a7]
+      OutOfLinePCRanges: [0xcdc360..0xcdc3c7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 StructureType main.mixedStruct
-          Locations: [{Range: 0xcdc240..0xcdc2a7, Pieces: []}]
+          Locations: [{Range: 0xcdc360..0xcdc3c7, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xcdc2c0..0xcdc35a]
+      OutOfLinePCRanges: [0xcdc3e0..0xcdc47a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc2c0..0xcdc34a
+            - Range: 0xcdc3e0..0xcdc46a
               Pieces: []
-            - Range: 0xcdc34a..0xcdc34b
+            - Range: 0xcdc46a..0xcdc46b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc34b..0xcdc35a
+            - Range: 0xcdc46b..0xcdc47a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc2c0..0xcdc34a
+            - Range: 0xcdc3e0..0xcdc46a
               Pieces: []
-            - Range: 0xcdc34a..0xcdc34b
+            - Range: 0xcdc46a..0xcdc46b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdc34b..0xcdc35a
+            - Range: 0xcdc46b..0xcdc47a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc2c0..0xcdc34a
+            - Range: 0xcdc3e0..0xcdc46a
               Pieces: []
-            - Range: 0xcdc34a..0xcdc34b
+            - Range: 0xcdc46a..0xcdc46b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdc34b..0xcdc35a
+            - Range: 0xcdc46b..0xcdc47a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc2c0..0xcdc34a
+            - Range: 0xcdc3e0..0xcdc46a
               Pieces: []
-            - Range: 0xcdc34a..0xcdc34b
+            - Range: 0xcdc46a..0xcdc46b
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdc34b..0xcdc35a
+            - Range: 0xcdc46b..0xcdc47a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc2c0..0xcdc34a
+            - Range: 0xcdc3e0..0xcdc46a
               Pieces: []
-            - Range: 0xcdc34a..0xcdc34b
+            - Range: 0xcdc46a..0xcdc46b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdc34b..0xcdc35a
+            - Range: 0xcdc46b..0xcdc47a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc2c0..0xcdc34a
+            - Range: 0xcdc3e0..0xcdc46a
               Pieces: []
-            - Range: 0xcdc34a..0xcdc34b
+            - Range: 0xcdc46a..0xcdc46b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdc34b..0xcdc35a
+            - Range: 0xcdc46b..0xcdc47a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc2c0..0xcdc34a
+            - Range: 0xcdc3e0..0xcdc46a
               Pieces: []
-            - Range: 0xcdc34a..0xcdc34b
+            - Range: 0xcdc46a..0xcdc46b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdc34b..0xcdc35a
+            - Range: 0xcdc46b..0xcdc47a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc2c0..0xcdc34a
+            - Range: 0xcdc3e0..0xcdc46a
               Pieces: []
-            - Range: 0xcdc34a..0xcdc34b
+            - Range: 0xcdc46a..0xcdc46b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdc34b..0xcdc35a
+            - Range: 0xcdc46b..0xcdc47a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdc2c0..0xcdc34a
+            - Range: 0xcdc3e0..0xcdc46a
               Pieces: []
-            - Range: 0xcdc34a..0xcdc34b
+            - Range: 0xcdc46a..0xcdc46b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcdc34b..0xcdc35a
+            - Range: 0xcdc46b..0xcdc47a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xcdc360..0xcdc405]
+      OutOfLinePCRanges: [0xcdc480..0xcdc525]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 StructureType main.wideStruct
           Locations:
-            - Range: 0xcdc360..0xcdc3f4
+            - Range: 0xcdc480..0xcdc514
               Pieces: []
-            - Range: 0xcdc3f4..0xcdc3f5
+            - Range: 0xcdc514..0xcdc515
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xcdc3f5..0xcdc405
+            - Range: 0xcdc515..0xcdc525
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xcdc420..0xcdc499]
+      OutOfLinePCRanges: [0xcdc540..0xcdc5b9]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc420..0xcdc48c
+            - Range: 0xcdc540..0xcdc5ac
               Pieces: []
-            - Range: 0xcdc48c..0xcdc48d
+            - Range: 0xcdc5ac..0xcdc5ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc48d..0xcdc499
+            - Range: 0xcdc5ad..0xcdc5b9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdc420..0xcdc499, Pieces: []}]
+          Locations: [{Range: 0xcdc540..0xcdc5b9, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc420..0xcdc48c
+            - Range: 0xcdc540..0xcdc5ac
               Pieces: []
-            - Range: 0xcdc48c..0xcdc48d
+            - Range: 0xcdc5ac..0xcdc5ad
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdc48d..0xcdc499
+            - Range: 0xcdc5ad..0xcdc5b9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdc420..0xcdc499, Pieces: []}]
+          Locations: [{Range: 0xcdc540..0xcdc5b9, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdc420..0xcdc48c
+            - Range: 0xcdc540..0xcdc5ac
               Pieces: []
-            - Range: 0xcdc48c..0xcdc48d
+            - Range: 0xcdc5ac..0xcdc5ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdc48d..0xcdc499
+            - Range: 0xcdc5ad..0xcdc5b9
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xcdc4a0..0xcdc51a]
+      OutOfLinePCRanges: [0xcdc5c0..0xcdc63a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdc4a0..0xcdc50d
+            - Range: 0xcdc5c0..0xcdc62d
               Pieces: []
-            - Range: 0xcdc50d..0xcdc50e
+            - Range: 0xcdc62d..0xcdc62e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcdc50e..0xcdc51a
+            - Range: 0xcdc62e..0xcdc63a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xcdc520..0xcdc57b]
+      OutOfLinePCRanges: [0xcdc640..0xcdc69b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdc520..0xcdc57b, Pieces: []}]
+          Locations: [{Range: 0xcdc640..0xcdc69b, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xcdc580..0xcdc5e7]
+      OutOfLinePCRanges: [0xcdc6a0..0xcdc707]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0xcdc580..0xcdc5e7, Pieces: []}]
+          Locations: [{Range: 0xcdc6a0..0xcdc707, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdc580..0xcdc5e7, Pieces: []}]
+          Locations: [{Range: 0xcdc6a0..0xcdc707, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xcdc600..0xcdc65d]
+      OutOfLinePCRanges: [0xcdc720..0xcdc77d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdc600..0xcdc650
+            - Range: 0xcdc720..0xcdc770
               Pieces: []
-            - Range: 0xcdc650..0xcdc651
+            - Range: 0xcdc770..0xcdc771
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc651..0xcdc65d
+            - Range: 0xcdc771..0xcdc77d
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xcdc600..0xcdc650
+            - Range: 0xcdc720..0xcdc770
               Pieces: []
-            - Range: 0xcdc650..0xcdc651
+            - Range: 0xcdc770..0xcdc771
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdc651..0xcdc65d
+            - Range: 0xcdc771..0xcdc77d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcdc660..0xcdc7e5]
+      OutOfLinePCRanges: [0xcdc780..0xcdc905]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdc660..0xcdc7e5
+            - Range: 0xcdc780..0xcdc905
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdc660..0xcdc7d3
+            - Range: 0xcdc780..0xcdc8f3
               Pieces: []
-            - Range: 0xcdc7d3..0xcdc7d4
+            - Range: 0xcdc8f3..0xcdc8f4
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xcdc7d4..0xcdc7e5
+            - Range: 0xcdc8f4..0xcdc905
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xcdc800..0xcdc8d2]
+      OutOfLinePCRanges: [0xcdc920..0xcdc9f2]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcdc800..0xcdc8d2
+            - Range: 0xcdc920..0xcdc9f2
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcdc800..0xcdc8c2
+            - Range: 0xcdc920..0xcdc9e2
               Pieces: []
-            - Range: 0xcdc8c2..0xcdc8c3
+            - Range: 0xcdc9e2..0xcdc9e3
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcdc8c3..0xcdc8d2
+            - Range: 0xcdc9e3..0xcdc9f2
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xcdc8e0..0xcdcb1a]
+      OutOfLinePCRanges: [0xcdca00..0xcdcc3a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdc8e0..0xcdcb1a
+            - Range: 0xcdca00..0xcdcc3a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdc8e0..0xcdcb1a
+            - Range: 0xcdca00..0xcdcc3a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdc8e0..0xcdcb0a
+            - Range: 0xcdca00..0xcdcc2a
               Pieces: []
-            - Range: 0xcdcb0a..0xcdcb0b
+            - Range: 0xcdcc2a..0xcdcc2b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xcdcb0b..0xcdcb1a
+            - Range: 0xcdcc2b..0xcdcc3a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xcdcb20..0xcdcdaf]
+      OutOfLinePCRanges: [0xcdcc40..0xcdcecf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcb20..0xcdcbd0
+            - Range: 0xcdcc40..0xcdccf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdcbd0..0xcdcdaf
+            - Range: 0xcdccf0..0xcdcecf
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcb20..0xcdcbd0
+            - Range: 0xcdcc40..0xcdccf0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdcbd0..0xcdcdaf
+            - Range: 0xcdccf0..0xcdcecf
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcb20..0xcdcbba
+            - Range: 0xcdcc40..0xcdccda
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdcbba..0xcdcdaf
+            - Range: 0xcdccda..0xcdcecf
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcb20..0xcdcb90
+            - Range: 0xcdcc40..0xcdccb0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdcb90..0xcdcdaf
+            - Range: 0xcdccb0..0xcdcecf
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcb20..0xcdcbd0
+            - Range: 0xcdcc40..0xcdccf0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdcbd0..0xcdcdaf
+            - Range: 0xcdccf0..0xcdcecf
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcb20..0xcdcbd0
+            - Range: 0xcdcc40..0xcdccf0
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdcbd0..0xcdcdaf
+            - Range: 0xcdccf0..0xcdcecf
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcb20..0xcdcbd0
+            - Range: 0xcdcc40..0xcdccf0
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdcbd0..0xcdcdaf
+            - Range: 0xcdccf0..0xcdcecf
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcb20..0xcdcbd0
+            - Range: 0xcdcc40..0xcdccf0
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdcbd0..0xcdcdaf
+            - Range: 0xcdccf0..0xcdcecf
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcb20..0xcdcbd0
+            - Range: 0xcdcc40..0xcdccf0
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xcdcbd0..0xcdcdaf
+            - Range: 0xcdccf0..0xcdcecf
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0xcdcb20..0xcdcd42
+            - Range: 0xcdcc40..0xcdce62
               Pieces: []
-            - Range: 0xcdcd42..0xcdcd43
+            - Range: 0xcdce62..0xcdce63
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcdcd43..0xcdcdaf
+            - Range: 0xcdce63..0xcdcecf
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xcdcdc0..0xcdd08c]
+      OutOfLinePCRanges: [0xcdcee0..0xcdd1ac]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcdc0..0xcdce6b
+            - Range: 0xcdcee0..0xcdcf8b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdce6b..0xcdd08c
+            - Range: 0xcdcf8b..0xcdd1ac
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcdc0..0xcdce6b
+            - Range: 0xcdcee0..0xcdcf8b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdce6b..0xcdd08c
+            - Range: 0xcdcf8b..0xcdd1ac
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcdc0..0xcdce55
+            - Range: 0xcdcee0..0xcdcf75
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdce55..0xcdd08c
+            - Range: 0xcdcf75..0xcdd1ac
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcdc0..0xcdce22
+            - Range: 0xcdcee0..0xcdcf42
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdce22..0xcdd08c
+            - Range: 0xcdcf42..0xcdd1ac
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcdc0..0xcdce6b
+            - Range: 0xcdcee0..0xcdcf8b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdce6b..0xcdd08c
+            - Range: 0xcdcf8b..0xcdd1ac
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcdc0..0xcdce6b
+            - Range: 0xcdcee0..0xcdcf8b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdce6b..0xcdd08c
+            - Range: 0xcdcf8b..0xcdd1ac
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcdc0..0xcdce6b
+            - Range: 0xcdcee0..0xcdcf8b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdce6b..0xcdd08c
+            - Range: 0xcdcf8b..0xcdd1ac
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcdc0..0xcdce6b
+            - Range: 0xcdcee0..0xcdcf8b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdce6b..0xcdd08c
+            - Range: 0xcdcf8b..0xcdd1ac
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdcdc0..0xcdd08c
+            - Range: 0xcdcee0..0xcdd1ac
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -8973,403 +8973,197 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdcdc0..0xcdd00b
+            - Range: 0xcdcee0..0xcdd12b
               Pieces: []
-            - Range: 0xcdd00b..0xcdd00c
+            - Range: 0xcdd12b..0xcdd12c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xcdd00c..0xcdd08c
+            - Range: 0xcdd12c..0xcdd1ac
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xcdd0a0..0xcdd12c]
+      OutOfLinePCRanges: [0xcdd1c0..0xcdd24c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0xcdd0a0..0xcdd12c
+            - Range: 0xcdd1c0..0xcdd24c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd0a0..0xcdd11c
+            - Range: 0xcdd1c0..0xcdd23c
               Pieces: []
-            - Range: 0xcdd11c..0xcdd11d
+            - Range: 0xcdd23c..0xcdd23d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd11d..0xcdd12c
+            - Range: 0xcdd23d..0xcdd24c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd0a0..0xcdd11c
+            - Range: 0xcdd1c0..0xcdd23c
               Pieces: []
-            - Range: 0xcdd11c..0xcdd11d
+            - Range: 0xcdd23c..0xcdd23d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdd11d..0xcdd12c
+            - Range: 0xcdd23d..0xcdd24c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd0a0..0xcdd11c
+            - Range: 0xcdd1c0..0xcdd23c
               Pieces: []
-            - Range: 0xcdd11c..0xcdd11d
+            - Range: 0xcdd23c..0xcdd23d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdd11d..0xcdd12c
+            - Range: 0xcdd23d..0xcdd24c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xcdd140..0xcdd22e]
+      OutOfLinePCRanges: [0xcdd260..0xcdd34e]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0xcdd140..0xcdd22e
+            - Range: 0xcdd260..0xcdd34e
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcdd140..0xcdd22e
+            - Range: 0xcdd260..0xcdd34e
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd140..0xcdd21e
+            - Range: 0xcdd260..0xcdd33e
               Pieces: []
-            - Range: 0xcdd21e..0xcdd21f
+            - Range: 0xcdd33e..0xcdd33f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd21f..0xcdd22e
+            - Range: 0xcdd33f..0xcdd34e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0xcdd140..0xcdd21e
+            - Range: 0xcdd260..0xcdd33e
               Pieces: []
-            - Range: 0xcdd21e..0xcdd21f
+            - Range: 0xcdd33e..0xcdd33f
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xcdd21f..0xcdd22e
+            - Range: 0xcdd33f..0xcdd34e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xcdd240..0xcdd30b]
+      OutOfLinePCRanges: [0xcdd360..0xcdd42b]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdd240..0xcdd30b
+            - Range: 0xcdd360..0xcdd42b
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd240..0xcdd2fa
+            - Range: 0xcdd360..0xcdd41a
               Pieces: []
-            - Range: 0xcdd2fa..0xcdd2fb
+            - Range: 0xcdd41a..0xcdd41b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd2fb..0xcdd30b
+            - Range: 0xcdd41b..0xcdd42b
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdd240..0xcdd2fa
+            - Range: 0xcdd360..0xcdd41a
               Pieces: []
-            - Range: 0xcdd2fa..0xcdd2fb
+            - Range: 0xcdd41a..0xcdd41b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcdd2fb..0xcdd30b
+            - Range: 0xcdd41b..0xcdd42b
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd2c6..0xcdd30b
+            - Range: 0xcdd3e6..0xcdd42b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xcdd320..0xcdd3c6]
+      OutOfLinePCRanges: [0xcdd440..0xcdd4e6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 ArrayType [0]int
-          Locations: [{Range: 0xcdd320..0xcdd3c6, Pieces: []}]
+          Locations: [{Range: 0xcdd440..0xcdd4e6, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd320..0xcdd365
+            - Range: 0xcdd440..0xcdd485
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd365..0xcdd387
+            - Range: 0xcdd485..0xcdd4a7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcdd387..0xcdd39a
+            - Range: 0xcdd4a7..0xcdd4ba
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcdd39a..0xcdd3c6
+            - Range: 0xcdd4ba..0xcdd4e6
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd320..0xcdd3ac
+            - Range: 0xcdd440..0xcdd4cc
               Pieces: []
-            - Range: 0xcdd3ac..0xcdd3ad
+            - Range: 0xcdd4cc..0xcdd4cd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd3ad..0xcdd3c6
+            - Range: 0xcdd4cd..0xcdd4e6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0xcdd320..0xcdd3ac
+            - Range: 0xcdd440..0xcdd4cc
               Pieces: []
-            - Range: 0xcdd3ac..0xcdd3ad
+            - Range: 0xcdd4cc..0xcdd4cd
               Pieces: []
-            - Range: 0xcdd3ad..0xcdd3c6
+            - Range: 0xcdd4cd..0xcdd4e6
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcdd8e0..0xcdd8e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdd8e0..0xcdd8e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 134
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcdd900..0xcdd901]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdd900..0xcdd901
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 135
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcdd920..0xcdd921]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 256 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xcdd920..0xcdd921
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 136
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcdd940..0xcdd941]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdd940..0xcdd941
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdd940..0xcdd941
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 137
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcdd960..0xcdd961]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdd960..0xcdd961
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdd960..0xcdd961
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 138
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcdd980..0xcdd981]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdd980..0xcdd981
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdd980..0xcdd981
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 139
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcdd9a0..0xcdd9a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 261 GoSliceHeaderType []string
-          Locations:
-            - Range: 0xcdd9a0..0xcdd9a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 140
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcdd9c0..0xcdd9c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 15 BaseType int8
-          Locations:
-            - Range: 0xcdd9c0..0xcdd9c1
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: s
-          Type: 262 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0xcdd9c0..0xcdd9c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: x
-          Type: 16 BaseType uint
-          Locations:
-            - Range: 0xcdd9c0..0xcdd9c1
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 141
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcdd9e0..0xcdd9e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xcdd9e0..0xcdd9e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 142
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcdda00..0xcdda01]
       InlinePCRanges: []
       Variables:
-        - Name: xs
+        - Name: u
           Type: 255 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdda00..0xcdda01
@@ -9383,13 +9177,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 143
-      Name: main.testSliceEmptyStructs
+    - ID: 134
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcdda20..0xcdda21]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 264 GoSliceHeaderType []struct {}
+        - Name: u
+          Type: 255 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdda20..0xcdda21
               Pieces:
@@ -9402,15 +9196,221 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 135
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcdda40..0xcdda41]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 256 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xcdda40..0xcdda41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 136
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcdda60..0xcdda61]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdda60..0xcdda61
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdda60..0xcdda61
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 137
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcdda80..0xcdda81]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdda80..0xcdda81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdda80..0xcdda81
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcddaa0..0xcddaa1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcddaa0..0xcddaa1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcddaa0..0xcddaa1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 139
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcddac0..0xcddac1]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 261 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcddac0..0xcddac1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 140
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xcddae0..0xcddae1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 15 BaseType int8
+          Locations:
+            - Range: 0xcddae0..0xcddae1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: s
+          Type: 262 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0xcddae0..0xcddae1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 16 BaseType uint
+          Locations:
+            - Range: 0xcddae0..0xcddae1
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 141
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xcddb00..0xcddb01]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 263 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0xcddb00..0xcddb01
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 142
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcddb20..0xcddb21]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcddb20..0xcddb21
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xcddb40..0xcddb41]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 264 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xcddb40..0xcddb41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xcdda40..0xcdda41]
+      OutOfLinePCRanges: [0xcddb60..0xcddb61]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdda40..0xcdda41
+            - Range: 0xcddb60..0xcddb61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9423,7 +9423,7 @@ Subprograms:
         - Name: bs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdda40..0xcdda41
+            - Range: 0xcddb60..0xcddb61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9436,7 +9436,7 @@ Subprograms:
         - Name: cs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdda40..0xcdda41
+            - Range: 0xcddb60..0xcddb61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9449,34 +9449,34 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0xcddde0..0xcdde32]
+      OutOfLinePCRanges: [0xcddf00..0xcddf52]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddde0..0xcdde25
+            - Range: 0xcddf00..0xcddf45
               Pieces: []
-            - Range: 0xcdde25..0xcdde26
+            - Range: 0xcddf45..0xcddf46
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdde26..0xcdde32
+            - Range: 0xcddf46..0xcddf52
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcdde40..0xcdde41]
+      OutOfLinePCRanges: [0xcddf60..0xcddf61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdde40..0xcdde41
+            - Range: 0xcddf60..0xcddf61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9487,13 +9487,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcdde60..0xcdde61]
+      OutOfLinePCRanges: [0xcddf80..0xcddf81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdde60..0xcdde61
+            - Range: 0xcddf80..0xcddf81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9504,7 +9504,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdde60..0xcdde61
+            - Range: 0xcddf80..0xcddf81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9515,7 +9515,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdde60..0xcdde61
+            - Range: 0xcddf80..0xcddf81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9526,13 +9526,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcdde80..0xcdde9f]
+      OutOfLinePCRanges: [0xcddfa0..0xcddfbf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 266 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcdde80..0xcdde9f
+            - Range: 0xcddfa0..0xcddfbf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9551,39 +9551,39 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcddea0..0xcddea1]
+      OutOfLinePCRanges: [0xcddfc0..0xcddfc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcddea0..0xcddea1
+            - Range: 0xcddfc0..0xcddfc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcddec0..0xcddec1]
+      OutOfLinePCRanges: [0xcddfe0..0xcddfe1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcddec0..0xcddec1
+            - Range: 0xcddfe0..0xcddfe1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcddee0..0xcddee1]
+      OutOfLinePCRanges: [0xcde000..0xcde001]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddee0..0xcddee1
+            - Range: 0xcde000..0xcde001
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9594,13 +9594,13 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcddf00..0xcddf01]
+      OutOfLinePCRanges: [0xcde020..0xcde021]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddf00..0xcddf01
+            - Range: 0xcde020..0xcde021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9611,13 +9611,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcddf20..0xcddf21]
+      OutOfLinePCRanges: [0xcde040..0xcde041]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddf20..0xcddf21
+            - Range: 0xcde040..0xcde041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9628,13 +9628,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xcddf40..0xcddf41]
+      OutOfLinePCRanges: [0xcde060..0xcde061]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddf40..0xcddf41
+            - Range: 0xcde060..0xcde061
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9645,7 +9645,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddf40..0xcddf41
+            - Range: 0xcde060..0xcde061
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9656,7 +9656,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddf40..0xcddf41
+            - Range: 0xcde060..0xcde061
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9667,26 +9667,26 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcde0c0..0xcde0c1]
+      OutOfLinePCRanges: [0xcde1e0..0xcde1e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcde0c0..0xcde0c1
+            - Range: 0xcde1e0..0xcde1e1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcde0e0..0xcde0ff]
+      OutOfLinePCRanges: [0xcde200..0xcde21f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 283 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcde0e0..0xcde0ff
+            - Range: 0xcde200..0xcde21f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9705,13 +9705,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcde220..0xcde243]
+      OutOfLinePCRanges: [0xcde340..0xcde363]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.aStruct
           Locations:
-            - Range: 0xcde220..0xcde243
+            - Range: 0xcde340..0xcde363
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9732,91 +9732,91 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xcde320..0xcde321]
+      OutOfLinePCRanges: [0xcde440..0xcde441]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 315 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xcde320..0xcde321
+            - Range: 0xcde440..0xcde441
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xcde340..0xcde341]
+      OutOfLinePCRanges: [0xcde460..0xcde461]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 StructureType main.tenStrings
           Locations:
-            - Range: 0xcde340..0xcde341
+            - Range: 0xcde460..0xcde461
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcde3a0..0xcde3a1]
+      OutOfLinePCRanges: [0xcde4c0..0xcde4c1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 318 StructureType main.emptyStruct
-          Locations: [{Range: 0xcde3a0..0xcde3a1, Pieces: []}]
+          Locations: [{Range: 0xcde4c0..0xcde4c1, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcde3c0..0xcde3c1]
+      OutOfLinePCRanges: [0xcde4e0..0xcde4e1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 319 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcde3c0..0xcde3c1
+            - Range: 0xcde4e0..0xcde4e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xce0680..0xce0684]
+      OutOfLinePCRanges: [0xce07a0..0xce07a4]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0680..0xce0684
+            - Range: 0xce07a0..0xce07a4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce0680..0xce0683
+            - Range: 0xce07a0..0xce07a3
               Pieces: []
-            - Range: 0xce0683..0xce0684
+            - Range: 0xce07a3..0xce07a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xce06a0..0xce06ac]
+      OutOfLinePCRanges: [0xce07c0..0xce07cc]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce06a0..0xce06ab
+            - Range: 0xce07c0..0xce07cb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce06ab..0xce06ac
+            - Range: 0xce07cb..0xce07cc
               Pieces:
                 - Size: 8
                   Op: null
@@ -9827,9 +9827,9 @@ Subprograms:
         - Name: ~r0
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce06a0..0xce06ab
+            - Range: 0xce07c0..0xce07cb
               Pieces: []
-            - Range: 0xce06ab..0xce06ac
+            - Range: 0xce07cb..0xce07cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9840,41 +9840,41 @@ Subprograms:
       DictRegister: 0
     - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xce06c0..0xce06c4]
+      OutOfLinePCRanges: [0xce07e0..0xce07e4]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce06c0..0xce06c4
+            - Range: 0xce07e0..0xce07e4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce06c0..0xce06c3
+            - Range: 0xce07e0..0xce07e3
               Pieces: []
-            - Range: 0xce06c3..0xce06c4
+            - Range: 0xce07e3..0xce07e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xce06e0..0xce06ec]
+      OutOfLinePCRanges: [0xce0800..0xce080c]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce06e0..0xce06eb
+            - Range: 0xce0800..0xce080b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce06eb..0xce06ec
+            - Range: 0xce080b..0xce080c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9885,9 +9885,9 @@ Subprograms:
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce06e0..0xce06eb
+            - Range: 0xce0800..0xce080b
               Pieces: []
-            - Range: 0xce06eb..0xce06ec
+            - Range: 0xce080b..0xce080c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9898,13 +9898,13 @@ Subprograms:
       DictRegister: 0
     - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xce0760..0xce0896]
+      OutOfLinePCRanges: [0xce0880..0xce09b6]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce0760..0xce0793
+            - Range: 0xce0880..0xce08b3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9912,7 +9912,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce0793..0xce079b
+            - Range: 0xce08b3..0xce08bb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9920,7 +9920,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xce079b..0xce0896
+            - Range: 0xce08bb..0xce09b6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9933,18 +9933,18 @@ Subprograms:
         - Name: pred
           Type: 326 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xce0760..0xce079b
+            - Range: 0xce0880..0xce08bb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce079b..0xce0896
+            - Range: 0xce08bb..0xce09b6
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce0760..0xce0854
+            - Range: 0xce0880..0xce0974
               Pieces: []
-            - Range: 0xce0854..0xce0855
+            - Range: 0xce0974..0xce0975
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9952,14 +9952,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce0855..0xce0896
+            - Range: 0xce0975..0xce09b6
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce079b..0xce07b9
+            - Range: 0xce08bb..0xce08d9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9967,7 +9967,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce07b9..0xce07c1
+            - Range: 0xce08d9..0xce08e1
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9975,7 +9975,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce07c1..0xce07c9
+            - Range: 0xce08e1..0xce08e9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9983,7 +9983,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce07c9..0xce07c9
+            - Range: 0xce08e9..0xce08e9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9991,7 +9991,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce07c9..0xce07f3
+            - Range: 0xce08e9..0xce0913
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -9999,7 +9999,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce07f3..0xce084b
+            - Range: 0xce0913..0xce096b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10007,7 +10007,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce084b..0xce0896
+            - Range: 0xce096b..0xce09b6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10020,132 +10020,132 @@ Subprograms:
         - Name: item
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce07e6..0xce07f3
+            - Range: 0xce0906..0xce0913
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce07f3..0xce084b
+            - Range: 0xce0913..0xce096b
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce08a0..0xce08e4]
+      OutOfLinePCRanges: [0xce09c0..0xce0a04]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce08a0..0xce08b9
+            - Range: 0xce09c0..0xce09d9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 327 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xce08a0..0xce08b9
+            - Range: 0xce09c0..0xce09d9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce08a0..0xce08b9
+            - Range: 0xce09c0..0xce09d9
               Pieces: []
-            - Range: 0xce08b9..0xce08ba
+            - Range: 0xce09d9..0xce09da
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce08ba..0xce08e4
+            - Range: 0xce09da..0xce0a04
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 168
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xce0b80..0xce0b84]
+      OutOfLinePCRanges: [0xce0ca0..0xce0ca4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 325 PointerType *go.shape.int
           Locations:
-            - Range: 0xce0b80..0xce0b84
+            - Range: 0xce0ca0..0xce0ca4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 325 PointerType *go.shape.int
           Locations:
-            - Range: 0xce0b80..0xce0b83
+            - Range: 0xce0ca0..0xce0ca3
               Pieces: []
-            - Range: 0xce0b83..0xce0b84
+            - Range: 0xce0ca3..0xce0ca4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xce0ba0..0xce0ba4]
+      OutOfLinePCRanges: [0xce0cc0..0xce0cc4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 328 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce0ba0..0xce0ba4
+            - Range: 0xce0cc0..0xce0cc4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce0ba0..0xce0ba3
+            - Range: 0xce0cc0..0xce0cc3
               Pieces: []
-            - Range: 0xce0ba3..0xce0ba4
+            - Range: 0xce0cc3..0xce0cc4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xce0bc0..0xce0bc4]
+      OutOfLinePCRanges: [0xce0ce0..0xce0ce4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 330 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce0bc0..0xce0bc4
+            - Range: 0xce0ce0..0xce0ce4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce0bc0..0xce0bc3
+            - Range: 0xce0ce0..0xce0ce3
               Pieces: []
-            - Range: 0xce0bc3..0xce0bc4
+            - Range: 0xce0ce3..0xce0ce4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xce0be0..0xce0bf1]
+      OutOfLinePCRanges: [0xce0d00..0xce0d11]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xce0be0..0xce0bf1
+            - Range: 0xce0d00..0xce0d11
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0be0..0xce0bf0
+            - Range: 0xce0d00..0xce0d10
               Pieces: []
-            - Range: 0xce0bf0..0xce0bf1
+            - Range: 0xce0d10..0xce0d11
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10156,69 +10156,69 @@ Subprograms:
       DictRegister: 0
     - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xce0c80..0xce0c89]
+      OutOfLinePCRanges: [0xce0da0..0xce0da9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xce0c80..0xce0c89
+            - Range: 0xce0da0..0xce0da9
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0c80..0xce0c88
+            - Range: 0xce0da0..0xce0da8
               Pieces: []
-            - Range: 0xce0c88..0xce0c89
+            - Range: 0xce0da8..0xce0da9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xce0d40..0xce0d48]
+      OutOfLinePCRanges: [0xce0e60..0xce0e68]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xce0d40..0xce0d48
+            - Range: 0xce0e60..0xce0e68
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0d40..0xce0d48
+            - Range: 0xce0e60..0xce0e68
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0xce0d40..0xce0d48
+            - Range: 0xce0e60..0xce0e68
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xce0de0..0xce0e51]
+      OutOfLinePCRanges: [0xce0f00..0xce0f71]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 338 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xce0de0..0xce0e51
+            - Range: 0xce0f00..0xce0f71
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0de0..0xce0e51
+            - Range: 0xce0f00..0xce0f71
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10229,20 +10229,20 @@ Subprograms:
         - Name: v
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0de0..0xce0e51
+            - Range: 0xce0f00..0xce0f71
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xce0ee0..0xce0ee8]
+      OutOfLinePCRanges: [0xce1000..0xce1008]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0ee0..0xce0ee8
+            - Range: 0xce1000..0xce1008
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10253,25 +10253,25 @@ Subprograms:
         - Name: b
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0xce0ee0..0xce0ee8
+            - Range: 0xce1000..0xce1008
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0xce0ee0..0xce0ee7
+            - Range: 0xce1000..0xce1007
               Pieces: []
-            - Range: 0xce0ee7..0xce0ee8
+            - Range: 0xce1007..0xce1008
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0ee0..0xce0ee7
+            - Range: 0xce1000..0xce1007
               Pieces: []
-            - Range: 0xce0ee7..0xce0ee8
+            - Range: 0xce1007..0xce1008
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10282,26 +10282,26 @@ Subprograms:
       DictRegister: 0
     - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce0f00..0xce0f0f]
+      OutOfLinePCRanges: [0xce1020..0xce102f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0f00..0xce0f0e
+            - Range: 0xce1020..0xce102e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0f00..0xce0f0b
+            - Range: 0xce1020..0xce102b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce0f0b..0xce0f0f
+            - Range: 0xce102b..0xce102f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10312,9 +10312,9 @@ Subprograms:
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0f00..0xce0f0e
+            - Range: 0xce1020..0xce102e
               Pieces: []
-            - Range: 0xce0f0e..0xce0f0f
+            - Range: 0xce102e..0xce102f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10325,56 +10325,56 @@ Subprograms:
         - Name: ~r1
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0f00..0xce0f0e
+            - Range: 0xce1020..0xce102e
               Pieces: []
-            - Range: 0xce0f0e..0xce0f0f
+            - Range: 0xce102e..0xce102f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xce0f20..0xce0f5a]
+      OutOfLinePCRanges: [0xce1040..0xce107a]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 340 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xce0f20..0xce0f39
+            - Range: 0xce1040..0xce1059
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce0f20..0xce0f39
+            - Range: 0xce1040..0xce1059
               Pieces: []
-            - Range: 0xce0f39..0xce0f3a
+            - Range: 0xce1059..0xce105a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce0f3a..0xce0f5a
+            - Range: 0xce105a..0xce107a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xce0f60..0xce0fad]
+      OutOfLinePCRanges: [0xce1080..0xce10cd]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 341 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xce0f60..0xce0f7f
+            - Range: 0xce1080..0xce109f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce0f7f..0xce0f82
+            - Range: 0xce109f..0xce10a2
               Pieces:
                 - Size: 8
                   Op: null
@@ -10385,37 +10385,37 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce0f60..0xce0f82
+            - Range: 0xce1080..0xce10a2
               Pieces: []
-            - Range: 0xce0f82..0xce0f83
+            - Range: 0xce10a2..0xce10a3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce0f83..0xce0fad
+            - Range: 0xce10a3..0xce10cd
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xce0fc0..0xce0fc8]
+      OutOfLinePCRanges: [0xce10e0..0xce10e8]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 342 PointerType *go.shape.string
           Locations:
-            - Range: 0xce0fc0..0xce0fc7
+            - Range: 0xce10e0..0xce10e7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0fc0..0xce0fc7
+            - Range: 0xce10e0..0xce10e7
               Pieces: []
-            - Range: 0xce0fc7..0xce0fc8
+            - Range: 0xce10e7..0xce10e8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10426,22 +10426,22 @@ Subprograms:
       DictRegister: 0
     - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xce0fe0..0xce1037]
+      OutOfLinePCRanges: [0xce1100..0xce1157]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 343 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce0fe0..0xce101d
+            - Range: 0xce1100..0xce113d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 344 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce0fe0..0xce1031
+            - Range: 0xce1100..0xce1151
               Pieces: []
-            - Range: 0xce1031..0xce1032
+            - Range: 0xce1151..0xce1152
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10455,20 +10455,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce1032..0xce1037
+            - Range: 0xce1152..0xce1157
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xce1040..0xce1064]
+      OutOfLinePCRanges: [0xce1160..0xce1184]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce1040..0xce1064
+            - Range: 0xce1160..0xce1184
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10481,33 +10481,33 @@ Subprograms:
         - Name: needle
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce1040..0xce1064
+            - Range: 0xce1160..0xce1184
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce1040..0xce1060
+            - Range: 0xce1160..0xce1180
               Pieces: []
-            - Range: 0xce1060..0xce1061
+            - Range: 0xce1180..0xce1181
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1061..0xce1063
+            - Range: 0xce1181..0xce1183
               Pieces: []
-            - Range: 0xce1063..0xce1064
+            - Range: 0xce1183..0xce1184
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xce1080..0xce113f]
+      OutOfLinePCRanges: [0xce11a0..0xce125f]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 345 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xce1080..0xce109d
+            - Range: 0xce11a0..0xce11bd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10515,7 +10515,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce109d..0xce109f
+            - Range: 0xce11bd..0xce11bf
               Pieces:
                 - Size: 8
                   Op: null
@@ -10528,13 +10528,13 @@ Subprograms:
         - Name: needle
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce1080..0xce10cc
+            - Range: 0xce11a0..0xce11ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce10cc..0xce113f
+            - Range: 0xce11ec..0xce125f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10545,28 +10545,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce1080..0xce10eb
+            - Range: 0xce11a0..0xce120b
               Pieces: []
-            - Range: 0xce10eb..0xce10ec
+            - Range: 0xce120b..0xce120c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce10ec..0xce10f3
+            - Range: 0xce120c..0xce1213
               Pieces: []
-            - Range: 0xce10f3..0xce10f4
+            - Range: 0xce1213..0xce1214
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce10f4..0xce113f
+            - Range: 0xce1214..0xce125f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce10af..0xce10c1
+            - Range: 0xce11cf..0xce11e1
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xce10c1..0xce10cc
+            - Range: 0xce11e1..0xce11ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10577,54 +10577,54 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xce1140..0xce1147]
+      OutOfLinePCRanges: [0xce1260..0xce1267]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xce1140..0xce1146
+            - Range: 0xce1260..0xce1266
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce1140..0xce1147
+            - Range: 0xce1260..0xce1267
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce1140..0xce1146
+            - Range: 0xce1260..0xce1266
               Pieces: []
-            - Range: 0xce1146..0xce1147
+            - Range: 0xce1266..0xce1267
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
     - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xce11c0..0xce122c]
+      OutOfLinePCRanges: [0xce12e0..0xce134c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xce11c0..0xce11e0
+            - Range: 0xce12e0..0xce1300
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce11e0..0xce11e8
+            - Range: 0xce1300..0xce1308
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce11e8..0xce11ed
+            - Range: 0xce1308..0xce130d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10635,7 +10635,7 @@ Subprograms:
         - Name: value
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce11c0..0xce11ed
+            - Range: 0xce12e0..0xce130d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10646,11 +10646,11 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce11c0..0xce11ed
+            - Range: 0xce12e0..0xce130d
               Pieces: []
-            - Range: 0xce11ed..0xce11ee
+            - Range: 0xce130d..0xce130e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce11ee..0xce122c
+            - Range: 0xce130e..0xce134c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10788,31 +10788,31 @@ Subprograms:
       DictRegister: 0
     - ID: 186
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcd7980..0xcd79e2]
+      OutOfLinePCRanges: [0xcd7aa0..0xcd7b02]
       InlinePCRanges:
-        - Ranges: [0xcd7a11..0xcd7a4d]
-          RootRanges: [0xcd7a00..0xcd7a71]
-        - Ranges: [0xcd7b52..0xcd7b8e]
-          RootRanges: [0xcd7b20..0xcd7ba8]
-        - Ranges: [0xcd7bdc..0xcd7c18]
-          RootRanges: [0xcd7bc0..0xcd7c85]
-        - Ranges: [0xcd7caf..0xcd7ceb]
-          RootRanges: [0xcd7ca0..0xcd7d02]
+        - Ranges: [0xcd7b31..0xcd7b6d]
+          RootRanges: [0xcd7b20..0xcd7b91]
+        - Ranges: [0xcd7c72..0xcd7cae]
+          RootRanges: [0xcd7c40..0xcd7cc8]
+        - Ranges: [0xcd7cfc..0xcd7d38]
+          RootRanges: [0xcd7ce0..0xcd7da5]
+        - Ranges: [0xcd7dcf..0xcd7e0b]
+          RootRanges: [0xcd7dc0..0xcd7e22]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd7980..0xcd7999
+            - Range: 0xcd7aa0..0xcd7ab9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd7a11..0xcd7a1c
+            - Range: 0xcd7b31..0xcd7b3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd7b52..0xcd7b5d
+            - Range: 0xcd7c72..0xcd7c7d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd7bd6..0xcd7be7
+            - Range: 0xcd7cf6..0xcd7d07
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd7be7..0xcd7c85
+            - Range: 0xcd7d07..0xcd7da5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcd7ca0..0xcd7cba
+            - Range: 0xcd7dc0..0xcd7dda
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10821,37 +10821,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd7c26..0xcd7c5e]
-          RootRanges: [0xcd7bc0..0xcd7c85]
+        - Ranges: [0xcd7d46..0xcd7d7e]
+          RootRanges: [0xcd7ce0..0xcd7da5]
       Variables: []
       DictRegister: null
     - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd7d33..0xcd7d71]
-          RootRanges: [0xcd7d20..0xcd7e2e]
+        - Ranges: [0xcd7e53..0xcd7e91]
+          RootRanges: [0xcd7e40..0xcd7f4e]
       Variables: []
       DictRegister: null
     - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd7de6..0xcd7e1e]
-          RootRanges: [0xcd7d20..0xcd7e2e]
+        - Ranges: [0xcd7f06..0xcd7f3e]
+          RootRanges: [0xcd7e40..0xcd7f4e]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd7e41..0xcd7e45]
-          RootRanges: [0xcd7e40..0xcd7e46]
+        - Ranges: [0xcd7f61..0xcd7f65]
+          RootRanges: [0xcd7f60..0xcd7f66]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd7e40..0xcd7e45
+            - Range: 0xcd7f60..0xcd7f65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10860,38 +10860,38 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd7e85..0xcd7e9d]
-          RootRanges: [0xcd7e60..0xcd7ea3]
-        - Ranges: [0xcd7f25..0xcd7f43]
-          RootRanges: [0xcd7ec0..0xcd8045]
+        - Ranges: [0xcd7fa5..0xcd7fbd]
+          RootRanges: [0xcd7f80..0xcd7fc3]
+        - Ranges: [0xcd8045..0xcd8063]
+          RootRanges: [0xcd7fe0..0xcd8165]
       Variables:
         - Name: a
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0xcd7e6d..0xcd7ea3
+            - Range: 0xcd7f8d..0xcd7fc3
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xcd7f0c..0xcd8045
+            - Range: 0xcd802c..0xcd8165
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 192
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xcd8060..0xcd80d1]
+      OutOfLinePCRanges: [0xcd8180..0xcd81f1]
       InlinePCRanges:
-        - Ranges: [0xce12e3..0xce1325]
-          RootRanges: [0xce12c0..0xce1356]
+        - Ranges: [0xce1403..0xce1445]
+          RootRanges: [0xce13e0..0xce1476]
       Variables:
         - Name: b
           Type: 352 StructureType main.firstBehavior
           Locations:
-            - Range: 0xcd8060..0xcd8088
+            - Range: 0xcd8180..0xcd81a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd8088..0xcd808d
+            - Range: 0xcd81a8..0xcd81ad
               Pieces:
                 - Size: 8
                   Op: null
@@ -10902,15 +10902,15 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8060..0xcd80b0
+            - Range: 0xcd8180..0xcd81d0
               Pieces: []
-            - Range: 0xcd80b0..0xcd80b1
+            - Range: 0xcd81d0..0xcd81d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd80b1..0xcd80d1
+            - Range: 0xcd81d1..0xcd81f1
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10919,8 +10919,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd880b..0xcd8812]
-          RootRanges: [0xcd86c0..0xcd8858]
+        - Ranges: [0xcd8930..0xcd8937]
+          RootRanges: [0xcd87e0..0xcd8978]
         - Ranges: [0x5230a1..0x5230a9]
           RootRanges: [0x5230a0..0x5230aa]
       Variables: []
@@ -10961,7 +10961,7 @@ Types:
       ID: 128
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 529280
+      GoRuntimeType: 529312
       GoKind: 22
       Pointee: 93 PointerType *string
     - __kind: PointerType
@@ -11228,7 +11228,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 488800
+      GoRuntimeType: 488832
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11270,14 +11270,14 @@ Types:
       ID: 1170
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.987296e+06
+      GoRuntimeType: 1.987584e+06
       GoKind: 22
       Pointee: 1171 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
       ID: 811
       Name: '*archive/tar.headerError'
       ByteSize: 8
-      GoRuntimeType: 930912
+      GoRuntimeType: 930944
       GoKind: 22
       Pointee: 812 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
@@ -11289,84 +11289,84 @@ Types:
       ID: 1105
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.438688e+06
+      GoRuntimeType: 1.438816e+06
       GoKind: 22
       Pointee: 1106 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
       ID: 1053
       Name: '*archive/zip.countWriter'
       ByteSize: 8
-      GoRuntimeType: 931104
+      GoRuntimeType: 931136
       GoKind: 22
       Pointee: 1054 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
       ID: 1055
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
-      GoRuntimeType: 931200
+      GoRuntimeType: 931232
       GoKind: 22
       Pointee: 1056 StructureType archive/zip.dirWriter
     - __kind: PointerType
       ID: 1153
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.906976e+06
+      GoRuntimeType: 1.907264e+06
       GoKind: 22
       Pointee: 1154 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 1081
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.0584e+06
+      GoRuntimeType: 1.058528e+06
       GoKind: 22
       Pointee: 1082 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 1083
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.058656e+06
+      GoRuntimeType: 1.058784e+06
       GoKind: 22
       Pointee: 1084 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 392800
+      GoRuntimeType: 392832
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 1128
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.176128e+06
+      GoRuntimeType: 2.176416e+06
       GoKind: 22
       Pointee: 1129 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1159
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.952e+06
+      GoRuntimeType: 1.952288e+06
       GoKind: 22
       Pointee: 1160 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1208
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.273408e+06
+      GoRuntimeType: 2.273696e+06
       GoKind: 22
       Pointee: 1209 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
       ID: 723
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 913440
+      GoRuntimeType: 913472
       GoKind: 22
       Pointee: 615 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
       ID: 724
       Name: '*compress/flate.InternalError'
       ByteSize: 8
-      GoRuntimeType: 913536
+      GoRuntimeType: 913568
       GoKind: 22
       Pointee: 616 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
@@ -11378,357 +11378,357 @@ Types:
       ID: 1103
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.428128e+06
+      GoRuntimeType: 1.428256e+06
       GoKind: 22
       Pointee: 1104 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
       ID: 1049
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
-      GoRuntimeType: 913632
+      GoRuntimeType: 913664
       GoKind: 22
       Pointee: 1050 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
       ID: 1125
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.728736e+06
+      GoRuntimeType: 1.729024e+06
       GoKind: 22
       Pointee: 1126 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 955
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.206144e+06
+      GoRuntimeType: 1.206272e+06
       GoKind: 22
       Pointee: 956 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 803
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 925536
+      GoRuntimeType: 925568
       GoKind: 22
       Pointee: 629 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
       ID: 804
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 925728
+      GoRuntimeType: 925760
       GoKind: 22
       Pointee: 630 BaseType crypto/des.KeySizeError
     - __kind: PointerType
       ID: 805
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 926016
+      GoRuntimeType: 926048
       GoKind: 22
       Pointee: 631 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
       ID: 1115
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
-      GoRuntimeType: 1.569568e+06
+      GoRuntimeType: 1.569856e+06
       GoKind: 22
       Pointee: 1116 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
       ID: 1149
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.865408e+06
+      GoRuntimeType: 1.865696e+06
       GoKind: 22
       Pointee: 1150 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
       ID: 1181
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
-      GoRuntimeType: 2.123456e+06
+      GoRuntimeType: 2.123744e+06
       GoKind: 22
       Pointee: 1182 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
       ID: 1155
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.907488e+06
+      GoRuntimeType: 1.907776e+06
       GoKind: 22
       Pointee: 1156 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
       ID: 1151
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.86608e+06
+      GoRuntimeType: 1.866368e+06
       GoKind: 22
       Pointee: 1152 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
       ID: 1147
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.85824e+06
+      GoRuntimeType: 1.858528e+06
       GoKind: 22
       Pointee: 1148 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
       ID: 806
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 926304
+      GoRuntimeType: 926336
       GoKind: 22
       Pointee: 632 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
       ID: 1165
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 1.956864e+06
+      GoRuntimeType: 1.957152e+06
       GoKind: 22
       Pointee: 1166 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1137
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
-      GoRuntimeType: 1.812224e+06
+      GoRuntimeType: 1.812512e+06
       GoKind: 22
       Pointee: 1138 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
       ID: 729
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
-      GoRuntimeType: 915168
+      GoRuntimeType: 915200
       GoKind: 22
       Pointee: 619 BaseType crypto/tls.AlertError
     - __kind: PointerType
       ID: 895
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.047008e+06
+      GoRuntimeType: 1.047136e+06
       GoKind: 22
       Pointee: 896 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1234
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.38528e+06
+      GoRuntimeType: 2.385568e+06
       GoKind: 22
       Pointee: 1235 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
       ID: 727
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
-      GoRuntimeType: 914976
+      GoRuntimeType: 915008
       GoKind: 22
       Pointee: 728 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
       ID: 725
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
-      GoRuntimeType: 914880
+      GoRuntimeType: 914912
       GoKind: 22
       Pointee: 726 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
       ID: 894
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.045344e+06
+      GoRuntimeType: 1.045472e+06
       GoKind: 22
       Pointee: 851 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 1113
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.562528e+06
+      GoRuntimeType: 1.562816e+06
       GoKind: 22
       Pointee: 1114 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
       ID: 1120
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.646432e+06
+      GoRuntimeType: 1.64672e+06
       GoKind: 22
       Pointee: 1121 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 990
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.428448e+06
+      GoRuntimeType: 1.428576e+06
       GoKind: 22
       Pointee: 991 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 1005
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.045344e+06
+      GoRuntimeType: 2.045632e+06
       GoKind: 22
       Pointee: 1006 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
       ID: 799
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
-      GoRuntimeType: 924576
+      GoRuntimeType: 924608
       GoKind: 22
       Pointee: 800 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
       ID: 793
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
-      GoRuntimeType: 924096
+      GoRuntimeType: 924128
       GoKind: 22
       Pointee: 794 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
       ID: 795
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
-      GoRuntimeType: 924192
+      GoRuntimeType: 924224
       GoKind: 22
       Pointee: 796 StructureType crypto/x509.HostnameError
     - __kind: PointerType
       ID: 792
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
-      GoRuntimeType: 924000
+      GoRuntimeType: 924032
       GoKind: 22
       Pointee: 628 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
       ID: 900
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.052768e+06
+      GoRuntimeType: 1.052896e+06
       GoKind: 22
       Pointee: 901 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
       ID: 801
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
-      GoRuntimeType: 924672
+      GoRuntimeType: 924704
       GoKind: 22
       Pointee: 802 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
       ID: 797
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
-      GoRuntimeType: 924480
+      GoRuntimeType: 924512
       GoKind: 22
       Pointee: 798 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
       ID: 815
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
-      GoRuntimeType: 931392
+      GoRuntimeType: 931424
       GoKind: 22
       Pointee: 816 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
       ID: 819
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 931584
+      GoRuntimeType: 931616
       GoKind: 22
       Pointee: 820 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
       ID: 817
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 931488
+      GoRuntimeType: 931520
       GoKind: 22
       Pointee: 818 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
       ID: 713
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 911808
+      GoRuntimeType: 911840
       GoKind: 22
       Pointee: 613 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 1071
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.042912e+06
+      GoRuntimeType: 1.04304e+06
       GoKind: 22
       Pointee: 1072 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
       ID: 716
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
-      GoRuntimeType: 912672
+      GoRuntimeType: 912704
       GoKind: 22
       Pointee: 614 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
       ID: 684
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 906528
+      GoRuntimeType: 906560
       GoKind: 22
       Pointee: 685 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 886
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.0392e+06
+      GoRuntimeType: 1.039328e+06
       GoKind: 22
       Pointee: 887 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 676
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 906144
+      GoRuntimeType: 906176
       GoKind: 22
       Pointee: 677 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 682
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 906432
+      GoRuntimeType: 906464
       GoKind: 22
       Pointee: 683 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 680
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
-      GoRuntimeType: 906336
+      GoRuntimeType: 906368
       GoKind: 22
       Pointee: 681 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
       ID: 678
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 906240
+      GoRuntimeType: 906272
       GoKind: 22
       Pointee: 679 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1214
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.298432e+06
+      GoRuntimeType: 2.29872e+06
       GoKind: 22
       Pointee: 1215 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
       ID: 686
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 906912
+      GoRuntimeType: 906944
       GoKind: 22
       Pointee: 687 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 1079
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.055328e+06
+      GoRuntimeType: 1.055456e+06
       GoKind: 22
       Pointee: 1080 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
       ID: 787
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 923040
+      GoRuntimeType: 923072
       GoKind: 22
       Pointee: 788 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 785
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
-      GoRuntimeType: 922944
+      GoRuntimeType: 922976
       GoKind: 22
       Pointee: 786 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
       ID: 789
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 923136
+      GoRuntimeType: 923168
       GoKind: 22
       Pointee: 625 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
@@ -11740,119 +11740,119 @@ Types:
       ID: 790
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
-      GoRuntimeType: 923232
+      GoRuntimeType: 923264
       GoKind: 22
       Pointee: 791 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 1192
       Name: '*encoding/xml.printer'
       ByteSize: 8
-      GoRuntimeType: 2.161888e+06
+      GoRuntimeType: 2.162176e+06
       GoKind: 22
       Pointee: 1193 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 104
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 391712
+      GoRuntimeType: 391744
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 654
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 896544
+      GoRuntimeType: 896576
       GoKind: 22
       Pointee: 655 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 853
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1.023712e+06
+      GoRuntimeType: 1.02384e+06
       GoKind: 22
       Pointee: 854 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 106
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 392672
+      GoRuntimeType: 392704
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 96
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 392736
+      GoRuntimeType: 392768
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 1202
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.265728e+06
+      GoRuntimeType: 2.266016e+06
       GoKind: 22
       Pointee: 1203 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 855
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.02384e+06
+      GoRuntimeType: 1.023968e+06
       GoKind: 22
       Pointee: 856 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 857
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.023968e+06
+      GoRuntimeType: 1.024096e+06
       GoKind: 22
       Pointee: 858 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
       ID: 714
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 912192
+      GoRuntimeType: 912224
       GoKind: 22
       Pointee: 715 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 695
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 909312
+      GoRuntimeType: 909344
       GoKind: 22
       Pointee: 696 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
       ID: 697
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 909408
+      GoRuntimeType: 909440
       GoKind: 22
       Pointee: 698 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 1017
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 909120
+      GoRuntimeType: 909152
       GoKind: 22
       Pointee: 1018 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
       ID: 701
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 909696
+      GoRuntimeType: 909728
       GoKind: 22
       Pointee: 702 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 1019
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 909216
+      GoRuntimeType: 909248
       GoKind: 22
       Pointee: 1020 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
       ID: 699
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 909504
+      GoRuntimeType: 909536
       GoKind: 22
       Pointee: 607 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -11864,7 +11864,7 @@ Types:
       ID: 694
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 909024
+      GoRuntimeType: 909056
       GoKind: 22
       Pointee: 604 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -11876,7 +11876,7 @@ Types:
       ID: 700
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 909600
+      GoRuntimeType: 909632
       GoKind: 22
       Pointee: 610 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -11888,98 +11888,98 @@ Types:
       ID: 1093
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.211648e+06
+      GoRuntimeType: 1.211776e+06
       GoKind: 22
       Pointee: 1094 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1178
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 2.060672e+06
+      GoRuntimeType: 2.06096e+06
       GoKind: 22
       Pointee: 1179 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
       ID: 809
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
-      GoRuntimeType: 929856
+      GoRuntimeType: 929888
       GoKind: 22
       Pointee: 810 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 964
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.215232e+06
+      GoRuntimeType: 1.21536e+06
       GoKind: 22
       Pointee: 965 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1210
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.275456e+06
+      GoRuntimeType: 2.275744e+06
       GoKind: 22
       Pointee: 1211 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
       ID: 736
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
-      GoRuntimeType: 918528
+      GoRuntimeType: 918560
       GoKind: 22
       Pointee: 737 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
       ID: 743
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
-      GoRuntimeType: 919584
+      GoRuntimeType: 919616
       GoKind: 22
       Pointee: 744 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
       ID: 738
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
-      GoRuntimeType: 919296
+      GoRuntimeType: 919328
       GoKind: 22
       Pointee: 624 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
       ID: 741
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
-      GoRuntimeType: 919488
+      GoRuntimeType: 919520
       GoKind: 22
       Pointee: 742 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
       ID: 739
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
-      GoRuntimeType: 919392
+      GoRuntimeType: 919424
       GoKind: 22
       Pointee: 740 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
       ID: 759
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
-      GoRuntimeType: 921504
+      GoRuntimeType: 921536
       GoKind: 22
       Pointee: 760 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
       ID: 763
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
-      GoRuntimeType: 921696
+      GoRuntimeType: 921728
       GoKind: 22
       Pointee: 764 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
       ID: 761
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
-      GoRuntimeType: 921600
+      GoRuntimeType: 921632
       GoKind: 22
       Pointee: 762 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
       ID: 757
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
-      GoRuntimeType: 921408
+      GoRuntimeType: 921440
       GoKind: 22
       Pointee: 758 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
@@ -11991,357 +11991,357 @@ Types:
       ID: 771
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
-      GoRuntimeType: 922080
+      GoRuntimeType: 922112
       GoKind: 22
       Pointee: 772 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
       ID: 765
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
-      GoRuntimeType: 921792
+      GoRuntimeType: 921824
       GoKind: 22
       Pointee: 766 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
       ID: 769
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
-      GoRuntimeType: 921984
+      GoRuntimeType: 922016
       GoKind: 22
       Pointee: 770 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
       ID: 767
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
-      GoRuntimeType: 921888
+      GoRuntimeType: 921920
       GoKind: 22
       Pointee: 768 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
       ID: 773
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
-      GoRuntimeType: 922176
+      GoRuntimeType: 922208
       GoKind: 22
       Pointee: 774 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
       ID: 779
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
-      GoRuntimeType: 922464
+      GoRuntimeType: 922496
       GoKind: 22
       Pointee: 780 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
       ID: 781
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
-      GoRuntimeType: 922560
+      GoRuntimeType: 922592
       GoKind: 22
       Pointee: 782 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
       ID: 777
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
-      GoRuntimeType: 922368
+      GoRuntimeType: 922400
       GoKind: 22
       Pointee: 778 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
       ID: 775
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
-      GoRuntimeType: 922272
+      GoRuntimeType: 922304
       GoKind: 22
       Pointee: 776 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
       ID: 783
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
-      GoRuntimeType: 922752
+      GoRuntimeType: 922784
       GoKind: 22
       Pointee: 784 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 703
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 910848
+      GoRuntimeType: 910880
       GoKind: 22
       Pointee: 704 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 1131
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.804832e+06
+      GoRuntimeType: 1.80512e+06
       GoKind: 22
       Pointee: 1132 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
       ID: 705
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 910944
+      GoRuntimeType: 910976
       GoKind: 22
       Pointee: 706 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 1111
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.561408e+06
+      GoRuntimeType: 1.561696e+06
       GoKind: 22
       Pointee: 1112 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 1067
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.041888e+06
+      GoRuntimeType: 1.042016e+06
       GoKind: 22
       Pointee: 1068 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1101
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.426208e+06
+      GoRuntimeType: 1.426336e+06
       GoKind: 22
       Pointee: 1102 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 709
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 911136
+      GoRuntimeType: 911168
       GoKind: 22
       Pointee: 710 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1168
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.977504e+06
+      GoRuntimeType: 1.977792e+06
       GoKind: 22
       Pointee: 1169 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1185
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.135424e+06
+      GoRuntimeType: 2.135712e+06
       GoKind: 22
       Pointee: 1180 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1184
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.13504e+06
+      GoRuntimeType: 2.135328e+06
       GoKind: 22
       Pointee: 1183 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 1069
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.042016e+06
+      GoRuntimeType: 1.042144e+06
       GoKind: 22
       Pointee: 1070 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 707
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 911040
+      GoRuntimeType: 911072
       GoKind: 22
       Pointee: 708 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
       ID: 711
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 911232
+      GoRuntimeType: 911264
       GoKind: 22
       Pointee: 712 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 1133
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.806624e+06
+      GoRuntimeType: 1.806912e+06
       GoKind: 22
       Pointee: 1134 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1174
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.013952e+06
+      GoRuntimeType: 2.01424e+06
       GoKind: 22
       Pointee: 1175 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1176
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.045024e+06
+      GoRuntimeType: 2.045312e+06
       GoKind: 22
       Pointee: 1177 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 995
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.441088e+06
+      GoRuntimeType: 1.441216e+06
       GoKind: 22
       Pointee: 996 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 908
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.066848e+06
+      GoRuntimeType: 1.066976e+06
       GoKind: 22
       Pointee: 909 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 906
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.06672e+06
+      GoRuntimeType: 1.066848e+06
       GoKind: 22
       Pointee: 907 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 910
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.070816e+06
+      GoRuntimeType: 1.070944e+06
       GoKind: 22
       Pointee: 911 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 912
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.070944e+06
+      GoRuntimeType: 1.071072e+06
       GoKind: 22
       Pointee: 913 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 1122
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.673504e+06
+      GoRuntimeType: 1.673792e+06
       GoKind: 22
       Pointee: 1123 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 902
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.053408e+06
+      GoRuntimeType: 1.053536e+06
       GoKind: 22
       Pointee: 903 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 717
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
-      GoRuntimeType: 912864
+      GoRuntimeType: 912896
       GoKind: 22
       Pointee: 718 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
       ID: 1226
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.361504e+06
+      GoRuntimeType: 2.361792e+06
       GoKind: 22
       Pointee: 1227 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 966
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.22368e+06
+      GoRuntimeType: 1.223808e+06
       GoKind: 22
       Pointee: 967 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 939
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.202432e+06
+      GoRuntimeType: 1.20256e+06
       GoKind: 22
       Pointee: 940 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 933
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.202048e+06
+      GoRuntimeType: 1.202176e+06
       GoKind: 22
       Pointee: 934 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 872
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.033184e+06
+      GoRuntimeType: 1.033312e+06
       GoKind: 22
       Pointee: 873 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 945
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.202816e+06
+      GoRuntimeType: 1.202944e+06
       GoKind: 22
       Pointee: 946 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 871
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1.033056e+06
+      GoRuntimeType: 1.033184e+06
       GoKind: 22
       Pointee: 850 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 937
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.202304e+06
+      GoRuntimeType: 1.202432e+06
       GoKind: 22
       Pointee: 938 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 935
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.202176e+06
+      GoRuntimeType: 1.202304e+06
       GoKind: 22
       Pointee: 936 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 943
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.202688e+06
+      GoRuntimeType: 1.202816e+06
       GoKind: 22
       Pointee: 944 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 941
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.20256e+06
+      GoRuntimeType: 1.202688e+06
       GoKind: 22
       Pointee: 942 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1230
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.373312e+06
+      GoRuntimeType: 2.3736e+06
       GoKind: 22
       Pointee: 1231 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 949
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.2032e+06
+      GoRuntimeType: 1.203328e+06
       GoKind: 22
       Pointee: 950 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 876
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1.03344e+06
+      GoRuntimeType: 1.033568e+06
       GoKind: 22
       Pointee: 877 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 874
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1.033312e+06
+      GoRuntimeType: 1.03344e+06
       GoKind: 22
       Pointee: 875 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 947
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.203072e+06
+      GoRuntimeType: 1.2032e+06
       GoKind: 22
       Pointee: 948 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
       ID: 831
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
-      GoRuntimeType: 944352
+      GoRuntimeType: 944384
       GoKind: 22
       Pointee: 637 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
@@ -12353,21 +12353,21 @@ Types:
       ID: 349
       Name: '*go.shape.float64'
       ByteSize: 8
-      GoRuntimeType: 479264
+      GoRuntimeType: 479296
       GoKind: 22
       Pointee: 350 BaseType go.shape.float64
     - __kind: PointerType
       ID: 325
       Name: '*go.shape.int'
       ByteSize: 8
-      GoRuntimeType: 478816
+      GoRuntimeType: 478848
       GoKind: 22
       Pointee: 320 BaseType go.shape.int
     - __kind: PointerType
       ID: 342
       Name: '*go.shape.string'
       ByteSize: 8
-      GoRuntimeType: 478880
+      GoRuntimeType: 478912
       GoKind: 22
       Pointee: 322 GoStringHeaderType go.shape.string
     - __kind: PointerType
@@ -12397,63 +12397,63 @@ Types:
       ID: 1008
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.671968e+06
+      GoRuntimeType: 1.672256e+06
       GoKind: 22
       Pointee: 1009 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 916
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.085664e+06
+      GoRuntimeType: 1.085792e+06
       GoKind: 22
       Pointee: 917 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 1099
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.263232e+06
+      GoRuntimeType: 1.26336e+06
       GoKind: 22
       Pointee: 1100 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1190
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.150016e+06
+      GoRuntimeType: 2.150304e+06
       GoKind: 22
       Pointee: 1191 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 1085
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.087968e+06
+      GoRuntimeType: 1.088096e+06
       GoKind: 22
       Pointee: 1086 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
       ID: 832
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 945600
+      GoRuntimeType: 945632
       GoKind: 22
       Pointee: 640 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
       ID: 974
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.264896e+06
+      GoRuntimeType: 1.265024e+06
       GoKind: 22
       Pointee: 975 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
       ID: 835
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
-      GoRuntimeType: 945888
+      GoRuntimeType: 945920
       GoKind: 22
       Pointee: 836 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
       ID: 834
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 945792
+      GoRuntimeType: 945824
       GoKind: 22
       Pointee: 644 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
@@ -12465,7 +12465,7 @@ Types:
       ID: 838
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 946080
+      GoRuntimeType: 946112
       GoKind: 22
       Pointee: 650 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
@@ -12477,7 +12477,7 @@ Types:
       ID: 837
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 945984
+      GoRuntimeType: 946016
       GoKind: 22
       Pointee: 647 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
@@ -12489,7 +12489,7 @@ Types:
       ID: 833
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 945696
+      GoRuntimeType: 945728
       GoKind: 22
       Pointee: 641 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
@@ -12501,266 +12501,266 @@ Types:
       ID: 1188
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.148096e+06
+      GoRuntimeType: 2.148384e+06
       GoKind: 22
       Pointee: 1189 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
       ID: 839
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
-      GoRuntimeType: 946176
+      GoRuntimeType: 946208
       GoKind: 22
       Pointee: 840 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
       ID: 841
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
-      GoRuntimeType: 946272
+      GoRuntimeType: 946304
       GoKind: 22
       Pointee: 653 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
       ID: 827
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
-      GoRuntimeType: 939552
+      GoRuntimeType: 939584
       GoKind: 22
       Pointee: 828 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
       ID: 972
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.261952e+06
+      GoRuntimeType: 1.26208e+06
       GoKind: 22
       Pointee: 973 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 997
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.448448e+06
+      GoRuntimeType: 1.448576e+06
       GoKind: 22
       Pointee: 998 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
       ID: 829
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
-      GoRuntimeType: 942624
+      GoRuntimeType: 942656
       GoKind: 22
       Pointee: 830 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 1139
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.812672e+06
+      GoRuntimeType: 1.81296e+06
       GoKind: 22
       Pointee: 1140 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 1097
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.258496e+06
+      GoRuntimeType: 1.258624e+06
       GoKind: 22
       Pointee: 1098 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 914
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.079904e+06
+      GoRuntimeType: 1.080032e+06
       GoKind: 22
       Pointee: 915 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 1057
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
-      GoRuntimeType: 942720
+      GoRuntimeType: 942752
       GoKind: 22
       Pointee: 1058 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
       ID: 807
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
-      GoRuntimeType: 927744
+      GoRuntimeType: 927776
       GoKind: 22
       Pointee: 808 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
       ID: 904
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.056736e+06
+      GoRuntimeType: 1.056864e+06
       GoKind: 22
       Pointee: 905 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 970
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.229952e+06
+      GoRuntimeType: 1.23008e+06
       GoKind: 22
       Pointee: 971 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 968
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.229696e+06
+      GoRuntimeType: 1.229824e+06
       GoKind: 22
       Pointee: 969 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
       ID: 821
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
-      GoRuntimeType: 932448
+      GoRuntimeType: 932480
       GoKind: 22
       Pointee: 822 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
       ID: 823
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
-      GoRuntimeType: 932544
+      GoRuntimeType: 932576
       GoKind: 22
       Pointee: 824 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
       ID: 751
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
-      GoRuntimeType: 919968
+      GoRuntimeType: 920000
       GoKind: 22
       Pointee: 752 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
       ID: 1145
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.853312e+06
+      GoRuntimeType: 1.8536e+06
       GoKind: 22
       Pointee: 1146 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 842
       Name: '*html/template.Error'
       ByteSize: 8
-      GoRuntimeType: 947040
+      GoRuntimeType: 947072
       GoKind: 22
       Pointee: 843 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 98
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 392352
+      GoRuntimeType: 392384
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 101
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 391968
+      GoRuntimeType: 392000
       GoKind: 22
       Pointee: 102 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 392096
+      GoRuntimeType: 392128
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 97
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 392224
+      GoRuntimeType: 392256
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
       ID: 103
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 391840
+      GoRuntimeType: 391872
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
       ID: 161
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 392928
+      GoRuntimeType: 392960
       GoKind: 22
       Pointee: 155 GoEmptyInterfaceType interface {}
     - __kind: PointerType
       ID: 721
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 913152
+      GoRuntimeType: 913184
       GoKind: 22
       Pointee: 722 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 719
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
-      GoRuntimeType: 913056
+      GoRuntimeType: 913088
       GoKind: 22
       Pointee: 720 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
       ID: 1043
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 901344
+      GoRuntimeType: 901376
       GoKind: 22
       Pointee: 1044 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
       ID: 931
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.20128e+06
+      GoRuntimeType: 1.201408e+06
       GoKind: 22
       Pointee: 932 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1232
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.378944e+06
+      GoRuntimeType: 2.379232e+06
       GoKind: 22
       Pointee: 1233 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 929
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.201152e+06
+      GoRuntimeType: 1.20128e+06
       GoKind: 22
       Pointee: 930 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 656
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 900288
+      GoRuntimeType: 900320
       GoKind: 22
       Pointee: 657 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 1089
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.19296e+06
+      GoRuntimeType: 1.193088e+06
       GoKind: 22
       Pointee: 1090 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1087
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.192576e+06
+      GoRuntimeType: 1.192704e+06
       GoKind: 22
       Pointee: 1088 StructureType io.discard
     - __kind: PointerType
       ID: 1061
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.024736e+06
+      GoRuntimeType: 1.024864e+06
       GoKind: 22
       Pointee: 1062 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 927
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.200896e+06
+      GoRuntimeType: 1.201024e+06
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 1135
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.806848e+06
+      GoRuntimeType: 1.807136e+06
       GoKind: 22
       Pointee: 1136 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -12785,105 +12785,105 @@ Types:
       ID: 370
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 385248
+      GoRuntimeType: 385280
       GoKind: 22
       Pointee: 371 StructureType main.deepMap2
     - __kind: PointerType
       ID: 1276
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 385184
+      GoRuntimeType: 385216
       GoKind: 22
       Pointee: 1277 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 147
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 384928
+      GoRuntimeType: 384960
       GoKind: 22
       Pointee: 148 StructureType main.deepMap7
     - __kind: PointerType
       ID: 1310
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 384864
+      GoRuntimeType: 384896
       GoKind: 22
       Pointee: 1311 StructureType main.deepMap8
     - __kind: PointerType
       ID: 1325
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 384800
+      GoRuntimeType: 384832
       GoKind: 22
       Pointee: 1326 StructureType main.deepMap9
     - __kind: PointerType
       ID: 131
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 385824
+      GoRuntimeType: 385856
       GoKind: 22
       Pointee: 132 StructureType main.deepPtr2
     - __kind: PointerType
       ID: 1236
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 385760
+      GoRuntimeType: 385792
       GoKind: 22
       Pointee: 1237 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 133
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 385504
+      GoRuntimeType: 385536
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr7
     - __kind: PointerType
       ID: 1280
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 385440
+      GoRuntimeType: 385472
       GoKind: 22
       Pointee: 1281 StructureType main.deepPtr8
     - __kind: PointerType
       ID: 1282
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 385376
+      GoRuntimeType: 385408
       GoKind: 22
       Pointee: 1283 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 138
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 386400
+      GoRuntimeType: 386432
       GoKind: 22
       Pointee: 361 StructureType main.deepSlice2
     - __kind: PointerType
       ID: 1261
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 386336
+      GoRuntimeType: 386368
       GoKind: 22
       Pointee: 1262 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 139
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 386080
+      GoRuntimeType: 386112
       GoKind: 22
       Pointee: 140 StructureType main.deepSlice7
     - __kind: PointerType
       ID: 1286
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 386016
+      GoRuntimeType: 386048
       GoKind: 22
       Pointee: 1287 StructureType main.deepSlice8
     - __kind: PointerType
       ID: 1292
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 385952
+      GoRuntimeType: 385984
       GoKind: 22
       Pointee: 1293 StructureType main.deepSlice9
     - __kind: PointerType
@@ -12896,28 +12896,28 @@ Types:
       ID: 157
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 386528
+      GoRuntimeType: 386560
       GoKind: 22
       Pointee: 158 StructureType main.esotericHeap
     - __kind: PointerType
       ID: 1253
       Name: '*main.firstBehavior'
       ByteSize: 8
-      GoRuntimeType: 896256
+      GoRuntimeType: 896288
       GoKind: 22
       Pointee: 352 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 1342
       Name: '*main.nestedStruct'
       ByteSize: 8
-      GoRuntimeType: 386784
+      GoRuntimeType: 386816
       GoKind: 22
       Pointee: 121 StructureType main.nestedStruct
     - __kind: PointerType
       ID: 245
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 386592
+      GoRuntimeType: 386624
       GoKind: 22
       Pointee: 244 StructureType main.node
     - __kind: PointerType
@@ -12930,14 +12930,14 @@ Types:
       ID: 1254
       Name: '*main.secondBehavior'
       ByteSize: 8
-      GoRuntimeType: 896352
+      GoRuntimeType: 896384
       GoKind: 22
       Pointee: 1255 StructureType main.secondBehavior
     - __kind: PointerType
       ID: 1241
       Name: '*main.somethingImpl'
       ByteSize: 8
-      GoRuntimeType: 896448
+      GoRuntimeType: 896480
       GoKind: 22
       Pointee: 1242 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
@@ -12971,7 +12971,7 @@ Types:
       ID: 422
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 384736
+      GoRuntimeType: 384768
       GoKind: 22
       Pointee: 163 StructureType main.structWithMap
     - __kind: PointerType
@@ -13147,77 +13147,77 @@ Types:
       ID: 755
       Name: '*math/big.ErrNaN'
       ByteSize: 8
-      GoRuntimeType: 920832
+      GoRuntimeType: 920864
       GoKind: 22
       Pointee: 756 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 1051
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
-      GoRuntimeType: 915648
+      GoRuntimeType: 915680
       GoKind: 22
       Pointee: 1052 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
       ID: 958
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.209472e+06
+      GoRuntimeType: 1.2096e+06
       GoKind: 22
       Pointee: 959 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 984
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.424448e+06
+      GoRuntimeType: 1.424576e+06
       GoKind: 22
       Pointee: 985 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1196
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.237024e+06
+      GoRuntimeType: 2.237312e+06
       GoKind: 22
       Pointee: 1197 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 982
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.424128e+06
+      GoRuntimeType: 1.424256e+06
       GoKind: 22
       Pointee: 983 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 960
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.2096e+06
+      GoRuntimeType: 1.209728e+06
       GoKind: 22
       Pointee: 961 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1206
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.266752e+06
+      GoRuntimeType: 2.26704e+06
       GoKind: 22
       Pointee: 1207 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1216
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.311744e+06
+      GoRuntimeType: 2.312032e+06
       GoKind: 22
       Pointee: 1217 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1204
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.26624e+06
+      GoRuntimeType: 2.266528e+06
       GoKind: 22
       Pointee: 1205 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 957
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.208704e+06
+      GoRuntimeType: 1.208832e+06
       GoKind: 22
       Pointee: 920 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13229,126 +13229,126 @@ Types:
       ID: 888
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.040096e+06
+      GoRuntimeType: 1.040224e+06
       GoKind: 22
       Pointee: 889 StructureType net.canceledError
     - __kind: PointerType
       ID: 1172
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2.011072e+06
+      GoRuntimeType: 2.01136e+06
       GoKind: 22
       Pointee: 1173 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1026
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.849056e+06
+      GoRuntimeType: 1.849344e+06
       GoKind: 22
       Pointee: 1027 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1218
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.316e+06
+      GoRuntimeType: 2.316288e+06
       GoKind: 22
       Pointee: 1219 UnresolvedPointeeType net.netFD
     - __kind: PointerType
       ID: 688
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 907872
+      GoRuntimeType: 907904
       GoKind: 22
       Pointee: 689 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 690
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 908544
+      GoRuntimeType: 908576
       GoKind: 22
       Pointee: 691 StructureType net.result·2
     - __kind: PointerType
       ID: 1200
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.252768e+06
+      GoRuntimeType: 2.253056e+06
       GoKind: 22
       Pointee: 1201 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1198
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.252288e+06
+      GoRuntimeType: 2.252576e+06
       GoKind: 22
       Pointee: 1199 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 962
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.21024e+06
+      GoRuntimeType: 1.210368e+06
       GoKind: 22
       Pointee: 963 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 986
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.424608e+06
+      GoRuntimeType: 1.424736e+06
       GoKind: 22
       Pointee: 987 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 878
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1.035872e+06
+      GoRuntimeType: 1.036e+06
       GoKind: 22
       Pointee: 879 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 1045
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 903648
+      GoRuntimeType: 903680
       GoKind: 22
       Pointee: 1046 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 665
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 904320
+      GoRuntimeType: 904352
       GoKind: 22
       Pointee: 585 BaseType net/http.http2ConnectionError
     - __kind: PointerType
       ID: 666
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 904416
+      GoRuntimeType: 904448
       GoKind: 22
       Pointee: 667 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 978
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.420288e+06
+      GoRuntimeType: 1.420416e+06
       GoKind: 22
       Pointee: 979 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 670
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 904992
+      GoRuntimeType: 905024
       GoKind: 22
       Pointee: 671 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 1107
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.557888e+06
+      GoRuntimeType: 1.558176e+06
       GoKind: 22
       Pointee: 1108 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
       ID: 669
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 904896
+      GoRuntimeType: 904928
       GoKind: 22
       Pointee: 589 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -13360,7 +13360,7 @@ Types:
       ID: 673
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 905184
+      GoRuntimeType: 905216
       GoKind: 22
       Pointee: 595 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -13372,7 +13372,7 @@ Types:
       ID: 672
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 905088
+      GoRuntimeType: 905120
       GoKind: 22
       Pointee: 592 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -13384,28 +13384,28 @@ Types:
       ID: 953
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.205248e+06
+      GoRuntimeType: 1.205376e+06
       GoKind: 22
       Pointee: 954 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 884
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1.036512e+06
+      GoRuntimeType: 1.03664e+06
       GoKind: 22
       Pointee: 885 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1161
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.953536e+06
+      GoRuntimeType: 1.953824e+06
       GoKind: 22
       Pointee: 1162 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
       ID: 668
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 904800
+      GoRuntimeType: 904832
       GoKind: 22
       Pointee: 586 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -13417,133 +13417,133 @@ Types:
       ID: 1047
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 905280
+      GoRuntimeType: 905312
       GoKind: 22
       Pointee: 1048 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 880
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1.036128e+06
+      GoRuntimeType: 1.036256e+06
       GoKind: 22
       Pointee: 881 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1109
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.177792e+06
+      GoRuntimeType: 2.17808e+06
       GoKind: 22
       Pointee: 1110 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1065
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1.036e+06
+      GoRuntimeType: 1.036128e+06
       GoKind: 22
       Pointee: 1066 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 1091
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.204352e+06
+      GoRuntimeType: 1.20448e+06
       GoKind: 22
       Pointee: 1092 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
       ID: 674
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 905376
+      GoRuntimeType: 905408
       GoKind: 22
       Pointee: 675 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 980
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.421408e+06
+      GoRuntimeType: 1.421536e+06
       GoKind: 22
       Pointee: 981 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 951
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.20512e+06
+      GoRuntimeType: 1.205248e+06
       GoKind: 22
       Pointee: 952 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 882
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1.036256e+06
+      GoRuntimeType: 1.036384e+06
       GoKind: 22
       Pointee: 883 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1143
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1.845696e+06
+      GoRuntimeType: 1.845984e+06
       GoKind: 22
       Pointee: 1144 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
       ID: 663
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 903552
+      GoRuntimeType: 903584
       GoKind: 22
       Pointee: 664 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 1163
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.955072e+06
+      GoRuntimeType: 1.95536e+06
       GoKind: 22
       Pointee: 1164 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 1075
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.04816e+06
+      GoRuntimeType: 1.048288e+06
       GoKind: 22
       Pointee: 1076 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
       ID: 747
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
-      GoRuntimeType: 919776
+      GoRuntimeType: 919808
       GoKind: 22
       Pointee: 748 StructureType net/netip.parseAddrError
     - __kind: PointerType
       ID: 745
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
-      GoRuntimeType: 919680
+      GoRuntimeType: 919712
       GoKind: 22
       Pointee: 746 StructureType net/netip.parsePrefixError
     - __kind: PointerType
       ID: 1117
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 2.122048e+06
+      GoRuntimeType: 2.122336e+06
       GoKind: 22
       Pointee: 1118 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 1077
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.053024e+06
+      GoRuntimeType: 1.053152e+06
       GoKind: 22
       Pointee: 1078 StructureType net/smtp.dataCloser
     - __kind: PointerType
       ID: 731
       Name: '*net/textproto.Error'
       ByteSize: 8
-      GoRuntimeType: 915840
+      GoRuntimeType: 915872
       GoKind: 22
       Pointee: 732 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
       ID: 730
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 915744
+      GoRuntimeType: 915776
       GoKind: 22
       Pointee: 620 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
@@ -13555,21 +13555,21 @@ Types:
       ID: 1073
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.047392e+06
+      GoRuntimeType: 1.04752e+06
       GoKind: 22
       Pointee: 1074 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 988
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.424928e+06
+      GoRuntimeType: 1.425056e+06
       GoKind: 22
       Pointee: 989 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
       ID: 692
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 908640
+      GoRuntimeType: 908672
       GoKind: 22
       Pointee: 598 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -13581,7 +13581,7 @@ Types:
       ID: 693
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 908736
+      GoRuntimeType: 908768
       GoKind: 22
       Pointee: 601 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -13728,70 +13728,70 @@ Types:
       ID: 1224
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.354656e+06
+      GoRuntimeType: 2.354944e+06
       GoKind: 22
       Pointee: 1225 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 861
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 1.027424e+06
+      GoRuntimeType: 1.027552e+06
       GoKind: 22
       Pointee: 862 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 923
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.194368e+06
+      GoRuntimeType: 1.194496e+06
       GoKind: 22
       Pointee: 924 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1222
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.350976e+06
+      GoRuntimeType: 2.351264e+06
       GoKind: 22
       Pointee: 1223 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1220
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.35024e+06
+      GoRuntimeType: 2.350528e+06
       GoKind: 22
       Pointee: 1221 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 890
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.044064e+06
+      GoRuntimeType: 1.044192e+06
       GoKind: 22
       Pointee: 891 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 1029
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 2.0912e+06
+      GoRuntimeType: 2.091488e+06
       GoKind: 22
       Pointee: 1030 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 1095
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.216512e+06
+      GoRuntimeType: 1.21664e+06
       GoKind: 22
       Pointee: 1096 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 892
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.044192e+06
+      GoRuntimeType: 1.04432e+06
       GoKind: 22
       Pointee: 893 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 826
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
-      GoRuntimeType: 937632
+      GoRuntimeType: 937664
       GoKind: 22
       Pointee: 634 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
@@ -13803,84 +13803,84 @@ Types:
       ID: 825
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
-      GoRuntimeType: 937536
+      GoRuntimeType: 937568
       GoKind: 22
       Pointee: 633 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
       ID: 658
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 900960
+      GoRuntimeType: 900992
       GoKind: 22
       Pointee: 659 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 753
       Name: '*regexp/syntax.Error'
       ByteSize: 8
-      GoRuntimeType: 920448
+      GoRuntimeType: 920480
       GoKind: 22
       Pointee: 754 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
       ID: 865
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1.02896e+06
+      GoRuntimeType: 1.029088e+06
       GoKind: 22
       Pointee: 866 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 869
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1.030752e+06
+      GoRuntimeType: 1.03088e+06
       GoKind: 22
       Pointee: 870 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 392992
+      GoRuntimeType: 393024
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.418368e+06
+      GoRuntimeType: 1.418496e+06
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 867
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1.029088e+06
+      GoRuntimeType: 1.029216e+06
       GoKind: 22
       Pointee: 868 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 393632
+      GoRuntimeType: 393664
       GoKind: 22
       Pointee: 63 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 393696
+      GoRuntimeType: 393728
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 925
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.199744e+06
+      GoRuntimeType: 1.199872e+06
       GoKind: 22
       Pointee: 926 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 863
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1.028576e+06
+      GoRuntimeType: 1.028704e+06
       GoKind: 22
       Pointee: 844 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -13892,21 +13892,21 @@ Types:
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 899520
+      GoRuntimeType: 899552
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.03024e+06
+      GoRuntimeType: 1.030368e+06
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 864
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1.028704e+06
+      GoRuntimeType: 1.028832e+06
       GoKind: 22
       Pointee: 847 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -13918,42 +13918,42 @@ Types:
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 394400
+      GoRuntimeType: 394432
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 1.555648e+06
+      GoRuntimeType: 1.555936e+06
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.057472e+06
+      GoRuntimeType: 2.05776e+06
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.623776e+06
+      GoRuntimeType: 1.624064e+06
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 859
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 1.026784e+06
+      GoRuntimeType: 1.026912e+06
       GoKind: 22
       Pointee: 860 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 93
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 391776
+      GoRuntimeType: 391808
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -13965,21 +13965,21 @@ Types:
       ID: 1157
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.951488e+06
+      GoRuntimeType: 1.951776e+06
       GoKind: 22
       Pointee: 1158 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 1063
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 1.026912e+06
+      GoRuntimeType: 1.02704e+06
       GoKind: 22
       Pointee: 1064 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
       ID: 1059
       Name: '*struct { io.Writer }'
       ByteSize: 8
-      GoRuntimeType: 971296
+      GoRuntimeType: 971424
       GoKind: 22
       Pointee: 1060 StructureType struct { io.Writer }
     - __kind: PointerType
@@ -13991,7 +13991,7 @@ Types:
       ID: 977
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.419648e+06
+      GoRuntimeType: 1.419776e+06
       GoKind: 22
       Pointee: 976 BaseType syscall.Errno
     - __kind: PointerType
@@ -14133,35 +14133,35 @@ Types:
       ID: 1194
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.162272e+06
+      GoRuntimeType: 2.16256e+06
       GoKind: 22
       Pointee: 1195 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 918
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.089504e+06
+      GoRuntimeType: 1.089632e+06
       GoKind: 22
       Pointee: 919 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 993
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.628768e+06
+      GoRuntimeType: 1.629056e+06
       GoKind: 22
       Pointee: 994 UnresolvedPointeeType time.Location
     - __kind: PointerType
       ID: 661
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 902112
+      GoRuntimeType: 902144
       GoKind: 22
       Pointee: 662 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 660
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 902016
+      GoRuntimeType: 902048
       GoKind: 22
       Pointee: 582 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -14173,84 +14173,84 @@ Types:
       ID: 105
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 392416
+      GoRuntimeType: 392448
       GoKind: 22
       Pointee: 16 BaseType uint
     - __kind: PointerType
       ID: 100
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 392032
+      GoRuntimeType: 392064
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 392160
+      GoRuntimeType: 392192
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 99
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 392288
+      GoRuntimeType: 392320
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 391904
+      GoRuntimeType: 391936
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 392480
+      GoRuntimeType: 392512
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
       ID: 749
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
-      GoRuntimeType: 919872
+      GoRuntimeType: 919904
       GoKind: 22
       Pointee: 750 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
       ID: 1186
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.137728e+06
+      GoRuntimeType: 2.138016e+06
       GoKind: 22
       Pointee: 1187 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
       ID: 733
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
-      GoRuntimeType: 916032
+      GoRuntimeType: 916064
       GoKind: 22
       Pointee: 734 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
       ID: 735
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
-      GoRuntimeType: 916128
+      GoRuntimeType: 916160
       GoKind: 22
       Pointee: 623 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
       ID: 897
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.047904e+06
+      GoRuntimeType: 1.048032e+06
       GoKind: 22
       Pointee: 898 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 899
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.048032e+06
+      GoRuntimeType: 1.04816e+06
       GoKind: 22
       Pointee: 852 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -23251,7 +23251,7 @@ Types:
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 686624
+      GoRuntimeType: 686656
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -23267,7 +23267,7 @@ Types:
       ID: 89
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 701664
+      GoRuntimeType: 701696
       GoKind: 17
       Count: 10
       HasCount: true
@@ -23276,7 +23276,7 @@ Types:
       ID: 333
       Name: '[16]uint8'
       ByteSize: 16
-      GoRuntimeType: 680288
+      GoRuntimeType: 680320
       GoKind: 17
       Count: 16
       HasCount: true
@@ -23285,7 +23285,7 @@ Types:
       ID: 250
       Name: '[1]int'
       ByteSize: 8
-      GoRuntimeType: 686720
+      GoRuntimeType: 686752
       GoKind: 17
       Count: 1
       HasCount: true
@@ -23294,7 +23294,7 @@ Types:
       ID: 75
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 701280
+      GoRuntimeType: 701312
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23303,7 +23303,7 @@ Types:
       ID: 74
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 701376
+      GoRuntimeType: 701408
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23328,7 +23328,7 @@ Types:
       ID: 81
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 701568
+      GoRuntimeType: 701600
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23345,7 +23345,7 @@ Types:
       ID: 111
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 683360
+      GoRuntimeType: 683392
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23362,7 +23362,7 @@ Types:
       ID: 108
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 684992
+      GoRuntimeType: 685024
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23403,7 +23403,7 @@ Types:
       ID: 109
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 685088
+      GoRuntimeType: 685120
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23443,7 +23443,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 685184
+      GoRuntimeType: 685216
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23452,7 +23452,7 @@ Types:
       ID: 107
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 684896
+      GoRuntimeType: 684928
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23461,7 +23461,7 @@ Types:
       ID: 87
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 735232
+      GoRuntimeType: 735264
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23470,7 +23470,7 @@ Types:
       ID: 65
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 701088
+      GoRuntimeType: 701120
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23479,7 +23479,7 @@ Types:
       ID: 249
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 685280
+      GoRuntimeType: 685312
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23488,7 +23488,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 700800
+      GoRuntimeType: 700832
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23497,7 +23497,7 @@ Types:
       ID: 455
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 682976
+      GoRuntimeType: 683008
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23506,7 +23506,7 @@ Types:
       ID: 412
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 683264
+      GoRuntimeType: 683296
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23515,7 +23515,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 692672
+      GoRuntimeType: 692704
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23532,7 +23532,7 @@ Types:
       ID: 1021
       Name: '[5]uint8'
       ByteSize: 5
-      GoRuntimeType: 684800
+      GoRuntimeType: 684832
       GoKind: 17
       Count: 5
       HasCount: true
@@ -23541,7 +23541,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 686144
+      GoRuntimeType: 686176
       GoKind: 17
       Count: 6
       HasCount: true
@@ -23550,7 +23550,7 @@ Types:
       ID: 82
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 701472
+      GoRuntimeType: 701504
       GoKind: 17
       Count: 8
       HasCount: true
@@ -23559,7 +23559,7 @@ Types:
       ID: 136
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 477280
+      GoRuntimeType: 477312
       GoKind: 23
       RawFields:
         - Name: array
@@ -23582,7 +23582,7 @@ Types:
       ID: 1259
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 477216
+      GoRuntimeType: 477248
       GoKind: 23
       RawFields:
         - Name: array
@@ -23605,7 +23605,7 @@ Types:
       ID: 1284
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 476896
+      GoRuntimeType: 476928
       GoKind: 23
       RawFields:
         - Name: array
@@ -23628,7 +23628,7 @@ Types:
       ID: 1290
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 476832
+      GoRuntimeType: 476864
       GoKind: 23
       RawFields:
         - Name: array
@@ -23651,7 +23651,7 @@ Types:
       ID: 127
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 475616
+      GoRuntimeType: 475648
       GoKind: 23
       RawFields:
         - Name: array
@@ -23968,7 +23968,7 @@ Types:
       ID: 262
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 487008
+      GoRuntimeType: 487040
       GoKind: 23
       RawFields:
         - Name: array
@@ -23991,7 +23991,7 @@ Types:
       ID: 1016
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 486880
+      GoRuntimeType: 486912
       GoKind: 23
       RawFields:
         - Name: array
@@ -24014,7 +24014,7 @@ Types:
       ID: 348
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 482144
+      GoRuntimeType: 482176
       GoKind: 23
       RawFields:
         - Name: array
@@ -24081,7 +24081,7 @@ Types:
       ID: 1296
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 487328
+      GoRuntimeType: 487360
       GoKind: 23
       RawFields:
         - Name: array
@@ -24126,7 +24126,7 @@ Types:
       ID: 421
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 477856
+      GoRuntimeType: 477888
       GoKind: 23
       RawFields:
         - Name: array
@@ -24337,7 +24337,7 @@ Types:
       ID: 261
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 487136
+      GoRuntimeType: 487168
       GoKind: 23
       RawFields:
         - Name: array
@@ -24381,7 +24381,7 @@ Types:
       ID: 255
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 486624
+      GoRuntimeType: 486656
       GoKind: 23
       RawFields:
         - Name: array
@@ -24404,7 +24404,7 @@ Types:
       ID: 263
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 485984
+      GoRuntimeType: 486016
       GoKind: 23
       RawFields:
         - Name: array
@@ -24427,7 +24427,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 485856
+      GoRuntimeType: 485888
       GoKind: 23
       RawFields:
         - Name: array
@@ -24450,7 +24450,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 486688
+      GoRuntimeType: 486720
       GoKind: 23
       RawFields:
         - Name: array
@@ -24477,7 +24477,7 @@ Types:
       ID: 812
       Name: archive/tar.headerError
       ByteSize: 24
-      GoRuntimeType: 931008
+      GoRuntimeType: 931040
       GoKind: 23
       RawFields:
         - Name: array
@@ -24507,7 +24507,7 @@ Types:
     - __kind: StructureType
       ID: 1056
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.121536e+06
+      GoRuntimeType: 1.121664e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24518,7 +24518,7 @@ Types:
       ID: 1082
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.568448e+06
+      GoRuntimeType: 1.568736e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -24532,7 +24532,7 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 584448
+      GoRuntimeType: 584480
       GoKind: 1
     - __kind: UnresolvedPointeeType
       ID: 1129
@@ -24549,36 +24549,36 @@ Types:
     - __kind: GoChannelType
       ID: 241
       Name: chan bool
-      GoRuntimeType: 596096
+      GoRuntimeType: 596128
       GoKind: 18
     - __kind: GoChannelType
       ID: 154
       Name: chan struct {}
-      GoRuntimeType: 595136
+      GoRuntimeType: 595168
       GoKind: 18
     - __kind: BaseType
       ID: 95
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 584256
+      GoRuntimeType: 584288
       GoKind: 16
     - __kind: BaseType
       ID: 94
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 584192
+      GoRuntimeType: 584224
       GoKind: 15
     - __kind: BaseType
       ID: 615
       Name: compress/flate.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 835136
+      GoRuntimeType: 835168
       GoKind: 6
     - __kind: GoStringHeaderType
       ID: 616
       Name: compress/flate.InternalError
       ByteSize: 16
-      GoRuntimeType: 835232
+      GoRuntimeType: 835264
       GoKind: 24
       RawFields:
         - Name: str
@@ -24608,26 +24608,26 @@ Types:
     - __kind: StructureType
       ID: 956
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.483008e+06
+      GoRuntimeType: 1.483296e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 629
       Name: crypto/aes.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 837728
+      GoRuntimeType: 837760
       GoKind: 2
     - __kind: BaseType
       ID: 630
       Name: crypto/des.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 837824
+      GoRuntimeType: 837856
       GoKind: 2
     - __kind: BaseType
       ID: 631
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 837920
+      GoRuntimeType: 837952
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1116
@@ -24657,7 +24657,7 @@ Types:
       ID: 632
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 838016
+      GoRuntimeType: 838048
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1166
@@ -24671,7 +24671,7 @@ Types:
       ID: 619
       Name: crypto/tls.AlertError
       ByteSize: 1
-      GoRuntimeType: 835712
+      GoRuntimeType: 835744
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 896
@@ -24689,7 +24689,7 @@ Types:
       ID: 726
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.733344e+06
+      GoRuntimeType: 1.733632e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24705,7 +24705,7 @@ Types:
       ID: 851
       Name: crypto/tls.alert
       ByteSize: 1
-      GoRuntimeType: 994112
+      GoRuntimeType: 994240
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1114
@@ -24727,7 +24727,7 @@ Types:
       ID: 800
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.736224e+06
+      GoRuntimeType: 1.736512e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -24742,14 +24742,14 @@ Types:
     - __kind: StructureType
       ID: 794
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.119104e+06
+      GoRuntimeType: 1.119232e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 796
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.603168e+06
+      GoRuntimeType: 1.603456e+06
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -24762,19 +24762,19 @@ Types:
       ID: 628
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
-      GoRuntimeType: 837344
+      GoRuntimeType: 837376
       GoKind: 2
     - __kind: BaseType
       ID: 1024
       Name: crypto/x509.InvalidReason
       ByteSize: 8
-      GoRuntimeType: 589632
+      GoRuntimeType: 589664
       GoKind: 2
     - __kind: StructureType
       ID: 901
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.564448e+06
+      GoRuntimeType: 1.564736e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -24783,14 +24783,14 @@ Types:
     - __kind: StructureType
       ID: 802
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.11936e+06
+      GoRuntimeType: 1.119488e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 798
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.736032e+06
+      GoRuntimeType: 1.73632e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -24806,7 +24806,7 @@ Types:
       ID: 816
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.439328e+06
+      GoRuntimeType: 1.439456e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24816,7 +24816,7 @@ Types:
       ID: 820
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.439488e+06
+      GoRuntimeType: 1.439616e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24830,7 +24830,7 @@ Types:
       ID: 613
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 834848
+      GoRuntimeType: 834880
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1072
@@ -24840,7 +24840,7 @@ Types:
       ID: 614
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
-      GoRuntimeType: 835040
+      GoRuntimeType: 835072
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 685
@@ -24874,7 +24874,7 @@ Types:
       ID: 687
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.423168e+06
+      GoRuntimeType: 1.423296e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -24896,7 +24896,7 @@ Types:
       ID: 625
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
-      GoRuntimeType: 837248
+      GoRuntimeType: 837280
       GoKind: 24
       RawFields:
         - Name: str
@@ -24923,7 +24923,7 @@ Types:
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.028448e+06
+      GoRuntimeType: 1.028576e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -24944,13 +24944,13 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 584320
+      GoRuntimeType: 584352
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 584384
+      GoRuntimeType: 584416
       GoKind: 14
     - __kind: UnresolvedPointeeType
       ID: 1203
@@ -24968,13 +24968,13 @@ Types:
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 475360
+      GoRuntimeType: 475392
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 70
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 849440
+      GoRuntimeType: 849472
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 351
@@ -25017,7 +25017,7 @@ Types:
       ID: 696
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.732192e+06
+      GoRuntimeType: 1.73248e+06
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25040,7 +25040,7 @@ Types:
     - __kind: StructureType
       ID: 702
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.115392e+06
+      GoRuntimeType: 1.11552e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25051,7 +25051,7 @@ Types:
       ID: 607
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 834272
+      GoRuntimeType: 834304
       GoKind: 24
       RawFields:
         - Name: str
@@ -25070,7 +25070,7 @@ Types:
       ID: 1014
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.22208e+06
+      GoRuntimeType: 2.222368e+06
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25119,13 +25119,13 @@ Types:
       ID: 1015
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 586688
+      GoRuntimeType: 586720
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 604
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 834176
+      GoRuntimeType: 834208
       GoKind: 24
       RawFields:
         - Name: str
@@ -25144,7 +25144,7 @@ Types:
       ID: 610
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 834368
+      GoRuntimeType: 834400
       GoKind: 24
       RawFields:
         - Name: str
@@ -25186,26 +25186,26 @@ Types:
     - __kind: StructureType
       ID: 744
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.118336e+06
+      GoRuntimeType: 1.118464e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 624
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
-      GoRuntimeType: 836384
+      GoRuntimeType: 836416
       GoKind: 2
     - __kind: StructureType
       ID: 742
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.118208e+06
+      GoRuntimeType: 1.118336e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 740
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.601248e+06
+      GoRuntimeType: 1.601536e+06
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25218,7 +25218,7 @@ Types:
       ID: 760
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.602048e+06
+      GoRuntimeType: 1.602336e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25231,7 +25231,7 @@ Types:
       ID: 764
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.735456e+06
+      GoRuntimeType: 1.735744e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25247,7 +25247,7 @@ Types:
       ID: 762
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.432928e+06
+      GoRuntimeType: 1.433056e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25257,7 +25257,7 @@ Types:
       ID: 758
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.432608e+06
+      GoRuntimeType: 1.432736e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25267,14 +25267,14 @@ Types:
       ID: 1000
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.503488e+06
+      GoRuntimeType: 1.503776e+06
       GoKind: 21
       HeaderType: 1002 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 1023
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.051488e+06
+      GoRuntimeType: 1.051616e+06
       GoKind: 23
       RawFields:
         - Name: array
@@ -25297,7 +25297,7 @@ Types:
       ID: 772
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.602368e+06
+      GoRuntimeType: 1.602656e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25310,7 +25310,7 @@ Types:
       ID: 766
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.433088e+06
+      GoRuntimeType: 1.433216e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25320,7 +25320,7 @@ Types:
       ID: 770
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.735648e+06
+      GoRuntimeType: 1.735936e+06
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25336,7 +25336,7 @@ Types:
       ID: 768
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.602208e+06
+      GoRuntimeType: 1.602496e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25349,7 +25349,7 @@ Types:
       ID: 774
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.433248e+06
+      GoRuntimeType: 1.433376e+06
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25359,7 +25359,7 @@ Types:
       ID: 780
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.602688e+06
+      GoRuntimeType: 1.602976e+06
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25372,7 +25372,7 @@ Types:
       ID: 782
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.433568e+06
+      GoRuntimeType: 1.433696e+06
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25382,7 +25382,7 @@ Types:
       ID: 778
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.602528e+06
+      GoRuntimeType: 1.602816e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25395,7 +25395,7 @@ Types:
       ID: 776
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.433408e+06
+      GoRuntimeType: 1.433536e+06
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25405,7 +25405,7 @@ Types:
       ID: 784
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.602848e+06
+      GoRuntimeType: 1.603136e+06
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25418,7 +25418,7 @@ Types:
       ID: 704
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.425408e+06
+      GoRuntimeType: 1.425536e+06
       GoKind: 25
       RawFields:
         - Name: message
@@ -25432,7 +25432,7 @@ Types:
       ID: 706
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.425568e+06
+      GoRuntimeType: 1.425696e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25454,7 +25454,7 @@ Types:
       ID: 710
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.425888e+06
+      GoRuntimeType: 1.426016e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25468,7 +25468,7 @@ Types:
       ID: 1180
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 2.110464e+06
+      GoRuntimeType: 2.110752e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25481,7 +25481,7 @@ Types:
       ID: 1183
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.134656e+06
+      GoRuntimeType: 2.134944e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25501,7 +25501,7 @@ Types:
       ID: 708
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.425728e+06
+      GoRuntimeType: 1.425856e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25511,7 +25511,7 @@ Types:
       ID: 712
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.426048e+06
+      GoRuntimeType: 1.426176e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25561,7 +25561,7 @@ Types:
       ID: 718
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.427008e+06
+      GoRuntimeType: 1.427136e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -25576,7 +25576,7 @@ Types:
       ID: 940
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.843904e+06
+      GoRuntimeType: 1.844192e+06
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -25596,7 +25596,7 @@ Types:
       ID: 873
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.70624e+06
+      GoRuntimeType: 1.706528e+06
       GoKind: 25
       RawFields:
         - Name: Got
@@ -25609,7 +25609,7 @@ Types:
       ID: 946
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.844352e+06
+      GoRuntimeType: 1.84464e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25625,13 +25625,13 @@ Types:
       ID: 850
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 991424
+      GoRuntimeType: 991552
       GoKind: 8
     - __kind: StructureType
       ID: 938
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.84368e+06
+      GoRuntimeType: 1.843968e+06
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -25647,13 +25647,13 @@ Types:
       ID: 1025
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 832448
+      GoRuntimeType: 832480
       GoKind: 8
     - __kind: StructureType
       ID: 936
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.843456e+06
+      GoRuntimeType: 1.843744e+06
       GoKind: 25
       RawFields:
         - Name: Method
@@ -25669,7 +25669,7 @@ Types:
       ID: 944
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.758464e+06
+      GoRuntimeType: 1.758752e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25682,7 +25682,7 @@ Types:
       ID: 942
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.844128e+06
+      GoRuntimeType: 1.844416e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25702,7 +25702,7 @@ Types:
       ID: 950
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.629728e+06
+      GoRuntimeType: 1.630016e+06
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -25711,20 +25711,20 @@ Types:
     - __kind: StructureType
       ID: 877
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.285696e+06
+      GoRuntimeType: 1.285824e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 875
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.285568e+06
+      GoRuntimeType: 1.285696e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 948
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.758656e+06
+      GoRuntimeType: 1.758944e+06
       GoKind: 25
       RawFields:
         - Name: cause
@@ -25737,7 +25737,7 @@ Types:
       ID: 637
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
-      GoRuntimeType: 839840
+      GoRuntimeType: 839872
       GoKind: 24
       RawFields:
         - Name: str
@@ -25756,25 +25756,25 @@ Types:
       ID: 337
       Name: go.shape.bool
       ByteSize: 1
-      GoRuntimeType: 596288
+      GoRuntimeType: 596320
       GoKind: 1
     - __kind: BaseType
       ID: 350
       Name: go.shape.float64
       ByteSize: 8
-      GoRuntimeType: 596352
+      GoRuntimeType: 596384
       GoKind: 14
     - __kind: BaseType
       ID: 320
       Name: go.shape.int
       ByteSize: 8
-      GoRuntimeType: 596160
+      GoRuntimeType: 596192
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 322
       Name: go.shape.string
       ByteSize: 16
-      GoRuntimeType: 596224
+      GoRuntimeType: 596256
       GoKind: 24
       RawFields:
         - Name: str
@@ -25848,7 +25848,7 @@ Types:
       ID: 917
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.451168e+06
+      GoRuntimeType: 1.451296e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -25858,7 +25858,7 @@ Types:
       ID: 1100
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.682336e+06
+      GoRuntimeType: 1.682624e+06
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -25872,7 +25872,7 @@ Types:
       ID: 1124
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.129088e+06
+      GoRuntimeType: 1.129216e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25885,7 +25885,7 @@ Types:
       ID: 1086
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.573408e+06
+      GoRuntimeType: 1.573696e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -25895,19 +25895,19 @@ Types:
       ID: 640
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
-      GoRuntimeType: 840416
+      GoRuntimeType: 840448
       GoKind: 10
     - __kind: BaseType
       ID: 1007
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.004576e+06
+      GoRuntimeType: 1.004704e+06
       GoKind: 10
     - __kind: StructureType
       ID: 975
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.882656e+06
+      GoRuntimeType: 1.882944e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -25923,7 +25923,7 @@ Types:
       ID: 836
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.609888e+06
+      GoRuntimeType: 1.610176e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -25936,7 +25936,7 @@ Types:
       ID: 644
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 840608
+      GoRuntimeType: 840640
       GoKind: 24
       RawFields:
         - Name: str
@@ -25955,7 +25955,7 @@ Types:
       ID: 650
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 840800
+      GoRuntimeType: 840832
       GoKind: 24
       RawFields:
         - Name: str
@@ -25974,7 +25974,7 @@ Types:
       ID: 647
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 840704
+      GoRuntimeType: 840736
       GoKind: 24
       RawFields:
         - Name: str
@@ -25993,7 +25993,7 @@ Types:
       ID: 641
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 840512
+      GoRuntimeType: 840544
       GoKind: 24
       RawFields:
         - Name: str
@@ -26016,7 +26016,7 @@ Types:
       ID: 840
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.451808e+06
+      GoRuntimeType: 1.451936e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26026,13 +26026,13 @@ Types:
       ID: 653
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
-      GoRuntimeType: 840896
+      GoRuntimeType: 840928
       GoKind: 2
     - __kind: StructureType
       ID: 828
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.446848e+06
+      GoRuntimeType: 1.446976e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26046,7 +26046,7 @@ Types:
       ID: 998
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.91056e+06
+      GoRuntimeType: 1.910848e+06
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26062,7 +26062,7 @@ Types:
       ID: 830
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.609408e+06
+      GoRuntimeType: 1.609696e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26075,7 +26075,7 @@ Types:
       ID: 1140
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.968128e+06
+      GoRuntimeType: 1.968416e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26092,7 +26092,7 @@ Types:
       ID: 915
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.571008e+06
+      GoRuntimeType: 1.571296e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26117,14 +26117,14 @@ Types:
     - __kind: StructureType
       ID: 969
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.514048e+06
+      GoRuntimeType: 1.514336e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 822
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.440128e+06
+      GoRuntimeType: 1.440256e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26134,7 +26134,7 @@ Types:
       ID: 824
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.440288e+06
+      GoRuntimeType: 1.440416e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26534,37 +26534,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 584000
+      GoRuntimeType: 584032
       GoKind: 2
     - __kind: BaseType
       ID: 102
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 583616
+      GoRuntimeType: 583648
       GoKind: 4
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 583744
+      GoRuntimeType: 583776
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 583872
+      GoRuntimeType: 583904
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 583488
+      GoRuntimeType: 583520
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 155
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 849152
+      GoRuntimeType: 849184
       GoKind: 20
       RawFields:
         - Name: _type
@@ -26581,7 +26581,7 @@ Types:
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.852192e+06
+      GoRuntimeType: 1.85248e+06
       GoKind: 25
       RawFields:
         - Name: buf
@@ -26618,7 +26618,7 @@ Types:
     - __kind: StructureType
       ID: 930
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.479808e+06
+      GoRuntimeType: 1.480096e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -26629,7 +26629,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.216e+06
+      GoRuntimeType: 1.216128e+06
       GoKind: 25
       RawFields:
         - Name: u
@@ -26639,7 +26639,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.64432e+06
+      GoRuntimeType: 1.644608e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26655,7 +26655,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.493568e+06
+      GoRuntimeType: 1.493856e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26668,7 +26668,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.493408e+06
+      GoRuntimeType: 1.493696e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26681,7 +26681,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.493728e+06
+      GoRuntimeType: 1.494016e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26693,20 +26693,20 @@ Types:
     - __kind: StructureType
       ID: 69
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 993824
+      GoRuntimeType: 993952
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 993728
+      GoRuntimeType: 993856
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1245
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.476768e+06
+      GoRuntimeType: 1.477056e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -26723,7 +26723,7 @@ Types:
       ID: 1130
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.192704e+06
+      GoRuntimeType: 1.192832e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26736,7 +26736,7 @@ Types:
       ID: 1167
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.024864e+06
+      GoRuntimeType: 1.024992e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26749,7 +26749,7 @@ Types:
       ID: 1119
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.11168e+06
+      GoRuntimeType: 1.111808e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26762,7 +26762,7 @@ Types:
       ID: 129
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.024608e+06
+      GoRuntimeType: 1.024736e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26774,7 +26774,7 @@ Types:
     - __kind: StructureType
       ID: 1088
       Name: io.discard
-      GoRuntimeType: 1.467168e+06
+      GoRuntimeType: 1.467456e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -26844,7 +26844,7 @@ Types:
       ID: 160
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.023456e+06
+      GoRuntimeType: 1.023584e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26857,7 +26857,7 @@ Types:
       ID: 126
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.616864e+06
+      GoRuntimeType: 1.617152e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -26873,7 +26873,7 @@ Types:
       ID: 141
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.188992e+06
+      GoRuntimeType: 1.18912e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26883,7 +26883,7 @@ Types:
       ID: 371
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.188864e+06
+      GoRuntimeType: 1.188992e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26897,7 +26897,7 @@ Types:
       ID: 148
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.188224e+06
+      GoRuntimeType: 1.188352e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26907,7 +26907,7 @@ Types:
       ID: 1311
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.188096e+06
+      GoRuntimeType: 1.188224e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26917,7 +26917,7 @@ Types:
       ID: 1326
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.187968e+06
+      GoRuntimeType: 1.188096e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26927,7 +26927,7 @@ Types:
       ID: 130
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.190144e+06
+      GoRuntimeType: 1.190272e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26937,7 +26937,7 @@ Types:
       ID: 132
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.190016e+06
+      GoRuntimeType: 1.190144e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26951,7 +26951,7 @@ Types:
       ID: 134
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.189376e+06
+      GoRuntimeType: 1.189504e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26961,7 +26961,7 @@ Types:
       ID: 1281
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.189248e+06
+      GoRuntimeType: 1.189376e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26971,7 +26971,7 @@ Types:
       ID: 1283
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.18912e+06
+      GoRuntimeType: 1.189248e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26981,7 +26981,7 @@ Types:
       ID: 135
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.191296e+06
+      GoRuntimeType: 1.191424e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26991,7 +26991,7 @@ Types:
       ID: 361
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.191168e+06
+      GoRuntimeType: 1.191296e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27005,7 +27005,7 @@ Types:
       ID: 140
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.190528e+06
+      GoRuntimeType: 1.190656e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27015,7 +27015,7 @@ Types:
       ID: 1287
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.1904e+06
+      GoRuntimeType: 1.190528e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27025,7 +27025,7 @@ Types:
       ID: 1293
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.190272e+06
+      GoRuntimeType: 1.1904e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27040,7 +27040,7 @@ Types:
       ID: 158
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.835616e+06
+      GoRuntimeType: 1.835904e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27062,7 +27062,7 @@ Types:
       ID: 153
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.96944e+06
+      GoRuntimeType: 1.969728e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -27090,7 +27090,7 @@ Types:
       ID: 352
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.416288e+06
+      GoRuntimeType: 1.416416e+06
       GoKind: 25
       RawFields:
         - Name: s
@@ -27217,7 +27217,7 @@ Types:
       ID: 121
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.466208e+06
+      GoRuntimeType: 1.466496e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -27230,7 +27230,7 @@ Types:
       ID: 244
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.465888e+06
+      GoRuntimeType: 1.466176e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -27252,14 +27252,14 @@ Types:
       ID: 1255
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.416448e+06
+      GoRuntimeType: 1.416576e+06
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 156
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.023584e+06
+      GoRuntimeType: 1.023712e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27312,7 +27312,7 @@ Types:
       ID: 162
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.187712e+06
+      GoRuntimeType: 1.18784e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27382,7 +27382,7 @@ Types:
       ID: 163
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.18784e+06
+      GoRuntimeType: 1.187968e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -28415,119 +28415,119 @@ Types:
       ID: 221
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.131136e+06
+      GoRuntimeType: 1.131264e+06
       GoKind: 21
       HeaderType: 223 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 216
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.131264e+06
+      GoRuntimeType: 1.131392e+06
       GoKind: 21
       HeaderType: 218 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 184
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.131392e+06
+      GoRuntimeType: 1.13152e+06
       GoKind: 21
       HeaderType: 186 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 196
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.13152e+06
+      GoRuntimeType: 1.131648e+06
       GoKind: 21
       HeaderType: 198 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 142
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.131008e+06
+      GoRuntimeType: 1.131136e+06
       GoKind: 21
       HeaderType: 144 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1265
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.13088e+06
+      GoRuntimeType: 1.131008e+06
       GoKind: 21
       HeaderType: 1267 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1299
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.13024e+06
+      GoRuntimeType: 1.130368e+06
       GoKind: 21
       HeaderType: 1301 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1314
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.130112e+06
+      GoRuntimeType: 1.13024e+06
       GoKind: 21
       HeaderType: 1316 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 164
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.129472e+06
+      GoRuntimeType: 1.1296e+06
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 1329
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.129984e+06
+      GoRuntimeType: 1.130112e+06
       GoKind: 21
       HeaderType: 1331 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 231
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.131648e+06
+      GoRuntimeType: 1.131776e+06
       GoKind: 21
       HeaderType: 233 GoSwissMapHeaderType map<int,struct {}>
     - __kind: GoMapType
       ID: 201
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.131776e+06
+      GoRuntimeType: 1.131904e+06
       GoKind: 21
       HeaderType: 203 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 191
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.131904e+06
+      GoRuntimeType: 1.132032e+06
       GoKind: 21
       HeaderType: 193 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 179
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.132032e+06
+      GoRuntimeType: 1.13216e+06
       GoKind: 21
       HeaderType: 181 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 174
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.13216e+06
+      GoRuntimeType: 1.132288e+06
       GoKind: 21
       HeaderType: 176 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 169
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.132288e+06
+      GoRuntimeType: 1.132416e+06
       GoKind: 21
       HeaderType: 171 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 226
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 1.132416e+06
+      GoRuntimeType: 1.132544e+06
       GoKind: 21
       HeaderType: 228 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
@@ -28570,28 +28570,28 @@ Types:
       ID: 236
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.132544e+06
+      GoRuntimeType: 1.132672e+06
       GoKind: 21
       HeaderType: 238 GoSwissMapHeaderType map<struct {},struct {}>
     - __kind: GoMapType
       ID: 211
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.132672e+06
+      GoRuntimeType: 1.1328e+06
       GoKind: 21
       HeaderType: 213 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 206
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.1328e+06
+      GoRuntimeType: 1.132928e+06
       GoKind: 21
       HeaderType: 208 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
       ID: 756
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.432288e+06
+      GoRuntimeType: 1.432416e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -28601,7 +28601,7 @@ Types:
       ID: 1052
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.429088e+06
+      GoRuntimeType: 1.429216e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -28615,7 +28615,7 @@ Types:
       ID: 1022
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.599968e+06
+      GoRuntimeType: 1.600256e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -28656,7 +28656,7 @@ Types:
       ID: 920
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.115008e+06
+      GoRuntimeType: 1.115136e+06
       GoKind: 24
       RawFields:
         - Name: str
@@ -28674,7 +28674,7 @@ Types:
     - __kind: StructureType
       ID: 889
       Name: net.canceledError
-      GoRuntimeType: 1.28672e+06
+      GoRuntimeType: 1.286848e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28685,7 +28685,7 @@ Types:
       ID: 1027
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 2.10976e+06
+      GoRuntimeType: 2.110048e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -28707,13 +28707,13 @@ Types:
     - __kind: StructureType
       ID: 1213
       Name: net.noReadFrom
-      GoRuntimeType: 1.115264e+06
+      GoRuntimeType: 1.115392e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1212
       Name: net.noWriteTo
-      GoRuntimeType: 1.115136e+06
+      GoRuntimeType: 1.115264e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28724,7 +28724,7 @@ Types:
       ID: 691
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.732e+06
+      GoRuntimeType: 1.732288e+06
       GoKind: 25
       RawFields:
         - Name: p
@@ -28740,7 +28740,7 @@ Types:
       ID: 1201
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.294496e+06
+      GoRuntimeType: 2.294784e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -28753,7 +28753,7 @@ Types:
       ID: 1199
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.293952e+06
+      GoRuntimeType: 2.29424e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -28778,7 +28778,7 @@ Types:
       ID: 1046
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.420608e+06
+      GoRuntimeType: 1.420736e+06
       GoKind: 25
       RawFields:
         - Name: w
@@ -28788,19 +28788,19 @@ Types:
       ID: 585
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 832928
+      GoRuntimeType: 832960
       GoKind: 10
     - __kind: BaseType
       ID: 999
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 991520
+      GoRuntimeType: 991648
       GoKind: 10
     - __kind: StructureType
       ID: 667
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.730272e+06
+      GoRuntimeType: 1.73056e+06
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -28816,7 +28816,7 @@ Types:
       ID: 979
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.901856e+06
+      GoRuntimeType: 1.902144e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -28832,7 +28832,7 @@ Types:
       ID: 671
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.599488e+06
+      GoRuntimeType: 1.599776e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -28849,7 +28849,7 @@ Types:
       ID: 589
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 833120
+      GoRuntimeType: 833152
       GoKind: 24
       RawFields:
         - Name: str
@@ -28868,7 +28868,7 @@ Types:
       ID: 595
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 833312
+      GoRuntimeType: 833344
       GoKind: 24
       RawFields:
         - Name: str
@@ -28887,7 +28887,7 @@ Types:
       ID: 592
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 833216
+      GoRuntimeType: 833248
       GoKind: 24
       RawFields:
         - Name: str
@@ -28909,7 +28909,7 @@ Types:
     - __kind: StructureType
       ID: 885
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.285952e+06
+      GoRuntimeType: 1.28608e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28920,7 +28920,7 @@ Types:
       ID: 586
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 833024
+      GoRuntimeType: 833056
       GoKind: 24
       RawFields:
         - Name: str
@@ -28939,7 +28939,7 @@ Types:
       ID: 1048
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
-      GoRuntimeType: 1.826144e+06
+      GoRuntimeType: 1.826432e+06
       GoKind: 25
       RawFields:
         - Name: group
@@ -28958,7 +28958,7 @@ Types:
       ID: 1141
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
-      GoRuntimeType: 1.419968e+06
+      GoRuntimeType: 1.420096e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -28970,7 +28970,7 @@ Types:
     - __kind: ArrayType
       ID: 1127
       Name: net/http.incomparable
-      GoRuntimeType: 903360
+      GoRuntimeType: 903392
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
@@ -28978,7 +28978,7 @@ Types:
       ID: 881
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.558528e+06
+      GoRuntimeType: 1.558816e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -28992,7 +28992,7 @@ Types:
       ID: 1066
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.558368e+06
+      GoRuntimeType: 1.558656e+06
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29002,7 +29002,7 @@ Types:
       ID: 1092
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.802144e+06
+      GoRuntimeType: 1.802432e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -29018,7 +29018,7 @@ Types:
       ID: 675
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.421568e+06
+      GoRuntimeType: 1.421696e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -29031,14 +29031,14 @@ Types:
     - __kind: StructureType
       ID: 952
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.482688e+06
+      GoRuntimeType: 1.482976e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 883
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.558688e+06
+      GoRuntimeType: 1.558976e+06
       GoKind: 25
       RawFields:
         - Name: err
@@ -29048,7 +29048,7 @@ Types:
       ID: 1144
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2.028032e+06
+      GoRuntimeType: 2.02832e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29065,7 +29065,7 @@ Types:
       ID: 1164
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 2.044064e+06
+      GoRuntimeType: 2.044352e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29079,7 +29079,7 @@ Types:
       ID: 748
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.735072e+06
+      GoRuntimeType: 1.73536e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29095,7 +29095,7 @@ Types:
       ID: 746
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.601408e+06
+      GoRuntimeType: 1.601696e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29112,7 +29112,7 @@ Types:
       ID: 1078
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.603328e+06
+      GoRuntimeType: 1.603616e+06
       GoKind: 25
       RawFields:
         - Name: c
@@ -29129,7 +29129,7 @@ Types:
       ID: 620
       Name: net/textproto.ProtocolError
       ByteSize: 16
-      GoRuntimeType: 835808
+      GoRuntimeType: 835840
       GoKind: 24
       RawFields:
         - Name: str
@@ -29156,7 +29156,7 @@ Types:
       ID: 598
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 833888
+      GoRuntimeType: 833920
       GoKind: 24
       RawFields:
         - Name: str
@@ -29175,7 +29175,7 @@ Types:
       ID: 601
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 833984
+      GoRuntimeType: 834016
       GoKind: 24
       RawFields:
         - Name: str
@@ -29194,7 +29194,7 @@ Types:
       ID: 470
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 683072
+      GoRuntimeType: 683104
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29203,7 +29203,7 @@ Types:
       ID: 462
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 683168
+      GoRuntimeType: 683200
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29212,7 +29212,7 @@ Types:
       ID: 410
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 683456
+      GoRuntimeType: 683488
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29221,7 +29221,7 @@ Types:
       ID: 429
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 683552
+      GoRuntimeType: 683584
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29230,7 +29230,7 @@ Types:
       ID: 368
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
-      GoRuntimeType: 682304
+      GoRuntimeType: 682336
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29239,7 +29239,7 @@ Types:
       ID: 1274
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
-      GoRuntimeType: 682208
+      GoRuntimeType: 682240
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29248,7 +29248,7 @@ Types:
       ID: 1308
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
-      GoRuntimeType: 681728
+      GoRuntimeType: 681760
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29257,7 +29257,7 @@ Types:
       ID: 1323
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
-      GoRuntimeType: 681632
+      GoRuntimeType: 681664
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29266,7 +29266,7 @@ Types:
       ID: 378
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 680384
+      GoRuntimeType: 680416
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29275,7 +29275,7 @@ Types:
       ID: 1338
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
-      GoRuntimeType: 681536
+      GoRuntimeType: 681568
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29284,7 +29284,7 @@ Types:
       ID: 486
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
-      GoRuntimeType: 683648
+      GoRuntimeType: 683680
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29293,7 +29293,7 @@ Types:
       ID: 437
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 683744
+      GoRuntimeType: 683776
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29302,7 +29302,7 @@ Types:
       ID: 419
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 683840
+      GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29311,7 +29311,7 @@ Types:
       ID: 402
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 683936
+      GoRuntimeType: 683968
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29320,7 +29320,7 @@ Types:
       ID: 1035
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
-      GoRuntimeType: 759040
+      GoRuntimeType: 759072
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29329,7 +29329,7 @@ Types:
       ID: 394
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 684032
+      GoRuntimeType: 684064
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29338,7 +29338,7 @@ Types:
       ID: 386
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 684128
+      GoRuntimeType: 684160
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29347,7 +29347,7 @@ Types:
       ID: 478
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
-      GoRuntimeType: 684224
+      GoRuntimeType: 684256
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29403,7 +29403,7 @@ Types:
     - __kind: ArrayType
       ID: 494
       Name: noalg.[8]struct { key struct {}; elem struct {} }
-      GoRuntimeType: 684320
+      GoRuntimeType: 684352
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29412,7 +29412,7 @@ Types:
       ID: 453
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 684416
+      GoRuntimeType: 684448
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29421,7 +29421,7 @@ Types:
       ID: 445
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 684512
+      GoRuntimeType: 684544
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29430,7 +29430,7 @@ Types:
       ID: 469
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.297984e+06
+      GoRuntimeType: 1.298112e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29443,7 +29443,7 @@ Types:
       ID: 461
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.29824e+06
+      GoRuntimeType: 1.298368e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29456,7 +29456,7 @@ Types:
       ID: 409
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.298496e+06
+      GoRuntimeType: 1.298624e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29469,7 +29469,7 @@ Types:
       ID: 428
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.298752e+06
+      GoRuntimeType: 1.29888e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29482,7 +29482,7 @@ Types:
       ID: 367
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.297728e+06
+      GoRuntimeType: 1.297856e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29495,7 +29495,7 @@ Types:
       ID: 1273
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.297472e+06
+      GoRuntimeType: 1.2976e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29508,7 +29508,7 @@ Types:
       ID: 1307
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.296192e+06
+      GoRuntimeType: 1.29632e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29521,7 +29521,7 @@ Types:
       ID: 1322
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.295936e+06
+      GoRuntimeType: 1.296064e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29534,7 +29534,7 @@ Types:
       ID: 377
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.294656e+06
+      GoRuntimeType: 1.294784e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29547,7 +29547,7 @@ Types:
       ID: 1337
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.29568e+06
+      GoRuntimeType: 1.295808e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29560,7 +29560,7 @@ Types:
       ID: 485
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
-      GoRuntimeType: 1.299008e+06
+      GoRuntimeType: 1.299136e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29573,7 +29573,7 @@ Types:
       ID: 436
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.299264e+06
+      GoRuntimeType: 1.299392e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29586,7 +29586,7 @@ Types:
       ID: 418
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.29952e+06
+      GoRuntimeType: 1.299648e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29599,7 +29599,7 @@ Types:
       ID: 401
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.299776e+06
+      GoRuntimeType: 1.299904e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29612,7 +29612,7 @@ Types:
       ID: 1034
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
-      GoRuntimeType: 1.361472e+06
+      GoRuntimeType: 1.3616e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29625,7 +29625,7 @@ Types:
       ID: 393
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.300032e+06
+      GoRuntimeType: 1.30016e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29638,7 +29638,7 @@ Types:
       ID: 385
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.300288e+06
+      GoRuntimeType: 1.300416e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29651,7 +29651,7 @@ Types:
       ID: 477
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
-      GoRuntimeType: 1.300544e+06
+      GoRuntimeType: 1.300672e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29736,7 +29736,7 @@ Types:
       ID: 493
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
-      GoRuntimeType: 1.3008e+06
+      GoRuntimeType: 1.300928e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29749,7 +29749,7 @@ Types:
       ID: 452
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.301056e+06
+      GoRuntimeType: 1.301184e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29762,7 +29762,7 @@ Types:
       ID: 444
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.301312e+06
+      GoRuntimeType: 1.30144e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29775,7 +29775,7 @@ Types:
       ID: 471
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.297856e+06
+      GoRuntimeType: 1.297984e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29788,7 +29788,7 @@ Types:
       ID: 463
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.298112e+06
+      GoRuntimeType: 1.29824e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29801,7 +29801,7 @@ Types:
       ID: 411
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.298368e+06
+      GoRuntimeType: 1.298496e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29814,7 +29814,7 @@ Types:
       ID: 430
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.298624e+06
+      GoRuntimeType: 1.298752e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29827,7 +29827,7 @@ Types:
       ID: 369
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.2976e+06
+      GoRuntimeType: 1.297728e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29840,7 +29840,7 @@ Types:
       ID: 1275
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.297344e+06
+      GoRuntimeType: 1.297472e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29853,7 +29853,7 @@ Types:
       ID: 1309
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.296064e+06
+      GoRuntimeType: 1.296192e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29866,7 +29866,7 @@ Types:
       ID: 1324
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.295808e+06
+      GoRuntimeType: 1.295936e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29879,7 +29879,7 @@ Types:
       ID: 379
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.294528e+06
+      GoRuntimeType: 1.294656e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29892,7 +29892,7 @@ Types:
       ID: 1339
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.295552e+06
+      GoRuntimeType: 1.29568e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29905,7 +29905,7 @@ Types:
       ID: 487
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
-      GoRuntimeType: 1.29888e+06
+      GoRuntimeType: 1.299008e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29918,7 +29918,7 @@ Types:
       ID: 438
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.299136e+06
+      GoRuntimeType: 1.299264e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29931,7 +29931,7 @@ Types:
       ID: 420
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.299392e+06
+      GoRuntimeType: 1.29952e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29944,7 +29944,7 @@ Types:
       ID: 403
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.299648e+06
+      GoRuntimeType: 1.299776e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29957,7 +29957,7 @@ Types:
       ID: 1036
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
-      GoRuntimeType: 1.361344e+06
+      GoRuntimeType: 1.361472e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29970,7 +29970,7 @@ Types:
       ID: 395
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.299904e+06
+      GoRuntimeType: 1.300032e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29983,7 +29983,7 @@ Types:
       ID: 387
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.30016e+06
+      GoRuntimeType: 1.300288e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29996,7 +29996,7 @@ Types:
       ID: 479
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
-      GoRuntimeType: 1.300416e+06
+      GoRuntimeType: 1.300544e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30080,7 +30080,7 @@ Types:
     - __kind: StructureType
       ID: 495
       Name: noalg.struct { key struct {}; elem struct {} }
-      GoRuntimeType: 1.300672e+06
+      GoRuntimeType: 1.3008e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30093,7 +30093,7 @@ Types:
       ID: 454
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.300928e+06
+      GoRuntimeType: 1.301056e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30106,7 +30106,7 @@ Types:
       ID: 446
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.301184e+06
+      GoRuntimeType: 1.301312e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30131,7 +30131,7 @@ Types:
       ID: 1223
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.363104e+06
+      GoRuntimeType: 2.363392e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -30144,7 +30144,7 @@ Types:
       ID: 1221
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.362304e+06
+      GoRuntimeType: 2.362592e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -30156,13 +30156,13 @@ Types:
     - __kind: StructureType
       ID: 1229
       Name: os.noReadFrom
-      GoRuntimeType: 1.112704e+06
+      GoRuntimeType: 1.112832e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1228
       Name: os.noWriteTo
-      GoRuntimeType: 1.112576e+06
+      GoRuntimeType: 1.112704e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -30181,7 +30181,7 @@ Types:
       ID: 893
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.706816e+06
+      GoRuntimeType: 1.707104e+06
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -30194,7 +30194,7 @@ Types:
       ID: 634
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
-      GoRuntimeType: 839072
+      GoRuntimeType: 839104
       GoKind: 24
       RawFields:
         - Name: str
@@ -30213,7 +30213,7 @@ Types:
       ID: 633
       Name: os/user.UnknownUserIdError
       ByteSize: 8
-      GoRuntimeType: 838976
+      GoRuntimeType: 839008
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 659
@@ -30243,7 +30243,7 @@ Types:
       ID: 868
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.890272e+06
+      GoRuntimeType: 1.89056e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -30262,7 +30262,7 @@ Types:
       ID: 1028
       Name: runtime.boundsErrorCode
       ByteSize: 1
-      GoRuntimeType: 584576
+      GoRuntimeType: 584608
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 63
@@ -30275,14 +30275,14 @@ Types:
     - __kind: StructureType
       ID: 84
       Name: runtime.dlogPerM
-      GoRuntimeType: 990656
+      GoRuntimeType: 990784
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 926
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.754624e+06
+      GoRuntimeType: 1.754912e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30295,7 +30295,7 @@ Types:
       ID: 844
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 990176
+      GoRuntimeType: 990304
       GoKind: 24
       RawFields:
         - Name: str
@@ -30314,7 +30314,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.411392e+06
+      GoRuntimeType: 2.41168e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30495,7 +30495,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.199488e+06
+      GoRuntimeType: 1.199616e+06
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -30505,7 +30505,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.971744e+06
+      GoRuntimeType: 1.972032e+06
       GoKind: 25
       RawFields:
         - Name: sp
@@ -30533,7 +30533,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.474688e+06
+      GoRuntimeType: 1.474976e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -30546,7 +30546,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.753664e+06
+      GoRuntimeType: 1.753952e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30565,13 +30565,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 831680
+      GoRuntimeType: 831712
       GoKind: 12
     - __kind: StructureType
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.474528e+06
+      GoRuntimeType: 1.474816e+06
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -30584,7 +30584,7 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.915648e+06
+      GoRuntimeType: 1.915936e+06
       GoKind: 25
       RawFields:
         - Name: fn
@@ -30609,13 +30609,13 @@ Types:
       ID: 91
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 831584
+      GoRuntimeType: 831616
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 2.416448e+06
+      GoRuntimeType: 2.416736e+06
       GoKind: 25
       RawFields:
         - Name: g0
@@ -30838,7 +30838,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.972032e+06
+      GoRuntimeType: 1.97232e+06
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -30866,7 +30866,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.840992e+06
+      GoRuntimeType: 1.84128e+06
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -30888,7 +30888,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.840768e+06
+      GoRuntimeType: 1.841056e+06
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -30910,7 +30910,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 1.199232e+06
+      GoRuntimeType: 1.19936e+06
       GoKind: 25
       RawFields:
         - Name: next
@@ -30920,20 +30920,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 831296
+      GoRuntimeType: 831328
       GoKind: 12
     - __kind: StructureType
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.199104e+06
+      GoRuntimeType: 1.199232e+06
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.474368e+06
+      GoRuntimeType: 1.474656e+06
       GoKind: 25
       RawFields:
         - Name: entries
@@ -30946,7 +30946,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.754432e+06
+      GoRuntimeType: 1.75472e+06
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -30965,7 +30965,7 @@ Types:
       ID: 847
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 990272
+      GoRuntimeType: 990400
       GoKind: 24
       RawFields:
         - Name: str
@@ -30984,13 +30984,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 831488
+      GoRuntimeType: 831520
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 899136
+      GoRuntimeType: 899168
       GoKind: 17
       Count: 2
       HasCount: true
@@ -30999,7 +30999,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.472768e+06
+      GoRuntimeType: 1.473056e+06
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31020,7 +31020,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 584704
+      GoRuntimeType: 584736
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -31030,7 +31030,7 @@ Types:
       ID: 71
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 584768
+      GoRuntimeType: 584800
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 77
@@ -31040,7 +31040,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.473728e+06
+      GoRuntimeType: 1.474016e+06
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -31053,12 +31053,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.284928e+06
+      GoRuntimeType: 1.285056e+06
       GoKind: 8
     - __kind: StructureType
       ID: 79
       Name: runtime.winlibcall
-      GoRuntimeType: 990560
+      GoRuntimeType: 990688
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -31069,7 +31069,7 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 583424
+      GoRuntimeType: 583456
       GoKind: 24
       RawFields:
         - Name: str
@@ -31096,7 +31096,7 @@ Types:
       ID: 1060
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.458848e+06
+      GoRuntimeType: 1.459136e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -31105,14 +31105,14 @@ Types:
     - __kind: StructureType
       ID: 123
       Name: struct {}
-      GoRuntimeType: 842720
+      GoRuntimeType: 842752
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1243
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.467488e+06
+      GoRuntimeType: 1.467776e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31125,7 +31125,7 @@ Types:
       ID: 1246
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.617632e+06
+      GoRuntimeType: 1.61792e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31141,7 +31141,7 @@ Types:
       ID: 1249
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.617824e+06
+      GoRuntimeType: 1.618112e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31156,14 +31156,14 @@ Types:
     - __kind: StructureType
       ID: 1244
       Name: sync.noCopy
-      GoRuntimeType: 989120
+      GoRuntimeType: 989248
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1252
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.468768e+06
+      GoRuntimeType: 1.469056e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31176,7 +31176,7 @@ Types:
       ID: 1247
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.468928e+06
+      GoRuntimeType: 1.469216e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31189,7 +31189,7 @@ Types:
       ID: 1250
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.618208e+06
+      GoRuntimeType: 1.618496e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31204,20 +31204,20 @@ Types:
     - __kind: StructureType
       ID: 1251
       Name: sync/atomic.align64
-      GoRuntimeType: 989312
+      GoRuntimeType: 989440
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1248
       Name: sync/atomic.noCopy
-      GoRuntimeType: 989216
+      GoRuntimeType: 989344
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 976
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.285312e+06
+      GoRuntimeType: 1.28544e+06
       GoKind: 12
     - __kind: StructureType
       ID: 466
@@ -31875,7 +31875,7 @@ Types:
       ID: 919
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.711232e+06
+      GoRuntimeType: 1.71152e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -31888,7 +31888,7 @@ Types:
       ID: 1142
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.916416e+06
+      GoRuntimeType: 1.916704e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 994
@@ -31902,7 +31902,7 @@ Types:
       ID: 992
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.377984e+06
+      GoRuntimeType: 2.378272e+06
       GoKind: 25
       RawFields:
         - Name: wall
@@ -31918,7 +31918,7 @@ Types:
       ID: 582
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 832064
+      GoRuntimeType: 832096
       GoKind: 24
       RawFields:
         - Name: str
@@ -31937,49 +31937,49 @@ Types:
       ID: 16
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 584064
+      GoRuntimeType: 584096
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 583680
+      GoRuntimeType: 583712
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 583808
+      GoRuntimeType: 583840
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 583936
+      GoRuntimeType: 583968
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 583552
+      GoRuntimeType: 583584
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 584128
+      GoRuntimeType: 584160
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 584512
+      GoRuntimeType: 584544
       GoKind: 26
     - __kind: StructureType
       ID: 1010
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 2.065472e+06
+      GoRuntimeType: 2.06576e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -32013,13 +32013,13 @@ Types:
       ID: 1013
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
-      GoRuntimeType: 995744
+      GoRuntimeType: 995872
       GoKind: 9
     - __kind: StructureType
       ID: 1011
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.927168e+06
+      GoRuntimeType: 1.927456e+06
       GoKind: 25
       RawFields:
         - Name: id
@@ -32048,7 +32048,7 @@ Types:
       ID: 1012
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
-      GoRuntimeType: 588160
+      GoRuntimeType: 588192
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1187
@@ -32058,7 +32058,7 @@ Types:
       ID: 734
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.429408e+06
+      GoRuntimeType: 1.429536e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -32068,13 +32068,13 @@ Types:
       ID: 623
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
-      GoRuntimeType: 835904
+      GoRuntimeType: 835936
       GoKind: 2
     - __kind: StructureType
       ID: 898
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.707008e+06
+      GoRuntimeType: 1.707296e+06
       GoKind: 25
       RawFields:
         - Name: label
@@ -32087,7 +32087,7 @@ Types:
       ID: 852
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
-      GoRuntimeType: 994592
+      GoRuntimeType: 994720
       GoKind: 5
 MaxTypeID: 1670
 Issues:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xce252a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce264a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1594 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xce2565", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2685", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0xcdc96a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdca8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1433 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0xcdc9a5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcac5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0xcdca0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcb2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1436 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0xcdca3d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcb5d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xce0f6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce108e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1565 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce1022", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1142", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0xcd9940", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0xcd98c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd99e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0xcd9900", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xcdd120", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0xcd98e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0xcd9920", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xcdf000", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf120", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1467 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xcdf012", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf132", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0xcda040", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda160", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1401 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0xcda05e", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda17e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1364 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0xcd9700", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce2960", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1613 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce2982", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2aa2", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1673 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcdc18e"
+                - PC: "0xcdc2ae"
                   Frameless: false
-                - PC: "0xcdc211"
+                - PC: "0xcdc331"
                   Frameless: false
-                - PC: "0xcdc352"
+                - PC: "0xcdc472"
                   Frameless: false
-                - PC: "0xcdc3dc"
+                - PC: "0xcdc4fc"
                   Frameless: false
-                - PC: "0xcdc4af"
+                - PC: "0xcdc5cf"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1674 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcdc18e"
+                - PC: "0xcdc2ae"
                   Frameless: false
-                - PC: "0xcdc211"
+                - PC: "0xcdc331"
                   Frameless: false
-                - PC: "0xcdc352"
+                - PC: "0xcdc472"
                   Frameless: false
-                - PC: "0xcdc3dc"
+                - PC: "0xcdc4fc"
                   Frameless: false
-                - PC: "0xcdc4af"
+                - PC: "0xcdc5cf"
                   Frameless: false
               Condition:
                 Type: 4 BaseType bool
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 1675 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcdc18e"
+                - PC: "0xcdc2ae"
                   Frameless: false
-                - PC: "0xcdc211"
+                - PC: "0xcdc331"
                   Frameless: false
-                - PC: "0xcdc352"
+                - PC: "0xcdc472"
                   Frameless: false
-                - PC: "0xcdc3dc"
+                - PC: "0xcdc4fc"
                   Frameless: false
-                - PC: "0xcdc4af"
+                - PC: "0xcdc5cf"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -474,7 +474,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcdec60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcded80", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -493,7 +493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcdec60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcded80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -519,7 +519,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1620 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xce2a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2ba0", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -554,7 +554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xcdf020", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -584,7 +584,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xcdec20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcded40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -613,11 +613,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1529 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xce01ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce02ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1530 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xce0271", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0391", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -639,7 +639,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xcdf3e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -661,7 +661,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1407 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0xcda520", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -683,7 +683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0xcda540", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -705,7 +705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0xcda200", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -727,7 +727,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0xcda220", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -749,7 +749,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0xcda3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -771,7 +771,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0xcda3c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -793,7 +793,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xce2040", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -820,7 +820,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1584 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xce20a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce21c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -848,7 +848,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xce2660", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -870,7 +870,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1621 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xce2ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -891,7 +891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1622 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xce2b00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2c20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -913,7 +913,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0xcdc9e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcb00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -947,7 +947,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1402 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0xcda0db", Frameless: false}]
+              InjectionPoints: [{PC: "0xcda1fb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -975,11 +975,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0xcdad6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdae8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0xcdadac", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdaecc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1001,11 +1001,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0xcdac4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdad6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1415 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0xcdacdb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdadfb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1027,11 +1027,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0xcdc640", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc760", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1427 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0xcdc645", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc765", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1053,11 +1053,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0xcdc664", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc784", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1429 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0xcdc69d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc7bd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1082,7 +1082,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1430 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0xcdc668", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc788", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1104,11 +1104,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1659 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xce5600", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5720", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1660 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce5607", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5727", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1122,11 +1122,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1661 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xce5624", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5744", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1662 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xce5671", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5791", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1149,11 +1149,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1655 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xce556a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce568a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1656 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xce5579", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5699", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1167,11 +1167,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xce55aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce56ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xce55c2", Frameless: false}]
+              InjectionPoints: [{PC: "0xce56e2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1194,14 +1194,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1663 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xce5680", Frameless: true}]
+              InjectionPoints: [{PC: "0xce57a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1664 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xce56a0"
+                - PC: "0xce57c0"
                   Frameless: true
-                - PC: "0xce56a3"
+                - PC: "0xce57c3"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1216,14 +1216,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1665 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xce56ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce57ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1666 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xce572b"
+                - PC: "0xce584b"
                   Frameless: false
-                - PC: "0xce5733"
+                - PC: "0xce5853"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1250,7 +1250,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1667 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xce5685", Frameless: true}]
+              InjectionPoints: [{PC: "0xce57a5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1262,7 +1262,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1668 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xce56df", Frameless: false}]
+              InjectionPoints: [{PC: "0xce57ff", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1283,11 +1283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1643 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xce5220", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5340", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1644 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xce5230", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1301,11 +1301,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1645 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xce52c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce53e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1646 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xce52c8", Frameless: true}]
+              InjectionPoints: [{PC: "0xce53e8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1329,11 +1329,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1631 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xce4dae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4ece", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1632 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce4e94", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4fb4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1375,11 +1375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1635 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce4eea", Frameless: false}]
+              InjectionPoints: [{PC: "0xce500a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1636 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce4ef9", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5019", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1402,11 +1402,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1669 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xce5780", Frameless: true}]
+              InjectionPoints: [{PC: "0xce58a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1670 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xce5786", Frameless: true}]
+              InjectionPoints: [{PC: "0xce58a6", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1420,11 +1420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1671 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xce580a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce592a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1672 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xce582d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce594d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1447,11 +1447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xce4d00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1628 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce4d03", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e23", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1465,11 +1465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xce4d20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1630 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce4d2b", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e4b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1492,11 +1492,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1647 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xce5380", Frameless: true}]
+              InjectionPoints: [{PC: "0xce54a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1648 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xce5387", Frameless: true}]
+              InjectionPoints: [{PC: "0xce54a7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1510,11 +1510,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1649 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xce542a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce554a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1650 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xce5453", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5573", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1537,11 +1537,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1637 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xce51c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce52e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1638 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce51c3", Frameless: true}]
+              InjectionPoints: [{PC: "0xce52e3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1555,11 +1555,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1639 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xce51e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5300", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1640 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xce51e3", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5303", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1573,11 +1573,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1641 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xce5200", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5320", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1642 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xce5203", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5323", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1600,11 +1600,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1651 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xce5520", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5640", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1652 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xce5527", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5647", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1618,11 +1618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1653 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce5540", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5660", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1654 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce554e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce566e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1645,11 +1645,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xce4cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4de0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1624 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce4cc3", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4de3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1663,11 +1663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xce4ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1626 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce4ceb", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e0b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1690,11 +1690,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0xcdc32a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc44a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1419 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0xcdc38e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc4ae", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1721,11 +1721,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0xcdc3ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc4ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1421 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0xcdc45e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc57e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1752,11 +1752,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0xcdc4aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc5ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1423 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0xcdc4eb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc60b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1778,7 +1778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1679 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0xcdc426", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc546", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1796,11 +1796,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1424 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0xcdc52e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc64e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1425 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0xcdc613", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc733", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1818,7 +1818,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1680 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0xcdc533", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc653", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1839,7 +1839,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1681 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0xcdc533", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc653", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1857,7 +1857,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1682 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0xcdc5db", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc6fb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1878,7 +1878,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1683 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0xcdc5db", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc6fb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1899,7 +1899,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x52bec1"
                   Frameless: true
-                - PC: "0xcdcfab"
+                - PC: "0xcdd0d0"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1920,20 +1920,20 @@ Probes:
             - Kind: Entry
               Type: 1676 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0xcdc18a"
+                - PC: "0xcdc2aa"
                   Frameless: false
-                - PC: "0xcdc211"
+                - PC: "0xcdc331"
                   Frameless: false
-                - PC: "0xcdc352"
+                - PC: "0xcdc472"
                   Frameless: false
-                - PC: "0xcdc3dc"
+                - PC: "0xcdc4fc"
                   Frameless: false
-                - PC: "0xcdc4af"
+                - PC: "0xcdc5cf"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1677 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0xcdc1ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc2ea", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1959,15 +1959,15 @@ Probes:
             - Kind: Line
               Type: 1678 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcdc18e"
+                - PC: "0xcdc2ae"
                   Frameless: false
-                - PC: "0xcdc211"
+                - PC: "0xcdc331"
                   Frameless: false
-                - PC: "0xcdc352"
+                - PC: "0xcdc472"
                   Frameless: false
-                - PC: "0xcdc3dc"
+                - PC: "0xcdc4fc"
                   Frameless: false
-                - PC: "0xcdc4af"
+                - PC: "0xcdc5cf"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1990,7 +1990,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1684 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0xcdc641", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc761", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2015,7 +2015,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1685 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0xcdc641", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc761", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2039,9 +2039,9 @@ Probes:
             - Kind: Entry
               Type: 1686 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0xcdc685"
+                - PC: "0xcdc7a5"
                   Frameless: false
-                - PC: "0xcdc725"
+                - PC: "0xcdc845"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2064,7 +2064,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0xcd97c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd98e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2086,7 +2086,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0xcd97e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2108,7 +2108,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0xcd9800", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2130,7 +2130,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0xcd97a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd98c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2152,7 +2152,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0xcd9780", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd98a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2174,7 +2174,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0xcdc940", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdca60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2195,11 +2195,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xce0dce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0eee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1563 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce0f33", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1053", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2221,7 +2221,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xcdf200", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2246,7 +2246,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1411 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcda5ba", Frameless: false}]
+              InjectionPoints: [{PC: "0xcda6da", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2268,7 +2268,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1412 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcda66d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcda78d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2290,7 +2290,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1413 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcda734", Frameless: false}]
+              InjectionPoints: [{PC: "0xcda854", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2333,11 +2333,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xce1293", Frameless: false}]
+              InjectionPoints: [{PC: "0xce13b3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1569 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xce14a2", Frameless: false}]
+              InjectionPoints: [{PC: "0xce15c2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2399,7 +2399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xcdd0e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2421,7 +2421,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xcdd1a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd2c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2443,7 +2443,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xcdd2e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2465,7 +2465,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xcdd320", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2487,7 +2487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xcdd300", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2509,7 +2509,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xcdd160", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2531,7 +2531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xcdd2c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd3e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2553,7 +2553,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xcdd2a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd3c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2577,7 +2577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcdd180", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2601,7 +2601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcdd180", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2623,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xcdd280", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd3a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2645,7 +2645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xcdd260", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2667,7 +2667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xcdd0a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd1c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2689,7 +2689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xcdd0c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd1e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2711,7 +2711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xcdd080", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd1a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2733,7 +2733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xcdd1c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd2e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2755,7 +2755,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xcdd220", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2777,7 +2777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xcdd240", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2799,7 +2799,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xcdd1e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2823,7 +2823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xcdd200", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2845,7 +2845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce2620", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2868,7 +2868,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce2620", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2915,11 +2915,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xce1533", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1653", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1571 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xce176b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce188b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2985,11 +2985,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xce18ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce19ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1575 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xce197f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1a9f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3020,11 +3020,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xce104e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce116e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1567 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xce126a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce138a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3050,11 +3050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1507 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdffee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce010e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1508 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce008f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3090,7 +3090,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xcdede0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdef00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3131,11 +3131,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1501 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcdff4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce006a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1502 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdffb5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce00d5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3159,11 +3159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1503 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcdff4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce006a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1504 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdffb5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce00d5", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3182,11 +3182,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1509 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdffee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce010e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1510 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce008f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01af", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3206,11 +3206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1511 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdffee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce010e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1512 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce008f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3243,11 +3243,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1505 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcdff4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce006a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1506 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdffb5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce00d5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3275,7 +3275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce2a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2b80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3300,7 +3300,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce2a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2b80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3331,7 +3331,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1618 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce2a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2b80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3356,7 +3356,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce2a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2b80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3383,7 +3383,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xcdf3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3410,7 +3410,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xce2120", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3437,7 +3437,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xce20c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce21e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3472,7 +3472,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xce2100", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3504,7 +3504,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xce2600", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3526,7 +3526,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xcdf220", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3548,7 +3548,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xcdd140", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3570,7 +3570,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xcdf1e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3594,11 +3594,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdf82a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf94a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1478 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdf87b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf99b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3618,11 +3618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1521 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce00ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1522 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce016d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce028d", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3663,11 +3663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1487 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdf94e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdfa6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1488 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdfa04", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdfb24", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3705,11 +3705,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdf82a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf94a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1480 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdf87b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf99b", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3750,11 +3750,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1489 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdf94e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdfa6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1490 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdfa04", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdfb24", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3794,11 +3794,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1523 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce00ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1524 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce016d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce028d", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3815,11 +3815,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1525 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce00ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1526 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce016d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce028d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3841,11 +3841,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdf82a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf94a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1482 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdf87b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf99b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3868,18 +3868,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1497 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xcdfbee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdfd0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1498 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xcdfc95"
+                - PC: "0xcdfdb5"
                   Frameless: false
-                - PC: "0xcdfce4"
+                - PC: "0xcdfe04"
                   Frameless: false
-                - PC: "0xcdfda0"
+                - PC: "0xcdfec0"
                   Frameless: false
-                - PC: "0xcdfdaa"
+                - PC: "0xcdfeca"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3907,18 +3907,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1495 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xcdfa8e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdfbae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1496 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xcdfae4"
+                - PC: "0xcdfc04"
                   Frameless: false
-                - PC: "0xcdfb33"
+                - PC: "0xcdfc53"
                   Frameless: false
-                - PC: "0xcdfb67"
+                - PC: "0xcdfc87"
                   Frameless: false
-                - PC: "0xcdfb99"
+                - PC: "0xcdfcb9"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3945,11 +3945,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1540 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xce086a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce098a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1541 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xce08cd", Frameless: false}]
+              InjectionPoints: [{PC: "0xce09ed", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3966,11 +3966,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1542 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xce08ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0a0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1543 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xce092b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0a4b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3987,11 +3987,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1544 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xce094a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0a6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1545 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xce0986", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0aa6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4008,11 +4008,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xce0a2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0b4e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1549 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xce0aaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0bca", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4029,11 +4029,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xce0d6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0e8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1561 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xce0db0", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0ed0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4050,11 +4050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xce072a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce084a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xce0786", Frameless: false}]
+              InjectionPoints: [{PC: "0xce08a6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4072,14 +4072,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xcdfa2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdfb4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1494 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xcdfa5a"
+                - PC: "0xcdfb7a"
                   Frameless: false
-                - PC: "0xcdfa65"
+                - PC: "0xcdfb85"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4101,11 +4101,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdf82a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf94a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1484 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdf87b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf99b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4126,11 +4126,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1491 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdf94e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdfa6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1492 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdfa04", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdfb24", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4151,11 +4151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1485 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xcdf8aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf9ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1486 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xcdf914", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdfa34", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4177,14 +4177,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1499 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xcdfdee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdff0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1500 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xcdfebf"
+                - PC: "0xcdffdf"
                   Frameless: false
-                - PC: "0xcdfec9"
+                - PC: "0xcdffe9"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4206,11 +4206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xce07ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce08ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1539 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xce0833", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0953", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4227,11 +4227,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xce062e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce074e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xce0707", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0827", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4248,11 +4248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1552 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xce0b8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0caa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1553 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xce0bec", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0d0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4269,11 +4269,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xce09aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0aca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1547 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xce09f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0b18", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4290,11 +4290,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xce0cea", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0e0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1559 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xce0d36", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0e56", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4314,7 +4314,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1531 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xce03af", Frameless: false}]
+              InjectionPoints: [{PC: "0xce04cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4335,11 +4335,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xce0c8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0daa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1557 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xce0cce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0dee", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4356,11 +4356,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xce05aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce06ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xce0611", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0731", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4377,11 +4377,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xce0c0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0d2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1555 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xce0c6d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0d8d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4398,11 +4398,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1550 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xce0ace", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0bee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1551 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xce0b54", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0c74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4420,7 +4420,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0xcd9720", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1513 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdffee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce010e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce008f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4505,7 +4505,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0xcd9d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4527,7 +4527,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0xcd9d00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9e20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4549,7 +4549,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0xcd9ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9fc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4567,7 +4567,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0xcd9ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9fe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0xcd9d60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0xcd9da0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9ec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4630,7 +4630,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0xcd9dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4652,7 +4652,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0xcd9de0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4681,7 +4681,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0xcd9d80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4712,7 +4712,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0xcd9d20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9e40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4734,7 +4734,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xce2580", Frameless: true}]
+              InjectionPoints: [{PC: "0xce26a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4756,7 +4756,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0xcd9e00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4778,7 +4778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0xcd9e40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4800,7 +4800,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0xcd9e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9f80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4822,7 +4822,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0xcd9e80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4844,7 +4844,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0xcd9e20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9f40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4866,7 +4866,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xce2160", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4888,7 +4888,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1582 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xce2060", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4910,7 +4910,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xcdd100", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4931,11 +4931,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1527 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce00ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce016d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce028d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4956,11 +4956,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1572 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xce180a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce192a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1573 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xce187c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce199c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4982,7 +4982,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0xcd9740", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5004,7 +5004,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1474 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xcdf360", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5026,7 +5026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1586 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xce20e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5048,7 +5048,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0xcda560", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5070,7 +5070,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0xcda580", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda6a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5092,11 +5092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce2960", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1615 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce2982", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2aa2", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5123,7 +5123,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xce2080", Frameless: true}]
+              InjectionPoints: [{PC: "0xce21a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5150,7 +5150,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0xcdca60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcb80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5171,11 +5171,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1576 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xce19ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1ace", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1577 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xce1a5c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1b7c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5197,11 +5197,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xce2820", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2940", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1611 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xce283e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce295e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5222,7 +5222,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xce2800", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5249,7 +5249,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xcdd060", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5281,7 +5281,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xce2180", Frameless: true}]
+              InjectionPoints: [{PC: "0xce22a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5321,7 +5321,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xce2680", Frameless: true}]
+              InjectionPoints: [{PC: "0xce27a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5354,11 +5354,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdffee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce010e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce008f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5379,11 +5379,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdffee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce010e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce008f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5406,11 +5406,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdffee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce010e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce008f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5439,7 +5439,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xce25a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce26c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5471,11 +5471,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce25c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce26e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1598 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce25de", Frameless: true}]
+              InjectionPoints: [{PC: "0xce26fe", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5505,11 +5505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce25c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce26e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1600 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce25de", Frameless: true}]
+              InjectionPoints: [{PC: "0xce26fe", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5541,7 +5541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1601 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce25e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce25e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0xcd9ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5625,7 +5625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0xcd9860", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5647,7 +5647,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0xcd9880", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd99a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5669,7 +5669,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0xcd98a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd99c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5691,7 +5691,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0xcd9840", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5713,7 +5713,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0xcd9820", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5735,7 +5735,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xcdf280", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf3a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5757,7 +5757,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1580 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xce2020", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5779,7 +5779,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xce2640", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5801,7 +5801,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xcdf240", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5823,7 +5823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0xcd9980", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5845,7 +5845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xce2140", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5867,7 +5867,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xce2140", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5890,14 +5890,14 @@ Probes:
             - Kind: Entry
               Type: 1687 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0xcdc86a"
+                - PC: "0xcdc98a"
                   Frameless: false
-                - PC: "0xce5923"
+                - PC: "0xce5a43"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1688 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0xcdc8a5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc9c5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5919,11 +5919,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xce1a8e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1bae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1579 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce1b0c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1c2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5940,383 +5940,266 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0xcd9700..0xcd9701]
+      OutOfLinePCRanges: [0xcd9820..0xcd9821]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]uint8
           Locations:
-            - Range: 0xcd9700..0xcd9701
+            - Range: 0xcd9820..0xcd9821
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0xcd9720..0xcd9721]
+      OutOfLinePCRanges: [0xcd9840..0xcd9841]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]int32
           Locations:
-            - Range: 0xcd9720..0xcd9721
+            - Range: 0xcd9840..0xcd9841
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0xcd9740..0xcd9741]
+      OutOfLinePCRanges: [0xcd9860..0xcd9861]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]string
           Locations:
-            - Range: 0xcd9740..0xcd9741
+            - Range: 0xcd9860..0xcd9861
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0xcd9760..0xcd9761]
+      OutOfLinePCRanges: [0xcd9880..0xcd9881]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]bool
           Locations:
-            - Range: 0xcd9760..0xcd9761
+            - Range: 0xcd9880..0xcd9881
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0xcd9780..0xcd9781]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 113 ArrayType [2]int
-          Locations:
-            - Range: 0xcd9780..0xcd9781
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 6
-      Name: main.testInt8Array
-      OutOfLinePCRanges: [0xcd97a0..0xcd97a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 114 ArrayType [2]int8
-          Locations:
-            - Range: 0xcd97a0..0xcd97a1
-              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 7
-      Name: main.testInt16Array
-      OutOfLinePCRanges: [0xcd97c0..0xcd97c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 115 ArrayType [2]int16
-          Locations:
-            - Range: 0xcd97c0..0xcd97c1
-              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 8
-      Name: main.testInt32Array
-      OutOfLinePCRanges: [0xcd97e0..0xcd97e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 110 ArrayType [2]int32
-          Locations:
-            - Range: 0xcd97e0..0xcd97e1
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 9
-      Name: main.testInt64Array
-      OutOfLinePCRanges: [0xcd9800..0xcd9801]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 116 ArrayType [2]int64
-          Locations:
-            - Range: 0xcd9800..0xcd9801
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 10
-      Name: main.testUintArray
-      OutOfLinePCRanges: [0xcd9820..0xcd9821]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 117 ArrayType [2]uint
-          Locations:
-            - Range: 0xcd9820..0xcd9821
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 11
-      Name: main.testUint8Array
-      OutOfLinePCRanges: [0xcd9840..0xcd9841]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 109 ArrayType [2]uint8
-          Locations:
-            - Range: 0xcd9840..0xcd9841
-              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 12
-      Name: main.testUint16Array
-      OutOfLinePCRanges: [0xcd9860..0xcd9861]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 118 ArrayType [2]uint16
-          Locations:
-            - Range: 0xcd9860..0xcd9861
-              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 13
-      Name: main.testUint32Array
-      OutOfLinePCRanges: [0xcd9880..0xcd9881]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 119 ArrayType [2]uint32
-          Locations:
-            - Range: 0xcd9880..0xcd9881
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 14
-      Name: main.testUint64Array
       OutOfLinePCRanges: [0xcd98a0..0xcd98a1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 54 ArrayType [2]uint64
+          Type: 113 ArrayType [2]int
           Locations:
             - Range: 0xcd98a0..0xcd98a1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 6
+      Name: main.testInt8Array
+      OutOfLinePCRanges: [0xcd98c0..0xcd98c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 114 ArrayType [2]int8
+          Locations:
+            - Range: 0xcd98c0..0xcd98c1
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 7
+      Name: main.testInt16Array
+      OutOfLinePCRanges: [0xcd98e0..0xcd98e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 115 ArrayType [2]int16
+          Locations:
+            - Range: 0xcd98e0..0xcd98e1
+              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 8
+      Name: main.testInt32Array
+      OutOfLinePCRanges: [0xcd9900..0xcd9901]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 110 ArrayType [2]int32
+          Locations:
+            - Range: 0xcd9900..0xcd9901
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 9
+      Name: main.testInt64Array
+      OutOfLinePCRanges: [0xcd9920..0xcd9921]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 116 ArrayType [2]int64
+          Locations:
+            - Range: 0xcd9920..0xcd9921
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 10
+      Name: main.testUintArray
+      OutOfLinePCRanges: [0xcd9940..0xcd9941]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 117 ArrayType [2]uint
+          Locations:
+            - Range: 0xcd9940..0xcd9941
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 11
+      Name: main.testUint8Array
+      OutOfLinePCRanges: [0xcd9960..0xcd9961]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 109 ArrayType [2]uint8
+          Locations:
+            - Range: 0xcd9960..0xcd9961
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 12
+      Name: main.testUint16Array
+      OutOfLinePCRanges: [0xcd9980..0xcd9981]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 118 ArrayType [2]uint16
+          Locations:
+            - Range: 0xcd9980..0xcd9981
+              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 13
+      Name: main.testUint32Array
+      OutOfLinePCRanges: [0xcd99a0..0xcd99a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 119 ArrayType [2]uint32
+          Locations:
+            - Range: 0xcd99a0..0xcd99a1
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 14
+      Name: main.testUint64Array
+      OutOfLinePCRanges: [0xcd99c0..0xcd99c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 54 ArrayType [2]uint64
+          Locations:
+            - Range: 0xcd99c0..0xcd99c1
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0xcd98c0..0xcd98c1]
+      OutOfLinePCRanges: [0xcd99e0..0xcd99e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 120 ArrayType [2][2]int
           Locations:
-            - Range: 0xcd98c0..0xcd98c1
+            - Range: 0xcd99e0..0xcd99e1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0xcd98e0..0xcd98e1]
+      OutOfLinePCRanges: [0xcd9a00..0xcd9a01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 111 ArrayType [2]string
           Locations:
-            - Range: 0xcd98e0..0xcd98e1
+            - Range: 0xcd9a00..0xcd9a01
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0xcd9900..0xcd9901]
+      OutOfLinePCRanges: [0xcd9a20..0xcd9a21]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 121 ArrayType [2][2][2]int
           Locations:
-            - Range: 0xcd9900..0xcd9901
+            - Range: 0xcd9a20..0xcd9a21
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0xcd9920..0xcd9921]
+      OutOfLinePCRanges: [0xcd9a40..0xcd9a41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 122 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0xcd9920..0xcd9921
+            - Range: 0xcd9a40..0xcd9a41
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0xcd9940..0xcd9941]
+      OutOfLinePCRanges: [0xcd9a60..0xcd9a61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 124 ArrayType [2]struct {}
           Locations:
-            - Range: 0xcd9940..0xcd9941
+            - Range: 0xcd9a60..0xcd9a61
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0xcd9980..0xcd9981]
+      OutOfLinePCRanges: [0xcd9aa0..0xcd9aa1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 126 ArrayType [100]uint
           Locations:
-            - Range: 0xcd9980..0xcd9981
+            - Range: 0xcd9aa0..0xcd9aa1
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xcd9d00..0xcd9d01]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 3 BaseType uint8
-          Locations:
-            - Range: 0xcd9d00..0xcd9d01
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 22
-      Name: main.testSingleRune
-      OutOfLinePCRanges: [0xcd9d20..0xcd9d21]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 BaseType int32
-          Locations:
-            - Range: 0xcd9d20..0xcd9d21
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 23
-      Name: main.testSingleBool
-      OutOfLinePCRanges: [0xcd9d40..0xcd9d41]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 4 BaseType bool
-          Locations:
-            - Range: 0xcd9d40..0xcd9d41
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 24
-      Name: main.testSingleInt
-      OutOfLinePCRanges: [0xcd9d60..0xcd9d61]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd9d60..0xcd9d61
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 25
-      Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xcd9d80..0xcd9d81]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 16 BaseType int8
-          Locations:
-            - Range: 0xcd9d80..0xcd9d81
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 26
-      Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xcd9da0..0xcd9da1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 104 BaseType int16
-          Locations:
-            - Range: 0xcd9da0..0xcd9da1
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 27
-      Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xcd9dc0..0xcd9dc1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 BaseType int32
-          Locations:
-            - Range: 0xcd9dc0..0xcd9dc1
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 28
-      Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xcd9de0..0xcd9de1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 BaseType int64
-          Locations:
-            - Range: 0xcd9de0..0xcd9de1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 29
-      Name: main.testSingleUint
-      OutOfLinePCRanges: [0xcd9e00..0xcd9e01]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 17 BaseType uint
-          Locations:
-            - Range: 0xcd9e00..0xcd9e01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 30
-      Name: main.testSingleUint8
       OutOfLinePCRanges: [0xcd9e20..0xcd9e21]
       InlinePCRanges: []
       Variables:
@@ -6328,93 +6211,210 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 31
-      Name: main.testSingleUint16
+    - ID: 22
+      Name: main.testSingleRune
       OutOfLinePCRanges: [0xcd9e40..0xcd9e41]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType uint16
+          Type: 10 BaseType int32
           Locations:
             - Range: 0xcd9e40..0xcd9e41
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 32
-      Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xcd9e60..0xcd9e61]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 2 BaseType uint32
-          Locations:
-            - Range: 0xcd9e60..0xcd9e61
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 33
-      Name: main.testSingleUint64
+    - ID: 23
+      Name: main.testSingleBool
+      OutOfLinePCRanges: [0xcd9e60..0xcd9e61]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xcd9e60..0xcd9e61
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 24
+      Name: main.testSingleInt
       OutOfLinePCRanges: [0xcd9e80..0xcd9e81]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 BaseType uint64
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd9e80..0xcd9e81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 25
+      Name: main.testSingleInt8
+      OutOfLinePCRanges: [0xcd9ea0..0xcd9ea1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 16 BaseType int8
+          Locations:
+            - Range: 0xcd9ea0..0xcd9ea1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 26
+      Name: main.testSingleInt16
+      OutOfLinePCRanges: [0xcd9ec0..0xcd9ec1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 104 BaseType int16
+          Locations:
+            - Range: 0xcd9ec0..0xcd9ec1
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 27
+      Name: main.testSingleInt32
+      OutOfLinePCRanges: [0xcd9ee0..0xcd9ee1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 BaseType int32
+          Locations:
+            - Range: 0xcd9ee0..0xcd9ee1
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 28
+      Name: main.testSingleInt64
+      OutOfLinePCRanges: [0xcd9f00..0xcd9f01]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 BaseType int64
+          Locations:
+            - Range: 0xcd9f00..0xcd9f01
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 29
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0xcd9f20..0xcd9f21]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 17 BaseType uint
+          Locations:
+            - Range: 0xcd9f20..0xcd9f21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 30
+      Name: main.testSingleUint8
+      OutOfLinePCRanges: [0xcd9f40..0xcd9f41]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0xcd9f40..0xcd9f41
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 31
+      Name: main.testSingleUint16
+      OutOfLinePCRanges: [0xcd9f60..0xcd9f61]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 6 BaseType uint16
+          Locations:
+            - Range: 0xcd9f60..0xcd9f61
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 32
+      Name: main.testSingleUint32
+      OutOfLinePCRanges: [0xcd9f80..0xcd9f81]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 2 BaseType uint32
+          Locations:
+            - Range: 0xcd9f80..0xcd9f81
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 33
+      Name: main.testSingleUint64
+      OutOfLinePCRanges: [0xcd9fa0..0xcd9fa1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0xcd9fa0..0xcd9fa1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xcd9ea0..0xcd9ea1]
+      OutOfLinePCRanges: [0xcd9fc0..0xcd9fc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcd9ea0..0xcd9ea1
+            - Range: 0xcd9fc0..0xcd9fc1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xcd9ec0..0xcd9ec1]
+      OutOfLinePCRanges: [0xcd9fe0..0xcd9fe1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcd9ec0..0xcd9ec1
+            - Range: 0xcd9fe0..0xcd9fe1
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xcd9ee0..0xcd9ee1]
+      OutOfLinePCRanges: [0xcda000..0xcda001]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 127 BaseType main.typeAlias
           Locations:
-            - Range: 0xcd9ee0..0xcd9ee1
+            - Range: 0xcda000..0xcda001
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xcda040..0xcda05f]
+      OutOfLinePCRanges: [0xcda160..0xcda17f]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 128 StructureType main.bigStruct
           Locations:
-            - Range: 0xcda040..0xcda05f
+            - Range: 0xcda160..0xcda17f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6433,87 +6433,87 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0xcda0a0..0xcda19a]
+      OutOfLinePCRanges: [0xcda1c0..0xcda2ba]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcda0a0..0xcda0b8
+            - Range: 0xcda1c0..0xcda1d8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcda0a0..0xcda19a, Pieces: []}]
+          Locations: [{Range: 0xcda1c0..0xcda2ba, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
-          Locations: [{Range: 0xcda0a0..0xcda19a, Pieces: []}]
+          Locations: [{Range: 0xcda1c0..0xcda2ba, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcda0c9..0xcda0e5
+            - Range: 0xcda1e9..0xcda205
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0xcda0e5..0xcda152
+            - Range: 0xcda205..0xcda272
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcda152..0xcda157
+            - Range: 0xcda272..0xcda277
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcda157..0xcda19a
+            - Range: 0xcda277..0xcda2ba
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}, {Size: 8, Op: null}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xcda200..0xcda201]
+      OutOfLinePCRanges: [0xcda320..0xcda321]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 132 StructureType main.deepPtr1
           Locations:
-            - Range: 0xcda200..0xcda201
+            - Range: 0xcda320..0xcda321
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xcda220..0xcda221]
+      OutOfLinePCRanges: [0xcda340..0xcda341]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 135 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xcda220..0xcda221
+            - Range: 0xcda340..0xcda341
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xcda3a0..0xcda3a1]
+      OutOfLinePCRanges: [0xcda4c0..0xcda4c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 137 StructureType main.deepSlice1
           Locations:
-            - Range: 0xcda3a0..0xcda3a1
+            - Range: 0xcda4c0..0xcda4c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6526,129 +6526,129 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xcda3c0..0xcda3c1]
+      OutOfLinePCRanges: [0xcda4e0..0xcda4e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 141 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xcda3c0..0xcda3c1
+            - Range: 0xcda4e0..0xcda4e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xcda520..0xcda521]
+      OutOfLinePCRanges: [0xcda640..0xcda641]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 143 StructureType main.deepMap1
           Locations:
-            - Range: 0xcda520..0xcda521
+            - Range: 0xcda640..0xcda641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xcda540..0xcda541]
+      OutOfLinePCRanges: [0xcda660..0xcda661]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 PointerType *main.deepMap7
           Locations:
-            - Range: 0xcda540..0xcda541
+            - Range: 0xcda660..0xcda661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xcda560..0xcda561]
+      OutOfLinePCRanges: [0xcda680..0xcda681]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 151 PointerType *main.stringType1
           Locations:
-            - Range: 0xcda560..0xcda561
+            - Range: 0xcda680..0xcda681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xcda580..0xcda581]
+      OutOfLinePCRanges: [0xcda6a0..0xcda6a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 153 PointerType **main.stringType2
           Locations:
-            - Range: 0xcda580..0xcda581
+            - Range: 0xcda6a0..0xcda6a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xcda5a0..0xcda7ea]
+      OutOfLinePCRanges: [0xcda6c0..0xcda90a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda684..0xcda6a5
+            - Range: 0xcda7a4..0xcda7c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda758..0xcda76f
+            - Range: 0xcda878..0xcda88f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda66d..0xcda670
+            - Range: 0xcda78d..0xcda790
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcda670..0xcda6a5
+            - Range: 0xcda790..0xcda7c5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcda6a5..0xcda74b
+            - Range: 0xcda7c5..0xcda86b
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xcda74b..0xcda758
+            - Range: 0xcda86b..0xcda878
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcda758..0xcda7ea
+            - Range: 0xcda878..0xcda90a
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda667..0xcda670
+            - Range: 0xcda787..0xcda790
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcda670..0xcda670
+            - Range: 0xcda790..0xcda790
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcda670..0xcda6a5
+            - Range: 0xcda790..0xcda7c5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcda6a5..0xcda74b
+            - Range: 0xcda7c5..0xcda86b
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xcda74b..0xcda750
+            - Range: 0xcda86b..0xcda870
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcda750..0xcda758
+            - Range: 0xcda870..0xcda878
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcda758..0xcda76f
+            - Range: 0xcda878..0xcda88f
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcda76f..0xcda7ea
+            - Range: 0xcda88f..0xcda90a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xcdac40..0xcdad45]
+      OutOfLinePCRanges: [0xcdad60..0xcdae65]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 155 StructureType main.esotericStack
           Locations:
-            - Range: 0xcdac40..0xcdac93
+            - Range: 0xcdad60..0xcdadb3
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6668,7 +6668,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcdac93..0xcdac98
+            - Range: 0xcdadb3..0xcdadb8
               Pieces:
                 - Size: 4
                   Op: null
@@ -6688,7 +6688,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcdac98..0xcdac9d
+            - Range: 0xcdadb8..0xcdadbd
               Pieces:
                 - Size: 4
                   Op: null
@@ -6713,253 +6713,153 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xcdad60..0xcdadc3]
+      OutOfLinePCRanges: [0xcdae80..0xcdaee3]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 159 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xcdad60..0xcdad8d
+            - Range: 0xcdae80..0xcdaead
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 50
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcdc320..0xcdc3a8]
+      OutOfLinePCRanges: [0xcdc440..0xcdc4c8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc320..0xcdc335
+            - Range: 0xcdc440..0xcdc455
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 51
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xcdc3c0..0xcdc485]
+      OutOfLinePCRanges: [0xcdc4e0..0xcdc5a5]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc3c0..0xcdc3d6
+            - Range: 0xcdc4e0..0xcdc4f6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc3c0..0xcdc3e7
+            - Range: 0xcdc4e0..0xcdc507
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc3d6..0xcdc3e7
+            - Range: 0xcdc4f6..0xcdc507
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc3e7..0xcdc485
+            - Range: 0xcdc507..0xcdc5a5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xcdc4a0..0xcdc502]
+      OutOfLinePCRanges: [0xcdc5c0..0xcdc622]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc4a0..0xcdc4ba
+            - Range: 0xcdc5c0..0xcdc5da
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xcdc520..0xcdc625]
+      OutOfLinePCRanges: [0xcdc640..0xcdc745]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc57b..0xcdc585
+            - Range: 0xcdc69b..0xcdc6a5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcdc585..0xcdc595
+            - Range: 0xcdc6a5..0xcdc6b5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcdc595..0xcdc5a9
+            - Range: 0xcdc6b5..0xcdc6c9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc576..0xcdc580
+            - Range: 0xcdc696..0xcdc6a0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcdc580..0xcdc595
+            - Range: 0xcdc6a0..0xcdc6b5
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcdc595..0xcdc5a4
+            - Range: 0xcdc6b5..0xcdc6c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xcdc640..0xcdc646]
+      OutOfLinePCRanges: [0xcdc760..0xcdc766]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc640..0xcdc645
+            - Range: 0xcdc760..0xcdc765
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc640..0xcdc645
+            - Range: 0xcdc760..0xcdc765
               Pieces: []
-            - Range: 0xcdc645..0xcdc646
+            - Range: 0xcdc765..0xcdc766
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xcdc660..0xcdc6a3]
+      OutOfLinePCRanges: [0xcdc780..0xcdc7c3]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0xcdc660..0xcdc6a3
+            - Range: 0xcdc780..0xcdc7c3
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc660..0xcdc69d
+            - Range: 0xcdc780..0xcdc7bd
               Pieces: []
-            - Range: 0xcdc69d..0xcdc69e
+            - Range: 0xcdc7bd..0xcdc7be
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc69e..0xcdc6a3
+            - Range: 0xcdc7be..0xcdc7c3
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcdc940..0xcdc941]
+      OutOfLinePCRanges: [0xcdca60..0xcdca61]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 162 GoInterfaceType main.behavior
-          Locations:
-            - Range: 0xcdc940..0xcdc941
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 57
-      Name: main.testAny
-      OutOfLinePCRanges: [0xcdc960..0xcdc9c6]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 157 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xcdc960..0xcdc989
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdc989..0xcdc98e
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcdc960..0xcdc9a5
-              Pieces: []
-            - Range: 0xcdc9a5..0xcdc9a6
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdc9a6..0xcdc9c6
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 58
-      Name: main.testError
-      OutOfLinePCRanges: [0xcdc9e0..0xcdc9e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 13 GoInterfaceType error
-          Locations:
-            - Range: 0xcdc9e0..0xcdc9e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 59
-      Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xcdca00..0xcdca54]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 163 PointerType *interface {}
-          Locations:
-            - Range: 0xcdca00..0xcdca26
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcdca00..0xcdca3d
-              Pieces: []
-            - Range: 0xcdca3d..0xcdca3e
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdca3e..0xcdca54
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 60
-      Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xcdca60..0xcdca61]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 164 StructureType main.structWithAny
           Locations:
             - Range: 0xcdca60..0xcdca61
               Pieces:
@@ -6970,348 +6870,448 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 57
+      Name: main.testAny
+      OutOfLinePCRanges: [0xcdca80..0xcdcae6]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 157 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xcdca80..0xcdcaa9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdcaa9..0xcdcaae
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdca80..0xcdcac5
+              Pieces: []
+            - Range: 0xcdcac5..0xcdcac6
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdcac6..0xcdcae6
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 58
+      Name: main.testError
+      OutOfLinePCRanges: [0xcdcb00..0xcdcb01]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 13 GoInterfaceType error
+          Locations:
+            - Range: 0xcdcb00..0xcdcb01
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 59
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0xcdcb20..0xcdcb74]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 163 PointerType *interface {}
+          Locations:
+            - Range: 0xcdcb20..0xcdcb46
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdcb20..0xcdcb5d
+              Pieces: []
+            - Range: 0xcdcb5d..0xcdcb5e
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdcb5e..0xcdcb74
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 60
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0xcdcb80..0xcdcb81]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 164 StructureType main.structWithAny
+          Locations:
+            - Range: 0xcdcb80..0xcdcb81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcdd060..0xcdd061]
+      OutOfLinePCRanges: [0xcdd180..0xcdd181]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 165 StructureType main.structWithMap
-          Locations:
-            - Range: 0xcdd060..0xcdd061
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcdd080..0xcdd081]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 171 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xcdd080..0xcdd081
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 63
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcdd0a0..0xcdd0a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 176 GoMapType map[string]int
-          Locations:
-            - Range: 0xcdd0a0..0xcdd0a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcdd0c0..0xcdd0c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 181 GoMapType map[string][]string
-          Locations:
-            - Range: 0xcdd0c0..0xcdd0c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcdd0e0..0xcdd0e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 186 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xcdd0e0..0xcdd0e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 66
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcdd100..0xcdd101]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 176 GoMapType map[string]int
-          Locations:
-            - Range: 0xcdd100..0xcdd101
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcdd120..0xcdd121]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 191 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xcdd120..0xcdd121
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcdd140..0xcdd141]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 192 PointerType *map[string]int
-          Locations:
-            - Range: 0xcdd140..0xcdd141
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcdd160..0xcdd161]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 166 GoMapType map[int]int
-          Locations:
-            - Range: 0xcdd160..0xcdd161
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcdd180..0xcdd181]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcdd180..0xcdd181
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 71
-      Name: main.testMapEmbeddedMaps
+    - ID: 62
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcdd1a0..0xcdd1a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 193 GoMapType map[string][]main.structWithMap
+          Type: 171 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcdd1a0..0xcdd1a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapWithLinkedList
+    - ID: 63
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcdd1c0..0xcdd1c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 198 GoMapType map[bool]main.node
+          Type: 176 GoMapType map[string]int
           Locations:
             - Range: 0xcdd1c0..0xcdd1c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapWithSmallValue
+    - ID: 64
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcdd1e0..0xcdd1e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 203 GoMapType map[int]uint8
+          Type: 181 GoMapType map[string][]string
           Locations:
             - Range: 0xcdd1e0..0xcdd1e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithSmallValueMassive
+    - ID: 65
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcdd200..0xcdd201]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 203 GoMapType map[int]uint8
+        - Name: m
+          Type: 186 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcdd200..0xcdd201
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 66
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xcdd220..0xcdd221]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 208 GoMapType map[uint8]uint8
+          Type: 176 GoMapType map[string]int
           Locations:
             - Range: 0xcdd220..0xcdd221
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 67
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcdd240..0xcdd241]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 208 GoMapType map[uint8]uint8
+          Type: 191 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcdd240..0xcdd241
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapSmallKeySmallValue
+    - ID: 68
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcdd260..0xcdd261]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 208 GoMapType map[uint8]uint8
+          Type: 192 PointerType *map[string]int
           Locations:
             - Range: 0xcdd260..0xcdd261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 69
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcdd280..0xcdd281]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 213 GoMapType map[uint8][4]int
+          Type: 166 GoMapType map[int]int
           Locations:
             - Range: 0xcdd280..0xcdd281
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapLargeKeySmallValue
+    - ID: 70
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xcdd2a0..0xcdd2a1]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 218 GoMapType map[[4]int]uint8
+        - Name: redactMyEntries
+          Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcdd2a0..0xcdd2a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 71
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xcdd2c0..0xcdd2c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 223 GoMapType map[[4]int][4]int
+          Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcdd2c0..0xcdd2c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapEmptyKey
+    - ID: 72
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xcdd2e0..0xcdd2e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 228 GoMapType map[struct {}]int
+          Type: 198 GoMapType map[bool]main.node
           Locations:
             - Range: 0xcdd2e0..0xcdd2e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapEmptyValue
+    - ID: 73
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xcdd300..0xcdd301]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 233 GoMapType map[int]struct {}
+          Type: 203 GoMapType map[int]uint8
           Locations:
             - Range: 0xcdd300..0xcdd301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 74
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xcdd320..0xcdd321]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 238 GoMapType map[struct {}]struct {}
+        - Name: redactMyEntries
+          Type: 203 GoMapType map[int]uint8
           Locations:
             - Range: 0xcdd320..0xcdd321
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 75
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcdd340..0xcdd341]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdd340..0xcdd341
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 76
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcdd360..0xcdd361]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdd360..0xcdd361
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcdd380..0xcdd381]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdd380..0xcdd381
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 78
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xcdd3a0..0xcdd3a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 213 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xcdd3a0..0xcdd3a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 79
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xcdd3c0..0xcdd3c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 218 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xcdd3c0..0xcdd3c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 80
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xcdd3e0..0xcdd3e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 223 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xcdd3e0..0xcdd3e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 81
+      Name: main.testMapEmptyKey
+      OutOfLinePCRanges: [0xcdd400..0xcdd401]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 228 GoMapType map[struct {}]int
+          Locations:
+            - Range: 0xcdd400..0xcdd401
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 82
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0xcdd420..0xcdd421]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 233 GoMapType map[int]struct {}
+          Locations:
+            - Range: 0xcdd420..0xcdd421
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0xcdd440..0xcdd441]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 238 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0xcdd440..0xcdd441
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcdec20..0xcdec21]
+      OutOfLinePCRanges: [0xcded40..0xcded41]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdec20..0xcdec21
+            - Range: 0xcded40..0xcded41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdec20..0xcdec21
+            - Range: 0xcded40..0xcded41
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcdec20..0xcdec21
+            - Range: 0xcded40..0xcded41
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xcdec60..0xcdec61]
+      OutOfLinePCRanges: [0xcded80..0xcded81]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdec60..0xcdec61
+            - Range: 0xcded80..0xcded81
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdec60..0xcdec61
+            - Range: 0xcded80..0xcded81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7322,48 +7322,48 @@ Subprograms:
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcdec60..0xcdec61
+            - Range: 0xcded80..0xcded81
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcdede0..0xcdede1]
+      OutOfLinePCRanges: [0xcdef00..0xcdef01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdede0..0xcdede1
+            - Range: 0xcdef00..0xcdef01
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdede0..0xcdede1
+            - Range: 0xcdef00..0xcdef01
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcdede0..0xcdede1
+            - Range: 0xcdef00..0xcdef01
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdede0..0xcdede1
+            - Range: 0xcdef00..0xcdef01
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdede0..0xcdede1
+            - Range: 0xcdef00..0xcdef01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7374,61 +7374,61 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xcdf000..0xcdf013]
+      OutOfLinePCRanges: [0xcdf120..0xcdf133]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcdf000..0xcdf012
+            - Range: 0xcdf120..0xcdf132
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcdf000..0xcdf012
+            - Range: 0xcdf120..0xcdf132
               Pieces: []
-            - Range: 0xcdf012..0xcdf013
+            - Range: 0xcdf132..0xcdf133
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcdf020..0xcdf021]
+      OutOfLinePCRanges: [0xcdf140..0xcdf141]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 243 GoChannelType chan bool
           Locations:
-            - Range: 0xcdf020..0xcdf021
+            - Range: 0xcdf140..0xcdf141
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcdf1e0..0xcdf1e1]
+      OutOfLinePCRanges: [0xcdf300..0xcdf301]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcdf1e0..0xcdf1e1
+            - Range: 0xcdf300..0xcdf301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcdf200..0xcdf201]
+      OutOfLinePCRanges: [0xcdf320..0xcdf321]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 246 StructureType main.node
           Locations:
-            - Range: 0xcdf200..0xcdf201
+            - Range: 0xcdf320..0xcdf321
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7439,273 +7439,273 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcdf220..0xcdf221]
+      OutOfLinePCRanges: [0xcdf340..0xcdf341]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.node
           Locations:
-            - Range: 0xcdf220..0xcdf221
+            - Range: 0xcdf340..0xcdf341
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcdf240..0xcdf241]
+      OutOfLinePCRanges: [0xcdf360..0xcdf361]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
-          Locations:
-            - Range: 0xcdf240..0xcdf241
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 93
-      Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcdf280..0xcdf281]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 107 PointerType *uint
-          Locations:
-            - Range: 0xcdf280..0xcdf281
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 94
-      Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcdf360..0xcdf361]
-      InlinePCRanges: []
-      Variables:
-        - Name: z
-          Type: 95 PointerType *string
           Locations:
             - Range: 0xcdf360..0xcdf361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 93
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0xcdf3a0..0xcdf3a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 107 PointerType *uint
+          Locations:
+            - Range: 0xcdf3a0..0xcdf3a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 94
+      Name: main.testStringPointer
+      OutOfLinePCRanges: [0xcdf480..0xcdf481]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 95 PointerType *string
+          Locations:
+            - Range: 0xcdf480..0xcdf481
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcdf3a0..0xcdf3a1]
+      OutOfLinePCRanges: [0xcdf4c0..0xcdf4c1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcdf3a0..0xcdf3a1
+            - Range: 0xcdf4c0..0xcdf4c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdf3a0..0xcdf3a1
+            - Range: 0xcdf4c0..0xcdf4c1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcdf3e0..0xcdf3e1]
+      OutOfLinePCRanges: [0xcdf500..0xcdf501]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 248 PointerType *main.t
           Locations:
-            - Range: 0xcdf3e0..0xcdf3e1
+            - Range: 0xcdf500..0xcdf501
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcdf820..0xcdf892]
+      OutOfLinePCRanges: [0xcdf940..0xcdf9b2]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf820..0xcdf832
+            - Range: 0xcdf940..0xcdf952
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf820..0xcdf87b
+            - Range: 0xcdf940..0xcdf99b
               Pieces: []
-            - Range: 0xcdf87b..0xcdf87c
+            - Range: 0xcdf99b..0xcdf99c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf87c..0xcdf892
+            - Range: 0xcdf99c..0xcdf9b2
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf832..0xcdf845
+            - Range: 0xcdf952..0xcdf965
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf845..0xcdf892
+            - Range: 0xcdf965..0xcdf9b2
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcdf8a0..0xcdf92f]
+      OutOfLinePCRanges: [0xcdf9c0..0xcdfa4f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf8a0..0xcdf8ba
+            - Range: 0xcdf9c0..0xcdf9da
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf8ba..0xcdf92f
+            - Range: 0xcdf9da..0xcdfa4f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdf8a0..0xcdf914
+            - Range: 0xcdf9c0..0xcdfa34
               Pieces: []
-            - Range: 0xcdf914..0xcdf915
+            - Range: 0xcdfa34..0xcdfa35
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf915..0xcdf92f
+            - Range: 0xcdfa35..0xcdfa4f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdf8bf..0xcdf8d9
+            - Range: 0xcdf9df..0xcdf9f9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf8d9..0xcdf92f
+            - Range: 0xcdf9f9..0xcdfa4f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcdf940..0xcdfa1e]
+      OutOfLinePCRanges: [0xcdfa60..0xcdfb3e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf940..0xcdf9a2
+            - Range: 0xcdfa60..0xcdfac2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf940..0xcdfa04
+            - Range: 0xcdfa60..0xcdfb24
               Pieces: []
-            - Range: 0xcdfa04..0xcdfa05
+            - Range: 0xcdfb24..0xcdfb25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdfa05..0xcdfa1e
+            - Range: 0xcdfb25..0xcdfb3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcdf940..0xcdfa1e, Pieces: []}]
+          Locations: [{Range: 0xcdfa60..0xcdfb3e, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf956..0xcdf9a7
+            - Range: 0xcdfa76..0xcdfac7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdf9a7..0xcdfa1e
+            - Range: 0xcdfac7..0xcdfb3e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcdf96f..0xcdf9a7
+            - Range: 0xcdfa8f..0xcdfac7
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcdf9a7..0xcdfa1e
+            - Range: 0xcdfac7..0xcdfb3e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcdfa20..0xcdfa7b]
+      OutOfLinePCRanges: [0xcdfb40..0xcdfb9b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdfa20..0xcdfa39
+            - Range: 0xcdfb40..0xcdfb59
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcdfa20..0xcdfa5a
+            - Range: 0xcdfb40..0xcdfb7a
               Pieces: []
-            - Range: 0xcdfa5a..0xcdfa5b
+            - Range: 0xcdfb7a..0xcdfb7b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfa5b..0xcdfa65
+            - Range: 0xcdfb7b..0xcdfb85
               Pieces: []
-            - Range: 0xcdfa65..0xcdfa66
+            - Range: 0xcdfb85..0xcdfb86
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfa66..0xcdfa7b
+            - Range: 0xcdfb86..0xcdfb9b
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcdfa80..0xcdfbc6]
+      OutOfLinePCRanges: [0xcdfba0..0xcdfce6]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdfa80..0xcdfacb
+            - Range: 0xcdfba0..0xcdfbeb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfacb..0xcdfad6
+            - Range: 0xcdfbeb..0xcdfbf6
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfb07..0xcdfb0a
+            - Range: 0xcdfc27..0xcdfc2a
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfb40..0xcdfb45
+            - Range: 0xcdfc60..0xcdfc65
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfb74..0xcdfb79
+            - Range: 0xcdfc94..0xcdfc99
               Pieces:
                 - Size: 8
                   Op: null
@@ -7716,117 +7716,117 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdfa80..0xcdfac3
+            - Range: 0xcdfba0..0xcdfbe3
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdfa80..0xcdfae4
+            - Range: 0xcdfba0..0xcdfc04
               Pieces: []
-            - Range: 0xcdfae4..0xcdfae5
+            - Range: 0xcdfc04..0xcdfc05
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfae5..0xcdfb33
+            - Range: 0xcdfc05..0xcdfc53
               Pieces: []
-            - Range: 0xcdfb33..0xcdfb34
+            - Range: 0xcdfc53..0xcdfc54
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfb34..0xcdfb67
+            - Range: 0xcdfc54..0xcdfc87
               Pieces: []
-            - Range: 0xcdfb67..0xcdfb68
+            - Range: 0xcdfc87..0xcdfc88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfb68..0xcdfb99
+            - Range: 0xcdfc88..0xcdfcb9
               Pieces: []
-            - Range: 0xcdfb99..0xcdfb9a
+            - Range: 0xcdfcb9..0xcdfcba
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfb9a..0xcdfbc6
+            - Range: 0xcdfcba..0xcdfce6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcdfa80..0xcdfae4
+            - Range: 0xcdfba0..0xcdfc04
               Pieces: []
-            - Range: 0xcdfae4..0xcdfae5
+            - Range: 0xcdfc04..0xcdfc05
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdfae5..0xcdfb33
+            - Range: 0xcdfc05..0xcdfc53
               Pieces: []
-            - Range: 0xcdfb33..0xcdfb34
+            - Range: 0xcdfc53..0xcdfc54
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdfb34..0xcdfb67
+            - Range: 0xcdfc54..0xcdfc87
               Pieces: []
-            - Range: 0xcdfb67..0xcdfb68
+            - Range: 0xcdfc87..0xcdfc88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdfb68..0xcdfb99
+            - Range: 0xcdfc88..0xcdfcb9
               Pieces: []
-            - Range: 0xcdfb99..0xcdfb9a
+            - Range: 0xcdfcb9..0xcdfcba
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdfb9a..0xcdfbc6
+            - Range: 0xcdfcba..0xcdfce6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdfacb..0xcdfad1
+            - Range: 0xcdfbeb..0xcdfbf1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcdfbe0..0xcdfdce]
+      OutOfLinePCRanges: [0xcdfd00..0xcdfeee]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdfbe0..0xcdfc2b
+            - Range: 0xcdfd00..0xcdfd4b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfc2b..0xcdfc32
+            - Range: 0xcdfd4b..0xcdfd52
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdfc32..0xcdfdce
+            - Range: 0xcdfd52..0xcdfeee
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7837,1128 +7837,1128 @@ Subprograms:
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdfbe0..0xcdfc95
+            - Range: 0xcdfd00..0xcdfdb5
               Pieces: []
-            - Range: 0xcdfc95..0xcdfc96
+            - Range: 0xcdfdb5..0xcdfdb6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfc96..0xcdfce4
+            - Range: 0xcdfdb6..0xcdfe04
               Pieces: []
-            - Range: 0xcdfce4..0xcdfce5
+            - Range: 0xcdfe04..0xcdfe05
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfce5..0xcdfda0
+            - Range: 0xcdfe05..0xcdfec0
               Pieces: []
-            - Range: 0xcdfda0..0xcdfda1
+            - Range: 0xcdfec0..0xcdfec1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfda1..0xcdfdaa
+            - Range: 0xcdfec1..0xcdfeca
               Pieces: []
-            - Range: 0xcdfdaa..0xcdfdab
+            - Range: 0xcdfeca..0xcdfecb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfdab..0xcdfdce
+            - Range: 0xcdfecb..0xcdfeee
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdfc80..0xcdfc86
+            - Range: 0xcdfda0..0xcdfda6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdfcc5..0xcdfce4
+            - Range: 0xcdfde5..0xcdfe04
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcdfde0..0xcdff34]
+      OutOfLinePCRanges: [0xcdff00..0xce0054]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdfde0..0xcdfe20
+            - Range: 0xcdff00..0xcdff40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfe20..0xcdfe6e
+            - Range: 0xcdff40..0xcdff8e
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdfe6e..0xcdfecf
+            - Range: 0xcdff8e..0xcdffef
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdfecf..0xcdfef1
+            - Range: 0xcdffef..0xce0011
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdfef1..0xcdfef8
+            - Range: 0xce0011..0xce0018
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdfef8..0xcdff34
+            - Range: 0xce0018..0xce0054
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdfde0..0xcdfebf
+            - Range: 0xcdff00..0xcdffdf
               Pieces: []
-            - Range: 0xcdfebf..0xcdfec0
+            - Range: 0xcdffdf..0xcdffe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfec0..0xcdfec9
+            - Range: 0xcdffe0..0xcdffe9
               Pieces: []
-            - Range: 0xcdfec9..0xcdfeca
+            - Range: 0xcdffe9..0xcdffea
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfeca..0xcdff34
+            - Range: 0xcdffea..0xce0054
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdfde0..0xcdfe20
+            - Range: 0xcdff00..0xcdff40
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfe20..0xcdfe6e
+            - Range: 0xcdff40..0xcdff8e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdfe6e..0xcdfe75
+            - Range: 0xcdff8e..0xcdff95
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdfe75..0xcdfec5
+            - Range: 0xcdff95..0xcdffe5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdfec5..0xcdfec7
+            - Range: 0xcdffe5..0xcdffe7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdfec7..0xcdfec9
+            - Range: 0xcdffe7..0xcdffe9
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdfec9..0xcdff34
+            - Range: 0xcdffe9..0xce0054
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcdff40..0xcdffcf]
+      OutOfLinePCRanges: [0xce0060..0xce00ef]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdff40..0xcdff51
+            - Range: 0xce0060..0xce0071
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdff40..0xcdffb5
+            - Range: 0xce0060..0xce00d5
               Pieces: []
-            - Range: 0xcdffb5..0xcdffb6
+            - Range: 0xce00d5..0xce00d6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdffb6..0xcdffcf
+            - Range: 0xce00d6..0xce00ef
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcdffe0..0xce00a9]
+      OutOfLinePCRanges: [0xce0100..0xce01c9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdffe0..0xce0031
+            - Range: 0xce0100..0xce0151
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdffe0..0xce008f
+            - Range: 0xce0100..0xce01af
               Pieces: []
-            - Range: 0xce008f..0xce0090
+            - Range: 0xce01af..0xce01b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0090..0xce00a9
+            - Range: 0xce01b0..0xce01c9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdffe0..0xce008f
+            - Range: 0xce0100..0xce01af
               Pieces: []
-            - Range: 0xce008f..0xce0090
+            - Range: 0xce01af..0xce01b0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce0090..0xce00a9
+            - Range: 0xce01b0..0xce01c9
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xce00c0..0xce0187]
+      OutOfLinePCRanges: [0xce01e0..0xce02a7]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce00c0..0xce0105
+            - Range: 0xce01e0..0xce0225
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0105..0xce0187
+            - Range: 0xce0225..0xce02a7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce00c0..0xce016d
+            - Range: 0xce01e0..0xce028d
               Pieces: []
-            - Range: 0xce016d..0xce016e
+            - Range: 0xce028d..0xce028e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce016e..0xce0187
+            - Range: 0xce028e..0xce02a7
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce00c0..0xce016d
+            - Range: 0xce01e0..0xce028d
               Pieces: []
-            - Range: 0xce016d..0xce016e
+            - Range: 0xce028d..0xce028e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce016e..0xce0187
+            - Range: 0xce028e..0xce02a7
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce00c0..0xce016d
+            - Range: 0xce01e0..0xce028d
               Pieces: []
-            - Range: 0xce016d..0xce016e
+            - Range: 0xce028d..0xce028e
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce016e..0xce0187
+            - Range: 0xce028e..0xce02a7
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xce01a0..0xce028f]
+      OutOfLinePCRanges: [0xce02c0..0xce03af]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce01a0..0xce01e5
+            - Range: 0xce02c0..0xce0305
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce01e5..0xce028f
+            - Range: 0xce0305..0xce03af
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce01a0..0xce0271
+            - Range: 0xce02c0..0xce0391
               Pieces: []
-            - Range: 0xce0271..0xce0272
+            - Range: 0xce0391..0xce0392
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0272..0xce028f
+            - Range: 0xce0392..0xce03af
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce01a0..0xce0271
+            - Range: 0xce02c0..0xce0391
               Pieces: []
-            - Range: 0xce0271..0xce0272
+            - Range: 0xce0391..0xce0392
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce0272..0xce028f
+            - Range: 0xce0392..0xce03af
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xce02a0..0xce04af]
+      OutOfLinePCRanges: [0xce03c0..0xce05cf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce02a0..0xce0326
+            - Range: 0xce03c0..0xce0446
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0326..0xce04af
+            - Range: 0xce0446..0xce05cf
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce02d7..0xce04af
+            - Range: 0xce03f7..0xce05cf
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce02dd..0xce04af
+            - Range: 0xce03fd..0xce05cf
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xce05a0..0xce061e]
+      OutOfLinePCRanges: [0xce06c0..0xce073e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xce05a0..0xce0611
+            - Range: 0xce06c0..0xce0731
               Pieces: []
-            - Range: 0xce0611..0xce0612
+            - Range: 0xce0731..0xce0732
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0612..0xce061e
+            - Range: 0xce0732..0xce073e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 104 BaseType int16
           Locations:
-            - Range: 0xce05a0..0xce0611
+            - Range: 0xce06c0..0xce0731
               Pieces: []
-            - Range: 0xce0611..0xce0612
+            - Range: 0xce0731..0xce0732
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce0612..0xce061e
+            - Range: 0xce0732..0xce073e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xce05a0..0xce0611
+            - Range: 0xce06c0..0xce0731
               Pieces: []
-            - Range: 0xce0611..0xce0612
+            - Range: 0xce0731..0xce0732
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce0612..0xce061e
+            - Range: 0xce0732..0xce073e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 12 BaseType int64
           Locations:
-            - Range: 0xce05a0..0xce0611
+            - Range: 0xce06c0..0xce0731
               Pieces: []
-            - Range: 0xce0611..0xce0612
+            - Range: 0xce0731..0xce0732
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce0612..0xce061e
+            - Range: 0xce0732..0xce073e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xce05a0..0xce0611
+            - Range: 0xce06c0..0xce0731
               Pieces: []
-            - Range: 0xce0611..0xce0612
+            - Range: 0xce0731..0xce0732
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce0612..0xce061e
+            - Range: 0xce0732..0xce073e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xce05a0..0xce0611
+            - Range: 0xce06c0..0xce0731
               Pieces: []
-            - Range: 0xce0611..0xce0612
+            - Range: 0xce0731..0xce0732
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce0612..0xce061e
+            - Range: 0xce0732..0xce073e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xce05a0..0xce0611
+            - Range: 0xce06c0..0xce0731
               Pieces: []
-            - Range: 0xce0611..0xce0612
+            - Range: 0xce0731..0xce0732
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce0612..0xce061e
+            - Range: 0xce0732..0xce073e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xce05a0..0xce0611
+            - Range: 0xce06c0..0xce0731
               Pieces: []
-            - Range: 0xce0611..0xce0612
+            - Range: 0xce0731..0xce0732
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce0612..0xce061e
+            - Range: 0xce0732..0xce073e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xce0620..0xce0717]
+      OutOfLinePCRanges: [0xce0740..0xce0837]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0837, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xce0620..0xce0707
+            - Range: 0xce0740..0xce0827
               Pieces: []
-            - Range: 0xce0707..0xce0708
+            - Range: 0xce0827..0xce0828
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xce0708..0xce0717
+            - Range: 0xce0828..0xce0837
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xce0620..0xce0707
+            - Range: 0xce0740..0xce0827
               Pieces: []
-            - Range: 0xce0707..0xce0708
+            - Range: 0xce0827..0xce0828
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce0708..0xce0717
+            - Range: 0xce0828..0xce0837
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xce0720..0xce0793]
+      OutOfLinePCRanges: [0xce0840..0xce08b3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 96 BaseType complex64
-          Locations: [{Range: 0xce0720..0xce0793, Pieces: []}]
+          Locations: [{Range: 0xce0840..0xce08b3, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 97 BaseType complex128
-          Locations: [{Range: 0xce0720..0xce0793, Pieces: []}]
+          Locations: [{Range: 0xce0840..0xce08b3, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xce07a0..0xce0845]
+      OutOfLinePCRanges: [0xce08c0..0xce0965]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce07a0..0xce0833
+            - Range: 0xce08c0..0xce0953
               Pieces: []
-            - Range: 0xce0833..0xce0834
+            - Range: 0xce0953..0xce0954
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xce0834..0xce0845
+            - Range: 0xce0954..0xce0965
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xce0860..0xce08da]
+      OutOfLinePCRanges: [0xce0980..0xce09fa]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xce0860..0xce08cd
+            - Range: 0xce0980..0xce09ed
               Pieces: []
-            - Range: 0xce08cd..0xce08ce
+            - Range: 0xce09ed..0xce09ee
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xce08ce..0xce08da
+            - Range: 0xce09ee..0xce09fa
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xce08e0..0xce0938]
+      OutOfLinePCRanges: [0xce0a00..0xce0a58]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 ArrayType [1]int
           Locations:
-            - Range: 0xce08e0..0xce092b
+            - Range: 0xce0a00..0xce0a4b
               Pieces: []
-            - Range: 0xce092b..0xce092c
+            - Range: 0xce0a4b..0xce0a4c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce092c..0xce0938
+            - Range: 0xce0a4c..0xce0a58
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xce0940..0xce0993]
+      OutOfLinePCRanges: [0xce0a60..0xce0ab3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0xce0940..0xce0986
+            - Range: 0xce0a60..0xce0aa6
               Pieces: []
-            - Range: 0xce0986..0xce0987
+            - Range: 0xce0aa6..0xce0aa7
               Pieces: []
-            - Range: 0xce0987..0xce0993
+            - Range: 0xce0aa7..0xce0ab3
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xce09a0..0xce0a07]
+      OutOfLinePCRanges: [0xce0ac0..0xce0b27]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
-          Locations: [{Range: 0xce09a0..0xce0a07, Pieces: []}]
+          Locations: [{Range: 0xce0ac0..0xce0b27, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xce0a20..0xce0aba]
+      OutOfLinePCRanges: [0xce0b40..0xce0bda]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0a20..0xce0aaa
+            - Range: 0xce0b40..0xce0bca
               Pieces: []
-            - Range: 0xce0aaa..0xce0aab
+            - Range: 0xce0bca..0xce0bcb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0aab..0xce0aba
+            - Range: 0xce0bcb..0xce0bda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0a20..0xce0aaa
+            - Range: 0xce0b40..0xce0bca
               Pieces: []
-            - Range: 0xce0aaa..0xce0aab
+            - Range: 0xce0bca..0xce0bcb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce0aab..0xce0aba
+            - Range: 0xce0bcb..0xce0bda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0a20..0xce0aaa
+            - Range: 0xce0b40..0xce0bca
               Pieces: []
-            - Range: 0xce0aaa..0xce0aab
+            - Range: 0xce0bca..0xce0bcb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce0aab..0xce0aba
+            - Range: 0xce0bcb..0xce0bda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0a20..0xce0aaa
+            - Range: 0xce0b40..0xce0bca
               Pieces: []
-            - Range: 0xce0aaa..0xce0aab
+            - Range: 0xce0bca..0xce0bcb
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce0aab..0xce0aba
+            - Range: 0xce0bcb..0xce0bda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0a20..0xce0aaa
+            - Range: 0xce0b40..0xce0bca
               Pieces: []
-            - Range: 0xce0aaa..0xce0aab
+            - Range: 0xce0bca..0xce0bcb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce0aab..0xce0aba
+            - Range: 0xce0bcb..0xce0bda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0a20..0xce0aaa
+            - Range: 0xce0b40..0xce0bca
               Pieces: []
-            - Range: 0xce0aaa..0xce0aab
+            - Range: 0xce0bca..0xce0bcb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce0aab..0xce0aba
+            - Range: 0xce0bcb..0xce0bda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0a20..0xce0aaa
+            - Range: 0xce0b40..0xce0bca
               Pieces: []
-            - Range: 0xce0aaa..0xce0aab
+            - Range: 0xce0bca..0xce0bcb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce0aab..0xce0aba
+            - Range: 0xce0bcb..0xce0bda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0a20..0xce0aaa
+            - Range: 0xce0b40..0xce0bca
               Pieces: []
-            - Range: 0xce0aaa..0xce0aab
+            - Range: 0xce0bca..0xce0bcb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce0aab..0xce0aba
+            - Range: 0xce0bcb..0xce0bda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce0a20..0xce0aaa
+            - Range: 0xce0b40..0xce0bca
               Pieces: []
-            - Range: 0xce0aaa..0xce0aab
+            - Range: 0xce0bca..0xce0bcb
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xce0aab..0xce0aba
+            - Range: 0xce0bcb..0xce0bda
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xce0ac0..0xce0b65]
+      OutOfLinePCRanges: [0xce0be0..0xce0c85]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.wideStruct
           Locations:
-            - Range: 0xce0ac0..0xce0b54
+            - Range: 0xce0be0..0xce0c74
               Pieces: []
-            - Range: 0xce0b54..0xce0b55
+            - Range: 0xce0c74..0xce0c75
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xce0b55..0xce0b65
+            - Range: 0xce0c75..0xce0c85
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xce0b80..0xce0bf9]
+      OutOfLinePCRanges: [0xce0ca0..0xce0d19]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0b80..0xce0bec
+            - Range: 0xce0ca0..0xce0d0c
               Pieces: []
-            - Range: 0xce0bec..0xce0bed
+            - Range: 0xce0d0c..0xce0d0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0bed..0xce0bf9
+            - Range: 0xce0d0d..0xce0d19
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0b80..0xce0bf9, Pieces: []}]
+          Locations: [{Range: 0xce0ca0..0xce0d19, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0b80..0xce0bec
+            - Range: 0xce0ca0..0xce0d0c
               Pieces: []
-            - Range: 0xce0bec..0xce0bed
+            - Range: 0xce0d0c..0xce0d0d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce0bed..0xce0bf9
+            - Range: 0xce0d0d..0xce0d19
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0b80..0xce0bf9, Pieces: []}]
+          Locations: [{Range: 0xce0ca0..0xce0d19, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce0b80..0xce0bec
+            - Range: 0xce0ca0..0xce0d0c
               Pieces: []
-            - Range: 0xce0bec..0xce0bed
+            - Range: 0xce0d0c..0xce0d0d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce0bed..0xce0bf9
+            - Range: 0xce0d0d..0xce0d19
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xce0c00..0xce0c7a]
+      OutOfLinePCRanges: [0xce0d20..0xce0d9a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xce0c00..0xce0c6d
+            - Range: 0xce0d20..0xce0d8d
               Pieces: []
-            - Range: 0xce0c6d..0xce0c6e
+            - Range: 0xce0d8d..0xce0d8e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xce0c6e..0xce0c7a
+            - Range: 0xce0d8e..0xce0d9a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xce0c80..0xce0cdb]
+      OutOfLinePCRanges: [0xce0da0..0xce0dfb]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0c80..0xce0cdb, Pieces: []}]
+          Locations: [{Range: 0xce0da0..0xce0dfb, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xce0ce0..0xce0d47]
+      OutOfLinePCRanges: [0xce0e00..0xce0e67]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0xce0ce0..0xce0d47, Pieces: []}]
+          Locations: [{Range: 0xce0e00..0xce0e67, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0ce0..0xce0d47, Pieces: []}]
+          Locations: [{Range: 0xce0e00..0xce0e67, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xce0d60..0xce0dbd]
+      OutOfLinePCRanges: [0xce0e80..0xce0edd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce0d60..0xce0db0
+            - Range: 0xce0e80..0xce0ed0
               Pieces: []
-            - Range: 0xce0db0..0xce0db1
+            - Range: 0xce0ed0..0xce0ed1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0db1..0xce0dbd
+            - Range: 0xce0ed1..0xce0edd
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xce0d60..0xce0db0
+            - Range: 0xce0e80..0xce0ed0
               Pieces: []
-            - Range: 0xce0db0..0xce0db1
+            - Range: 0xce0ed0..0xce0ed1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce0db1..0xce0dbd
+            - Range: 0xce0ed1..0xce0edd
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xce0dc0..0xce0f45]
+      OutOfLinePCRanges: [0xce0ee0..0xce1065]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce0dc0..0xce0f45
+            - Range: 0xce0ee0..0xce1065
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce0dc0..0xce0f33
+            - Range: 0xce0ee0..0xce1053
               Pieces: []
-            - Range: 0xce0f33..0xce0f34
+            - Range: 0xce1053..0xce1054
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xce0f34..0xce0f45
+            - Range: 0xce1054..0xce1065
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xce0f60..0xce1032]
+      OutOfLinePCRanges: [0xce1080..0xce1152]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xce0f60..0xce1032
+            - Range: 0xce1080..0xce1152
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xce0f60..0xce1022
+            - Range: 0xce1080..0xce1142
               Pieces: []
-            - Range: 0xce1022..0xce1023
+            - Range: 0xce1142..0xce1143
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xce1023..0xce1032
+            - Range: 0xce1143..0xce1152
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xce1040..0xce127a]
+      OutOfLinePCRanges: [0xce1160..0xce139a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce1040..0xce127a
+            - Range: 0xce1160..0xce139a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce1040..0xce127a
+            - Range: 0xce1160..0xce139a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce1040..0xce126a
+            - Range: 0xce1160..0xce138a
               Pieces: []
-            - Range: 0xce126a..0xce126b
+            - Range: 0xce138a..0xce138b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xce126b..0xce127a
+            - Range: 0xce138b..0xce139a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xce1280..0xce150f]
+      OutOfLinePCRanges: [0xce13a0..0xce162f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1280..0xce1330
+            - Range: 0xce13a0..0xce1450
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1330..0xce150f
+            - Range: 0xce1450..0xce162f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1280..0xce1330
+            - Range: 0xce13a0..0xce1450
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce1330..0xce150f
+            - Range: 0xce1450..0xce162f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1280..0xce131a
+            - Range: 0xce13a0..0xce143a
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce131a..0xce150f
+            - Range: 0xce143a..0xce162f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1280..0xce12f0
+            - Range: 0xce13a0..0xce1410
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce12f0..0xce150f
+            - Range: 0xce1410..0xce162f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1280..0xce1330
+            - Range: 0xce13a0..0xce1450
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce1330..0xce150f
+            - Range: 0xce1450..0xce162f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1280..0xce1330
+            - Range: 0xce13a0..0xce1450
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce1330..0xce150f
+            - Range: 0xce1450..0xce162f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1280..0xce1330
+            - Range: 0xce13a0..0xce1450
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce1330..0xce150f
+            - Range: 0xce1450..0xce162f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1280..0xce1330
+            - Range: 0xce13a0..0xce1450
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce1330..0xce150f
+            - Range: 0xce1450..0xce162f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1280..0xce1330
+            - Range: 0xce13a0..0xce1450
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xce1330..0xce150f
+            - Range: 0xce1450..0xce162f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0xce1280..0xce14a2
+            - Range: 0xce13a0..0xce15c2
               Pieces: []
-            - Range: 0xce14a2..0xce14a3
+            - Range: 0xce15c2..0xce15c3
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xce14a3..0xce150f
+            - Range: 0xce15c3..0xce162f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xce1520..0xce17ec]
+      OutOfLinePCRanges: [0xce1640..0xce190c]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1520..0xce15cb
+            - Range: 0xce1640..0xce16eb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce15cb..0xce17ec
+            - Range: 0xce16eb..0xce190c
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1520..0xce15cb
+            - Range: 0xce1640..0xce16eb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce15cb..0xce17ec
+            - Range: 0xce16eb..0xce190c
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1520..0xce15b5
+            - Range: 0xce1640..0xce16d5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce15b5..0xce17ec
+            - Range: 0xce16d5..0xce190c
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1520..0xce1582
+            - Range: 0xce1640..0xce16a2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce1582..0xce17ec
+            - Range: 0xce16a2..0xce190c
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1520..0xce15cb
+            - Range: 0xce1640..0xce16eb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce15cb..0xce17ec
+            - Range: 0xce16eb..0xce190c
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1520..0xce15cb
+            - Range: 0xce1640..0xce16eb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce15cb..0xce17ec
+            - Range: 0xce16eb..0xce190c
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1520..0xce15cb
+            - Range: 0xce1640..0xce16eb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce15cb..0xce17ec
+            - Range: 0xce16eb..0xce190c
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1520..0xce15cb
+            - Range: 0xce1640..0xce16eb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce15cb..0xce17ec
+            - Range: 0xce16eb..0xce190c
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce1520..0xce17ec
+            - Range: 0xce1640..0xce190c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -8969,403 +8969,197 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce1520..0xce176b
+            - Range: 0xce1640..0xce188b
               Pieces: []
-            - Range: 0xce176b..0xce176c
+            - Range: 0xce188b..0xce188c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xce176c..0xce17ec
+            - Range: 0xce188c..0xce190c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xce1800..0xce188c]
+      OutOfLinePCRanges: [0xce1920..0xce19ac]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0xce1800..0xce188c
+            - Range: 0xce1920..0xce19ac
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1800..0xce187c
+            - Range: 0xce1920..0xce199c
               Pieces: []
-            - Range: 0xce187c..0xce187d
+            - Range: 0xce199c..0xce199d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce187d..0xce188c
+            - Range: 0xce199d..0xce19ac
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1800..0xce187c
+            - Range: 0xce1920..0xce199c
               Pieces: []
-            - Range: 0xce187c..0xce187d
+            - Range: 0xce199c..0xce199d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce187d..0xce188c
+            - Range: 0xce199d..0xce19ac
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1800..0xce187c
+            - Range: 0xce1920..0xce199c
               Pieces: []
-            - Range: 0xce187c..0xce187d
+            - Range: 0xce199c..0xce199d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce187d..0xce188c
+            - Range: 0xce199d..0xce19ac
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xce18a0..0xce198f]
+      OutOfLinePCRanges: [0xce19c0..0xce1aaf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0xce18a0..0xce198f
+            - Range: 0xce19c0..0xce1aaf
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xce18a0..0xce198f
+            - Range: 0xce19c0..0xce1aaf
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce18a0..0xce197f
+            - Range: 0xce19c0..0xce1a9f
               Pieces: []
-            - Range: 0xce197f..0xce1980
+            - Range: 0xce1a9f..0xce1aa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1980..0xce198f
+            - Range: 0xce1aa0..0xce1aaf
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0xce18a0..0xce197f
+            - Range: 0xce19c0..0xce1a9f
               Pieces: []
-            - Range: 0xce197f..0xce1980
+            - Range: 0xce1a9f..0xce1aa0
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xce1980..0xce198f
+            - Range: 0xce1aa0..0xce1aaf
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xce19a0..0xce1a6c]
+      OutOfLinePCRanges: [0xce1ac0..0xce1b8c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xce19a0..0xce1a6c
+            - Range: 0xce1ac0..0xce1b8c
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce19a0..0xce1a5c
+            - Range: 0xce1ac0..0xce1b7c
               Pieces: []
-            - Range: 0xce1a5c..0xce1a5d
+            - Range: 0xce1b7c..0xce1b7d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1a5d..0xce1a6c
+            - Range: 0xce1b7d..0xce1b8c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xce19a0..0xce1a5c
+            - Range: 0xce1ac0..0xce1b7c
               Pieces: []
-            - Range: 0xce1a5c..0xce1a5d
+            - Range: 0xce1b7c..0xce1b7d
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xce1a5d..0xce1a6c
+            - Range: 0xce1b7d..0xce1b8c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1a26..0xce1a6c
+            - Range: 0xce1b46..0xce1b8c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xce1a80..0xce1b26]
+      OutOfLinePCRanges: [0xce1ba0..0xce1c46]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 ArrayType [0]int
-          Locations: [{Range: 0xce1a80..0xce1b26, Pieces: []}]
+          Locations: [{Range: 0xce1ba0..0xce1c46, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1a80..0xce1ac5
+            - Range: 0xce1ba0..0xce1be5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1ac5..0xce1ae7
+            - Range: 0xce1be5..0xce1c07
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xce1ae7..0xce1afa
+            - Range: 0xce1c07..0xce1c1a
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xce1afa..0xce1b26
+            - Range: 0xce1c1a..0xce1c46
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1a80..0xce1b0c
+            - Range: 0xce1ba0..0xce1c2c
               Pieces: []
-            - Range: 0xce1b0c..0xce1b0d
+            - Range: 0xce1c2c..0xce1c2d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1b0d..0xce1b26
+            - Range: 0xce1c2d..0xce1c46
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0xce1a80..0xce1b0c
+            - Range: 0xce1ba0..0xce1c2c
               Pieces: []
-            - Range: 0xce1b0c..0xce1b0d
+            - Range: 0xce1c2c..0xce1c2d
               Pieces: []
-            - Range: 0xce1b0d..0xce1b26
+            - Range: 0xce1c2d..0xce1c46
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xce2020..0xce2021]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xce2020..0xce2021
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 134
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xce2040..0xce2041]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xce2040..0xce2041
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 135
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xce2060..0xce2061]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 258 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xce2060..0xce2061
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 136
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xce2080..0xce2081]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xce2080..0xce2081
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xce2080..0xce2081
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 137
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xce20a0..0xce20a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xce20a0..0xce20a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xce20a0..0xce20a1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 138
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xce20c0..0xce20c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xce20c0..0xce20c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xce20c0..0xce20c1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 139
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xce20e0..0xce20e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 263 GoSliceHeaderType []string
-          Locations:
-            - Range: 0xce20e0..0xce20e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 140
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xce2100..0xce2101]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 16 BaseType int8
-          Locations:
-            - Range: 0xce2100..0xce2101
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: s
-          Type: 264 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0xce2100..0xce2101
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: x
-          Type: 17 BaseType uint
-          Locations:
-            - Range: 0xce2100..0xce2101
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 141
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xce2120..0xce2121]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 265 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xce2120..0xce2121
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 142
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xce2140..0xce2141]
       InlinePCRanges: []
       Variables:
-        - Name: xs
+        - Name: u
           Type: 257 GoSliceHeaderType []uint
           Locations:
             - Range: 0xce2140..0xce2141
@@ -9379,13 +9173,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 143
-      Name: main.testSliceEmptyStructs
+    - ID: 134
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xce2160..0xce2161]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []struct {}
+        - Name: u
+          Type: 257 GoSliceHeaderType []uint
           Locations:
             - Range: 0xce2160..0xce2161
               Pieces:
@@ -9398,15 +9192,221 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 135
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xce2180..0xce2181]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 258 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xce2180..0xce2181
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 136
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xce21a0..0xce21a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xce21a0..0xce21a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xce21a0..0xce21a1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 137
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xce21c0..0xce21c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xce21c0..0xce21c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xce21c0..0xce21c1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xce21e0..0xce21e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xce21e0..0xce21e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xce21e0..0xce21e1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 139
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xce2200..0xce2201]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 263 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xce2200..0xce2201
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 140
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xce2220..0xce2221]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 16 BaseType int8
+          Locations:
+            - Range: 0xce2220..0xce2221
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: s
+          Type: 264 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0xce2220..0xce2221
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 17 BaseType uint
+          Locations:
+            - Range: 0xce2220..0xce2221
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 141
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xce2240..0xce2241]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 265 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0xce2240..0xce2241
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 142
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xce2260..0xce2261]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 257 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xce2260..0xce2261
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xce2280..0xce2281]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xce2280..0xce2281
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xce2180..0xce2181]
+      OutOfLinePCRanges: [0xce22a0..0xce22a1]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce2180..0xce2181
+            - Range: 0xce22a0..0xce22a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9419,7 +9419,7 @@ Subprograms:
         - Name: bs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce2180..0xce2181
+            - Range: 0xce22a0..0xce22a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9432,7 +9432,7 @@ Subprograms:
         - Name: cs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce2180..0xce2181
+            - Range: 0xce22a0..0xce22a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9445,34 +9445,34 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0xce2520..0xce2572]
+      OutOfLinePCRanges: [0xce2640..0xce2692]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2520..0xce2565
+            - Range: 0xce2640..0xce2685
               Pieces: []
-            - Range: 0xce2565..0xce2566
+            - Range: 0xce2685..0xce2686
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce2566..0xce2572
+            - Range: 0xce2686..0xce2692
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xce2580..0xce2581]
+      OutOfLinePCRanges: [0xce26a0..0xce26a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2580..0xce2581
+            - Range: 0xce26a0..0xce26a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9483,13 +9483,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xce25a0..0xce25a1]
+      OutOfLinePCRanges: [0xce26c0..0xce26c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce25a0..0xce25a1
+            - Range: 0xce26c0..0xce26c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9500,7 +9500,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce25a0..0xce25a1
+            - Range: 0xce26c0..0xce26c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9511,7 +9511,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce25a0..0xce25a1
+            - Range: 0xce26c0..0xce26c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9522,13 +9522,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xce25c0..0xce25df]
+      OutOfLinePCRanges: [0xce26e0..0xce26ff]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xce25c0..0xce25df
+            - Range: 0xce26e0..0xce26ff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9547,39 +9547,39 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xce25e0..0xce25e1]
+      OutOfLinePCRanges: [0xce2700..0xce2701]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 269 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xce25e0..0xce25e1
+            - Range: 0xce2700..0xce2701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xce2600..0xce2601]
+      OutOfLinePCRanges: [0xce2720..0xce2721]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xce2600..0xce2601
+            - Range: 0xce2720..0xce2721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xce2620..0xce2621]
+      OutOfLinePCRanges: [0xce2740..0xce2741]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2620..0xce2621
+            - Range: 0xce2740..0xce2741
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9590,13 +9590,13 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xce2640..0xce2641]
+      OutOfLinePCRanges: [0xce2760..0xce2761]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2640..0xce2641
+            - Range: 0xce2760..0xce2761
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9607,13 +9607,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xce2660..0xce2661]
+      OutOfLinePCRanges: [0xce2780..0xce2781]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2660..0xce2661
+            - Range: 0xce2780..0xce2781
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9624,13 +9624,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xce2680..0xce2681]
+      OutOfLinePCRanges: [0xce27a0..0xce27a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2680..0xce2681
+            - Range: 0xce27a0..0xce27a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9641,7 +9641,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2680..0xce2681
+            - Range: 0xce27a0..0xce27a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9652,7 +9652,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2680..0xce2681
+            - Range: 0xce27a0..0xce27a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9663,26 +9663,26 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xce2800..0xce2801]
+      OutOfLinePCRanges: [0xce2920..0xce2921]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xce2800..0xce2801
+            - Range: 0xce2920..0xce2921
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xce2820..0xce283f]
+      OutOfLinePCRanges: [0xce2940..0xce295f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 285 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xce2820..0xce283f
+            - Range: 0xce2940..0xce295f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9701,13 +9701,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0xce2960..0xce2983]
+      OutOfLinePCRanges: [0xce2a80..0xce2aa3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 316 StructureType main.aStruct
           Locations:
-            - Range: 0xce2960..0xce2983
+            - Range: 0xce2a80..0xce2aa3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9728,91 +9728,91 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xce2a60..0xce2a61]
+      OutOfLinePCRanges: [0xce2b80..0xce2b81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xce2a60..0xce2a61
+            - Range: 0xce2b80..0xce2b81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xce2a80..0xce2a81]
+      OutOfLinePCRanges: [0xce2ba0..0xce2ba1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 319 StructureType main.tenStrings
           Locations:
-            - Range: 0xce2a80..0xce2a81
+            - Range: 0xce2ba0..0xce2ba1
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xce2ae0..0xce2ae1]
+      OutOfLinePCRanges: [0xce2c00..0xce2c01]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 320 StructureType main.emptyStruct
-          Locations: [{Range: 0xce2ae0..0xce2ae1, Pieces: []}]
+          Locations: [{Range: 0xce2c00..0xce2c01, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xce2b00..0xce2b01]
+      OutOfLinePCRanges: [0xce2c20..0xce2c21]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 321 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xce2b00..0xce2b01
+            - Range: 0xce2c20..0xce2c21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xce4cc0..0xce4cc4]
+      OutOfLinePCRanges: [0xce4de0..0xce4de4]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce4cc0..0xce4cc4
+            - Range: 0xce4de0..0xce4de4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce4cc0..0xce4cc3
+            - Range: 0xce4de0..0xce4de3
               Pieces: []
-            - Range: 0xce4cc3..0xce4cc4
+            - Range: 0xce4de3..0xce4de4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xce4ce0..0xce4cec]
+      OutOfLinePCRanges: [0xce4e00..0xce4e0c]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce4ce0..0xce4ceb
+            - Range: 0xce4e00..0xce4e0b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce4ceb..0xce4cec
+            - Range: 0xce4e0b..0xce4e0c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9823,9 +9823,9 @@ Subprograms:
         - Name: ~r0
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce4ce0..0xce4ceb
+            - Range: 0xce4e00..0xce4e0b
               Pieces: []
-            - Range: 0xce4ceb..0xce4cec
+            - Range: 0xce4e0b..0xce4e0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9836,41 +9836,41 @@ Subprograms:
       DictRegister: 0
     - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xce4d00..0xce4d04]
+      OutOfLinePCRanges: [0xce4e20..0xce4e24]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce4d00..0xce4d04
+            - Range: 0xce4e20..0xce4e24
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce4d00..0xce4d03
+            - Range: 0xce4e20..0xce4e23
               Pieces: []
-            - Range: 0xce4d03..0xce4d04
+            - Range: 0xce4e23..0xce4e24
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xce4d20..0xce4d2c]
+      OutOfLinePCRanges: [0xce4e40..0xce4e4c]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce4d20..0xce4d2b
+            - Range: 0xce4e40..0xce4e4b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce4d2b..0xce4d2c
+            - Range: 0xce4e4b..0xce4e4c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9881,9 +9881,9 @@ Subprograms:
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce4d20..0xce4d2b
+            - Range: 0xce4e40..0xce4e4b
               Pieces: []
-            - Range: 0xce4d2b..0xce4d2c
+            - Range: 0xce4e4b..0xce4e4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9894,13 +9894,13 @@ Subprograms:
       DictRegister: 0
     - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xce4da0..0xce4ed6]
+      OutOfLinePCRanges: [0xce4ec0..0xce4ff6]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce4da0..0xce4dd3
+            - Range: 0xce4ec0..0xce4ef3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9908,7 +9908,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce4dd3..0xce4ddb
+            - Range: 0xce4ef3..0xce4efb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9916,7 +9916,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xce4ddb..0xce4ed6
+            - Range: 0xce4efb..0xce4ff6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9929,18 +9929,18 @@ Subprograms:
         - Name: pred
           Type: 328 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xce4da0..0xce4ddb
+            - Range: 0xce4ec0..0xce4efb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce4ddb..0xce4ed6
+            - Range: 0xce4efb..0xce4ff6
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce4da0..0xce4e94
+            - Range: 0xce4ec0..0xce4fb4
               Pieces: []
-            - Range: 0xce4e94..0xce4e95
+            - Range: 0xce4fb4..0xce4fb5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9948,14 +9948,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce4e95..0xce4ed6
+            - Range: 0xce4fb5..0xce4ff6
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce4ddb..0xce4df9
+            - Range: 0xce4efb..0xce4f19
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9963,7 +9963,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce4df9..0xce4e01
+            - Range: 0xce4f19..0xce4f21
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9971,7 +9971,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce4e01..0xce4e09
+            - Range: 0xce4f21..0xce4f29
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9979,7 +9979,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce4e09..0xce4e09
+            - Range: 0xce4f29..0xce4f29
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9987,7 +9987,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce4e09..0xce4e33
+            - Range: 0xce4f29..0xce4f53
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -9995,7 +9995,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce4e33..0xce4e8b
+            - Range: 0xce4f53..0xce4fab
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10003,7 +10003,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce4e8b..0xce4ed6
+            - Range: 0xce4fab..0xce4ff6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10016,132 +10016,132 @@ Subprograms:
         - Name: item
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce4e26..0xce4e33
+            - Range: 0xce4f46..0xce4f53
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce4e33..0xce4e8b
+            - Range: 0xce4f53..0xce4fab
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce4ee0..0xce4f24]
+      OutOfLinePCRanges: [0xce5000..0xce5044]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce4ee0..0xce4ef9
+            - Range: 0xce5000..0xce5019
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 329 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xce4ee0..0xce4ef9
+            - Range: 0xce5000..0xce5019
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce4ee0..0xce4ef9
+            - Range: 0xce5000..0xce5019
               Pieces: []
-            - Range: 0xce4ef9..0xce4efa
+            - Range: 0xce5019..0xce501a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4efa..0xce4f24
+            - Range: 0xce501a..0xce5044
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 168
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xce51c0..0xce51c4]
+      OutOfLinePCRanges: [0xce52e0..0xce52e4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 327 PointerType *go.shape.int
           Locations:
-            - Range: 0xce51c0..0xce51c4
+            - Range: 0xce52e0..0xce52e4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 327 PointerType *go.shape.int
           Locations:
-            - Range: 0xce51c0..0xce51c3
+            - Range: 0xce52e0..0xce52e3
               Pieces: []
-            - Range: 0xce51c3..0xce51c4
+            - Range: 0xce52e3..0xce52e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xce51e0..0xce51e4]
+      OutOfLinePCRanges: [0xce5300..0xce5304]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 330 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce51e0..0xce51e4
+            - Range: 0xce5300..0xce5304
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce51e0..0xce51e3
+            - Range: 0xce5300..0xce5303
               Pieces: []
-            - Range: 0xce51e3..0xce51e4
+            - Range: 0xce5303..0xce5304
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xce5200..0xce5204]
+      OutOfLinePCRanges: [0xce5320..0xce5324]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 332 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce5200..0xce5204
+            - Range: 0xce5320..0xce5324
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 332 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce5200..0xce5203
+            - Range: 0xce5320..0xce5323
               Pieces: []
-            - Range: 0xce5203..0xce5204
+            - Range: 0xce5323..0xce5324
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xce5220..0xce5231]
+      OutOfLinePCRanges: [0xce5340..0xce5351]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xce5220..0xce5231
+            - Range: 0xce5340..0xce5351
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5220..0xce5230
+            - Range: 0xce5340..0xce5350
               Pieces: []
-            - Range: 0xce5230..0xce5231
+            - Range: 0xce5350..0xce5351
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10152,69 +10152,69 @@ Subprograms:
       DictRegister: 0
     - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xce52c0..0xce52c9]
+      OutOfLinePCRanges: [0xce53e0..0xce53e9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 336 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xce52c0..0xce52c9
+            - Range: 0xce53e0..0xce53e9
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce52c0..0xce52c8
+            - Range: 0xce53e0..0xce53e8
               Pieces: []
-            - Range: 0xce52c8..0xce52c9
+            - Range: 0xce53e8..0xce53e9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xce5380..0xce5388]
+      OutOfLinePCRanges: [0xce54a0..0xce54a8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 337 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xce5380..0xce5388
+            - Range: 0xce54a0..0xce54a8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce5380..0xce5388
+            - Range: 0xce54a0..0xce54a8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0xce5380..0xce5388
+            - Range: 0xce54a0..0xce54a8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xce5420..0xce548e]
+      OutOfLinePCRanges: [0xce5540..0xce55ae]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xce5420..0xce548e
+            - Range: 0xce5540..0xce55ae
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5420..0xce548e
+            - Range: 0xce5540..0xce55ae
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10225,20 +10225,20 @@ Subprograms:
         - Name: v
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce5420..0xce548e
+            - Range: 0xce5540..0xce55ae
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xce5520..0xce5528]
+      OutOfLinePCRanges: [0xce5640..0xce5648]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5520..0xce5528
+            - Range: 0xce5640..0xce5648
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10249,25 +10249,25 @@ Subprograms:
         - Name: b
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0xce5520..0xce5528
+            - Range: 0xce5640..0xce5648
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0xce5520..0xce5527
+            - Range: 0xce5640..0xce5647
               Pieces: []
-            - Range: 0xce5527..0xce5528
+            - Range: 0xce5647..0xce5648
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5520..0xce5527
+            - Range: 0xce5640..0xce5647
               Pieces: []
-            - Range: 0xce5527..0xce5528
+            - Range: 0xce5647..0xce5648
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10278,26 +10278,26 @@ Subprograms:
       DictRegister: 0
     - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce5540..0xce554f]
+      OutOfLinePCRanges: [0xce5660..0xce566f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce5540..0xce554e
+            - Range: 0xce5660..0xce566e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5540..0xce554b
+            - Range: 0xce5660..0xce566b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce554b..0xce554f
+            - Range: 0xce566b..0xce566f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10308,9 +10308,9 @@ Subprograms:
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5540..0xce554e
+            - Range: 0xce5660..0xce566e
               Pieces: []
-            - Range: 0xce554e..0xce554f
+            - Range: 0xce566e..0xce566f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10321,56 +10321,56 @@ Subprograms:
         - Name: ~r1
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce5540..0xce554e
+            - Range: 0xce5660..0xce566e
               Pieces: []
-            - Range: 0xce554e..0xce554f
+            - Range: 0xce566e..0xce566f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xce5560..0xce559a]
+      OutOfLinePCRanges: [0xce5680..0xce56ba]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 342 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xce5560..0xce5579
+            - Range: 0xce5680..0xce5699
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce5560..0xce5579
+            - Range: 0xce5680..0xce5699
               Pieces: []
-            - Range: 0xce5579..0xce557a
+            - Range: 0xce5699..0xce569a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce557a..0xce559a
+            - Range: 0xce569a..0xce56ba
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xce55a0..0xce55ed]
+      OutOfLinePCRanges: [0xce56c0..0xce570d]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 343 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xce55a0..0xce55bf
+            - Range: 0xce56c0..0xce56df
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce55bf..0xce55c2
+            - Range: 0xce56df..0xce56e2
               Pieces:
                 - Size: 8
                   Op: null
@@ -10381,37 +10381,37 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce55a0..0xce55c2
+            - Range: 0xce56c0..0xce56e2
               Pieces: []
-            - Range: 0xce55c2..0xce55c3
+            - Range: 0xce56e2..0xce56e3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce55c3..0xce55ed
+            - Range: 0xce56e3..0xce570d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xce5600..0xce5608]
+      OutOfLinePCRanges: [0xce5720..0xce5728]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 344 PointerType *go.shape.string
           Locations:
-            - Range: 0xce5600..0xce5607
+            - Range: 0xce5720..0xce5727
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5600..0xce5607
+            - Range: 0xce5720..0xce5727
               Pieces: []
-            - Range: 0xce5607..0xce5608
+            - Range: 0xce5727..0xce5728
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10422,22 +10422,22 @@ Subprograms:
       DictRegister: 0
     - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xce5620..0xce5677]
+      OutOfLinePCRanges: [0xce5740..0xce5797]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 345 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce5620..0xce565d
+            - Range: 0xce5740..0xce577d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 346 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce5620..0xce5671
+            - Range: 0xce5740..0xce5791
               Pieces: []
-            - Range: 0xce5671..0xce5672
+            - Range: 0xce5791..0xce5792
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10451,20 +10451,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce5672..0xce5677
+            - Range: 0xce5792..0xce5797
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xce5680..0xce56a4]
+      OutOfLinePCRanges: [0xce57a0..0xce57c4]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce5680..0xce56a4
+            - Range: 0xce57a0..0xce57c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10477,33 +10477,33 @@ Subprograms:
         - Name: needle
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce5680..0xce56a4
+            - Range: 0xce57a0..0xce57c4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce5680..0xce56a0
+            - Range: 0xce57a0..0xce57c0
               Pieces: []
-            - Range: 0xce56a0..0xce56a1
+            - Range: 0xce57c0..0xce57c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce56a1..0xce56a3
+            - Range: 0xce57c1..0xce57c3
               Pieces: []
-            - Range: 0xce56a3..0xce56a4
+            - Range: 0xce57c3..0xce57c4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xce56c0..0xce577f]
+      OutOfLinePCRanges: [0xce57e0..0xce589f]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 347 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xce56c0..0xce56dd
+            - Range: 0xce57e0..0xce57fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10511,7 +10511,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce56dd..0xce56df
+            - Range: 0xce57fd..0xce57ff
               Pieces:
                 - Size: 8
                   Op: null
@@ -10524,13 +10524,13 @@ Subprograms:
         - Name: needle
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce56c0..0xce570c
+            - Range: 0xce57e0..0xce582c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce570c..0xce577f
+            - Range: 0xce582c..0xce589f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10541,28 +10541,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce56c0..0xce572b
+            - Range: 0xce57e0..0xce584b
               Pieces: []
-            - Range: 0xce572b..0xce572c
+            - Range: 0xce584b..0xce584c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce572c..0xce5733
+            - Range: 0xce584c..0xce5853
               Pieces: []
-            - Range: 0xce5733..0xce5734
+            - Range: 0xce5853..0xce5854
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce5734..0xce577f
+            - Range: 0xce5854..0xce589f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce56ef..0xce5701
+            - Range: 0xce580f..0xce5821
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xce5701..0xce570c
+            - Range: 0xce5821..0xce582c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10573,54 +10573,54 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xce5780..0xce5787]
+      OutOfLinePCRanges: [0xce58a0..0xce58a7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 348 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xce5780..0xce5786
+            - Range: 0xce58a0..0xce58a6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce5780..0xce5787
+            - Range: 0xce58a0..0xce58a7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce5780..0xce5786
+            - Range: 0xce58a0..0xce58a6
               Pieces: []
-            - Range: 0xce5786..0xce5787
+            - Range: 0xce58a6..0xce58a7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
     - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xce5800..0xce586c]
+      OutOfLinePCRanges: [0xce5920..0xce598c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 349 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xce5800..0xce5820
+            - Range: 0xce5920..0xce5940
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce5820..0xce5828
+            - Range: 0xce5940..0xce5948
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce5828..0xce582d
+            - Range: 0xce5948..0xce594d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10631,7 +10631,7 @@ Subprograms:
         - Name: value
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5800..0xce582d
+            - Range: 0xce5920..0xce594d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10642,11 +10642,11 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce5800..0xce582d
+            - Range: 0xce5920..0xce594d
               Pieces: []
-            - Range: 0xce582d..0xce582e
+            - Range: 0xce594d..0xce594e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce582e..0xce586c
+            - Range: 0xce594e..0xce598c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10784,31 +10784,31 @@ Subprograms:
       DictRegister: 0
     - ID: 186
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcdc180..0xcdc1e2]
+      OutOfLinePCRanges: [0xcdc2a0..0xcdc302]
       InlinePCRanges:
-        - Ranges: [0xcdc211..0xcdc24d]
-          RootRanges: [0xcdc200..0xcdc271]
-        - Ranges: [0xcdc352..0xcdc38e]
-          RootRanges: [0xcdc320..0xcdc3a8]
-        - Ranges: [0xcdc3dc..0xcdc418]
-          RootRanges: [0xcdc3c0..0xcdc485]
-        - Ranges: [0xcdc4af..0xcdc4eb]
-          RootRanges: [0xcdc4a0..0xcdc502]
+        - Ranges: [0xcdc331..0xcdc36d]
+          RootRanges: [0xcdc320..0xcdc391]
+        - Ranges: [0xcdc472..0xcdc4ae]
+          RootRanges: [0xcdc440..0xcdc4c8]
+        - Ranges: [0xcdc4fc..0xcdc538]
+          RootRanges: [0xcdc4e0..0xcdc5a5]
+        - Ranges: [0xcdc5cf..0xcdc60b]
+          RootRanges: [0xcdc5c0..0xcdc622]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc180..0xcdc199
+            - Range: 0xcdc2a0..0xcdc2b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc211..0xcdc21c
+            - Range: 0xcdc331..0xcdc33c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc352..0xcdc35d
+            - Range: 0xcdc472..0xcdc47d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc3d6..0xcdc3e7
+            - Range: 0xcdc4f6..0xcdc507
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc3e7..0xcdc485
+            - Range: 0xcdc507..0xcdc5a5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcdc4a0..0xcdc4ba
+            - Range: 0xcdc5c0..0xcdc5da
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10817,37 +10817,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdc426..0xcdc45e]
-          RootRanges: [0xcdc3c0..0xcdc485]
+        - Ranges: [0xcdc546..0xcdc57e]
+          RootRanges: [0xcdc4e0..0xcdc5a5]
       Variables: []
       DictRegister: null
     - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdc533..0xcdc571]
-          RootRanges: [0xcdc520..0xcdc625]
+        - Ranges: [0xcdc653..0xcdc691]
+          RootRanges: [0xcdc640..0xcdc745]
       Variables: []
       DictRegister: null
     - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdc5db..0xcdc613]
-          RootRanges: [0xcdc520..0xcdc625]
+        - Ranges: [0xcdc6fb..0xcdc733]
+          RootRanges: [0xcdc640..0xcdc745]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdc641..0xcdc645]
-          RootRanges: [0xcdc640..0xcdc646]
+        - Ranges: [0xcdc761..0xcdc765]
+          RootRanges: [0xcdc760..0xcdc766]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc640..0xcdc645
+            - Range: 0xcdc760..0xcdc765
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10856,32 +10856,32 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdc685..0xcdc69d]
-          RootRanges: [0xcdc660..0xcdc6a3]
-        - Ranges: [0xcdc725..0xcdc743]
-          RootRanges: [0xcdc6c0..0xcdc845]
+        - Ranges: [0xcdc7a5..0xcdc7bd]
+          RootRanges: [0xcdc780..0xcdc7c3]
+        - Ranges: [0xcdc845..0xcdc863]
+          RootRanges: [0xcdc7e0..0xcdc965]
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0xcdc66d..0xcdc6a3
+            - Range: 0xcdc78d..0xcdc7c3
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xcdc70c..0xcdc845
+            - Range: 0xcdc82c..0xcdc965
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 192
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xcdc860..0xcdc8c6]
+      OutOfLinePCRanges: [0xcdc980..0xcdc9e6]
       InlinePCRanges:
-        - Ranges: [0xce5923..0xce5951]
-          RootRanges: [0xce5900..0xce597f]
+        - Ranges: [0xce5a43..0xce5a71]
+          RootRanges: [0xce5a20..0xce5a9f]
       Variables:
         - Name: b
           Type: 354 StructureType main.firstBehavior
           Locations:
-            - Range: 0xcdc860..0xcdc87e
+            - Range: 0xcdc980..0xcdc99e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10892,15 +10892,15 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdc860..0xcdc8a5
+            - Range: 0xcdc980..0xcdc9c5
               Pieces: []
-            - Range: 0xcdc8a5..0xcdc8a6
+            - Range: 0xcdc9c5..0xcdc9c6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdc8a6..0xcdc8c6
+            - Range: 0xcdc9c6..0xcdc9e6
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10909,8 +10909,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdcfab..0xcdcfb2]
-          RootRanges: [0xcdce60..0xcdcff8]
+        - Ranges: [0xcdd0d0..0xcdd0d7]
+          RootRanges: [0xcdcf80..0xcdd118]
         - Ranges: [0x52bec1..0x52bec9]
           RootRanges: [0x52bec0..0x52beca]
       Variables: []
@@ -11271,7 +11271,7 @@ Types:
       ID: 1189
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.99632e+06
+      GoRuntimeType: 1.996576e+06
       GoKind: 22
       Pointee: 1190 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
@@ -11290,7 +11290,7 @@ Types:
       ID: 1124
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.443008e+06
+      GoRuntimeType: 1.443104e+06
       GoKind: 22
       Pointee: 1125 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
@@ -11311,21 +11311,21 @@ Types:
       ID: 1168
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.914464e+06
+      GoRuntimeType: 1.91472e+06
       GoKind: 22
       Pointee: 1169 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 1100
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.062912e+06
+      GoRuntimeType: 1.063008e+06
       GoKind: 22
       Pointee: 1101 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 1102
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.063168e+06
+      GoRuntimeType: 1.063264e+06
       GoKind: 22
       Pointee: 1103 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
@@ -11339,21 +11339,21 @@ Types:
       ID: 1147
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.18512e+06
+      GoRuntimeType: 2.185376e+06
       GoKind: 22
       Pointee: 1148 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1178
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.959712e+06
+      GoRuntimeType: 1.959968e+06
       GoKind: 22
       Pointee: 1179 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1227
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.277984e+06
+      GoRuntimeType: 2.27824e+06
       GoKind: 22
       Pointee: 1228 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -11379,7 +11379,7 @@ Types:
       ID: 1122
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.432608e+06
+      GoRuntimeType: 1.432704e+06
       GoKind: 22
       Pointee: 1123 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
@@ -11393,14 +11393,14 @@ Types:
       ID: 1144
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.735744e+06
+      GoRuntimeType: 1.736e+06
       GoKind: 22
       Pointee: 1145 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 972
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.209984e+06
+      GoRuntimeType: 1.21008e+06
       GoKind: 22
       Pointee: 973 StructureType context.deadlineExceededError
     - __kind: PointerType
@@ -11428,49 +11428,49 @@ Types:
       ID: 1139
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
-      GoRuntimeType: 1.67648e+06
+      GoRuntimeType: 1.676736e+06
       GoKind: 22
       Pointee: 1140 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
       ID: 921
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
-      GoRuntimeType: 1.07072e+06
+      GoRuntimeType: 1.070816e+06
       GoKind: 22
       Pointee: 922 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
       ID: 1170
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.914976e+06
+      GoRuntimeType: 1.915232e+06
       GoKind: 22
       Pointee: 1171 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
       ID: 1200
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
-      GoRuntimeType: 2.130272e+06
+      GoRuntimeType: 2.130528e+06
       GoKind: 22
       Pointee: 1201 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
       ID: 1174
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.915488e+06
+      GoRuntimeType: 1.915744e+06
       GoKind: 22
       Pointee: 1175 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
       ID: 1172
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.915232e+06
+      GoRuntimeType: 1.915488e+06
       GoKind: 22
       Pointee: 1173 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
       ID: 1166
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.912672e+06
+      GoRuntimeType: 1.912928e+06
       GoKind: 22
       Pointee: 1167 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
@@ -11484,14 +11484,14 @@ Types:
       ID: 1187
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 1.99344e+06
+      GoRuntimeType: 1.993696e+06
       GoKind: 22
       Pointee: 1188 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1162
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
-      GoRuntimeType: 1.882048e+06
+      GoRuntimeType: 1.882304e+06
       GoKind: 22
       Pointee: 1163 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
@@ -11505,14 +11505,14 @@ Types:
       ID: 910
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.05152e+06
+      GoRuntimeType: 1.051616e+06
       GoKind: 22
       Pointee: 911 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1253
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.389504e+06
+      GoRuntimeType: 2.38976e+06
       GoKind: 22
       Pointee: 1254 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
@@ -11533,14 +11533,14 @@ Types:
       ID: 909
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.049856e+06
+      GoRuntimeType: 1.049952e+06
       GoKind: 22
       Pointee: 864 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 1132
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.567872e+06
+      GoRuntimeType: 1.568128e+06
       GoKind: 22
       Pointee: 1133 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
@@ -11554,21 +11554,21 @@ Types:
       ID: 1137
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.65152e+06
+      GoRuntimeType: 1.651776e+06
       GoKind: 22
       Pointee: 1138 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 1007
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.433088e+06
+      GoRuntimeType: 1.433184e+06
       GoKind: 22
       Pointee: 1008 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 1024
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.052608e+06
+      GoRuntimeType: 2.052864e+06
       GoKind: 22
       Pointee: 1025 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
@@ -11603,7 +11603,7 @@ Types:
       ID: 915
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.05728e+06
+      GoRuntimeType: 1.057376e+06
       GoKind: 22
       Pointee: 916 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
@@ -11652,7 +11652,7 @@ Types:
       ID: 1090
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.047296e+06
+      GoRuntimeType: 1.047392e+06
       GoKind: 22
       Pointee: 1091 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -11673,7 +11673,7 @@ Types:
       ID: 899
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.043456e+06
+      GoRuntimeType: 1.043552e+06
       GoKind: 22
       Pointee: 900 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
@@ -11708,7 +11708,7 @@ Types:
       ID: 1233
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.30352e+06
+      GoRuntimeType: 2.303776e+06
       GoKind: 22
       Pointee: 1234 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
@@ -11722,7 +11722,7 @@ Types:
       ID: 1098
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.05984e+06
+      GoRuntimeType: 1.059936e+06
       GoKind: 22
       Pointee: 1099 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
@@ -11762,7 +11762,7 @@ Types:
       ID: 1211
       Name: '*encoding/xml.printer'
       ByteSize: 8
-      GoRuntimeType: 2.170112e+06
+      GoRuntimeType: 2.170368e+06
       GoKind: 22
       Pointee: 1212 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
@@ -11783,7 +11783,7 @@ Types:
       ID: 866
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1.027968e+06
+      GoRuntimeType: 1.028064e+06
       GoKind: 22
       Pointee: 867 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -11804,21 +11804,21 @@ Types:
       ID: 1221
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.270304e+06
+      GoRuntimeType: 2.27056e+06
       GoKind: 22
       Pointee: 1222 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 868
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.028096e+06
+      GoRuntimeType: 1.028192e+06
       GoKind: 22
       Pointee: 869 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 870
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.028224e+06
+      GoRuntimeType: 1.02832e+06
       GoKind: 22
       Pointee: 871 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -11903,14 +11903,14 @@ Types:
       ID: 1110
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.215488e+06
+      GoRuntimeType: 1.215584e+06
       GoKind: 22
       Pointee: 1111 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1197
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 2.067936e+06
+      GoRuntimeType: 2.068192e+06
       GoKind: 22
       Pointee: 1198 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
@@ -11924,14 +11924,14 @@ Types:
       ID: 981
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.219072e+06
+      GoRuntimeType: 1.219168e+06
       GoKind: 22
       Pointee: 982 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1229
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.280032e+06
+      GoRuntimeType: 2.280288e+06
       GoKind: 22
       Pointee: 1230 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
@@ -12083,7 +12083,7 @@ Types:
       ID: 1150
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.812608e+06
+      GoRuntimeType: 1.812864e+06
       GoKind: 22
       Pointee: 1151 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
@@ -12097,21 +12097,21 @@ Types:
       ID: 1130
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.566592e+06
+      GoRuntimeType: 1.566848e+06
       GoKind: 22
       Pointee: 1131 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 1086
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.046144e+06
+      GoRuntimeType: 1.04624e+06
       GoKind: 22
       Pointee: 1087 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1120
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.430688e+06
+      GoRuntimeType: 1.430784e+06
       GoKind: 22
       Pointee: 1121 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
@@ -12125,28 +12125,28 @@ Types:
       ID: 1185
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.985952e+06
+      GoRuntimeType: 1.986208e+06
       GoKind: 22
       Pointee: 1186 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1204
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.143296e+06
+      GoRuntimeType: 2.143552e+06
       GoKind: 22
       Pointee: 1199 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1203
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.142912e+06
+      GoRuntimeType: 2.143168e+06
       GoKind: 22
       Pointee: 1202 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 1088
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.046272e+06
+      GoRuntimeType: 1.046368e+06
       GoKind: 22
       Pointee: 1089 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
@@ -12167,70 +12167,70 @@ Types:
       ID: 1152
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.8144e+06
+      GoRuntimeType: 1.814656e+06
       GoKind: 22
       Pointee: 1153 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1193
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.021792e+06
+      GoRuntimeType: 2.022048e+06
       GoKind: 22
       Pointee: 1194 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1195
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.052288e+06
+      GoRuntimeType: 2.052544e+06
       GoKind: 22
       Pointee: 1196 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 1012
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.445408e+06
+      GoRuntimeType: 1.445504e+06
       GoKind: 22
       Pointee: 1013 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 925
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.071488e+06
+      GoRuntimeType: 1.071584e+06
       GoKind: 22
       Pointee: 926 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 923
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.07136e+06
+      GoRuntimeType: 1.071456e+06
       GoKind: 22
       Pointee: 924 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 927
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.075456e+06
+      GoRuntimeType: 1.075552e+06
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 929
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.075584e+06
+      GoRuntimeType: 1.07568e+06
       GoKind: 22
       Pointee: 930 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 1141
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.678784e+06
+      GoRuntimeType: 1.67904e+06
       GoKind: 22
       Pointee: 1142 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 917
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.05792e+06
+      GoRuntimeType: 1.058016e+06
       GoKind: 22
       Pointee: 918 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
@@ -12244,112 +12244,112 @@ Types:
       ID: 1245
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.365952e+06
+      GoRuntimeType: 2.366208e+06
       GoKind: 22
       Pointee: 1246 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 983
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.227648e+06
+      GoRuntimeType: 1.227744e+06
       GoKind: 22
       Pointee: 984 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 956
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.206528e+06
+      GoRuntimeType: 1.206624e+06
       GoKind: 22
       Pointee: 957 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 950
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.206144e+06
+      GoRuntimeType: 1.20624e+06
       GoKind: 22
       Pointee: 951 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 885
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.03744e+06
+      GoRuntimeType: 1.037536e+06
       GoKind: 22
       Pointee: 886 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 962
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.206912e+06
+      GoRuntimeType: 1.207008e+06
       GoKind: 22
       Pointee: 963 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 884
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1.037312e+06
+      GoRuntimeType: 1.037408e+06
       GoKind: 22
       Pointee: 863 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 954
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.2064e+06
+      GoRuntimeType: 1.206496e+06
       GoKind: 22
       Pointee: 955 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 952
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.206272e+06
+      GoRuntimeType: 1.206368e+06
       GoKind: 22
       Pointee: 953 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 960
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.206784e+06
+      GoRuntimeType: 1.20688e+06
       GoKind: 22
       Pointee: 961 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 958
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.206656e+06
+      GoRuntimeType: 1.206752e+06
       GoKind: 22
       Pointee: 959 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1249
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.37856e+06
+      GoRuntimeType: 2.378816e+06
       GoKind: 22
       Pointee: 1250 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 966
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.207296e+06
+      GoRuntimeType: 1.207392e+06
       GoKind: 22
       Pointee: 967 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 889
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1.037696e+06
+      GoRuntimeType: 1.037792e+06
       GoKind: 22
       Pointee: 890 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 887
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1.037568e+06
+      GoRuntimeType: 1.037664e+06
       GoKind: 22
       Pointee: 888 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 964
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.207168e+06
+      GoRuntimeType: 1.207264e+06
       GoKind: 22
       Pointee: 965 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -12412,35 +12412,35 @@ Types:
       ID: 1027
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.677248e+06
+      GoRuntimeType: 1.677504e+06
       GoKind: 22
       Pointee: 1028 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 933
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.090304e+06
+      GoRuntimeType: 1.0904e+06
       GoKind: 22
       Pointee: 934 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 1116
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.267456e+06
+      GoRuntimeType: 1.267552e+06
       GoKind: 22
       Pointee: 1117 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1209
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.158272e+06
+      GoRuntimeType: 2.158528e+06
       GoKind: 22
       Pointee: 1210 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 1104
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.092608e+06
+      GoRuntimeType: 1.092704e+06
       GoKind: 22
       Pointee: 1105 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
@@ -12454,7 +12454,7 @@ Types:
       ID: 991
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.26912e+06
+      GoRuntimeType: 1.269216e+06
       GoKind: 22
       Pointee: 992 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
@@ -12516,7 +12516,7 @@ Types:
       ID: 1207
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.156352e+06
+      GoRuntimeType: 2.156608e+06
       GoKind: 22
       Pointee: 1208 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -12544,14 +12544,14 @@ Types:
       ID: 989
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.266176e+06
+      GoRuntimeType: 1.266272e+06
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 1014
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.452768e+06
+      GoRuntimeType: 1.452864e+06
       GoKind: 22
       Pointee: 1015 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
@@ -12565,21 +12565,21 @@ Types:
       ID: 1156
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.82e+06
+      GoRuntimeType: 1.820256e+06
       GoKind: 22
       Pointee: 1157 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 1114
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.26272e+06
+      GoRuntimeType: 1.262816e+06
       GoKind: 22
       Pointee: 1115 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 931
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.084544e+06
+      GoRuntimeType: 1.08464e+06
       GoKind: 22
       Pointee: 932 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
@@ -12600,21 +12600,21 @@ Types:
       ID: 919
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.061248e+06
+      GoRuntimeType: 1.061344e+06
       GoKind: 22
       Pointee: 920 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 987
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.234048e+06
+      GoRuntimeType: 1.234144e+06
       GoKind: 22
       Pointee: 988 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 985
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.233792e+06
+      GoRuntimeType: 1.233888e+06
       GoKind: 22
       Pointee: 986 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
@@ -12642,7 +12642,7 @@ Types:
       ID: 1164
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.910624e+06
+      GoRuntimeType: 1.91088e+06
       GoKind: 22
       Pointee: 1165 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
@@ -12698,7 +12698,7 @@ Types:
       ID: 1016
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 2.222624e+06
+      GoRuntimeType: 2.22288e+06
       GoKind: 22
       Pointee: 1017 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
@@ -12726,21 +12726,21 @@ Types:
       ID: 948
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.205376e+06
+      GoRuntimeType: 1.205472e+06
       GoKind: 22
       Pointee: 949 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1251
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.384224e+06
+      GoRuntimeType: 2.38448e+06
       GoKind: 22
       Pointee: 1252 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 946
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.205248e+06
+      GoRuntimeType: 1.205344e+06
       GoKind: 22
       Pointee: 947 StructureType internal/poll.errNetClosing
     - __kind: PointerType
@@ -12766,42 +12766,42 @@ Types:
       ID: 903
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.048192e+06
+      GoRuntimeType: 1.048288e+06
       GoKind: 22
       Pointee: 904 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
       ID: 1108
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.196928e+06
+      GoRuntimeType: 1.197024e+06
       GoKind: 22
       Pointee: 1109 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1106
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.196544e+06
+      GoRuntimeType: 1.19664e+06
       GoKind: 22
       Pointee: 1107 StructureType io.discard
     - __kind: PointerType
       ID: 1080
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.028992e+06
+      GoRuntimeType: 1.029088e+06
       GoKind: 22
       Pointee: 1081 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 944
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.204736e+06
+      GoRuntimeType: 1.204832e+06
       GoKind: 22
       Pointee: 945 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 1154
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.814624e+06
+      GoRuntimeType: 1.81488e+06
       GoKind: 22
       Pointee: 1155 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13202,63 +13202,63 @@ Types:
       ID: 975
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.213312e+06
+      GoRuntimeType: 1.213408e+06
       GoKind: 22
       Pointee: 976 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1001
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.428928e+06
+      GoRuntimeType: 1.429024e+06
       GoKind: 22
       Pointee: 1002 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1215
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.243456e+06
+      GoRuntimeType: 2.243712e+06
       GoKind: 22
       Pointee: 1216 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 999
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.428608e+06
+      GoRuntimeType: 1.428704e+06
       GoKind: 22
       Pointee: 1000 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 977
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.21344e+06
+      GoRuntimeType: 1.213536e+06
       GoKind: 22
       Pointee: 978 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1225
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.271328e+06
+      GoRuntimeType: 2.271584e+06
       GoKind: 22
       Pointee: 1226 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1235
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.316832e+06
+      GoRuntimeType: 2.317088e+06
       GoKind: 22
       Pointee: 1236 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1223
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.270816e+06
+      GoRuntimeType: 2.271072e+06
       GoKind: 22
       Pointee: 1224 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 974
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.212544e+06
+      GoRuntimeType: 1.21264e+06
       GoKind: 22
       Pointee: 937 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13270,28 +13270,28 @@ Types:
       ID: 901
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.044352e+06
+      GoRuntimeType: 1.044448e+06
       GoKind: 22
       Pointee: 902 StructureType net.canceledError
     - __kind: PointerType
       ID: 1191
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2.0192e+06
+      GoRuntimeType: 2.019456e+06
       GoKind: 22
       Pointee: 1192 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1045
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.857856e+06
+      GoRuntimeType: 1.858112e+06
       GoKind: 22
       Pointee: 1046 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1237
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.321088e+06
+      GoRuntimeType: 2.321344e+06
       GoKind: 22
       Pointee: 1238 UnresolvedPointeeType net.netFD
     - __kind: PointerType
@@ -13312,35 +13312,35 @@ Types:
       ID: 1219
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.257344e+06
+      GoRuntimeType: 2.2576e+06
       GoKind: 22
       Pointee: 1220 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1217
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.256864e+06
+      GoRuntimeType: 2.25712e+06
       GoKind: 22
       Pointee: 1218 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 979
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.21408e+06
+      GoRuntimeType: 1.214176e+06
       GoKind: 22
       Pointee: 980 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1003
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.429088e+06
+      GoRuntimeType: 1.429184e+06
       GoKind: 22
       Pointee: 1004 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 891
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1.040128e+06
+      GoRuntimeType: 1.040224e+06
       GoKind: 22
       Pointee: 892 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
@@ -13368,7 +13368,7 @@ Types:
       ID: 995
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.424608e+06
+      GoRuntimeType: 1.424704e+06
       GoKind: 22
       Pointee: 996 StructureType net/http.http2StreamError
     - __kind: PointerType
@@ -13382,7 +13382,7 @@ Types:
       ID: 1126
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.563072e+06
+      GoRuntimeType: 1.563328e+06
       GoKind: 22
       Pointee: 1127 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
@@ -13425,21 +13425,21 @@ Types:
       ID: 970
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.209216e+06
+      GoRuntimeType: 1.209312e+06
       GoKind: 22
       Pointee: 971 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 897
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1.040768e+06
+      GoRuntimeType: 1.040864e+06
       GoKind: 22
       Pointee: 898 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1180
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.961504e+06
+      GoRuntimeType: 1.96176e+06
       GoKind: 22
       Pointee: 1181 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
@@ -13465,28 +13465,28 @@ Types:
       ID: 893
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1.040384e+06
+      GoRuntimeType: 1.04048e+06
       GoKind: 22
       Pointee: 894 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1128
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.186784e+06
+      GoRuntimeType: 2.18704e+06
       GoKind: 22
       Pointee: 1129 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1084
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1.040256e+06
+      GoRuntimeType: 1.040352e+06
       GoKind: 22
       Pointee: 1085 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 1118
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.424768e+06
+      GoRuntimeType: 1.424864e+06
       GoKind: 22
       Pointee: 1119 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
@@ -13500,28 +13500,28 @@ Types:
       ID: 997
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.425888e+06
+      GoRuntimeType: 1.425984e+06
       GoKind: 22
       Pointee: 998 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 968
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.209088e+06
+      GoRuntimeType: 1.209184e+06
       GoKind: 22
       Pointee: 969 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 895
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1.040512e+06
+      GoRuntimeType: 1.040608e+06
       GoKind: 22
       Pointee: 896 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1160
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1.854496e+06
+      GoRuntimeType: 1.854752e+06
       GoKind: 22
       Pointee: 1161 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
@@ -13535,14 +13535,14 @@ Types:
       ID: 1182
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.963296e+06
+      GoRuntimeType: 1.963552e+06
       GoKind: 22
       Pointee: 1183 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 1094
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.052672e+06
+      GoRuntimeType: 1.052768e+06
       GoKind: 22
       Pointee: 1095 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
@@ -13563,14 +13563,14 @@ Types:
       ID: 1134
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 2.128864e+06
+      GoRuntimeType: 2.12912e+06
       GoKind: 22
       Pointee: 1135 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 1096
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.057536e+06
+      GoRuntimeType: 1.057632e+06
       GoKind: 22
       Pointee: 1097 StructureType net/smtp.dataCloser
     - __kind: PointerType
@@ -13596,14 +13596,14 @@ Types:
       ID: 1092
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.051904e+06
+      GoRuntimeType: 1.052e+06
       GoKind: 22
       Pointee: 1093 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 1005
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.429408e+06
+      GoRuntimeType: 1.429504e+06
       GoKind: 22
       Pointee: 1006 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
@@ -13769,63 +13769,63 @@ Types:
       ID: 1243
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.360576e+06
+      GoRuntimeType: 2.360832e+06
       GoKind: 22
       Pointee: 1244 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 874
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 1.03168e+06
+      GoRuntimeType: 1.031776e+06
       GoKind: 22
       Pointee: 875 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 940
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.198208e+06
+      GoRuntimeType: 1.198304e+06
       GoKind: 22
       Pointee: 941 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1241
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.359104e+06
+      GoRuntimeType: 2.35936e+06
       GoKind: 22
       Pointee: 1242 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1239
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.358368e+06
+      GoRuntimeType: 2.358624e+06
       GoKind: 22
       Pointee: 1240 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 905
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.048576e+06
+      GoRuntimeType: 1.048672e+06
       GoKind: 22
       Pointee: 906 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 1048
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 2.099424e+06
+      GoRuntimeType: 2.09968e+06
       GoKind: 22
       Pointee: 1049 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 1112
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.220352e+06
+      GoRuntimeType: 1.220448e+06
       GoKind: 22
       Pointee: 1113 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 907
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.048704e+06
+      GoRuntimeType: 1.0488e+06
       GoKind: 22
       Pointee: 908 StructureType os/exec.wrappedError
     - __kind: PointerType
@@ -13865,14 +13865,14 @@ Types:
       ID: 878
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1.033216e+06
+      GoRuntimeType: 1.033312e+06
       GoKind: 22
       Pointee: 879 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 882
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1.035008e+06
+      GoRuntimeType: 1.035104e+06
       GoKind: 22
       Pointee: 883 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
@@ -13886,14 +13886,14 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.422368e+06
+      GoRuntimeType: 1.422464e+06
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 880
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1.033344e+06
+      GoRuntimeType: 1.03344e+06
       GoKind: 22
       Pointee: 881 StructureType runtime.boundsError
     - __kind: PointerType
@@ -13914,14 +13914,14 @@ Types:
       ID: 942
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.203712e+06
+      GoRuntimeType: 1.203808e+06
       GoKind: 22
       Pointee: 943 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 876
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1.032832e+06
+      GoRuntimeType: 1.032928e+06
       GoKind: 22
       Pointee: 857 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -13940,21 +13940,21 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.423008e+06
+      GoRuntimeType: 1.423104e+06
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.034368e+06
+      GoRuntimeType: 1.034464e+06
       GoKind: 22
       Pointee: 361 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 877
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1.03296e+06
+      GoRuntimeType: 1.033056e+06
       GoKind: 22
       Pointee: 860 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -13973,7 +13973,7 @@ Types:
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.560832e+06
+      GoRuntimeType: 1.561088e+06
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
@@ -13987,21 +13987,21 @@ Types:
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.064416e+06
+      GoRuntimeType: 2.064672e+06
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.628864e+06
+      GoRuntimeType: 1.62912e+06
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 872
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 1.03104e+06
+      GoRuntimeType: 1.031136e+06
       GoKind: 22
       Pointee: 873 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
@@ -14020,21 +14020,21 @@ Types:
       ID: 1176
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.9592e+06
+      GoRuntimeType: 1.959456e+06
       GoKind: 22
       Pointee: 1177 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 1082
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 1.031168e+06
+      GoRuntimeType: 1.031264e+06
       GoKind: 22
       Pointee: 1083 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
       ID: 1078
       Name: '*struct { io.Writer }'
       ByteSize: 8
-      GoRuntimeType: 976224
+      GoRuntimeType: 976320
       GoKind: 22
       Pointee: 1079 StructureType struct { io.Writer }
     - __kind: PointerType
@@ -14048,7 +14048,7 @@ Types:
       ID: 994
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.423968e+06
+      GoRuntimeType: 1.424064e+06
       GoKind: 22
       Pointee: 993 BaseType syscall.Errno
     - __kind: PointerType
@@ -14190,21 +14190,21 @@ Types:
       ID: 1213
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.170496e+06
+      GoRuntimeType: 2.170752e+06
       GoKind: 22
       Pointee: 1214 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 935
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.094144e+06
+      GoRuntimeType: 1.09424e+06
       GoKind: 22
       Pointee: 936 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 1010
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.633856e+06
+      GoRuntimeType: 1.634112e+06
       GoKind: 22
       Pointee: 1011 UnresolvedPointeeType time.Location
     - __kind: PointerType
@@ -14279,7 +14279,7 @@ Types:
       ID: 1205
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.145984e+06
+      GoRuntimeType: 2.14624e+06
       GoKind: 22
       Pointee: 1206 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -14300,14 +14300,14 @@ Types:
       ID: 912
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.052416e+06
+      GoRuntimeType: 1.052512e+06
       GoKind: 22
       Pointee: 913 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 914
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.052544e+06
+      GoRuntimeType: 1.05264e+06
       GoKind: 22
       Pointee: 865 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -24580,7 +24580,7 @@ Types:
     - __kind: StructureType
       ID: 1075
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.126336e+06
+      GoRuntimeType: 1.126432e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24591,7 +24591,7 @@ Types:
       ID: 1101
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.573792e+06
+      GoRuntimeType: 1.574048e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -24681,7 +24681,7 @@ Types:
     - __kind: StructureType
       ID: 973
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.488352e+06
+      GoRuntimeType: 1.488608e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -24709,7 +24709,7 @@ Types:
     - __kind: StructureType
       ID: 922
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
-      GoRuntimeType: 1.296192e+06
+      GoRuntimeType: 1.296288e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24768,7 +24768,7 @@ Types:
       ID: 737
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.740352e+06
+      GoRuntimeType: 1.740608e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24784,7 +24784,7 @@ Types:
       ID: 864
       Name: crypto/tls.alert
       ByteSize: 1
-      GoRuntimeType: 998592
+      GoRuntimeType: 998688
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1133
@@ -24810,7 +24810,7 @@ Types:
       ID: 813
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.743232e+06
+      GoRuntimeType: 1.743488e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -24825,14 +24825,14 @@ Types:
     - __kind: StructureType
       ID: 807
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.123904e+06
+      GoRuntimeType: 1.124e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 809
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.607904e+06
+      GoRuntimeType: 1.60816e+06
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -24857,7 +24857,7 @@ Types:
       ID: 916
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.569792e+06
+      GoRuntimeType: 1.570048e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -24866,14 +24866,14 @@ Types:
     - __kind: StructureType
       ID: 815
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.12416e+06
+      GoRuntimeType: 1.124256e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 811
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.74304e+06
+      GoRuntimeType: 1.743296e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -24889,7 +24889,7 @@ Types:
       ID: 829
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.443648e+06
+      GoRuntimeType: 1.443744e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24899,7 +24899,7 @@ Types:
       ID: 833
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.443808e+06
+      GoRuntimeType: 1.443904e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24957,7 +24957,7 @@ Types:
       ID: 697
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.427648e+06
+      GoRuntimeType: 1.427744e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -25006,7 +25006,7 @@ Types:
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.032704e+06
+      GoRuntimeType: 1.0328e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25100,7 +25100,7 @@ Types:
       ID: 706
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.7392e+06
+      GoRuntimeType: 1.739456e+06
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25123,7 +25123,7 @@ Types:
     - __kind: StructureType
       ID: 712
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.120192e+06
+      GoRuntimeType: 1.120288e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25153,7 +25153,7 @@ Types:
       ID: 1033
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.229792e+06
+      GoRuntimeType: 2.230048e+06
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25269,7 +25269,7 @@ Types:
     - __kind: StructureType
       ID: 757
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.123136e+06
+      GoRuntimeType: 1.123232e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25281,14 +25281,14 @@ Types:
     - __kind: StructureType
       ID: 755
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.123008e+06
+      GoRuntimeType: 1.123104e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 753
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.605984e+06
+      GoRuntimeType: 1.60624e+06
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25301,7 +25301,7 @@ Types:
       ID: 773
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.606784e+06
+      GoRuntimeType: 1.60704e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25314,7 +25314,7 @@ Types:
       ID: 777
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.742464e+06
+      GoRuntimeType: 1.74272e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25330,7 +25330,7 @@ Types:
       ID: 775
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.437568e+06
+      GoRuntimeType: 1.437664e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25340,7 +25340,7 @@ Types:
       ID: 771
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.437248e+06
+      GoRuntimeType: 1.437344e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25350,14 +25350,14 @@ Types:
       ID: 1019
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.508672e+06
+      GoRuntimeType: 1.508928e+06
       GoKind: 21
       HeaderType: 1021 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 1042
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.056e+06
+      GoRuntimeType: 1.056096e+06
       GoKind: 23
       RawFields:
         - Name: array
@@ -25380,7 +25380,7 @@ Types:
       ID: 785
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.607104e+06
+      GoRuntimeType: 1.60736e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25393,7 +25393,7 @@ Types:
       ID: 779
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.437728e+06
+      GoRuntimeType: 1.437824e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25403,7 +25403,7 @@ Types:
       ID: 783
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.742656e+06
+      GoRuntimeType: 1.742912e+06
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25419,7 +25419,7 @@ Types:
       ID: 781
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.606944e+06
+      GoRuntimeType: 1.6072e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25432,7 +25432,7 @@ Types:
       ID: 787
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.437888e+06
+      GoRuntimeType: 1.437984e+06
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25442,7 +25442,7 @@ Types:
       ID: 793
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.607424e+06
+      GoRuntimeType: 1.60768e+06
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25455,7 +25455,7 @@ Types:
       ID: 795
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.438208e+06
+      GoRuntimeType: 1.438304e+06
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25465,7 +25465,7 @@ Types:
       ID: 791
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.607264e+06
+      GoRuntimeType: 1.60752e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25478,7 +25478,7 @@ Types:
       ID: 789
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.438048e+06
+      GoRuntimeType: 1.438144e+06
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25488,7 +25488,7 @@ Types:
       ID: 797
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.607584e+06
+      GoRuntimeType: 1.60784e+06
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25501,7 +25501,7 @@ Types:
       ID: 714
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.429888e+06
+      GoRuntimeType: 1.429984e+06
       GoKind: 25
       RawFields:
         - Name: message
@@ -25515,7 +25515,7 @@ Types:
       ID: 716
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.430048e+06
+      GoRuntimeType: 1.430144e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25537,7 +25537,7 @@ Types:
       ID: 720
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.430368e+06
+      GoRuntimeType: 1.430464e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25551,7 +25551,7 @@ Types:
       ID: 1199
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 2.11728e+06
+      GoRuntimeType: 2.117536e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25564,7 +25564,7 @@ Types:
       ID: 1202
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.142528e+06
+      GoRuntimeType: 2.142784e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25584,7 +25584,7 @@ Types:
       ID: 718
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.430208e+06
+      GoRuntimeType: 1.430304e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25594,7 +25594,7 @@ Types:
       ID: 722
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.430528e+06
+      GoRuntimeType: 1.430624e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25644,7 +25644,7 @@ Types:
       ID: 728
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.431488e+06
+      GoRuntimeType: 1.431584e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -25659,7 +25659,7 @@ Types:
       ID: 957
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.852704e+06
+      GoRuntimeType: 1.85296e+06
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -25679,7 +25679,7 @@ Types:
       ID: 886
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.711904e+06
+      GoRuntimeType: 1.71216e+06
       GoKind: 25
       RawFields:
         - Name: Got
@@ -25692,7 +25692,7 @@ Types:
       ID: 963
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.853152e+06
+      GoRuntimeType: 1.853408e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25708,13 +25708,13 @@ Types:
       ID: 863
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 995904
+      GoRuntimeType: 996000
       GoKind: 8
     - __kind: StructureType
       ID: 955
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.85248e+06
+      GoRuntimeType: 1.852736e+06
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -25736,7 +25736,7 @@ Types:
       ID: 953
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.852256e+06
+      GoRuntimeType: 1.852512e+06
       GoKind: 25
       RawFields:
         - Name: Method
@@ -25752,7 +25752,7 @@ Types:
       ID: 961
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.766624e+06
+      GoRuntimeType: 1.76688e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25765,7 +25765,7 @@ Types:
       ID: 959
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.852928e+06
+      GoRuntimeType: 1.853184e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25785,7 +25785,7 @@ Types:
       ID: 967
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.634816e+06
+      GoRuntimeType: 1.635072e+06
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -25794,20 +25794,20 @@ Types:
     - __kind: StructureType
       ID: 890
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.290176e+06
+      GoRuntimeType: 1.290272e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 888
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.290048e+06
+      GoRuntimeType: 1.290144e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 965
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.766816e+06
+      GoRuntimeType: 1.767072e+06
       GoKind: 25
       RawFields:
         - Name: cause
@@ -25931,7 +25931,7 @@ Types:
       ID: 934
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.455488e+06
+      GoRuntimeType: 1.455584e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -25941,7 +25941,7 @@ Types:
       ID: 1117
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.687616e+06
+      GoRuntimeType: 1.687872e+06
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -25955,7 +25955,7 @@ Types:
       ID: 1143
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.133888e+06
+      GoRuntimeType: 1.133984e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25968,7 +25968,7 @@ Types:
       ID: 1105
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.578592e+06
+      GoRuntimeType: 1.578848e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -25984,13 +25984,13 @@ Types:
       ID: 1026
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.009056e+06
+      GoRuntimeType: 1.009152e+06
       GoKind: 10
     - __kind: StructureType
       ID: 992
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.890784e+06
+      GoRuntimeType: 1.89104e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26006,7 +26006,7 @@ Types:
       ID: 849
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.614624e+06
+      GoRuntimeType: 1.61488e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26099,7 +26099,7 @@ Types:
       ID: 853
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.456128e+06
+      GoRuntimeType: 1.456224e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26115,7 +26115,7 @@ Types:
       ID: 841
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.451168e+06
+      GoRuntimeType: 1.451264e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26129,7 +26129,7 @@ Types:
       ID: 1015
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.91856e+06
+      GoRuntimeType: 1.918816e+06
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26145,7 +26145,7 @@ Types:
       ID: 843
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.614144e+06
+      GoRuntimeType: 1.6144e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26158,7 +26158,7 @@ Types:
       ID: 1157
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.976608e+06
+      GoRuntimeType: 1.976864e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26175,7 +26175,7 @@ Types:
       ID: 932
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.576192e+06
+      GoRuntimeType: 1.576448e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26200,14 +26200,14 @@ Types:
     - __kind: StructureType
       ID: 986
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.519392e+06
+      GoRuntimeType: 1.519648e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 835
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.444448e+06
+      GoRuntimeType: 1.444544e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26217,7 +26217,7 @@ Types:
       ID: 837
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.444608e+06
+      GoRuntimeType: 1.444704e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26668,7 +26668,7 @@ Types:
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.860768e+06
+      GoRuntimeType: 1.861024e+06
       GoKind: 25
       RawFields:
         - Name: buf
@@ -26705,7 +26705,7 @@ Types:
     - __kind: StructureType
       ID: 947
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.485152e+06
+      GoRuntimeType: 1.485408e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -26716,7 +26716,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.21984e+06
+      GoRuntimeType: 1.219936e+06
       GoKind: 25
       RawFields:
         - Name: u
@@ -26726,7 +26726,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.649408e+06
+      GoRuntimeType: 1.649664e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26742,7 +26742,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.498912e+06
+      GoRuntimeType: 1.499168e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26755,7 +26755,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.498752e+06
+      GoRuntimeType: 1.499008e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26768,7 +26768,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.499072e+06
+      GoRuntimeType: 1.499328e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26780,13 +26780,13 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 998304
+      GoRuntimeType: 998400
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 998208
+      GoRuntimeType: 998304
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
@@ -26812,7 +26812,7 @@ Types:
       ID: 904
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
-      GoRuntimeType: 1.567552e+06
+      GoRuntimeType: 1.567808e+06
       GoKind: 25
       RawFields:
         - Name: typ
@@ -26822,7 +26822,7 @@ Types:
       ID: 1264
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.482112e+06
+      GoRuntimeType: 1.482368e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -26839,7 +26839,7 @@ Types:
       ID: 1149
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.196672e+06
+      GoRuntimeType: 1.196768e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26852,7 +26852,7 @@ Types:
       ID: 1184
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.02912e+06
+      GoRuntimeType: 1.029216e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26865,7 +26865,7 @@ Types:
       ID: 1136
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.11648e+06
+      GoRuntimeType: 1.116576e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26878,7 +26878,7 @@ Types:
       ID: 131
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.028864e+06
+      GoRuntimeType: 1.02896e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26890,7 +26890,7 @@ Types:
     - __kind: StructureType
       ID: 1107
       Name: io.discard
-      GoRuntimeType: 1.471712e+06
+      GoRuntimeType: 1.471968e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -26960,7 +26960,7 @@ Types:
       ID: 162
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.027712e+06
+      GoRuntimeType: 1.027808e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26973,7 +26973,7 @@ Types:
       ID: 128
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.62176e+06
+      GoRuntimeType: 1.622016e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -26989,7 +26989,7 @@ Types:
       ID: 143
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.19296e+06
+      GoRuntimeType: 1.193056e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26999,7 +26999,7 @@ Types:
       ID: 376
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.192832e+06
+      GoRuntimeType: 1.192928e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27013,7 +27013,7 @@ Types:
       ID: 150
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.192192e+06
+      GoRuntimeType: 1.192288e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27023,7 +27023,7 @@ Types:
       ID: 1330
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.192064e+06
+      GoRuntimeType: 1.19216e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27033,7 +27033,7 @@ Types:
       ID: 1345
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.191936e+06
+      GoRuntimeType: 1.192032e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27043,7 +27043,7 @@ Types:
       ID: 132
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.194112e+06
+      GoRuntimeType: 1.194208e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27053,7 +27053,7 @@ Types:
       ID: 134
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.193984e+06
+      GoRuntimeType: 1.19408e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27067,7 +27067,7 @@ Types:
       ID: 136
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.193344e+06
+      GoRuntimeType: 1.19344e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27077,7 +27077,7 @@ Types:
       ID: 1300
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.193216e+06
+      GoRuntimeType: 1.193312e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27087,7 +27087,7 @@ Types:
       ID: 1302
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.193088e+06
+      GoRuntimeType: 1.193184e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27097,7 +27097,7 @@ Types:
       ID: 137
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.195264e+06
+      GoRuntimeType: 1.19536e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27107,7 +27107,7 @@ Types:
       ID: 366
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.195136e+06
+      GoRuntimeType: 1.195232e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27121,7 +27121,7 @@ Types:
       ID: 142
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.194496e+06
+      GoRuntimeType: 1.194592e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27131,7 +27131,7 @@ Types:
       ID: 1306
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.194368e+06
+      GoRuntimeType: 1.194464e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27141,7 +27141,7 @@ Types:
       ID: 1312
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.19424e+06
+      GoRuntimeType: 1.194336e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27156,7 +27156,7 @@ Types:
       ID: 160
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.844864e+06
+      GoRuntimeType: 1.84512e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27178,7 +27178,7 @@ Types:
       ID: 155
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.978176e+06
+      GoRuntimeType: 1.978432e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -27206,7 +27206,7 @@ Types:
       ID: 354
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.420128e+06
+      GoRuntimeType: 1.420224e+06
       GoKind: 25
       RawFields:
         - Name: s
@@ -27333,7 +27333,7 @@ Types:
       ID: 123
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.470752e+06
+      GoRuntimeType: 1.471008e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -27346,7 +27346,7 @@ Types:
       ID: 246
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.470432e+06
+      GoRuntimeType: 1.470688e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -27368,14 +27368,14 @@ Types:
       ID: 1274
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.420288e+06
+      GoRuntimeType: 1.420384e+06
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 158
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.02784e+06
+      GoRuntimeType: 1.027936e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27428,7 +27428,7 @@ Types:
       ID: 164
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.19168e+06
+      GoRuntimeType: 1.191776e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27498,7 +27498,7 @@ Types:
       ID: 165
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.191808e+06
+      GoRuntimeType: 1.191904e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -28612,119 +28612,119 @@ Types:
       ID: 223
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.135936e+06
+      GoRuntimeType: 1.136032e+06
       GoKind: 21
       HeaderType: 225 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 218
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.136064e+06
+      GoRuntimeType: 1.13616e+06
       GoKind: 21
       HeaderType: 220 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 186
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.136192e+06
+      GoRuntimeType: 1.136288e+06
       GoKind: 21
       HeaderType: 188 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 198
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.13632e+06
+      GoRuntimeType: 1.136416e+06
       GoKind: 21
       HeaderType: 200 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 144
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.135808e+06
+      GoRuntimeType: 1.135904e+06
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1284
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.13568e+06
+      GoRuntimeType: 1.135776e+06
       GoKind: 21
       HeaderType: 1286 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1318
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.13504e+06
+      GoRuntimeType: 1.135136e+06
       GoKind: 21
       HeaderType: 1320 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1333
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.134912e+06
+      GoRuntimeType: 1.135008e+06
       GoKind: 21
       HeaderType: 1335 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 166
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.134272e+06
+      GoRuntimeType: 1.134368e+06
       GoKind: 21
       HeaderType: 168 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 1348
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.134784e+06
+      GoRuntimeType: 1.13488e+06
       GoKind: 21
       HeaderType: 1350 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 233
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.136448e+06
+      GoRuntimeType: 1.136544e+06
       GoKind: 21
       HeaderType: 235 GoSwissMapHeaderType map<int,struct {}>
     - __kind: GoMapType
       ID: 203
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.136576e+06
+      GoRuntimeType: 1.136672e+06
       GoKind: 21
       HeaderType: 205 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 193
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.136704e+06
+      GoRuntimeType: 1.1368e+06
       GoKind: 21
       HeaderType: 195 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 181
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.136832e+06
+      GoRuntimeType: 1.136928e+06
       GoKind: 21
       HeaderType: 183 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 176
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.13696e+06
+      GoRuntimeType: 1.137056e+06
       GoKind: 21
       HeaderType: 178 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 171
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.137088e+06
+      GoRuntimeType: 1.137184e+06
       GoKind: 21
       HeaderType: 173 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 228
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 1.137216e+06
+      GoRuntimeType: 1.137312e+06
       GoKind: 21
       HeaderType: 230 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
@@ -28767,28 +28767,28 @@ Types:
       ID: 238
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.137344e+06
+      GoRuntimeType: 1.13744e+06
       GoKind: 21
       HeaderType: 240 GoSwissMapHeaderType map<struct {},struct {}>
     - __kind: GoMapType
       ID: 213
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.137472e+06
+      GoRuntimeType: 1.137568e+06
       GoKind: 21
       HeaderType: 215 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 208
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.1376e+06
+      GoRuntimeType: 1.137696e+06
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
       ID: 769
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.436768e+06
+      GoRuntimeType: 1.436864e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -28798,7 +28798,7 @@ Types:
       ID: 1071
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.433568e+06
+      GoRuntimeType: 1.433664e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -28812,7 +28812,7 @@ Types:
       ID: 1041
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.604704e+06
+      GoRuntimeType: 1.60496e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -28853,7 +28853,7 @@ Types:
       ID: 937
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.119808e+06
+      GoRuntimeType: 1.119904e+06
       GoKind: 24
       RawFields:
         - Name: str
@@ -28871,7 +28871,7 @@ Types:
     - __kind: StructureType
       ID: 902
       Name: net.canceledError
-      GoRuntimeType: 1.2912e+06
+      GoRuntimeType: 1.291296e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28882,7 +28882,7 @@ Types:
       ID: 1046
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 2.116576e+06
+      GoRuntimeType: 2.116832e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -28904,13 +28904,13 @@ Types:
     - __kind: StructureType
       ID: 1232
       Name: net.noReadFrom
-      GoRuntimeType: 1.120064e+06
+      GoRuntimeType: 1.12016e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1231
       Name: net.noWriteTo
-      GoRuntimeType: 1.119936e+06
+      GoRuntimeType: 1.120032e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28921,7 +28921,7 @@ Types:
       ID: 701
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.739008e+06
+      GoRuntimeType: 1.739264e+06
       GoKind: 25
       RawFields:
         - Name: p
@@ -28937,7 +28937,7 @@ Types:
       ID: 1220
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.299584e+06
+      GoRuntimeType: 2.29984e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -28950,7 +28950,7 @@ Types:
       ID: 1218
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.29904e+06
+      GoRuntimeType: 2.299296e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -28975,7 +28975,7 @@ Types:
       ID: 1065
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.425088e+06
+      GoRuntimeType: 1.425184e+06
       GoKind: 25
       RawFields:
         - Name: w
@@ -28991,13 +28991,13 @@ Types:
       ID: 1018
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 996000
+      GoRuntimeType: 996096
       GoKind: 10
     - __kind: StructureType
       ID: 677
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.73728e+06
+      GoRuntimeType: 1.737536e+06
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -29013,7 +29013,7 @@ Types:
       ID: 996
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.909088e+06
+      GoRuntimeType: 1.909344e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -29029,7 +29029,7 @@ Types:
       ID: 681
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.604224e+06
+      GoRuntimeType: 1.60448e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29106,7 +29106,7 @@ Types:
     - __kind: StructureType
       ID: 898
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.290432e+06
+      GoRuntimeType: 1.290528e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29136,7 +29136,7 @@ Types:
       ID: 1067
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
-      GoRuntimeType: 1.834944e+06
+      GoRuntimeType: 1.8352e+06
       GoKind: 25
       RawFields:
         - Name: group
@@ -29155,7 +29155,7 @@ Types:
       ID: 1158
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
-      GoRuntimeType: 1.424288e+06
+      GoRuntimeType: 1.424384e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29175,7 +29175,7 @@ Types:
       ID: 894
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.563712e+06
+      GoRuntimeType: 1.563968e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -29189,7 +29189,7 @@ Types:
       ID: 1085
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.563552e+06
+      GoRuntimeType: 1.563808e+06
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29199,7 +29199,7 @@ Types:
       ID: 1119
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.80992e+06
+      GoRuntimeType: 1.810176e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -29215,7 +29215,7 @@ Types:
       ID: 685
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.426048e+06
+      GoRuntimeType: 1.426144e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -29228,14 +29228,14 @@ Types:
     - __kind: StructureType
       ID: 969
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.488032e+06
+      GoRuntimeType: 1.488288e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 896
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.563872e+06
+      GoRuntimeType: 1.564128e+06
       GoKind: 25
       RawFields:
         - Name: err
@@ -29245,7 +29245,7 @@ Types:
       ID: 1161
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2.035584e+06
+      GoRuntimeType: 2.03584e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29262,7 +29262,7 @@ Types:
       ID: 1183
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 2.051328e+06
+      GoRuntimeType: 2.051584e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29276,7 +29276,7 @@ Types:
       ID: 761
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.74208e+06
+      GoRuntimeType: 1.742336e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29292,7 +29292,7 @@ Types:
       ID: 759
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.606144e+06
+      GoRuntimeType: 1.6064e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29309,7 +29309,7 @@ Types:
       ID: 1097
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.608064e+06
+      GoRuntimeType: 1.60832e+06
       GoKind: 25
       RawFields:
         - Name: c
@@ -29627,7 +29627,7 @@ Types:
       ID: 474
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.302464e+06
+      GoRuntimeType: 1.30256e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29640,7 +29640,7 @@ Types:
       ID: 466
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.30272e+06
+      GoRuntimeType: 1.302816e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29653,7 +29653,7 @@ Types:
       ID: 414
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.302976e+06
+      GoRuntimeType: 1.303072e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29666,7 +29666,7 @@ Types:
       ID: 433
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.303232e+06
+      GoRuntimeType: 1.303328e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29679,7 +29679,7 @@ Types:
       ID: 372
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.302208e+06
+      GoRuntimeType: 1.302304e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29692,7 +29692,7 @@ Types:
       ID: 1292
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.301952e+06
+      GoRuntimeType: 1.302048e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29705,7 +29705,7 @@ Types:
       ID: 1326
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.300672e+06
+      GoRuntimeType: 1.300768e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29718,7 +29718,7 @@ Types:
       ID: 1341
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.300416e+06
+      GoRuntimeType: 1.300512e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29731,7 +29731,7 @@ Types:
       ID: 382
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.299136e+06
+      GoRuntimeType: 1.299232e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29744,7 +29744,7 @@ Types:
       ID: 1356
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.30016e+06
+      GoRuntimeType: 1.300256e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29757,7 +29757,7 @@ Types:
       ID: 490
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
-      GoRuntimeType: 1.303488e+06
+      GoRuntimeType: 1.303584e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29770,7 +29770,7 @@ Types:
       ID: 441
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.303744e+06
+      GoRuntimeType: 1.30384e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29783,7 +29783,7 @@ Types:
       ID: 423
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.304e+06
+      GoRuntimeType: 1.304096e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29796,7 +29796,7 @@ Types:
       ID: 406
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.304256e+06
+      GoRuntimeType: 1.304352e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29809,7 +29809,7 @@ Types:
       ID: 1053
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
-      GoRuntimeType: 1.365696e+06
+      GoRuntimeType: 1.365792e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29822,7 +29822,7 @@ Types:
       ID: 398
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.304512e+06
+      GoRuntimeType: 1.304608e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29835,7 +29835,7 @@ Types:
       ID: 390
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.304768e+06
+      GoRuntimeType: 1.304864e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29848,7 +29848,7 @@ Types:
       ID: 482
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
-      GoRuntimeType: 1.305024e+06
+      GoRuntimeType: 1.30512e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29933,7 +29933,7 @@ Types:
       ID: 498
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
-      GoRuntimeType: 1.30528e+06
+      GoRuntimeType: 1.305376e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29946,7 +29946,7 @@ Types:
       ID: 457
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.305536e+06
+      GoRuntimeType: 1.305632e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29959,7 +29959,7 @@ Types:
       ID: 449
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.305792e+06
+      GoRuntimeType: 1.305888e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29972,7 +29972,7 @@ Types:
       ID: 476
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.302336e+06
+      GoRuntimeType: 1.302432e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29985,7 +29985,7 @@ Types:
       ID: 468
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.302592e+06
+      GoRuntimeType: 1.302688e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29998,7 +29998,7 @@ Types:
       ID: 416
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.302848e+06
+      GoRuntimeType: 1.302944e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30011,7 +30011,7 @@ Types:
       ID: 435
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.303104e+06
+      GoRuntimeType: 1.3032e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30024,7 +30024,7 @@ Types:
       ID: 374
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.30208e+06
+      GoRuntimeType: 1.302176e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30037,7 +30037,7 @@ Types:
       ID: 1294
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.301824e+06
+      GoRuntimeType: 1.30192e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30050,7 +30050,7 @@ Types:
       ID: 1328
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.300544e+06
+      GoRuntimeType: 1.30064e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30063,7 +30063,7 @@ Types:
       ID: 1343
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.300288e+06
+      GoRuntimeType: 1.300384e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30076,7 +30076,7 @@ Types:
       ID: 384
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.299008e+06
+      GoRuntimeType: 1.299104e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30089,7 +30089,7 @@ Types:
       ID: 1358
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.300032e+06
+      GoRuntimeType: 1.300128e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30102,7 +30102,7 @@ Types:
       ID: 492
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
-      GoRuntimeType: 1.30336e+06
+      GoRuntimeType: 1.303456e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30115,7 +30115,7 @@ Types:
       ID: 443
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.303616e+06
+      GoRuntimeType: 1.303712e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30128,7 +30128,7 @@ Types:
       ID: 425
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.303872e+06
+      GoRuntimeType: 1.303968e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30141,7 +30141,7 @@ Types:
       ID: 408
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.304128e+06
+      GoRuntimeType: 1.304224e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30154,7 +30154,7 @@ Types:
       ID: 1055
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
-      GoRuntimeType: 1.365568e+06
+      GoRuntimeType: 1.365664e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30167,7 +30167,7 @@ Types:
       ID: 400
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.304384e+06
+      GoRuntimeType: 1.30448e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30180,7 +30180,7 @@ Types:
       ID: 392
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.30464e+06
+      GoRuntimeType: 1.304736e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30193,7 +30193,7 @@ Types:
       ID: 484
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
-      GoRuntimeType: 1.304896e+06
+      GoRuntimeType: 1.304992e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30277,7 +30277,7 @@ Types:
     - __kind: StructureType
       ID: 500
       Name: noalg.struct { key struct {}; elem struct {} }
-      GoRuntimeType: 1.305152e+06
+      GoRuntimeType: 1.305248e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30290,7 +30290,7 @@ Types:
       ID: 459
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.305408e+06
+      GoRuntimeType: 1.305504e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30303,7 +30303,7 @@ Types:
       ID: 451
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.305664e+06
+      GoRuntimeType: 1.30576e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30328,7 +30328,7 @@ Types:
       ID: 1242
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.369952e+06
+      GoRuntimeType: 2.370208e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -30341,7 +30341,7 @@ Types:
       ID: 1240
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.369152e+06
+      GoRuntimeType: 2.369408e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -30353,13 +30353,13 @@ Types:
     - __kind: StructureType
       ID: 1248
       Name: os.noReadFrom
-      GoRuntimeType: 1.117504e+06
+      GoRuntimeType: 1.1176e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1247
       Name: os.noWriteTo
-      GoRuntimeType: 1.117376e+06
+      GoRuntimeType: 1.117472e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -30378,7 +30378,7 @@ Types:
       ID: 908
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.71248e+06
+      GoRuntimeType: 1.712736e+06
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -30440,7 +30440,7 @@ Types:
       ID: 881
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.897952e+06
+      GoRuntimeType: 1.898208e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -30472,14 +30472,14 @@ Types:
     - __kind: StructureType
       ID: 87
       Name: runtime.dlogPerM
-      GoRuntimeType: 995136
+      GoRuntimeType: 995232
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 943
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.762784e+06
+      GoRuntimeType: 1.76304e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30492,7 +30492,7 @@ Types:
       ID: 857
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 994560
+      GoRuntimeType: 994656
       GoKind: 24
       RawFields:
         - Name: str
@@ -30511,7 +30511,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.416768e+06
+      GoRuntimeType: 2.417024e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30701,7 +30701,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.203456e+06
+      GoRuntimeType: 1.203552e+06
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -30711,7 +30711,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.923872e+06
+      GoRuntimeType: 1.924128e+06
       GoKind: 25
       RawFields:
         - Name: sp
@@ -30736,7 +30736,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.479712e+06
+      GoRuntimeType: 1.479968e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -30749,7 +30749,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.761632e+06
+      GoRuntimeType: 1.761888e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30774,7 +30774,7 @@ Types:
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.479552e+06
+      GoRuntimeType: 1.479808e+06
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -30787,7 +30787,7 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.92464e+06
+      GoRuntimeType: 1.924896e+06
       GoKind: 25
       RawFields:
         - Name: fn
@@ -30818,7 +30818,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 2.420064e+06
+      GoRuntimeType: 2.42032e+06
       GoKind: 25
       RawFields:
         - Name: g0
@@ -31038,7 +31038,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.924384e+06
+      GoRuntimeType: 1.92464e+06
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31063,7 +31063,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.849792e+06
+      GoRuntimeType: 1.850048e+06
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31085,7 +31085,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.849568e+06
+      GoRuntimeType: 1.849824e+06
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -31107,7 +31107,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.479232e+06
+      GoRuntimeType: 1.479488e+06
       GoKind: 25
       RawFields:
         - Name: next
@@ -31126,7 +31126,7 @@ Types:
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.2032e+06
+      GoRuntimeType: 1.203296e+06
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -31137,7 +31137,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.479392e+06
+      GoRuntimeType: 1.479648e+06
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31150,7 +31150,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.762592e+06
+      GoRuntimeType: 1.762848e+06
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -31169,7 +31169,7 @@ Types:
       ID: 860
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 994656
+      GoRuntimeType: 994752
       GoKind: 24
       RawFields:
         - Name: str
@@ -31203,7 +31203,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.477472e+06
+      GoRuntimeType: 1.477728e+06
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31224,7 +31224,7 @@ Types:
       ID: 665
       Name: runtime.synctestDeadlockError
       ByteSize: 24
-      GoRuntimeType: 1.603904e+06
+      GoRuntimeType: 1.60416e+06
       GoKind: 25
       RawFields:
         - Name: reason
@@ -31257,7 +31257,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.478432e+06
+      GoRuntimeType: 1.478688e+06
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -31270,12 +31270,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.289408e+06
+      GoRuntimeType: 1.289504e+06
       GoKind: 8
     - __kind: StructureType
       ID: 82
       Name: runtime.winlibcall
-      GoRuntimeType: 995040
+      GoRuntimeType: 995136
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -31313,7 +31313,7 @@ Types:
       ID: 1079
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.463328e+06
+      GoRuntimeType: 1.463584e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -31329,7 +31329,7 @@ Types:
       ID: 1262
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.472032e+06
+      GoRuntimeType: 1.472288e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31342,7 +31342,7 @@ Types:
       ID: 1265
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.62272e+06
+      GoRuntimeType: 1.622976e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31358,7 +31358,7 @@ Types:
       ID: 1268
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.622528e+06
+      GoRuntimeType: 1.622784e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31373,14 +31373,14 @@ Types:
     - __kind: StructureType
       ID: 1263
       Name: sync.noCopy
-      GoRuntimeType: 993504
+      GoRuntimeType: 993600
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1266
       Name: sync/atomic.Bool
       ByteSize: 4
-      GoRuntimeType: 1.473152e+06
+      GoRuntimeType: 1.473408e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31393,7 +31393,7 @@ Types:
       ID: 1271
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.473312e+06
+      GoRuntimeType: 1.473568e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31406,7 +31406,7 @@ Types:
       ID: 1269
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.623104e+06
+      GoRuntimeType: 1.62336e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31421,20 +31421,20 @@ Types:
     - __kind: StructureType
       ID: 1270
       Name: sync/atomic.align64
-      GoRuntimeType: 993696
+      GoRuntimeType: 993792
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1267
       Name: sync/atomic.noCopy
-      GoRuntimeType: 993600
+      GoRuntimeType: 993696
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 993
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.289792e+06
+      GoRuntimeType: 1.289888e+06
       GoKind: 12
     - __kind: StructureType
       ID: 471
@@ -32092,7 +32092,7 @@ Types:
       ID: 936
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.716896e+06
+      GoRuntimeType: 1.717152e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -32105,7 +32105,7 @@ Types:
       ID: 1159
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.925408e+06
+      GoRuntimeType: 1.925664e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1011
@@ -32119,7 +32119,7 @@ Types:
       ID: 1009
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.383264e+06
+      GoRuntimeType: 2.38352e+06
       GoKind: 25
       RawFields:
         - Name: wall
@@ -32196,7 +32196,7 @@ Types:
       ID: 1029
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 2.073056e+06
+      GoRuntimeType: 2.073312e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -32230,13 +32230,13 @@ Types:
       ID: 1032
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
-      GoRuntimeType: 1.000224e+06
+      GoRuntimeType: 1.00032e+06
       GoKind: 9
     - __kind: StructureType
       ID: 1030
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.936416e+06
+      GoRuntimeType: 1.936672e+06
       GoKind: 25
       RawFields:
         - Name: id
@@ -32275,7 +32275,7 @@ Types:
       ID: 747
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.433888e+06
+      GoRuntimeType: 1.433984e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -32291,7 +32291,7 @@ Types:
       ID: 913
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.712672e+06
+      GoRuntimeType: 1.712928e+06
       GoKind: 25
       RawFields:
         - Name: label
@@ -32304,7 +32304,7 @@ Types:
       ID: 865
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
-      GoRuntimeType: 999072
+      GoRuntimeType: 999168
       GoKind: 5
 MaxTypeID: 1689
 Issues:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xcee86a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee94a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1594 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xcee8a5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee985", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0xce8cca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8daa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1433 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0xce8d05", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8de5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0xce8d6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8e4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1436 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0xce8d9d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8e7d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xced26e", Frameless: false}]
+              InjectionPoints: [{PC: "0xced34e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1565 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xced32a", Frameless: false}]
+              InjectionPoints: [{PC: "0xced40a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0xce5cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5da0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0xce5c40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5d20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0xce5c80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xce94e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce95c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0xce5c60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5d40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0xce5ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5d80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xceb300", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb3e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1467 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xceb312", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb3f2", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,7 +267,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0xce6400", Frameless: true}]
+              InjectionPoints: [{PC: "0xce64e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -289,7 +289,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0xce5ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5bc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -311,7 +311,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0xce5a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5b60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xceeca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceed80", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -358,15 +358,15 @@ Probes:
             - Kind: Line
               Type: 1668 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xce84ee"
+                - PC: "0xce85ce"
                   Frameless: false
-                - PC: "0xce8571"
+                - PC: "0xce8651"
                   Frameless: false
-                - PC: "0xce86b2"
+                - PC: "0xce8792"
                   Frameless: false
-                - PC: "0xce873c"
+                - PC: "0xce881c"
                   Frameless: false
-                - PC: "0xce880f"
+                - PC: "0xce88ef"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -388,15 +388,15 @@ Probes:
             - Kind: Line
               Type: 1669 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xce84ee"
+                - PC: "0xce85ce"
                   Frameless: false
-                - PC: "0xce8571"
+                - PC: "0xce8651"
                   Frameless: false
-                - PC: "0xce86b2"
+                - PC: "0xce8792"
                   Frameless: false
-                - PC: "0xce873c"
+                - PC: "0xce881c"
                   Frameless: false
-                - PC: "0xce880f"
+                - PC: "0xce88ef"
                   Frameless: false
               Condition:
                 Type: 4 BaseType bool
@@ -430,15 +430,15 @@ Probes:
             - Kind: Line
               Type: 1670 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xce84ee"
+                - PC: "0xce85ce"
                   Frameless: false
-                - PC: "0xce8571"
+                - PC: "0xce8651"
                   Frameless: false
-                - PC: "0xce86b2"
+                - PC: "0xce8792"
                   Frameless: false
-                - PC: "0xce873c"
+                - PC: "0xce881c"
                   Frameless: false
-                - PC: "0xce880f"
+                - PC: "0xce88ef"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -466,7 +466,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xceaf60", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb040", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -485,7 +485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xceaf60", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -511,7 +511,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xceed80", Frameless: true}]
+              InjectionPoints: [{PC: "0xceee60", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -546,7 +546,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xceb320", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -576,7 +576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xceaf20", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -605,11 +605,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1529 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xcec4ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec58e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1530 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xcec571", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec651", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -631,7 +631,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xceb6e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb7c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -653,7 +653,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1407 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0xce68e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce69c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -675,7 +675,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0xce6900", Frameless: true}]
+              InjectionPoints: [{PC: "0xce69e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -697,7 +697,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0xce65e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce66c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -719,7 +719,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0xce6600", Frameless: true}]
+              InjectionPoints: [{PC: "0xce66e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -741,7 +741,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0xce6760", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -763,7 +763,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0xce6780", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -785,7 +785,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xcee3c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee4a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -812,7 +812,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1584 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xcee420", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -840,7 +840,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xcee9a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceea80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -862,7 +862,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xceede0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceeec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -883,7 +883,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xceee00", Frameless: true}]
+              InjectionPoints: [{PC: "0xceeee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -905,7 +905,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0xce8d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8e20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -939,7 +939,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1402 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0xce64b4", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6594", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -967,11 +967,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0xce70ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce71aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0xce710c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce71ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -993,11 +993,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0xce6fae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce708e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1415 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0xce703b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce711b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1019,11 +1019,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0xce89a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8a80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1427 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0xce89a5", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8a85", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1045,11 +1045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0xce89c4", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8aa4", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1429 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0xce8a05", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8ae5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1074,7 +1074,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1430 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0xce89c8", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8aa8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1096,11 +1096,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1654 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf1700", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf17e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1655 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf1707", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf17e7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1114,11 +1114,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1656 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xcf1724", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1804", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1657 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xcf1775", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1855", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1141,11 +1141,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1650 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xcf166a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf174a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1651 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xcf1679", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1759", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1159,11 +1159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1652 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xcf16aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf178a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1653 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xcf16c2", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf17a2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1186,14 +1186,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1658 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf1780", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1860", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1659 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xcf17a0"
+                - PC: "0xcf1880"
                   Frameless: true
-                - PC: "0xcf17a3"
+                - PC: "0xcf1883"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1208,14 +1208,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1660 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf17ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf18aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1661 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xcf182b"
+                - PC: "0xcf190b"
                   Frameless: false
-                - PC: "0xcf1833"
+                - PC: "0xcf1913"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1242,7 +1242,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1662 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xcf1785", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1865", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1254,7 +1254,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1663 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xcf17df", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf18bf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1275,11 +1275,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1638 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xcf1320", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1400", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1639 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xcf1330", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1410", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1293,11 +1293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1640 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xcf1400", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf14e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1641 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xcf1408", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf14e8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1321,11 +1321,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1626 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf0e53", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf0f33", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1627 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf0fda", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf10ba", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1367,11 +1367,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1630 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xcf104a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf112a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1631 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf1059", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1139", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1394,11 +1394,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1664 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xcf1880", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1960", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1665 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xcf1886", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1966", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1412,11 +1412,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1666 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xcf18ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf19ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1667 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xcf190d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf19ed", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1439,11 +1439,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1622 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf0da0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1623 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf0da3", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e83", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1457,11 +1457,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf0dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0ea0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1625 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf0dcb", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0eab", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1484,11 +1484,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1642 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xcf14c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf15a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1643 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xcf14c7", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf15a7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1502,11 +1502,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1644 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xcf154a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf162a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1645 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xcf1573", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1653", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1529,11 +1529,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1632 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf12c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf13a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1633 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf12c3", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf13a3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1547,11 +1547,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1634 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xcf12e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf13c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1635 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xcf12e3", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf13c3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1565,11 +1565,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1636 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xcf1300", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf13e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1637 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xcf1303", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf13e3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1592,11 +1592,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1646 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xcf1620", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1700", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1647 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xcf1627", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1707", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1610,11 +1610,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1648 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xcf1640", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1720", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1649 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf164e", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf172e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1637,11 +1637,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1618 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf0d60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1619 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf0d63", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e43", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1655,11 +1655,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1620 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf0d80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1621 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf0d8b", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e6b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1682,11 +1682,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0xce868a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce876a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1419 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0xce86ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce87ce", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1713,11 +1713,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0xce872e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce880e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1421 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0xce87be", Frameless: false}]
+              InjectionPoints: [{PC: "0xce889e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1744,11 +1744,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0xce880a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce88ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1423 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0xce884b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce892b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1770,7 +1770,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1674 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0xce8786", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8866", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1788,11 +1788,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1424 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0xce888e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce896e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1425 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0xce8973", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8a53", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1810,7 +1810,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1675 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0xce8893", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8973", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1831,7 +1831,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1676 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0xce8893", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8973", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1849,7 +1849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1677 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0xce893b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8a1b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1870,7 +1870,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1678 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0xce893b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8a1b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1891,7 +1891,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x53dae1"
                   Frameless: true
-                - PC: "0xce936e"
+                - PC: "0xce9453"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1912,20 +1912,20 @@ Probes:
             - Kind: Entry
               Type: 1671 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0xce84ea"
+                - PC: "0xce85ca"
                   Frameless: false
-                - PC: "0xce8571"
+                - PC: "0xce8651"
                   Frameless: false
-                - PC: "0xce86b2"
+                - PC: "0xce8792"
                   Frameless: false
-                - PC: "0xce873c"
+                - PC: "0xce881c"
                   Frameless: false
-                - PC: "0xce880f"
+                - PC: "0xce88ef"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1672 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0xce852a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce860a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1951,15 +1951,15 @@ Probes:
             - Kind: Line
               Type: 1673 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xce84ee"
+                - PC: "0xce85ce"
                   Frameless: false
-                - PC: "0xce8571"
+                - PC: "0xce8651"
                   Frameless: false
-                - PC: "0xce86b2"
+                - PC: "0xce8792"
                   Frameless: false
-                - PC: "0xce873c"
+                - PC: "0xce881c"
                   Frameless: false
-                - PC: "0xce880f"
+                - PC: "0xce88ef"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1982,7 +1982,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1679 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0xce89a1", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8a81", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2007,7 +2007,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1680 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0xce89a1", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8a81", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2031,9 +2031,9 @@ Probes:
             - Kind: Entry
               Type: 1681 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0xce89ed"
+                - PC: "0xce8acd"
                   Frameless: false
-                - PC: "0xce8a83"
+                - PC: "0xce8b63"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2056,7 +2056,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0xce5b40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5c20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2078,7 +2078,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0xce5b60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5c40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2100,7 +2100,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0xce5b80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5c60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2122,7 +2122,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0xce5b20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2144,7 +2144,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0xce5b00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2166,7 +2166,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0xce8ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8d80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2187,11 +2187,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xced0ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xced1ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1563 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xced24d", Frameless: false}]
+              InjectionPoints: [{PC: "0xced32d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2213,7 +2213,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xceb500", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2238,7 +2238,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1411 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xce697a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6a5a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2260,7 +2260,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1412 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xce6a3f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6b1f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2282,7 +2282,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1413 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xce6b05", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6be5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2325,11 +2325,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xced593", Frameless: false}]
+              InjectionPoints: [{PC: "0xced673", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1569 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xced7c2", Frameless: false}]
+              InjectionPoints: [{PC: "0xced8a2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2391,7 +2391,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xce94a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2413,7 +2413,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xce9560", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2435,7 +2435,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xce96a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2457,7 +2457,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xce96e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce97c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2479,7 +2479,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xce96c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce97a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2501,7 +2501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xce9520", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2523,7 +2523,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xce9680", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2545,7 +2545,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xce9660", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2569,7 +2569,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xce9540", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2593,7 +2593,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xce9540", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2615,7 +2615,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xce9640", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2637,7 +2637,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xce9620", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2659,7 +2659,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xce9460", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2681,7 +2681,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xce9480", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2703,7 +2703,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xce9440", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2725,7 +2725,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xce9580", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2747,7 +2747,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xce95e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce96c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2769,7 +2769,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xce9600", Frameless: true}]
+              InjectionPoints: [{PC: "0xce96e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2791,7 +2791,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xce95a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2815,7 +2815,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xce95c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce96a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2837,7 +2837,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcee960", Frameless: true}]
+              InjectionPoints: [{PC: "0xceea40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2860,7 +2860,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcee960", Frameless: true}]
+              InjectionPoints: [{PC: "0xceea40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2907,11 +2907,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xced853", Frameless: false}]
+              InjectionPoints: [{PC: "0xced933", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1571 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xceda82", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedb62", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2977,11 +2977,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xcedbce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedcae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1575 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xcedc9d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedd7d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3012,11 +3012,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xced34e", Frameless: false}]
+              InjectionPoints: [{PC: "0xced42e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1567 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xced56b", Frameless: false}]
+              InjectionPoints: [{PC: "0xced64b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3042,11 +3042,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1507 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcec2ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec3ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1508 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec38f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec46f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3082,7 +3082,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xceb0e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb1c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3123,11 +3123,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1501 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcec24a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec32a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1502 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec2bb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec39b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3151,11 +3151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1503 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcec24a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec32a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1504 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec2bb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec39b", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3174,11 +3174,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1509 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcec2ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec3ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1510 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec38f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec46f", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3198,11 +3198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1511 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcec2ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec3ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1512 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec38f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec46f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3235,11 +3235,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1505 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcec24a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec32a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1506 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec2bb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec39b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3267,7 +3267,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xceed60", Frameless: true}]
+              InjectionPoints: [{PC: "0xceee40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3292,7 +3292,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xceed60", Frameless: true}]
+              InjectionPoints: [{PC: "0xceee40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3323,7 +3323,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xceed60", Frameless: true}]
+              InjectionPoints: [{PC: "0xceee40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3348,7 +3348,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xceed60", Frameless: true}]
+              InjectionPoints: [{PC: "0xceee40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3375,7 +3375,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xceb6a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3402,7 +3402,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xcee4a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3429,7 +3429,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xcee440", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3464,7 +3464,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xcee480", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3496,7 +3496,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1601 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xcee940", Frameless: true}]
+              InjectionPoints: [{PC: "0xceea20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3518,7 +3518,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xceb520", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3540,7 +3540,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xce9500", Frameless: true}]
+              InjectionPoints: [{PC: "0xce95e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3562,7 +3562,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xceb4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3586,11 +3586,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcebb0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebbea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1478 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcebb5b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebc3b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3610,11 +3610,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1521 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcec3ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec4ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1522 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec46d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec54d", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3655,11 +3655,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1487 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcebc2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebd0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1488 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcebce5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebdc5", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3697,11 +3697,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcebb0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebbea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1480 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcebb5b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebc3b", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3742,11 +3742,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1489 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcebc2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebd0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1490 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcebce5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebdc5", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3786,11 +3786,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1523 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcec3ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec4ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1524 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec46d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec54d", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3807,11 +3807,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1525 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcec3ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec4ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1526 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec46d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec54d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3833,11 +3833,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcebb0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebbea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1482 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcebb5b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebc3b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3860,18 +3860,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1497 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xcebeee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebfce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1498 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xcebf95"
+                - PC: "0xcec075"
                   Frameless: false
-                - PC: "0xcebfe4"
+                - PC: "0xcec0c4"
                   Frameless: false
-                - PC: "0xcec0af"
+                - PC: "0xcec18f"
                   Frameless: false
-                - PC: "0xcec0b9"
+                - PC: "0xcec199"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3899,18 +3899,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1495 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xcebd8e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebe6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1496 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xcebde4"
+                - PC: "0xcebec4"
                   Frameless: false
-                - PC: "0xcebe33"
+                - PC: "0xcebf13"
                   Frameless: false
-                - PC: "0xcebe73"
+                - PC: "0xcebf53"
                   Frameless: false
-                - PC: "0xcebeaf"
+                - PC: "0xcebf8f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3937,11 +3937,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1540 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xcecb6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecc4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1541 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xcecbcf", Frameless: false}]
+              InjectionPoints: [{PC: "0xceccaf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3958,11 +3958,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1542 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xcecbea", Frameless: false}]
+              InjectionPoints: [{PC: "0xceccca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1543 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xcecc2b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecd0b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3979,11 +3979,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1544 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xcecc4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecd2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1545 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xcecc86", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecd66", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4000,11 +4000,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xcecd2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcece0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1549 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xcecdaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcece8a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4021,11 +4021,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xced08a", Frameless: false}]
+              InjectionPoints: [{PC: "0xced16a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1561 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xced0d0", Frameless: false}]
+              InjectionPoints: [{PC: "0xced1b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4042,11 +4042,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xceca2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecb0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xceca86", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecb66", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4064,14 +4064,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xcebd0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebdea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1494 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xcebd44"
+                - PC: "0xcebe24"
                   Frameless: false
-                - PC: "0xcebd4e"
+                - PC: "0xcebe2e"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4093,11 +4093,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcebb0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebbea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1484 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcebb5b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebc3b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4118,11 +4118,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1491 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcebc2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebd0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1492 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcebce5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebdc5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4143,11 +4143,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1485 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xcebb8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebc6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1486 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xcebbf4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebcd4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4169,14 +4169,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1499 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xcec0ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec1ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1500 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xcec1bd"
+                - PC: "0xcec29d"
                   Frameless: false
-                - PC: "0xcec1c7"
+                - PC: "0xcec2a7"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4198,11 +4198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xcecaae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecb8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1539 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xcecb43", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecc23", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4219,11 +4219,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xcec92e", Frameless: false}]
+              InjectionPoints: [{PC: "0xceca0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xceca07", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecae7", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4240,11 +4240,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1552 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xceceaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecf8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1553 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xcecf0c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecfec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4261,11 +4261,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xceccaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecd8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1547 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xceccf8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecdd8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4282,11 +4282,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xced00a", Frameless: false}]
+              InjectionPoints: [{PC: "0xced0ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1559 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xced056", Frameless: false}]
+              InjectionPoints: [{PC: "0xced136", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4306,7 +4306,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1531 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xcec6af", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec78f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xcecfaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xced08a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1557 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xcecfee", Frameless: false}]
+              InjectionPoints: [{PC: "0xced0ce", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xcec8aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec98a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xcec911", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec9f1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4369,11 +4369,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xcecf2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xced00a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1555 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xcecf8f", Frameless: false}]
+              InjectionPoints: [{PC: "0xced06f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4390,11 +4390,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1550 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xcecdce", Frameless: false}]
+              InjectionPoints: [{PC: "0xceceae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1551 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xcece72", Frameless: false}]
+              InjectionPoints: [{PC: "0xcecf52", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4412,7 +4412,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0xce5aa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5b80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4447,11 +4447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1513 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcec2ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec3ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec38f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec46f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4497,7 +4497,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0xce6100", Frameless: true}]
+              InjectionPoints: [{PC: "0xce61e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4519,7 +4519,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0xce60c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce61a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4541,7 +4541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0xce6260", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4559,7 +4559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0xce6280", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4577,7 +4577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0xce6120", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4599,7 +4599,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0xce6160", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4622,7 +4622,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0xce6180", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4644,7 +4644,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0xce61a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4673,7 +4673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0xce6140", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4704,7 +4704,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0xce60e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce61c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4726,7 +4726,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xcee8c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee9a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4748,7 +4748,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0xce61c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce62a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4770,7 +4770,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0xce6200", Frameless: true}]
+              InjectionPoints: [{PC: "0xce62e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0xce6220", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4814,7 +4814,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0xce6240", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4836,7 +4836,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0xce61e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce62c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4858,7 +4858,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xcee4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4880,7 +4880,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1582 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xcee3e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4902,7 +4902,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xce94c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce95a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4923,11 +4923,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1527 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcec3ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec4ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec46d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec54d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4948,11 +4948,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1572 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xcedb2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1573 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xcedb9e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc7e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4974,7 +4974,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0xce5ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5ba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4996,7 +4996,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1474 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xceb660", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5018,7 +5018,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1586 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xcee460", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5040,7 +5040,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0xce6920", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0xce6940", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xceeca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceed80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5111,7 +5111,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xcee400", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5138,7 +5138,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0xce8dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5159,11 +5159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1576 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xcedcce", Frameless: false}]
+              InjectionPoints: [{PC: "0xceddae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1577 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xcedd84", Frameless: false}]
+              InjectionPoints: [{PC: "0xcede64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5185,7 +5185,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xceeb60", Frameless: true}]
+              InjectionPoints: [{PC: "0xceec40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5206,7 +5206,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xceeb40", Frameless: true}]
+              InjectionPoints: [{PC: "0xceec20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5233,7 +5233,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xce9420", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5265,7 +5265,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xcee500", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5305,7 +5305,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xcee9c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceeaa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5338,11 +5338,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcec2ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec3ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec38f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec46f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5363,11 +5363,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcec2ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec3ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec38f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec46f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5390,11 +5390,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcec2ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec3ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcec38f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcec46f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5423,7 +5423,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xcee8e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee9c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5455,7 +5455,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcee900", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee9e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5485,7 +5485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcee900", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee9e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5517,7 +5517,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcee920", Frameless: true}]
+              InjectionPoints: [{PC: "0xceea00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5547,7 +5547,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcee920", Frameless: true}]
+              InjectionPoints: [{PC: "0xceea00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5579,7 +5579,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0xce62a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5601,7 +5601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0xce5be0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5cc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5623,7 +5623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0xce5c00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5ce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5645,7 +5645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0xce5c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5d00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5667,7 +5667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0xce5bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5ca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5689,7 +5689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0xce5ba0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5c80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5711,7 +5711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xceb580", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5733,7 +5733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1580 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xcee3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5755,7 +5755,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xcee980", Frameless: true}]
+              InjectionPoints: [{PC: "0xceea60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5777,7 +5777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xceb540", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5799,7 +5799,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0xce5d00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5821,7 +5821,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcee4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5843,7 +5843,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcee4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5866,14 +5866,14 @@ Probes:
             - Kind: Entry
               Type: 1682 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0xce8bca"
+                - PC: "0xce8caa"
                   Frameless: false
-                - PC: "0xcf19da"
+                - PC: "0xcf1aba"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1683 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0xce8c05", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8ce5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5895,11 +5895,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xceddae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcede8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1579 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcede2c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedf0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5916,481 +5916,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0xce5a80..0xce5a81]
+      OutOfLinePCRanges: [0xce5b60..0xce5b61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 ArrayType [2]uint8
           Locations:
-            - Range: 0xce5a80..0xce5a81
+            - Range: 0xce5b60..0xce5b61
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0xce5aa0..0xce5aa1]
+      OutOfLinePCRanges: [0xce5b80..0xce5b81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]int32
           Locations:
-            - Range: 0xce5aa0..0xce5aa1
+            - Range: 0xce5b80..0xce5b81
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0xce5ac0..0xce5ac1]
+      OutOfLinePCRanges: [0xce5ba0..0xce5ba1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]string
           Locations:
-            - Range: 0xce5ac0..0xce5ac1
+            - Range: 0xce5ba0..0xce5ba1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0xce5ae0..0xce5ae1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 118 ArrayType [2]bool
-          Locations:
-            - Range: 0xce5ae0..0xce5ae1
-              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 5
-      Name: main.testIntArray
-      OutOfLinePCRanges: [0xce5b00..0xce5b01]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 119 ArrayType [2]int
-          Locations:
-            - Range: 0xce5b00..0xce5b01
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 6
-      Name: main.testInt8Array
-      OutOfLinePCRanges: [0xce5b20..0xce5b21]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 120 ArrayType [2]int8
-          Locations:
-            - Range: 0xce5b20..0xce5b21
-              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 7
-      Name: main.testInt16Array
-      OutOfLinePCRanges: [0xce5b40..0xce5b41]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 121 ArrayType [2]int16
-          Locations:
-            - Range: 0xce5b40..0xce5b41
-              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 8
-      Name: main.testInt32Array
-      OutOfLinePCRanges: [0xce5b60..0xce5b61]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 116 ArrayType [2]int32
-          Locations:
-            - Range: 0xce5b60..0xce5b61
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 9
-      Name: main.testInt64Array
-      OutOfLinePCRanges: [0xce5b80..0xce5b81]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 122 ArrayType [2]int64
-          Locations:
-            - Range: 0xce5b80..0xce5b81
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 10
-      Name: main.testUintArray
-      OutOfLinePCRanges: [0xce5ba0..0xce5ba1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 123 ArrayType [2]uint
-          Locations:
-            - Range: 0xce5ba0..0xce5ba1
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 11
-      Name: main.testUint8Array
       OutOfLinePCRanges: [0xce5bc0..0xce5bc1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 115 ArrayType [2]uint8
+          Type: 118 ArrayType [2]bool
           Locations:
             - Range: 0xce5bc0..0xce5bc1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 5
+      Name: main.testIntArray
+      OutOfLinePCRanges: [0xce5be0..0xce5be1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 119 ArrayType [2]int
+          Locations:
+            - Range: 0xce5be0..0xce5be1
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 6
+      Name: main.testInt8Array
+      OutOfLinePCRanges: [0xce5c00..0xce5c01]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 120 ArrayType [2]int8
+          Locations:
+            - Range: 0xce5c00..0xce5c01
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 7
+      Name: main.testInt16Array
+      OutOfLinePCRanges: [0xce5c20..0xce5c21]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 121 ArrayType [2]int16
+          Locations:
+            - Range: 0xce5c20..0xce5c21
+              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 8
+      Name: main.testInt32Array
+      OutOfLinePCRanges: [0xce5c40..0xce5c41]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 116 ArrayType [2]int32
+          Locations:
+            - Range: 0xce5c40..0xce5c41
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 9
+      Name: main.testInt64Array
+      OutOfLinePCRanges: [0xce5c60..0xce5c61]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 122 ArrayType [2]int64
+          Locations:
+            - Range: 0xce5c60..0xce5c61
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 10
+      Name: main.testUintArray
+      OutOfLinePCRanges: [0xce5c80..0xce5c81]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 123 ArrayType [2]uint
+          Locations:
+            - Range: 0xce5c80..0xce5c81
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 11
+      Name: main.testUint8Array
+      OutOfLinePCRanges: [0xce5ca0..0xce5ca1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 115 ArrayType [2]uint8
+          Locations:
+            - Range: 0xce5ca0..0xce5ca1
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0xce5be0..0xce5be1]
+      OutOfLinePCRanges: [0xce5cc0..0xce5cc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 124 ArrayType [2]uint16
           Locations:
-            - Range: 0xce5be0..0xce5be1
+            - Range: 0xce5cc0..0xce5cc1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0xce5c00..0xce5c01]
+      OutOfLinePCRanges: [0xce5ce0..0xce5ce1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 125 ArrayType [2]uint32
           Locations:
-            - Range: 0xce5c00..0xce5c01
+            - Range: 0xce5ce0..0xce5ce1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0xce5c20..0xce5c21]
+      OutOfLinePCRanges: [0xce5d00..0xce5d01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 58 ArrayType [2]uint64
           Locations:
-            - Range: 0xce5c20..0xce5c21
+            - Range: 0xce5d00..0xce5d01
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0xce5c40..0xce5c41]
+      OutOfLinePCRanges: [0xce5d20..0xce5d21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 126 ArrayType [2][2]int
           Locations:
-            - Range: 0xce5c40..0xce5c41
+            - Range: 0xce5d20..0xce5d21
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0xce5c60..0xce5c61]
+      OutOfLinePCRanges: [0xce5d40..0xce5d41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 117 ArrayType [2]string
           Locations:
-            - Range: 0xce5c60..0xce5c61
+            - Range: 0xce5d40..0xce5d41
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0xce5c80..0xce5c81]
+      OutOfLinePCRanges: [0xce5d60..0xce5d61]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 127 ArrayType [2][2][2]int
           Locations:
-            - Range: 0xce5c80..0xce5c81
+            - Range: 0xce5d60..0xce5d61
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0xce5ca0..0xce5ca1]
+      OutOfLinePCRanges: [0xce5d80..0xce5d81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 128 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0xce5ca0..0xce5ca1
+            - Range: 0xce5d80..0xce5d81
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0xce5cc0..0xce5cc1]
+      OutOfLinePCRanges: [0xce5da0..0xce5da1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 130 ArrayType [2]struct {}
           Locations:
-            - Range: 0xce5cc0..0xce5cc1
+            - Range: 0xce5da0..0xce5da1
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0xce5d00..0xce5d01]
+      OutOfLinePCRanges: [0xce5de0..0xce5de1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 132 ArrayType [100]uint
           Locations:
-            - Range: 0xce5d00..0xce5d01
+            - Range: 0xce5de0..0xce5de1
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xce60c0..0xce60c1]
+      OutOfLinePCRanges: [0xce61a0..0xce61a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xce60c0..0xce60c1
+            - Range: 0xce61a0..0xce61a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0xce60e0..0xce60e1]
+      OutOfLinePCRanges: [0xce61c0..0xce61c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xce60e0..0xce60e1
+            - Range: 0xce61c0..0xce61c1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0xce6100..0xce6101]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 4 BaseType bool
-          Locations:
-            - Range: 0xce6100..0xce6101
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 24
-      Name: main.testSingleInt
-      OutOfLinePCRanges: [0xce6120..0xce6121]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xce6120..0xce6121
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 25
-      Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xce6140..0xce6141]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 20 BaseType int8
-          Locations:
-            - Range: 0xce6140..0xce6141
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 26
-      Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xce6160..0xce6161]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 109 BaseType int16
-          Locations:
-            - Range: 0xce6160..0xce6161
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 27
-      Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xce6180..0xce6181]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 BaseType int32
-          Locations:
-            - Range: 0xce6180..0xce6181
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 28
-      Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xce61a0..0xce61a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 BaseType int64
-          Locations:
-            - Range: 0xce61a0..0xce61a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 29
-      Name: main.testSingleUint
-      OutOfLinePCRanges: [0xce61c0..0xce61c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 14 BaseType uint
-          Locations:
-            - Range: 0xce61c0..0xce61c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 30
-      Name: main.testSingleUint8
       OutOfLinePCRanges: [0xce61e0..0xce61e1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 BaseType uint8
+          Type: 4 BaseType bool
           Locations:
             - Range: 0xce61e0..0xce61e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 24
+      Name: main.testSingleInt
+      OutOfLinePCRanges: [0xce6200..0xce6201]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xce6200..0xce6201
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 25
+      Name: main.testSingleInt8
+      OutOfLinePCRanges: [0xce6220..0xce6221]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 20 BaseType int8
+          Locations:
+            - Range: 0xce6220..0xce6221
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 26
+      Name: main.testSingleInt16
+      OutOfLinePCRanges: [0xce6240..0xce6241]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 109 BaseType int16
+          Locations:
+            - Range: 0xce6240..0xce6241
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 27
+      Name: main.testSingleInt32
+      OutOfLinePCRanges: [0xce6260..0xce6261]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 BaseType int32
+          Locations:
+            - Range: 0xce6260..0xce6261
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 28
+      Name: main.testSingleInt64
+      OutOfLinePCRanges: [0xce6280..0xce6281]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 BaseType int64
+          Locations:
+            - Range: 0xce6280..0xce6281
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 29
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0xce62a0..0xce62a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 14 BaseType uint
+          Locations:
+            - Range: 0xce62a0..0xce62a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 30
+      Name: main.testSingleUint8
+      OutOfLinePCRanges: [0xce62c0..0xce62c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0xce62c0..0xce62c1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0xce6200..0xce6201]
+      OutOfLinePCRanges: [0xce62e0..0xce62e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xce6200..0xce6201
+            - Range: 0xce62e0..0xce62e1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xce6220..0xce6221]
+      OutOfLinePCRanges: [0xce6300..0xce6301]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xce6220..0xce6221
+            - Range: 0xce6300..0xce6301
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0xce6240..0xce6241]
+      OutOfLinePCRanges: [0xce6320..0xce6321]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xce6240..0xce6241
+            - Range: 0xce6320..0xce6321
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xce6260..0xce6261]
+      OutOfLinePCRanges: [0xce6340..0xce6341]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xce6260..0xce6261
+            - Range: 0xce6340..0xce6341
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xce6280..0xce6281]
+      OutOfLinePCRanges: [0xce6360..0xce6361]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType float64
           Locations:
-            - Range: 0xce6280..0xce6281
+            - Range: 0xce6360..0xce6361
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xce62a0..0xce62a1]
+      OutOfLinePCRanges: [0xce6380..0xce6381]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 133 BaseType main.typeAlias
           Locations:
-            - Range: 0xce62a0..0xce62a1
+            - Range: 0xce6380..0xce6381
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xce6400..0xce6401]
+      OutOfLinePCRanges: [0xce64e0..0xce64e1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 134 StructureType main.bigStruct
           Locations:
-            - Range: 0xce6400..0xce6401
+            - Range: 0xce64e0..0xce64e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6409,87 +6409,87 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0xce6460..0xce6565]
+      OutOfLinePCRanges: [0xce6540..0xce6645]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce6460..0xce6478
+            - Range: 0xce6540..0xce6558
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xce6460..0xce6565, Pieces: []}]
+          Locations: [{Range: 0xce6540..0xce6645, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
-          Locations: [{Range: 0xce6460..0xce6565, Pieces: []}]
+          Locations: [{Range: 0xce6540..0xce6645, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xce6493..0xce64af
+            - Range: 0xce6573..0xce658f
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0xce64af..0xce651d
+            - Range: 0xce658f..0xce65fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce651d..0xce6520
+            - Range: 0xce65fd..0xce6600
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce6520..0xce6565
+            - Range: 0xce6600..0xce6645
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}, {Size: 8, Op: null}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xce65e0..0xce65e1]
+      OutOfLinePCRanges: [0xce66c0..0xce66c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 138 StructureType main.deepPtr1
           Locations:
-            - Range: 0xce65e0..0xce65e1
+            - Range: 0xce66c0..0xce66c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xce6600..0xce6601]
+      OutOfLinePCRanges: [0xce66e0..0xce66e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 141 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xce6600..0xce6601
+            - Range: 0xce66e0..0xce66e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xce6760..0xce6761]
+      OutOfLinePCRanges: [0xce6840..0xce6841]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 143 StructureType main.deepSlice1
           Locations:
-            - Range: 0xce6760..0xce6761
+            - Range: 0xce6840..0xce6841
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6502,131 +6502,131 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xce6780..0xce6781]
+      OutOfLinePCRanges: [0xce6860..0xce6861]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 147 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xce6780..0xce6781
+            - Range: 0xce6860..0xce6861
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xce68e0..0xce68e1]
+      OutOfLinePCRanges: [0xce69c0..0xce69c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 StructureType main.deepMap1
           Locations:
-            - Range: 0xce68e0..0xce68e1
+            - Range: 0xce69c0..0xce69c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xce6900..0xce6901]
+      OutOfLinePCRanges: [0xce69e0..0xce69e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 155 PointerType *main.deepMap7
           Locations:
-            - Range: 0xce6900..0xce6901
+            - Range: 0xce69e0..0xce69e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xce6920..0xce6921]
+      OutOfLinePCRanges: [0xce6a00..0xce6a01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 157 PointerType *main.stringType1
           Locations:
-            - Range: 0xce6920..0xce6921
+            - Range: 0xce6a00..0xce6a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xce6940..0xce6941]
+      OutOfLinePCRanges: [0xce6a20..0xce6a21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 159 PointerType **main.stringType2
           Locations:
-            - Range: 0xce6940..0xce6941
+            - Range: 0xce6a20..0xce6a21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xce6960..0xce6b98]
+      OutOfLinePCRanges: [0xce6a40..0xce6c78]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce6a3f..0xce6a57
+            - Range: 0xce6b1f..0xce6b37
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6b05..0xce6b1d
+            - Range: 0xce6be5..0xce6bfd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce6a28..0xce6a2b
+            - Range: 0xce6b08..0xce6b0b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6a2b..0xce6a3f
+            - Range: 0xce6b0b..0xce6b1f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6a3f..0xce6a57
+            - Range: 0xce6b1f..0xce6b37
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xce6a57..0xce6af8
+            - Range: 0xce6b37..0xce6bd8
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xce6af8..0xce6b05
+            - Range: 0xce6bd8..0xce6be5
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xce6b05..0xce6b98
+            - Range: 0xce6be5..0xce6c78
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce6a22..0xce6a2b
+            - Range: 0xce6b02..0xce6b0b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6a2b..0xce6a2b
+            - Range: 0xce6b0b..0xce6b0b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce6a2b..0xce6a3f
+            - Range: 0xce6b0b..0xce6b1f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6a3f..0xce6af8
+            - Range: 0xce6b1f..0xce6bd8
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xce6af8..0xce6afd
+            - Range: 0xce6bd8..0xce6bdd
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xce6afd..0xce6b05
+            - Range: 0xce6bdd..0xce6be5
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xce6b05..0xce6b0a
+            - Range: 0xce6be5..0xce6bea
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xce6b0a..0xce6b98
+            - Range: 0xce6bea..0xce6c78
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xce6fa0..0xce70a5]
+      OutOfLinePCRanges: [0xce7080..0xce7185]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 161 StructureType main.esotericStack
           Locations:
-            - Range: 0xce6fa0..0xce6ff3
+            - Range: 0xce7080..0xce70d3
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6646,7 +6646,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xce6ff3..0xce6ff8
+            - Range: 0xce70d3..0xce70d8
               Pieces:
                 - Size: 4
                   Op: null
@@ -6666,7 +6666,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xce6ff8..0xce6ffd
+            - Range: 0xce70d8..0xce70dd
               Pieces:
                 - Size: 4
                   Op: null
@@ -6691,155 +6691,155 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xce70c0..0xce7123]
+      OutOfLinePCRanges: [0xce71a0..0xce7203]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 165 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xce70c0..0xce70ed
+            - Range: 0xce71a0..0xce71cd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 50
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xce8680..0xce8708]
+      OutOfLinePCRanges: [0xce8760..0xce87e8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce8680..0xce8695
+            - Range: 0xce8760..0xce8775
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 51
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xce8720..0xce87e5]
+      OutOfLinePCRanges: [0xce8800..0xce88c5]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce8720..0xce8736
+            - Range: 0xce8800..0xce8816
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce8720..0xce8747
+            - Range: 0xce8800..0xce8827
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce8736..0xce8747
+            - Range: 0xce8816..0xce8827
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8747..0xce87e5
+            - Range: 0xce8827..0xce88c5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xce8800..0xce8862]
+      OutOfLinePCRanges: [0xce88e0..0xce8942]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce8800..0xce881a
+            - Range: 0xce88e0..0xce88fa
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xce8880..0xce8985]
+      OutOfLinePCRanges: [0xce8960..0xce8a65]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce88db..0xce88e5
+            - Range: 0xce89bb..0xce89c5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xce88e5..0xce88f5
+            - Range: 0xce89c5..0xce89d5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xce88f5..0xce8909
+            - Range: 0xce89d5..0xce89e9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce88d6..0xce88e0
+            - Range: 0xce89b6..0xce89c0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xce88e0..0xce88f5
+            - Range: 0xce89c0..0xce89d5
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xce88f5..0xce8904
+            - Range: 0xce89d5..0xce89e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xce89a0..0xce89a6]
+      OutOfLinePCRanges: [0xce8a80..0xce8a86]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce89a0..0xce89a5
+            - Range: 0xce8a80..0xce8a85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce89a0..0xce89a5
+            - Range: 0xce8a80..0xce8a85
               Pieces: []
-            - Range: 0xce89a5..0xce89a6
+            - Range: 0xce8a85..0xce8a86
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xce89c0..0xce8a0b]
+      OutOfLinePCRanges: [0xce8aa0..0xce8aeb]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0xce89c0..0xce8a0b
+            - Range: 0xce8aa0..0xce8aeb
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce89c0..0xce8a05
+            - Range: 0xce8aa0..0xce8ae5
               Pieces: []
-            - Range: 0xce8a05..0xce8a06
+            - Range: 0xce8ae5..0xce8ae6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8a06..0xce8a0b
+            - Range: 0xce8ae6..0xce8aeb
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0xce8ca0..0xce8ca1]
+      OutOfLinePCRanges: [0xce8d80..0xce8d81]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xce8ca0..0xce8ca1
+            - Range: 0xce8d80..0xce8d81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6850,19 +6850,19 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0xce8cc0..0xce8d26]
+      OutOfLinePCRanges: [0xce8da0..0xce8e06]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce8cc0..0xce8ce9
+            - Range: 0xce8da0..0xce8dc9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce8ce9..0xce8cee
+            - Range: 0xce8dc9..0xce8dce
               Pieces:
                 - Size: 8
                   Op: null
@@ -6873,28 +6873,28 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce8cc0..0xce8d05
+            - Range: 0xce8da0..0xce8de5
               Pieces: []
-            - Range: 0xce8d05..0xce8d06
+            - Range: 0xce8de5..0xce8de6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce8d06..0xce8d26
+            - Range: 0xce8de6..0xce8e06
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0xce8d40..0xce8d41]
+      OutOfLinePCRanges: [0xce8e20..0xce8e21]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xce8d40..0xce8d41
+            - Range: 0xce8e20..0xce8e21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6905,41 +6905,41 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xce8d60..0xce8db4]
+      OutOfLinePCRanges: [0xce8e40..0xce8e94]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 169 PointerType *interface {}
           Locations:
-            - Range: 0xce8d60..0xce8d86
+            - Range: 0xce8e40..0xce8e66
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce8d60..0xce8d9d
+            - Range: 0xce8e40..0xce8e7d
               Pieces: []
-            - Range: 0xce8d9d..0xce8d9e
+            - Range: 0xce8e7d..0xce8e7e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce8d9e..0xce8db4
+            - Range: 0xce8e7e..0xce8e94
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xce8dc0..0xce8dc1]
+      OutOfLinePCRanges: [0xce8ea0..0xce8ea1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 170 StructureType main.structWithAny
           Locations:
-            - Range: 0xce8dc0..0xce8dc1
+            - Range: 0xce8ea0..0xce8ea1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6950,346 +6950,346 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xce9420..0xce9421]
+      OutOfLinePCRanges: [0xce9500..0xce9501]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 171 StructureType main.structWithMap
-          Locations:
-            - Range: 0xce9420..0xce9421
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xce9440..0xce9441]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 177 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xce9440..0xce9441
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 63
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xce9460..0xce9461]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 182 GoMapType map[string]int
-          Locations:
-            - Range: 0xce9460..0xce9461
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xce9480..0xce9481]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 187 GoMapType map[string][]string
-          Locations:
-            - Range: 0xce9480..0xce9481
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xce94a0..0xce94a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 192 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xce94a0..0xce94a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 66
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xce94c0..0xce94c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 182 GoMapType map[string]int
-          Locations:
-            - Range: 0xce94c0..0xce94c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xce94e0..0xce94e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 197 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xce94e0..0xce94e1
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xce9500..0xce9501]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 198 PointerType *map[string]int
           Locations:
             - Range: 0xce9500..0xce9501
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 69
-      Name: main.testMapIntToInt
+    - ID: 62
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xce9520..0xce9521]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 172 GoMapType map[int]int
+          Type: 177 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xce9520..0xce9521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 70
-      Name: main.testMapMassive
+    - ID: 63
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xce9540..0xce9541]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 199 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 182 GoMapType map[string]int
           Locations:
             - Range: 0xce9540..0xce9541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 71
-      Name: main.testMapEmbeddedMaps
+    - ID: 64
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xce9560..0xce9561]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 199 GoMapType map[string][]main.structWithMap
+          Type: 187 GoMapType map[string][]string
           Locations:
             - Range: 0xce9560..0xce9561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapWithLinkedList
+    - ID: 65
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xce9580..0xce9581]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 204 GoMapType map[bool]main.node
+          Type: 192 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xce9580..0xce9581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapWithSmallValue
+    - ID: 66
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xce95a0..0xce95a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 209 GoMapType map[int]uint8
+          Type: 182 GoMapType map[string]int
           Locations:
             - Range: 0xce95a0..0xce95a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithSmallValueMassive
+    - ID: 67
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xce95c0..0xce95c1]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 209 GoMapType map[int]uint8
+        - Name: m
+          Type: 197 ArrayType [2]map[string]int
           Locations:
             - Range: 0xce95c0..0xce95c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 68
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xce95e0..0xce95e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 214 GoMapType map[uint8]uint8
+          Type: 198 PointerType *map[string]int
           Locations:
             - Range: 0xce95e0..0xce95e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 69
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xce9600..0xce9601]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 214 GoMapType map[uint8]uint8
+          Type: 172 GoMapType map[int]int
           Locations:
             - Range: 0xce9600..0xce9601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapSmallKeySmallValue
+    - ID: 70
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xce9620..0xce9621]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 214 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 199 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xce9620..0xce9621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 71
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xce9640..0xce9641]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 219 GoMapType map[uint8][4]int
+          Type: 199 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xce9640..0xce9641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapLargeKeySmallValue
+    - ID: 72
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xce9660..0xce9661]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 224 GoMapType map[[4]int]uint8
+          Type: 204 GoMapType map[bool]main.node
           Locations:
             - Range: 0xce9660..0xce9661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 73
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xce9680..0xce9681]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 229 GoMapType map[[4]int][4]int
+          Type: 209 GoMapType map[int]uint8
           Locations:
             - Range: 0xce9680..0xce9681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapEmptyKey
+    - ID: 74
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xce96a0..0xce96a1]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 234 GoMapType map[struct {}]int
+        - Name: redactMyEntries
+          Type: 209 GoMapType map[int]uint8
           Locations:
             - Range: 0xce96a0..0xce96a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapEmptyValue
+    - ID: 75
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xce96c0..0xce96c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 239 GoMapType map[int]struct {}
+          Type: 214 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xce96c0..0xce96c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 76
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xce96e0..0xce96e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 244 GoMapType map[struct {}]struct {}
+          Type: 214 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xce96e0..0xce96e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xce9700..0xce9701]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 214 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xce9700..0xce9701
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 78
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xce9720..0xce9721]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 219 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xce9720..0xce9721
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 79
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xce9740..0xce9741]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 224 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xce9740..0xce9741
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 80
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xce9760..0xce9761]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 229 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xce9760..0xce9761
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 81
+      Name: main.testMapEmptyKey
+      OutOfLinePCRanges: [0xce9780..0xce9781]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 234 GoMapType map[struct {}]int
+          Locations:
+            - Range: 0xce9780..0xce9781
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 82
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0xce97a0..0xce97a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 239 GoMapType map[int]struct {}
+          Locations:
+            - Range: 0xce97a0..0xce97a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0xce97c0..0xce97c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 244 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0xce97c0..0xce97c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xceaf20..0xceaf21]
+      OutOfLinePCRanges: [0xceb000..0xceb001]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xceaf20..0xceaf21
+            - Range: 0xceb000..0xceb001
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xceaf20..0xceaf21
+            - Range: 0xceb000..0xceb001
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xceaf20..0xceaf21
+            - Range: 0xceb000..0xceb001
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xceaf60..0xceaf61]
+      OutOfLinePCRanges: [0xceb040..0xceb041]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xceaf60..0xceaf61
+            - Range: 0xceb040..0xceb041
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xceaf60..0xceaf61
+            - Range: 0xceb040..0xceb041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7300,48 +7300,48 @@ Subprograms:
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xceaf60..0xceaf61
+            - Range: 0xceb040..0xceb041
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xceb0e0..0xceb0e1]
+      OutOfLinePCRanges: [0xceb1c0..0xceb1c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xceb0e0..0xceb0e1
+            - Range: 0xceb1c0..0xceb1c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xceb0e0..0xceb0e1
+            - Range: 0xceb1c0..0xceb1c1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xceb0e0..0xceb0e1
+            - Range: 0xceb1c0..0xceb1c1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 14 BaseType uint
           Locations:
-            - Range: 0xceb0e0..0xceb0e1
+            - Range: 0xceb1c0..0xceb1c1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xceb0e0..0xceb0e1
+            - Range: 0xceb1c0..0xceb1c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7352,61 +7352,61 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xceb300..0xceb313]
+      OutOfLinePCRanges: [0xceb3e0..0xceb3f3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xceb300..0xceb312
+            - Range: 0xceb3e0..0xceb3f2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xceb300..0xceb312
+            - Range: 0xceb3e0..0xceb3f2
               Pieces: []
-            - Range: 0xceb312..0xceb313
+            - Range: 0xceb3f2..0xceb3f3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0xceb320..0xceb321]
+      OutOfLinePCRanges: [0xceb400..0xceb401]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 249 GoChannelType chan bool
           Locations:
-            - Range: 0xceb320..0xceb321
+            - Range: 0xceb400..0xceb401
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xceb4e0..0xceb4e1]
+      OutOfLinePCRanges: [0xceb5c0..0xceb5c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 250 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xceb4e0..0xceb4e1
+            - Range: 0xceb5c0..0xceb5c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xceb500..0xceb501]
+      OutOfLinePCRanges: [0xceb5e0..0xceb5e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 StructureType main.node
           Locations:
-            - Range: 0xceb500..0xceb501
+            - Range: 0xceb5e0..0xceb5e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7417,273 +7417,273 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xceb520..0xceb521]
+      OutOfLinePCRanges: [0xceb600..0xceb601]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 PointerType *main.node
           Locations:
-            - Range: 0xceb520..0xceb521
+            - Range: 0xceb600..0xceb601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xceb540..0xceb541]
+      OutOfLinePCRanges: [0xceb620..0xceb621]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xceb540..0xceb541
+            - Range: 0xceb620..0xceb621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xceb580..0xceb581]
+      OutOfLinePCRanges: [0xceb660..0xceb661]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 PointerType *uint
-          Locations:
-            - Range: 0xceb580..0xceb581
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 94
-      Name: main.testStringPointer
-      OutOfLinePCRanges: [0xceb660..0xceb661]
-      InlinePCRanges: []
-      Variables:
-        - Name: z
-          Type: 101 PointerType *string
           Locations:
             - Range: 0xceb660..0xceb661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 94
+      Name: main.testStringPointer
+      OutOfLinePCRanges: [0xceb740..0xceb741]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 101 PointerType *string
+          Locations:
+            - Range: 0xceb740..0xceb741
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xceb6a0..0xceb6a1]
+      OutOfLinePCRanges: [0xceb780..0xceb781]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xceb6a0..0xceb6a1
+            - Range: 0xceb780..0xceb781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 14 BaseType uint
           Locations:
-            - Range: 0xceb6a0..0xceb6a1
+            - Range: 0xceb780..0xceb781
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0xceb6e0..0xceb6e1]
+      OutOfLinePCRanges: [0xceb7c0..0xceb7c1]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 254 PointerType *main.t
           Locations:
-            - Range: 0xceb6e0..0xceb6e1
+            - Range: 0xceb7c0..0xceb7c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcebb00..0xcebb72]
+      OutOfLinePCRanges: [0xcebbe0..0xcebc52]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcebb00..0xcebb12
+            - Range: 0xcebbe0..0xcebbf2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcebb00..0xcebb5b
+            - Range: 0xcebbe0..0xcebc3b
               Pieces: []
-            - Range: 0xcebb5b..0xcebb5c
+            - Range: 0xcebc3b..0xcebc3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcebb5c..0xcebb72
+            - Range: 0xcebc3c..0xcebc52
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcebb12..0xcebb25
+            - Range: 0xcebbf2..0xcebc05
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcebb25..0xcebb72
+            - Range: 0xcebc05..0xcebc52
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcebb80..0xcebc0f]
+      OutOfLinePCRanges: [0xcebc60..0xcebcef]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcebb80..0xcebb9a
+            - Range: 0xcebc60..0xcebc7a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcebb9a..0xcebc0f
+            - Range: 0xcebc7a..0xcebcef
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 104 PointerType *int
           Locations:
-            - Range: 0xcebb80..0xcebbf4
+            - Range: 0xcebc60..0xcebcd4
               Pieces: []
-            - Range: 0xcebbf4..0xcebbf5
+            - Range: 0xcebcd4..0xcebcd5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcebbf5..0xcebc0f
+            - Range: 0xcebcd5..0xcebcef
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 104 PointerType *int
           Locations:
-            - Range: 0xcebb9f..0xcebbb9
+            - Range: 0xcebc7f..0xcebc99
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcebbb9..0xcebc0f
+            - Range: 0xcebc99..0xcebcef
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcebc20..0xcebcff]
+      OutOfLinePCRanges: [0xcebd00..0xcebddf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcebc20..0xcebc83
+            - Range: 0xcebd00..0xcebd63
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcebc20..0xcebce5
+            - Range: 0xcebd00..0xcebdc5
               Pieces: []
-            - Range: 0xcebce5..0xcebce6
+            - Range: 0xcebdc5..0xcebdc6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcebce6..0xcebcff
+            - Range: 0xcebdc6..0xcebddf
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcebc20..0xcebcff, Pieces: []}]
+          Locations: [{Range: 0xcebd00..0xcebddf, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcebc36..0xcebc88
+            - Range: 0xcebd16..0xcebd68
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcebc88..0xcebcff
+            - Range: 0xcebd68..0xcebddf
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 13 BaseType float64
           Locations:
-            - Range: 0xcebc4f..0xcebc88
+            - Range: 0xcebd2f..0xcebd68
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcebc88..0xcebcff
+            - Range: 0xcebd68..0xcebddf
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcebd00..0xcebd64]
+      OutOfLinePCRanges: [0xcebde0..0xcebe44]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcebd00..0xcebd17
+            - Range: 0xcebde0..0xcebdf7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xcebd00..0xcebd44
+            - Range: 0xcebde0..0xcebe24
               Pieces: []
-            - Range: 0xcebd44..0xcebd45
+            - Range: 0xcebe24..0xcebe25
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcebd45..0xcebd4e
+            - Range: 0xcebe25..0xcebe2e
               Pieces: []
-            - Range: 0xcebd4e..0xcebd4f
+            - Range: 0xcebe2e..0xcebe2f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcebd4f..0xcebd64
+            - Range: 0xcebe2f..0xcebe44
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcebd80..0xcebedc]
+      OutOfLinePCRanges: [0xcebe60..0xcebfbc]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcebd80..0xcebdcb
+            - Range: 0xcebe60..0xcebeab
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcebdcb..0xcebdd6
+            - Range: 0xcebeab..0xcebeb6
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcebe07..0xcebe0a
+            - Range: 0xcebee7..0xcebeea
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcebe3e..0xcebe45
+            - Range: 0xcebf1e..0xcebf25
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcebe7e..0xcebe85
+            - Range: 0xcebf5e..0xcebf65
               Pieces:
                 - Size: 8
                   Op: null
@@ -7694,117 +7694,117 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcebd80..0xcebdd6
+            - Range: 0xcebe60..0xcebeb6
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcebd80..0xcebde4
+            - Range: 0xcebe60..0xcebec4
               Pieces: []
-            - Range: 0xcebde4..0xcebde5
+            - Range: 0xcebec4..0xcebec5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcebde5..0xcebe33
+            - Range: 0xcebec5..0xcebf13
               Pieces: []
-            - Range: 0xcebe33..0xcebe34
+            - Range: 0xcebf13..0xcebf14
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcebe34..0xcebe73
+            - Range: 0xcebf14..0xcebf53
               Pieces: []
-            - Range: 0xcebe73..0xcebe74
+            - Range: 0xcebf53..0xcebf54
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcebe74..0xcebeaf
+            - Range: 0xcebf54..0xcebf8f
               Pieces: []
-            - Range: 0xcebeaf..0xcebeb0
+            - Range: 0xcebf8f..0xcebf90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcebeb0..0xcebedc
+            - Range: 0xcebf90..0xcebfbc
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xcebd80..0xcebde4
+            - Range: 0xcebe60..0xcebec4
               Pieces: []
-            - Range: 0xcebde4..0xcebde5
+            - Range: 0xcebec4..0xcebec5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcebde5..0xcebe33
+            - Range: 0xcebec5..0xcebf13
               Pieces: []
-            - Range: 0xcebe33..0xcebe34
+            - Range: 0xcebf13..0xcebf14
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcebe34..0xcebe73
+            - Range: 0xcebf14..0xcebf53
               Pieces: []
-            - Range: 0xcebe73..0xcebe74
+            - Range: 0xcebf53..0xcebf54
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcebe74..0xcebeaf
+            - Range: 0xcebf54..0xcebf8f
               Pieces: []
-            - Range: 0xcebeaf..0xcebeb0
+            - Range: 0xcebf8f..0xcebf90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcebeb0..0xcebedc
+            - Range: 0xcebf90..0xcebfbc
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcebdcb..0xcebdd1
+            - Range: 0xcebeab..0xcebeb1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcebee0..0xcec0dd]
+      OutOfLinePCRanges: [0xcebfc0..0xcec1bd]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcebee0..0xcebf2b
+            - Range: 0xcebfc0..0xcec00b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcebf2b..0xcebf32
+            - Range: 0xcec00b..0xcec012
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcebf32..0xcec0dd
+            - Range: 0xcec012..0xcec1bd
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7815,264 +7815,216 @@ Subprograms:
         - Name: ~r0
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcebee0..0xcebf95
+            - Range: 0xcebfc0..0xcec075
               Pieces: []
-            - Range: 0xcebf95..0xcebf96
+            - Range: 0xcec075..0xcec076
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcebf96..0xcebfe4
+            - Range: 0xcec076..0xcec0c4
               Pieces: []
-            - Range: 0xcebfe4..0xcebfe5
+            - Range: 0xcec0c4..0xcec0c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcebfe5..0xcec0af
+            - Range: 0xcec0c5..0xcec18f
               Pieces: []
-            - Range: 0xcec0af..0xcec0b0
+            - Range: 0xcec18f..0xcec190
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcec0b0..0xcec0b9
+            - Range: 0xcec190..0xcec199
               Pieces: []
-            - Range: 0xcec0b9..0xcec0ba
+            - Range: 0xcec199..0xcec19a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcec0ba..0xcec0dd
+            - Range: 0xcec19a..0xcec1bd
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcebf80..0xcebf86
+            - Range: 0xcec060..0xcec066
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 104 PointerType *int
           Locations:
-            - Range: 0xcebfc5..0xcebfe4
+            - Range: 0xcec0a5..0xcec0c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcec0e0..0xcec234]
+      OutOfLinePCRanges: [0xcec1c0..0xcec314]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcec0e0..0xcec120
+            - Range: 0xcec1c0..0xcec200
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcec120..0xcec170
+            - Range: 0xcec200..0xcec250
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcec170..0xcec1cd
+            - Range: 0xcec250..0xcec2ad
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcec1cd..0xcec1f1
+            - Range: 0xcec2ad..0xcec2d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcec1f1..0xcec1f8
+            - Range: 0xcec2d1..0xcec2d8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcec1f8..0xcec234
+            - Range: 0xcec2d8..0xcec314
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcec0e0..0xcec1bd
+            - Range: 0xcec1c0..0xcec29d
               Pieces: []
-            - Range: 0xcec1bd..0xcec1be
+            - Range: 0xcec29d..0xcec29e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcec1be..0xcec1c7
+            - Range: 0xcec29e..0xcec2a7
               Pieces: []
-            - Range: 0xcec1c7..0xcec1c8
+            - Range: 0xcec2a7..0xcec2a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcec1c8..0xcec234
+            - Range: 0xcec2a8..0xcec314
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcec0e0..0xcec120
+            - Range: 0xcec1c0..0xcec200
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcec120..0xcec170
+            - Range: 0xcec200..0xcec250
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcec170..0xcec177
+            - Range: 0xcec250..0xcec257
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcec177..0xcec1c3
+            - Range: 0xcec257..0xcec2a3
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcec1c3..0xcec1c5
+            - Range: 0xcec2a3..0xcec2a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcec1c5..0xcec1c7
+            - Range: 0xcec2a5..0xcec2a7
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcec1c7..0xcec234
+            - Range: 0xcec2a7..0xcec314
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcec240..0xcec2d5]
+      OutOfLinePCRanges: [0xcec320..0xcec3b5]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcec240..0xcec251
+            - Range: 0xcec320..0xcec331
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcec240..0xcec2bb
+            - Range: 0xcec320..0xcec39b
               Pieces: []
-            - Range: 0xcec2bb..0xcec2bc
+            - Range: 0xcec39b..0xcec39c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcec2bc..0xcec2d5
+            - Range: 0xcec39c..0xcec3b5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcec2e0..0xcec3a9]
+      OutOfLinePCRanges: [0xcec3c0..0xcec489]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcec2e0..0xcec332
+            - Range: 0xcec3c0..0xcec412
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcec2e0..0xcec38f
+            - Range: 0xcec3c0..0xcec46f
               Pieces: []
-            - Range: 0xcec38f..0xcec390
+            - Range: 0xcec46f..0xcec470
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcec390..0xcec3a9
+            - Range: 0xcec470..0xcec489
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcec2e0..0xcec38f
+            - Range: 0xcec3c0..0xcec46f
               Pieces: []
-            - Range: 0xcec38f..0xcec390
+            - Range: 0xcec46f..0xcec470
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcec390..0xcec3a9
+            - Range: 0xcec470..0xcec489
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcec3c0..0xcec487]
-      InlinePCRanges: []
-      Variables:
-        - Name: i
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcec3c0..0xcec405
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcec405..0xcec487
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcec3c0..0xcec46d
-              Pieces: []
-            - Range: 0xcec46d..0xcec46e
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcec46e..0xcec487
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: result2
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcec3c0..0xcec46d
-              Pieces: []
-            - Range: 0xcec46d..0xcec46e
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcec46e..0xcec487
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r2
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcec3c0..0xcec46d
-              Pieces: []
-            - Range: 0xcec46d..0xcec46e
-              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcec46e..0xcec487
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 107
-      Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xcec4a0..0xcec58f]
+      OutOfLinePCRanges: [0xcec4a0..0xcec567]
       InlinePCRanges: []
       Variables:
         - Name: i
@@ -8080,863 +8032,911 @@ Subprograms:
           Locations:
             - Range: 0xcec4a0..0xcec4e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcec4e5..0xcec58f
+            - Range: 0xcec4e5..0xcec567
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcec4a0..0xcec571
+            - Range: 0xcec4a0..0xcec54d
               Pieces: []
-            - Range: 0xcec571..0xcec572
+            - Range: 0xcec54d..0xcec54e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcec572..0xcec58f
+            - Range: 0xcec54e..0xcec567
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: result2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcec4a0..0xcec54d
+              Pieces: []
+            - Range: 0xcec54d..0xcec54e
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcec54e..0xcec567
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcec4a0..0xcec54d
+              Pieces: []
+            - Range: 0xcec54d..0xcec54e
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcec54e..0xcec567
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 107
+      Name: main.testConflictingReturn
+      OutOfLinePCRanges: [0xcec580..0xcec66f]
+      InlinePCRanges: []
+      Variables:
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcec580..0xcec5c5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcec5c5..0xcec66f
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcec580..0xcec651
+              Pieces: []
+            - Range: 0xcec651..0xcec652
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcec652..0xcec66f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec4a0..0xcec571
+            - Range: 0xcec580..0xcec651
               Pieces: []
-            - Range: 0xcec571..0xcec572
+            - Range: 0xcec651..0xcec652
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcec572..0xcec58f
+            - Range: 0xcec652..0xcec66f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xcec5a0..0xcec7af]
+      OutOfLinePCRanges: [0xcec680..0xcec88f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcec5a0..0xcec626
+            - Range: 0xcec680..0xcec706
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcec626..0xcec7af
+            - Range: 0xcec706..0xcec88f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec5d7..0xcec7af
+            - Range: 0xcec6b7..0xcec88f
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec5dd..0xcec7af
+            - Range: 0xcec6bd..0xcec88f
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcec8a0..0xcec91e]
+      OutOfLinePCRanges: [0xcec980..0xcec9fe]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 20 BaseType int8
           Locations:
-            - Range: 0xcec8a0..0xcec911
+            - Range: 0xcec980..0xcec9f1
               Pieces: []
-            - Range: 0xcec911..0xcec912
+            - Range: 0xcec9f1..0xcec9f2
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcec912..0xcec91e
+            - Range: 0xcec9f2..0xcec9fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 109 BaseType int16
           Locations:
-            - Range: 0xcec8a0..0xcec911
+            - Range: 0xcec980..0xcec9f1
               Pieces: []
-            - Range: 0xcec911..0xcec912
+            - Range: 0xcec9f1..0xcec9f2
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcec912..0xcec91e
+            - Range: 0xcec9f2..0xcec9fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcec8a0..0xcec911
+            - Range: 0xcec980..0xcec9f1
               Pieces: []
-            - Range: 0xcec911..0xcec912
+            - Range: 0xcec9f1..0xcec9f2
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcec912..0xcec91e
+            - Range: 0xcec9f2..0xcec9fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 12 BaseType int64
           Locations:
-            - Range: 0xcec8a0..0xcec911
+            - Range: 0xcec980..0xcec9f1
               Pieces: []
-            - Range: 0xcec911..0xcec912
+            - Range: 0xcec9f1..0xcec9f2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcec912..0xcec91e
+            - Range: 0xcec9f2..0xcec9fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcec8a0..0xcec911
+            - Range: 0xcec980..0xcec9f1
               Pieces: []
-            - Range: 0xcec911..0xcec912
+            - Range: 0xcec9f1..0xcec9f2
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcec912..0xcec91e
+            - Range: 0xcec9f2..0xcec9fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xcec8a0..0xcec911
+            - Range: 0xcec980..0xcec9f1
               Pieces: []
-            - Range: 0xcec911..0xcec912
+            - Range: 0xcec9f1..0xcec9f2
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcec912..0xcec91e
+            - Range: 0xcec9f2..0xcec9fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xcec8a0..0xcec911
+            - Range: 0xcec980..0xcec9f1
               Pieces: []
-            - Range: 0xcec911..0xcec912
+            - Range: 0xcec9f1..0xcec9f2
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcec912..0xcec91e
+            - Range: 0xcec9f2..0xcec9fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcec8a0..0xcec911
+            - Range: 0xcec980..0xcec9f1
               Pieces: []
-            - Range: 0xcec911..0xcec912
+            - Range: 0xcec9f1..0xcec9f2
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcec912..0xcec91e
+            - Range: 0xcec9f2..0xcec9fe
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcec920..0xceca17]
+      OutOfLinePCRanges: [0xceca00..0xcecaf7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
+          Locations: [{Range: 0xceca00..0xcecaf7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 13 BaseType float64
           Locations:
-            - Range: 0xcec920..0xceca07
+            - Range: 0xceca00..0xcecae7
               Pieces: []
-            - Range: 0xceca07..0xceca08
+            - Range: 0xcecae7..0xcecae8
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xceca08..0xceca17
+            - Range: 0xcecae8..0xcecaf7
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 13 BaseType float64
           Locations:
-            - Range: 0xcec920..0xceca07
+            - Range: 0xceca00..0xcecae7
               Pieces: []
-            - Range: 0xceca07..0xceca08
+            - Range: 0xcecae7..0xcecae8
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xceca08..0xceca17
+            - Range: 0xcecae8..0xcecaf7
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xceca20..0xceca93]
+      OutOfLinePCRanges: [0xcecb00..0xcecb73]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 102 BaseType complex64
-          Locations: [{Range: 0xceca20..0xceca93, Pieces: []}]
+          Locations: [{Range: 0xcecb00..0xcecb73, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType complex128
-          Locations: [{Range: 0xceca20..0xceca93, Pieces: []}]
+          Locations: [{Range: 0xcecb00..0xcecb73, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xcecaa0..0xcecb53]
+      OutOfLinePCRanges: [0xcecb80..0xcecc33]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xcecaa0..0xcecb43
+            - Range: 0xcecb80..0xcecc23
               Pieces: []
-            - Range: 0xcecb43..0xcecb44
+            - Range: 0xcecc23..0xcecc24
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xcecb44..0xcecb53
+            - Range: 0xcecc24..0xcecc33
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xcecb60..0xcecbdc]
+      OutOfLinePCRanges: [0xcecc40..0xceccbc]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xcecb60..0xcecbcf
+            - Range: 0xcecc40..0xceccaf
               Pieces: []
-            - Range: 0xcecbcf..0xcecbd0
+            - Range: 0xceccaf..0xceccb0
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcecbd0..0xcecbdc
+            - Range: 0xceccb0..0xceccbc
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xcecbe0..0xcecc38]
+      OutOfLinePCRanges: [0xceccc0..0xcecd18]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 ArrayType [1]int
           Locations:
-            - Range: 0xcecbe0..0xcecc2b
+            - Range: 0xceccc0..0xcecd0b
               Pieces: []
-            - Range: 0xcecc2b..0xcecc2c
+            - Range: 0xcecd0b..0xcecd0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcecc2c..0xcecc38
+            - Range: 0xcecd0c..0xcecd18
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xcecc40..0xcecc93]
+      OutOfLinePCRanges: [0xcecd20..0xcecd73]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0xcecc40..0xcecc86
+            - Range: 0xcecd20..0xcecd66
               Pieces: []
-            - Range: 0xcecc86..0xcecc87
+            - Range: 0xcecd66..0xcecd67
               Pieces: []
-            - Range: 0xcecc87..0xcecc93
+            - Range: 0xcecd67..0xcecd73
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xcecca0..0xcecd07]
+      OutOfLinePCRanges: [0xcecd80..0xcecde7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 260 StructureType main.mixedStruct
-          Locations: [{Range: 0xcecca0..0xcecd07, Pieces: []}]
+          Locations: [{Range: 0xcecd80..0xcecde7, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xcecd20..0xcecdba]
+      OutOfLinePCRanges: [0xcece00..0xcece9a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcecd20..0xcecdaa
+            - Range: 0xcece00..0xcece8a
               Pieces: []
-            - Range: 0xcecdaa..0xcecdab
+            - Range: 0xcece8a..0xcece8b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcecdab..0xcecdba
+            - Range: 0xcece8b..0xcece9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcecd20..0xcecdaa
+            - Range: 0xcece00..0xcece8a
               Pieces: []
-            - Range: 0xcecdaa..0xcecdab
+            - Range: 0xcece8a..0xcece8b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcecdab..0xcecdba
+            - Range: 0xcece8b..0xcece9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcecd20..0xcecdaa
+            - Range: 0xcece00..0xcece8a
               Pieces: []
-            - Range: 0xcecdaa..0xcecdab
+            - Range: 0xcece8a..0xcece8b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcecdab..0xcecdba
+            - Range: 0xcece8b..0xcece9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcecd20..0xcecdaa
+            - Range: 0xcece00..0xcece8a
               Pieces: []
-            - Range: 0xcecdaa..0xcecdab
+            - Range: 0xcece8a..0xcece8b
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcecdab..0xcecdba
+            - Range: 0xcece8b..0xcece9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcecd20..0xcecdaa
+            - Range: 0xcece00..0xcece8a
               Pieces: []
-            - Range: 0xcecdaa..0xcecdab
+            - Range: 0xcece8a..0xcece8b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcecdab..0xcecdba
+            - Range: 0xcece8b..0xcece9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcecd20..0xcecdaa
+            - Range: 0xcece00..0xcece8a
               Pieces: []
-            - Range: 0xcecdaa..0xcecdab
+            - Range: 0xcece8a..0xcece8b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcecdab..0xcecdba
+            - Range: 0xcece8b..0xcece9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcecd20..0xcecdaa
+            - Range: 0xcece00..0xcece8a
               Pieces: []
-            - Range: 0xcecdaa..0xcecdab
+            - Range: 0xcece8a..0xcece8b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcecdab..0xcecdba
+            - Range: 0xcece8b..0xcece9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcecd20..0xcecdaa
+            - Range: 0xcece00..0xcece8a
               Pieces: []
-            - Range: 0xcecdaa..0xcecdab
+            - Range: 0xcece8a..0xcece8b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcecdab..0xcecdba
+            - Range: 0xcece8b..0xcece9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcecd20..0xcecdaa
+            - Range: 0xcece00..0xcece8a
               Pieces: []
-            - Range: 0xcecdaa..0xcecdab
+            - Range: 0xcece8a..0xcece8b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcecdab..0xcecdba
+            - Range: 0xcece8b..0xcece9a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xcecdc0..0xcece85]
+      OutOfLinePCRanges: [0xcecea0..0xcecf65]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.wideStruct
           Locations:
-            - Range: 0xcecdc0..0xcece72
+            - Range: 0xcecea0..0xcecf52
               Pieces: []
-            - Range: 0xcece72..0xcece73
+            - Range: 0xcecf52..0xcecf53
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xcece73..0xcece85
+            - Range: 0xcecf53..0xcecf65
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xcecea0..0xcecf19]
+      OutOfLinePCRanges: [0xcecf80..0xcecff9]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcecea0..0xcecf0c
+            - Range: 0xcecf80..0xcecfec
               Pieces: []
-            - Range: 0xcecf0c..0xcecf0d
+            - Range: 0xcecfec..0xcecfed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcecf0d..0xcecf19
+            - Range: 0xcecfed..0xcecff9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcecea0..0xcecf19, Pieces: []}]
+          Locations: [{Range: 0xcecf80..0xcecff9, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcecea0..0xcecf0c
+            - Range: 0xcecf80..0xcecfec
               Pieces: []
-            - Range: 0xcecf0c..0xcecf0d
+            - Range: 0xcecfec..0xcecfed
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcecf0d..0xcecf19
+            - Range: 0xcecfed..0xcecff9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcecea0..0xcecf19, Pieces: []}]
+          Locations: [{Range: 0xcecf80..0xcecff9, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcecea0..0xcecf0c
+            - Range: 0xcecf80..0xcecfec
               Pieces: []
-            - Range: 0xcecf0c..0xcecf0d
+            - Range: 0xcecfec..0xcecfed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcecf0d..0xcecf19
+            - Range: 0xcecfed..0xcecff9
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xcecf20..0xcecf9c]
+      OutOfLinePCRanges: [0xced000..0xced07c]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0xcecf20..0xcecf8f
+            - Range: 0xced000..0xced06f
               Pieces: []
-            - Range: 0xcecf8f..0xcecf90
+            - Range: 0xced06f..0xced070
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcecf90..0xcecf9c
+            - Range: 0xced070..0xced07c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xcecfa0..0xcecffb]
+      OutOfLinePCRanges: [0xced080..0xced0db]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcecfa0..0xcecffb, Pieces: []}]
+          Locations: [{Range: 0xced080..0xced0db, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xced000..0xced067]
+      OutOfLinePCRanges: [0xced0e0..0xced147]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0xced000..0xced067, Pieces: []}]
+          Locations: [{Range: 0xced0e0..0xced147, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 13 BaseType float64
-          Locations: [{Range: 0xced000..0xced067, Pieces: []}]
+          Locations: [{Range: 0xced0e0..0xced147, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xced080..0xced0dd]
+      OutOfLinePCRanges: [0xced160..0xced1bd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xced080..0xced0d0
+            - Range: 0xced160..0xced1b0
               Pieces: []
-            - Range: 0xced0d0..0xced0d1
+            - Range: 0xced1b0..0xced1b1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xced0d1..0xced0dd
+            - Range: 0xced1b1..0xced1bd
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xced080..0xced0d0
+            - Range: 0xced160..0xced1b0
               Pieces: []
-            - Range: 0xced0d0..0xced0d1
+            - Range: 0xced1b0..0xced1b1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xced0d1..0xced0dd
+            - Range: 0xced1b1..0xced1bd
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xced0e0..0xced25d]
+      OutOfLinePCRanges: [0xced1c0..0xced33d]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xced0e0..0xced25d
+            - Range: 0xced1c0..0xced33d
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xced0e0..0xced24d
+            - Range: 0xced1c0..0xced32d
               Pieces: []
-            - Range: 0xced24d..0xced24e
+            - Range: 0xced32d..0xced32e
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xced24e..0xced25d
+            - Range: 0xced32e..0xced33d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xced260..0xced33a]
+      OutOfLinePCRanges: [0xced340..0xced41a]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xced260..0xced33a
+            - Range: 0xced340..0xced41a
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xced260..0xced32a
+            - Range: 0xced340..0xced40a
               Pieces: []
-            - Range: 0xced32a..0xced32b
+            - Range: 0xced40a..0xced40b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xced32b..0xced33a
+            - Range: 0xced40b..0xced41a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xced340..0xced57b]
+      OutOfLinePCRanges: [0xced420..0xced65b]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xced340..0xced57b
+            - Range: 0xced420..0xced65b
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xced340..0xced57b
+            - Range: 0xced420..0xced65b
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xced340..0xced56b
+            - Range: 0xced420..0xced64b
               Pieces: []
-            - Range: 0xced56b..0xced56c
+            - Range: 0xced64b..0xced64c
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xced56c..0xced57b
+            - Range: 0xced64c..0xced65b
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xced580..0xced82f]
+      OutOfLinePCRanges: [0xced660..0xced90f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced580..0xced647
+            - Range: 0xced660..0xced727
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xced647..0xced82f
+            - Range: 0xced727..0xced90f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced580..0xced647
+            - Range: 0xced660..0xced727
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xced647..0xced82f
+            - Range: 0xced727..0xced90f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced580..0xced5ea
+            - Range: 0xced660..0xced6ca
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xced5ea..0xced82f
+            - Range: 0xced6ca..0xced90f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced580..0xced647
+            - Range: 0xced660..0xced727
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xced647..0xced82f
+            - Range: 0xced727..0xced90f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced580..0xced647
+            - Range: 0xced660..0xced727
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xced647..0xced82f
+            - Range: 0xced727..0xced90f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced580..0xced647
+            - Range: 0xced660..0xced727
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xced647..0xced82f
+            - Range: 0xced727..0xced90f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced580..0xced647
+            - Range: 0xced660..0xced727
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xced647..0xced82f
+            - Range: 0xced727..0xced90f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced580..0xced647
+            - Range: 0xced660..0xced727
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xced647..0xced82f
+            - Range: 0xced727..0xced90f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced580..0xced647
+            - Range: 0xced660..0xced727
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xced647..0xced82f
+            - Range: 0xced727..0xced90f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0xced580..0xced7c2
+            - Range: 0xced660..0xced8a2
               Pieces: []
-            - Range: 0xced7c2..0xced7c3
+            - Range: 0xced8a2..0xced8a3
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xced7c3..0xced82f
+            - Range: 0xced8a3..0xced90f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xced840..0xcedb05]
+      OutOfLinePCRanges: [0xced920..0xcedbe5]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced840..0xced8ea
+            - Range: 0xced920..0xced9ca
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xced8ea..0xcedb05
+            - Range: 0xced9ca..0xcedbe5
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced840..0xced8ea
+            - Range: 0xced920..0xced9ca
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xced8ea..0xcedb05
+            - Range: 0xced9ca..0xcedbe5
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced840..0xced8a2
+            - Range: 0xced920..0xced982
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xced8a2..0xcedb05
+            - Range: 0xced982..0xcedbe5
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced840..0xced8ea
+            - Range: 0xced920..0xced9ca
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xced8ea..0xcedb05
+            - Range: 0xced9ca..0xcedbe5
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced840..0xced8ea
+            - Range: 0xced920..0xced9ca
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xced8ea..0xcedb05
+            - Range: 0xced9ca..0xcedbe5
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced840..0xced8ea
+            - Range: 0xced920..0xced9ca
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xced8ea..0xcedb05
+            - Range: 0xced9ca..0xcedbe5
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced840..0xced8ea
+            - Range: 0xced920..0xced9ca
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xced8ea..0xcedb05
+            - Range: 0xced9ca..0xcedbe5
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced840..0xced8ea
+            - Range: 0xced920..0xced9ca
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xced8ea..0xcedb05
+            - Range: 0xced9ca..0xcedbe5
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xced840..0xcedb05
+            - Range: 0xced920..0xcedbe5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -8947,200 +8947,200 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xced840..0xceda82
+            - Range: 0xced920..0xcedb62
               Pieces: []
-            - Range: 0xceda82..0xceda83
+            - Range: 0xcedb62..0xcedb63
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xceda83..0xcedb05
+            - Range: 0xcedb63..0xcedbe5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xcedb20..0xcedbae]
+      OutOfLinePCRanges: [0xcedc00..0xcedc8e]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0xcedb20..0xcedbae
+            - Range: 0xcedc00..0xcedc8e
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcedb20..0xcedb9e
+            - Range: 0xcedc00..0xcedc7e
               Pieces: []
-            - Range: 0xcedb9e..0xcedb9f
+            - Range: 0xcedc7e..0xcedc7f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedb9f..0xcedbae
+            - Range: 0xcedc7f..0xcedc8e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcedb20..0xcedb9e
+            - Range: 0xcedc00..0xcedc7e
               Pieces: []
-            - Range: 0xcedb9e..0xcedb9f
+            - Range: 0xcedc7e..0xcedc7f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcedb9f..0xcedbae
+            - Range: 0xcedc7f..0xcedc8e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcedb20..0xcedb9e
+            - Range: 0xcedc00..0xcedc7e
               Pieces: []
-            - Range: 0xcedb9e..0xcedb9f
+            - Range: 0xcedc7e..0xcedc7f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcedb9f..0xcedbae
+            - Range: 0xcedc7f..0xcedc8e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xcedbc0..0xcedcad]
+      OutOfLinePCRanges: [0xcedca0..0xcedd8d]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0xcedbc0..0xcedcad
+            - Range: 0xcedca0..0xcedd8d
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xcedbc0..0xcedcad
+            - Range: 0xcedca0..0xcedd8d
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcedbc0..0xcedc9d
+            - Range: 0xcedca0..0xcedd7d
               Pieces: []
-            - Range: 0xcedc9d..0xcedc9e
+            - Range: 0xcedd7d..0xcedd7e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedc9e..0xcedcad
+            - Range: 0xcedd7e..0xcedd8d
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0xcedbc0..0xcedc9d
+            - Range: 0xcedca0..0xcedd7d
               Pieces: []
-            - Range: 0xcedc9d..0xcedc9e
+            - Range: 0xcedd7d..0xcedd7e
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xcedc9e..0xcedcad
+            - Range: 0xcedd7e..0xcedd8d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xcedcc0..0xcedd94]
+      OutOfLinePCRanges: [0xcedda0..0xcede74]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0xcedcc0..0xcedd94
+            - Range: 0xcedda0..0xcede74
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcedcc0..0xcedd84
+            - Range: 0xcedda0..0xcede64
               Pieces: []
-            - Range: 0xcedd84..0xcedd85
+            - Range: 0xcede64..0xcede65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedd85..0xcedd94
+            - Range: 0xcede65..0xcede74
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0xcedcc0..0xcedd84
+            - Range: 0xcedda0..0xcede64
               Pieces: []
-            - Range: 0xcedd84..0xcedd85
+            - Range: 0xcede64..0xcede65
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcedd85..0xcedd94
+            - Range: 0xcede65..0xcede74
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcedd4e..0xcedd94
+            - Range: 0xcede2e..0xcede74
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xcedda0..0xcede46]
+      OutOfLinePCRanges: [0xcede80..0xcedf26]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 259 ArrayType [0]int
-          Locations: [{Range: 0xcedda0..0xcede46, Pieces: []}]
+          Locations: [{Range: 0xcede80..0xcedf26, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcedda0..0xcedde5
+            - Range: 0xcede80..0xcedec5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedde5..0xcede07
+            - Range: 0xcedec5..0xcedee7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcede07..0xcede1a
+            - Range: 0xcedee7..0xcedefa
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcede1a..0xcede46
+            - Range: 0xcedefa..0xcedf26
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcedda0..0xcede2c
+            - Range: 0xcede80..0xcedf0c
               Pieces: []
-            - Range: 0xcede2c..0xcede2d
+            - Range: 0xcedf0c..0xcedf0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcede2d..0xcede46
+            - Range: 0xcedf0d..0xcedf26
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0xcedda0..0xcede2c
+            - Range: 0xcede80..0xcedf0c
               Pieces: []
-            - Range: 0xcede2c..0xcede2d
+            - Range: 0xcedf0c..0xcedf0d
               Pieces: []
-            - Range: 0xcede2d..0xcede46
+            - Range: 0xcedf0d..0xcedf26
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcee3a0..0xcee3a1]
+      OutOfLinePCRanges: [0xcee480..0xcee481]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcee3a0..0xcee3a1
+            - Range: 0xcee480..0xcee481
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9153,179 +9153,11 @@ Subprograms:
       DictRegister: null
     - ID: 134
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcee3c0..0xcee3c1]
+      OutOfLinePCRanges: [0xcee4a0..0xcee4a1]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcee3c0..0xcee3c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 135
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcee3e0..0xcee3e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 264 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xcee3e0..0xcee3e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 136
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcee400..0xcee401]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcee400..0xcee401
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcee400..0xcee401
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 137
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcee420..0xcee421]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcee420..0xcee421
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcee420..0xcee421
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 138
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcee440..0xcee441]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcee440..0xcee441
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcee440..0xcee441
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 139
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcee460..0xcee461]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 269 GoSliceHeaderType []string
-          Locations:
-            - Range: 0xcee460..0xcee461
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 140
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcee480..0xcee481]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 20 BaseType int8
-          Locations:
-            - Range: 0xcee480..0xcee481
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: s
-          Type: 270 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0xcee480..0xcee481
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: x
-          Type: 14 BaseType uint
-          Locations:
-            - Range: 0xcee480..0xcee481
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 141
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcee4a0..0xcee4a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 271 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xcee4a0..0xcee4a1
               Pieces:
@@ -9338,13 +9170,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 142
-      Name: main.testVeryLargeSlice
+    - ID: 135
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcee4c0..0xcee4c1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []uint
+        - Name: u
+          Type: 264 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xcee4c0..0xcee4c1
               Pieces:
@@ -9357,15 +9189,183 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 136
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcee4e0..0xcee4e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcee4e0..0xcee4e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcee4e0..0xcee4e1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 137
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcee500..0xcee501]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcee500..0xcee501
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcee500..0xcee501
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcee520..0xcee521]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcee520..0xcee521
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcee520..0xcee521
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 139
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcee540..0xcee541]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 269 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcee540..0xcee541
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 140
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xcee560..0xcee561]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 20 BaseType int8
+          Locations:
+            - Range: 0xcee560..0xcee561
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: s
+          Type: 270 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0xcee560..0xcee561
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 14 BaseType uint
+          Locations:
+            - Range: 0xcee560..0xcee561
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 141
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xcee580..0xcee581]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 271 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0xcee580..0xcee581
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 142
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcee5a0..0xcee5a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 263 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcee5a0..0xcee5a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 143
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xcee4e0..0xcee4e1]
+      OutOfLinePCRanges: [0xcee5c0..0xcee5c1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 272 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0xcee4e0..0xcee4e1
+            - Range: 0xcee5c0..0xcee5c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9378,13 +9378,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xcee500..0xcee501]
+      OutOfLinePCRanges: [0xcee5e0..0xcee5e1]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcee500..0xcee501
+            - Range: 0xcee5e0..0xcee5e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9397,7 +9397,7 @@ Subprograms:
         - Name: bs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcee500..0xcee501
+            - Range: 0xcee5e0..0xcee5e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9410,7 +9410,7 @@ Subprograms:
         - Name: cs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcee500..0xcee501
+            - Range: 0xcee5e0..0xcee5e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9423,34 +9423,34 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0xcee860..0xcee8b2]
+      OutOfLinePCRanges: [0xcee940..0xcee992]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee860..0xcee8a5
+            - Range: 0xcee940..0xcee985
               Pieces: []
-            - Range: 0xcee8a5..0xcee8a6
+            - Range: 0xcee985..0xcee986
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee8a6..0xcee8b2
+            - Range: 0xcee986..0xcee992
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcee8c0..0xcee8c1]
+      OutOfLinePCRanges: [0xcee9a0..0xcee9a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee8c0..0xcee8c1
+            - Range: 0xcee9a0..0xcee9a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9461,13 +9461,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcee8e0..0xcee8e1]
+      OutOfLinePCRanges: [0xcee9c0..0xcee9c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee8e0..0xcee8e1
+            - Range: 0xcee9c0..0xcee9c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9478,7 +9478,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee8e0..0xcee8e1
+            - Range: 0xcee9c0..0xcee9c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9489,7 +9489,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee8e0..0xcee8e1
+            - Range: 0xcee9c0..0xcee9c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9500,13 +9500,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcee900..0xcee901]
+      OutOfLinePCRanges: [0xcee9e0..0xcee9e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcee900..0xcee901
+            - Range: 0xcee9e0..0xcee9e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9525,39 +9525,39 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcee920..0xcee921]
+      OutOfLinePCRanges: [0xceea00..0xceea01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 275 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcee920..0xcee921
+            - Range: 0xceea00..0xceea01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcee940..0xcee941]
+      OutOfLinePCRanges: [0xceea20..0xceea21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 276 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcee940..0xcee941
+            - Range: 0xceea20..0xceea21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcee960..0xcee961]
+      OutOfLinePCRanges: [0xceea40..0xceea41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee960..0xcee961
+            - Range: 0xceea40..0xceea41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9568,13 +9568,13 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcee980..0xcee981]
+      OutOfLinePCRanges: [0xceea60..0xceea61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee980..0xcee981
+            - Range: 0xceea60..0xceea61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9585,13 +9585,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcee9a0..0xcee9a1]
+      OutOfLinePCRanges: [0xceea80..0xceea81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee9a0..0xcee9a1
+            - Range: 0xceea80..0xceea81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9602,13 +9602,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xcee9c0..0xcee9c1]
+      OutOfLinePCRanges: [0xceeaa0..0xceeaa1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee9c0..0xcee9c1
+            - Range: 0xceeaa0..0xceeaa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9619,7 +9619,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee9c0..0xcee9c1
+            - Range: 0xceeaa0..0xceeaa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9630,7 +9630,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee9c0..0xcee9c1
+            - Range: 0xceeaa0..0xceeaa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9641,26 +9641,26 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xceeb40..0xceeb41]
+      OutOfLinePCRanges: [0xceec20..0xceec21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xceeb40..0xceeb41
+            - Range: 0xceec20..0xceec21
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xceeb60..0xceeb61]
+      OutOfLinePCRanges: [0xceec40..0xceec41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 291 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xceeb60..0xceeb61
+            - Range: 0xceec40..0xceec41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9679,13 +9679,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0xceeca0..0xceeca1]
+      OutOfLinePCRanges: [0xceed80..0xceed81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 322 StructureType main.aStruct
           Locations:
-            - Range: 0xceeca0..0xceeca1
+            - Range: 0xceed80..0xceed81
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9706,91 +9706,91 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xceed60..0xceed61]
+      OutOfLinePCRanges: [0xceee40..0xceee41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xceed60..0xceed61
+            - Range: 0xceee40..0xceee41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xceed80..0xceed81]
+      OutOfLinePCRanges: [0xceee60..0xceee61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 325 StructureType main.tenStrings
           Locations:
-            - Range: 0xceed80..0xceed81
+            - Range: 0xceee60..0xceee61
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xceede0..0xceede1]
+      OutOfLinePCRanges: [0xceeec0..0xceeec1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 326 StructureType main.emptyStruct
-          Locations: [{Range: 0xceede0..0xceede1, Pieces: []}]
+          Locations: [{Range: 0xceeec0..0xceeec1, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xceee00..0xceee01]
+      OutOfLinePCRanges: [0xceeee0..0xceeee1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 327 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xceee00..0xceee01
+            - Range: 0xceeee0..0xceeee1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xcf0d60..0xcf0d64]
+      OutOfLinePCRanges: [0xcf0e40..0xcf0e44]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf0d60..0xcf0d64
+            - Range: 0xcf0e40..0xcf0e44
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf0d60..0xcf0d63
+            - Range: 0xcf0e40..0xcf0e43
               Pieces: []
-            - Range: 0xcf0d63..0xcf0d64
+            - Range: 0xcf0e43..0xcf0e44
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xcf0d80..0xcf0d8c]
+      OutOfLinePCRanges: [0xcf0e60..0xcf0e6c]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf0d80..0xcf0d8b
+            - Range: 0xcf0e60..0xcf0e6b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf0d8b..0xcf0d8c
+            - Range: 0xcf0e6b..0xcf0e6c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9801,9 +9801,9 @@ Subprograms:
         - Name: ~r0
           Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf0d80..0xcf0d8b
+            - Range: 0xcf0e60..0xcf0e6b
               Pieces: []
-            - Range: 0xcf0d8b..0xcf0d8c
+            - Range: 0xcf0e6b..0xcf0e6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9814,41 +9814,41 @@ Subprograms:
       DictRegister: 0
     - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xcf0da0..0xcf0da4]
+      OutOfLinePCRanges: [0xcf0e80..0xcf0e84]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf0da0..0xcf0da4
+            - Range: 0xcf0e80..0xcf0e84
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf0da0..0xcf0da3
+            - Range: 0xcf0e80..0xcf0e83
               Pieces: []
-            - Range: 0xcf0da3..0xcf0da4
+            - Range: 0xcf0e83..0xcf0e84
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xcf0dc0..0xcf0dcc]
+      OutOfLinePCRanges: [0xcf0ea0..0xcf0eac]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf0dc0..0xcf0dcb
+            - Range: 0xcf0ea0..0xcf0eab
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf0dcb..0xcf0dcc
+            - Range: 0xcf0eab..0xcf0eac
               Pieces:
                 - Size: 8
                   Op: null
@@ -9859,9 +9859,9 @@ Subprograms:
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf0dc0..0xcf0dcb
+            - Range: 0xcf0ea0..0xcf0eab
               Pieces: []
-            - Range: 0xcf0dcb..0xcf0dcc
+            - Range: 0xcf0eab..0xcf0eac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9872,13 +9872,13 @@ Subprograms:
       DictRegister: 0
     - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xcf0e40..0xcf1025]
+      OutOfLinePCRanges: [0xcf0f20..0xcf1105]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf0e40..0xcf0e7e
+            - Range: 0xcf0f20..0xcf0f5e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9886,7 +9886,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf0e7e..0xcf0e89
+            - Range: 0xcf0f5e..0xcf0f69
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9894,7 +9894,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xcf0e89..0xcf1025
+            - Range: 0xcf0f69..0xcf1105
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9907,18 +9907,18 @@ Subprograms:
         - Name: pred
           Type: 334 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xcf0e40..0xcf0e89
+            - Range: 0xcf0f20..0xcf0f69
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcf0e89..0xcf1025
+            - Range: 0xcf0f69..0xcf1105
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf0e40..0xcf0fda
+            - Range: 0xcf0f20..0xcf10ba
               Pieces: []
-            - Range: 0xcf0fda..0xcf0fdb
+            - Range: 0xcf10ba..0xcf10bb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9926,14 +9926,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf0fdb..0xcf1025
+            - Range: 0xcf10bb..0xcf1105
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf0e89..0xcf0eb6
+            - Range: 0xcf0f69..0xcf0f96
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9941,7 +9941,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf0eb6..0xcf0eb6
+            - Range: 0xcf0f96..0xcf0f96
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9949,7 +9949,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf0eb6..0xcf0eec
+            - Range: 0xcf0f96..0xcf0fcc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9957,7 +9957,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf0eec..0xcf0fa5
+            - Range: 0xcf0fcc..0xcf1085
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9965,7 +9965,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf0fa5..0xcf0fb6
+            - Range: 0xcf1085..0xcf1096
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9973,7 +9973,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf0fb6..0xcf0fc8
+            - Range: 0xcf1096..0xcf10a8
               Pieces:
                 - Size: 8
                   Op: null
@@ -9981,7 +9981,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf0fd1..0xcf0fd7
+            - Range: 0xcf10b1..0xcf10b7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9989,7 +9989,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf0fd7..0xcf1025
+            - Range: 0xcf10b7..0xcf1105
               Pieces:
                 - Size: 8
                   Op: null
@@ -10002,132 +10002,132 @@ Subprograms:
         - Name: item
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf0edf..0xcf0eec
+            - Range: 0xcf0fbf..0xcf0fcc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf0eec..0xcf0fa5
+            - Range: 0xcf0fcc..0xcf1085
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xcf1040..0xcf1084]
+      OutOfLinePCRanges: [0xcf1120..0xcf1164]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf1040..0xcf1059
+            - Range: 0xcf1120..0xcf1139
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 335 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xcf1040..0xcf1059
+            - Range: 0xcf1120..0xcf1139
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf1040..0xcf1059
+            - Range: 0xcf1120..0xcf1139
               Pieces: []
-            - Range: 0xcf1059..0xcf105a
+            - Range: 0xcf1139..0xcf113a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf105a..0xcf1084
+            - Range: 0xcf113a..0xcf1164
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 168
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xcf12c0..0xcf12c4]
+      OutOfLinePCRanges: [0xcf13a0..0xcf13a4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 333 PointerType *go.shape.int
           Locations:
-            - Range: 0xcf12c0..0xcf12c4
+            - Range: 0xcf13a0..0xcf13a4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 333 PointerType *go.shape.int
           Locations:
-            - Range: 0xcf12c0..0xcf12c3
+            - Range: 0xcf13a0..0xcf13a3
               Pieces: []
-            - Range: 0xcf12c3..0xcf12c4
+            - Range: 0xcf13a3..0xcf13a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xcf12e0..0xcf12e4]
+      OutOfLinePCRanges: [0xcf13c0..0xcf13c4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 336 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xcf12e0..0xcf12e4
+            - Range: 0xcf13c0..0xcf13c4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 336 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xcf12e0..0xcf12e3
+            - Range: 0xcf13c0..0xcf13c3
               Pieces: []
-            - Range: 0xcf12e3..0xcf12e4
+            - Range: 0xcf13c3..0xcf13c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xcf1300..0xcf1304]
+      OutOfLinePCRanges: [0xcf13e0..0xcf13e4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 338 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xcf1300..0xcf1304
+            - Range: 0xcf13e0..0xcf13e4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 338 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xcf1300..0xcf1303
+            - Range: 0xcf13e0..0xcf13e3
               Pieces: []
-            - Range: 0xcf1303..0xcf1304
+            - Range: 0xcf13e3..0xcf13e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xcf1320..0xcf1331]
+      OutOfLinePCRanges: [0xcf1400..0xcf1411]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xcf1320..0xcf1331
+            - Range: 0xcf1400..0xcf1411
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf1320..0xcf1330
+            - Range: 0xcf1400..0xcf1410
               Pieces: []
-            - Range: 0xcf1330..0xcf1331
+            - Range: 0xcf1410..0xcf1411
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10138,69 +10138,69 @@ Subprograms:
       DictRegister: 0
     - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xcf1400..0xcf1409]
+      OutOfLinePCRanges: [0xcf14e0..0xcf14e9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 342 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xcf1400..0xcf1409
+            - Range: 0xcf14e0..0xcf14e9
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf1400..0xcf1408
+            - Range: 0xcf14e0..0xcf14e8
               Pieces: []
-            - Range: 0xcf1408..0xcf1409
+            - Range: 0xcf14e8..0xcf14e9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xcf14c0..0xcf14c8]
+      OutOfLinePCRanges: [0xcf15a0..0xcf15a8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 343 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xcf14c0..0xcf14c8
+            - Range: 0xcf15a0..0xcf15a8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf14c0..0xcf14c8
+            - Range: 0xcf15a0..0xcf15a8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf14c0..0xcf14c8
+            - Range: 0xcf15a0..0xcf15a8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xcf1540..0xcf15ae]
+      OutOfLinePCRanges: [0xcf1620..0xcf168e]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xcf1540..0xcf15ae
+            - Range: 0xcf1620..0xcf168e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf1540..0xcf15ae
+            - Range: 0xcf1620..0xcf168e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10211,20 +10211,20 @@ Subprograms:
         - Name: v
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf1540..0xcf15ae
+            - Range: 0xcf1620..0xcf168e
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xcf1620..0xcf1628]
+      OutOfLinePCRanges: [0xcf1700..0xcf1708]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf1620..0xcf1628
+            - Range: 0xcf1700..0xcf1708
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10235,25 +10235,25 @@ Subprograms:
         - Name: b
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf1620..0xcf1628
+            - Range: 0xcf1700..0xcf1708
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf1620..0xcf1627
+            - Range: 0xcf1700..0xcf1707
               Pieces: []
-            - Range: 0xcf1627..0xcf1628
+            - Range: 0xcf1707..0xcf1708
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf1620..0xcf1627
+            - Range: 0xcf1700..0xcf1707
               Pieces: []
-            - Range: 0xcf1627..0xcf1628
+            - Range: 0xcf1707..0xcf1708
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10264,26 +10264,26 @@ Subprograms:
       DictRegister: 0
     - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xcf1640..0xcf164f]
+      OutOfLinePCRanges: [0xcf1720..0xcf172f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf1640..0xcf164e
+            - Range: 0xcf1720..0xcf172e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf1640..0xcf164b
+            - Range: 0xcf1720..0xcf172b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf164b..0xcf164f
+            - Range: 0xcf172b..0xcf172f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10294,9 +10294,9 @@ Subprograms:
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf1640..0xcf164e
+            - Range: 0xcf1720..0xcf172e
               Pieces: []
-            - Range: 0xcf164e..0xcf164f
+            - Range: 0xcf172e..0xcf172f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10307,56 +10307,56 @@ Subprograms:
         - Name: ~r1
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf1640..0xcf164e
+            - Range: 0xcf1720..0xcf172e
               Pieces: []
-            - Range: 0xcf164e..0xcf164f
+            - Range: 0xcf172e..0xcf172f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xcf1660..0xcf169a]
+      OutOfLinePCRanges: [0xcf1740..0xcf177a]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 348 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xcf1660..0xcf1679
+            - Range: 0xcf1740..0xcf1759
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcf1660..0xcf1679
+            - Range: 0xcf1740..0xcf1759
               Pieces: []
-            - Range: 0xcf1679..0xcf167a
+            - Range: 0xcf1759..0xcf175a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf167a..0xcf169a
+            - Range: 0xcf175a..0xcf177a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xcf16a0..0xcf16ed]
+      OutOfLinePCRanges: [0xcf1780..0xcf17cd]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 349 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xcf16a0..0xcf16bf
+            - Range: 0xcf1780..0xcf179f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf16bf..0xcf16c2
+            - Range: 0xcf179f..0xcf17a2
               Pieces:
                 - Size: 8
                   Op: null
@@ -10367,37 +10367,37 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcf16a0..0xcf16c2
+            - Range: 0xcf1780..0xcf17a2
               Pieces: []
-            - Range: 0xcf16c2..0xcf16c3
+            - Range: 0xcf17a2..0xcf17a3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf16c3..0xcf16ed
+            - Range: 0xcf17a3..0xcf17cd
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xcf1700..0xcf1708]
+      OutOfLinePCRanges: [0xcf17e0..0xcf17e8]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 350 PointerType *go.shape.string
           Locations:
-            - Range: 0xcf1700..0xcf1707
+            - Range: 0xcf17e0..0xcf17e7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf1700..0xcf1707
+            - Range: 0xcf17e0..0xcf17e7
               Pieces: []
-            - Range: 0xcf1707..0xcf1708
+            - Range: 0xcf17e7..0xcf17e8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10408,22 +10408,22 @@ Subprograms:
       DictRegister: 0
     - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xcf1720..0xcf177b]
+      OutOfLinePCRanges: [0xcf1800..0xcf185b]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcf1720..0xcf1761
+            - Range: 0xcf1800..0xcf1841
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 352 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcf1720..0xcf1775
+            - Range: 0xcf1800..0xcf1855
               Pieces: []
-            - Range: 0xcf1775..0xcf1776
+            - Range: 0xcf1855..0xcf1856
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10437,20 +10437,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcf1776..0xcf177b
+            - Range: 0xcf1856..0xcf185b
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xcf1780..0xcf17a4]
+      OutOfLinePCRanges: [0xcf1860..0xcf1884]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf1780..0xcf17a4
+            - Range: 0xcf1860..0xcf1884
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10463,33 +10463,33 @@ Subprograms:
         - Name: needle
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf1780..0xcf17a4
+            - Range: 0xcf1860..0xcf1884
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcf1780..0xcf17a0
+            - Range: 0xcf1860..0xcf1880
               Pieces: []
-            - Range: 0xcf17a0..0xcf17a1
+            - Range: 0xcf1880..0xcf1881
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf17a1..0xcf17a3
+            - Range: 0xcf1881..0xcf1883
               Pieces: []
-            - Range: 0xcf17a3..0xcf17a4
+            - Range: 0xcf1883..0xcf1884
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xcf17c0..0xcf187f]
+      OutOfLinePCRanges: [0xcf18a0..0xcf195f]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 353 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xcf17c0..0xcf17dd
+            - Range: 0xcf18a0..0xcf18bd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10497,7 +10497,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf17dd..0xcf17df
+            - Range: 0xcf18bd..0xcf18bf
               Pieces:
                 - Size: 8
                   Op: null
@@ -10510,13 +10510,13 @@ Subprograms:
         - Name: needle
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf17c0..0xcf180c
+            - Range: 0xcf18a0..0xcf18ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcf180c..0xcf187f
+            - Range: 0xcf18ec..0xcf195f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10527,28 +10527,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcf17c0..0xcf182b
+            - Range: 0xcf18a0..0xcf190b
               Pieces: []
-            - Range: 0xcf182b..0xcf182c
+            - Range: 0xcf190b..0xcf190c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf182c..0xcf1833
+            - Range: 0xcf190c..0xcf1913
               Pieces: []
-            - Range: 0xcf1833..0xcf1834
+            - Range: 0xcf1913..0xcf1914
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf1834..0xcf187f
+            - Range: 0xcf1914..0xcf195f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf17ef..0xcf1801
+            - Range: 0xcf18cf..0xcf18e1
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcf1801..0xcf180c
+            - Range: 0xcf18e1..0xcf18ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10559,54 +10559,54 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xcf1880..0xcf1887]
+      OutOfLinePCRanges: [0xcf1960..0xcf1967]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 354 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xcf1880..0xcf1886
+            - Range: 0xcf1960..0xcf1966
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf1880..0xcf1887
+            - Range: 0xcf1960..0xcf1967
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcf1880..0xcf1886
+            - Range: 0xcf1960..0xcf1966
               Pieces: []
-            - Range: 0xcf1886..0xcf1887
+            - Range: 0xcf1966..0xcf1967
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
     - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xcf18e0..0xcf194c]
+      OutOfLinePCRanges: [0xcf19c0..0xcf1a2c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 355 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xcf18e0..0xcf1900
+            - Range: 0xcf19c0..0xcf19e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf1900..0xcf1908
+            - Range: 0xcf19e0..0xcf19e8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf1908..0xcf190d
+            - Range: 0xcf19e8..0xcf19ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10617,7 +10617,7 @@ Subprograms:
         - Name: value
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf18e0..0xcf190d
+            - Range: 0xcf19c0..0xcf19ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10628,11 +10628,11 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcf18e0..0xcf190d
+            - Range: 0xcf19c0..0xcf19ed
               Pieces: []
-            - Range: 0xcf190d..0xcf190e
+            - Range: 0xcf19ed..0xcf19ee
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf190e..0xcf194c
+            - Range: 0xcf19ee..0xcf1a2c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10778,31 +10778,31 @@ Subprograms:
       DictRegister: 0
     - ID: 186
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xce84e0..0xce8542]
+      OutOfLinePCRanges: [0xce85c0..0xce8622]
       InlinePCRanges:
-        - Ranges: [0xce8571..0xce85ad]
-          RootRanges: [0xce8560..0xce85d1]
-        - Ranges: [0xce86b2..0xce86ee]
-          RootRanges: [0xce8680..0xce8708]
-        - Ranges: [0xce873c..0xce8778]
-          RootRanges: [0xce8720..0xce87e5]
-        - Ranges: [0xce880f..0xce884b]
-          RootRanges: [0xce8800..0xce8862]
+        - Ranges: [0xce8651..0xce868d]
+          RootRanges: [0xce8640..0xce86b1]
+        - Ranges: [0xce8792..0xce87ce]
+          RootRanges: [0xce8760..0xce87e8]
+        - Ranges: [0xce881c..0xce8858]
+          RootRanges: [0xce8800..0xce88c5]
+        - Ranges: [0xce88ef..0xce892b]
+          RootRanges: [0xce88e0..0xce8942]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce84e0..0xce84f9
+            - Range: 0xce85c0..0xce85d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8571..0xce857c
+            - Range: 0xce8651..0xce865c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce86b2..0xce86bd
+            - Range: 0xce8792..0xce879d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8736..0xce8747
+            - Range: 0xce8816..0xce8827
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8747..0xce87e5
+            - Range: 0xce8827..0xce88c5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xce8800..0xce881a
+            - Range: 0xce88e0..0xce88fa
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10811,37 +10811,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce8786..0xce87be]
-          RootRanges: [0xce8720..0xce87e5]
+        - Ranges: [0xce8866..0xce889e]
+          RootRanges: [0xce8800..0xce88c5]
       Variables: []
       DictRegister: null
     - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce8893..0xce88d1]
-          RootRanges: [0xce8880..0xce8985]
+        - Ranges: [0xce8973..0xce89b1]
+          RootRanges: [0xce8960..0xce8a65]
       Variables: []
       DictRegister: null
     - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce893b..0xce8973]
-          RootRanges: [0xce8880..0xce8985]
+        - Ranges: [0xce8a1b..0xce8a53]
+          RootRanges: [0xce8960..0xce8a65]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce89a1..0xce89a5]
-          RootRanges: [0xce89a0..0xce89a6]
+        - Ranges: [0xce8a81..0xce8a85]
+          RootRanges: [0xce8a80..0xce8a86]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce89a0..0xce89a5
+            - Range: 0xce8a80..0xce8a85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10850,32 +10850,32 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce89ed..0xce8a05]
-          RootRanges: [0xce89c0..0xce8a0b]
-        - Ranges: [0xce8a83..0xce8aa1]
-          RootRanges: [0xce8a20..0xce8ba5]
+        - Ranges: [0xce8acd..0xce8ae5]
+          RootRanges: [0xce8aa0..0xce8aeb]
+        - Ranges: [0xce8b63..0xce8b81]
+          RootRanges: [0xce8b00..0xce8c85]
       Variables:
         - Name: a
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0xce89cc..0xce8a0b
+            - Range: 0xce8aac..0xce8aeb
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xce8a67..0xce8ba5
+            - Range: 0xce8b47..0xce8c85
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 192
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xce8bc0..0xce8c26]
+      OutOfLinePCRanges: [0xce8ca0..0xce8d06]
       InlinePCRanges:
-        - Ranges: [0xcf19da..0xcf1a08]
-          RootRanges: [0xcf19c0..0xcf1a25]
+        - Ranges: [0xcf1aba..0xcf1ae8]
+          RootRanges: [0xcf1aa0..0xcf1b05]
       Variables:
         - Name: b
           Type: 360 StructureType main.firstBehavior
           Locations:
-            - Range: 0xce8bc0..0xce8bde
+            - Range: 0xce8ca0..0xce8cbe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10886,15 +10886,15 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce8bc0..0xce8c05
+            - Range: 0xce8ca0..0xce8ce5
               Pieces: []
-            - Range: 0xce8c05..0xce8c06
+            - Range: 0xce8ce5..0xce8ce6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce8c06..0xce8c26
+            - Range: 0xce8ce6..0xce8d06
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10903,8 +10903,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce936e..0xce9375]
-          RootRanges: [0xce9220..0xce93b8]
+        - Ranges: [0xce9453..0xce945a]
+          RootRanges: [0xce9300..0xce9498]
         - Ranges: [0x53dae1..0x53dae9]
           RootRanges: [0x53dae0..0x53daea]
       Variables: []
@@ -11265,7 +11265,7 @@ Types:
       ID: 1192
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.017312e+06
+      GoRuntimeType: 2.017568e+06
       GoKind: 22
       Pointee: 1193 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
@@ -11284,7 +11284,7 @@ Types:
       ID: 1126
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.454144e+06
+      GoRuntimeType: 1.45424e+06
       GoKind: 22
       Pointee: 1127 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
@@ -11305,21 +11305,21 @@ Types:
       ID: 1169
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.933344e+06
+      GoRuntimeType: 1.9336e+06
       GoKind: 22
       Pointee: 1170 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 1102
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.071392e+06
+      GoRuntimeType: 1.071488e+06
       GoKind: 22
       Pointee: 1103 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 1104
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.071648e+06
+      GoRuntimeType: 1.071744e+06
       GoKind: 22
       Pointee: 1105 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
@@ -11333,21 +11333,21 @@ Types:
       ID: 1150
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.207392e+06
+      GoRuntimeType: 2.207648e+06
       GoKind: 22
       Pointee: 1151 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1181
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.979872e+06
+      GoRuntimeType: 1.980128e+06
       GoKind: 22
       Pointee: 1182 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1228
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.309376e+06
+      GoRuntimeType: 2.309632e+06
       GoKind: 22
       Pointee: 1229 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -11380,7 +11380,7 @@ Types:
       ID: 1124
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.442944e+06
+      GoRuntimeType: 1.44304e+06
       GoKind: 22
       Pointee: 1125 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
@@ -11394,14 +11394,14 @@ Types:
       ID: 1146
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.75248e+06
+      GoRuntimeType: 1.752736e+06
       GoKind: 22
       Pointee: 1147 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 974
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.218208e+06
+      GoRuntimeType: 1.218304e+06
       GoKind: 22
       Pointee: 975 StructureType context.deadlineExceededError
     - __kind: PointerType
@@ -11429,49 +11429,49 @@ Types:
       ID: 1141
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
-      GoRuntimeType: 1.693024e+06
+      GoRuntimeType: 1.69328e+06
       GoKind: 22
       Pointee: 1142 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
       ID: 923
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
-      GoRuntimeType: 1.0792e+06
+      GoRuntimeType: 1.079296e+06
       GoKind: 22
       Pointee: 924 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
       ID: 1171
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.933856e+06
+      GoRuntimeType: 1.934112e+06
       GoKind: 22
       Pointee: 1172 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
       ID: 1203
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
-      GoRuntimeType: 2.151392e+06
+      GoRuntimeType: 2.151648e+06
       GoKind: 22
       Pointee: 1204 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
       ID: 1177
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.934624e+06
+      GoRuntimeType: 1.93488e+06
       GoKind: 22
       Pointee: 1178 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
       ID: 1173
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.934112e+06
+      GoRuntimeType: 1.934368e+06
       GoKind: 22
       Pointee: 1174 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
       ID: 1167
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.931296e+06
+      GoRuntimeType: 1.931552e+06
       GoKind: 22
       Pointee: 1168 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
@@ -11485,21 +11485,21 @@ Types:
       ID: 1190
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 2.015008e+06
+      GoRuntimeType: 2.015264e+06
       GoKind: 22
       Pointee: 1191 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1175
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
-      GoRuntimeType: 1.934368e+06
+      GoRuntimeType: 1.934624e+06
       GoKind: 22
       Pointee: 1176 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
       ID: 1159
       Name: '*crypto/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.836032e+06
+      GoRuntimeType: 1.836288e+06
       GoKind: 22
       Pointee: 1160 UnresolvedPointeeType crypto/sha3.SHAKE
     - __kind: PointerType
@@ -11513,14 +11513,14 @@ Types:
       ID: 912
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.06064e+06
+      GoRuntimeType: 1.060736e+06
       GoKind: 22
       Pointee: 913 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1254
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.412096e+06
+      GoRuntimeType: 2.412352e+06
       GoKind: 22
       Pointee: 1255 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
@@ -11541,14 +11541,14 @@ Types:
       ID: 911
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.058976e+06
+      GoRuntimeType: 1.059072e+06
       GoKind: 22
       Pointee: 866 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 1134
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.581856e+06
+      GoRuntimeType: 1.582112e+06
       GoKind: 22
       Pointee: 1135 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
@@ -11562,21 +11562,21 @@ Types:
       ID: 1139
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.667104e+06
+      GoRuntimeType: 1.66736e+06
       GoKind: 22
       Pointee: 1140 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 1009
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.443424e+06
+      GoRuntimeType: 1.44352e+06
       GoKind: 22
       Pointee: 1010 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 1026
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.043648e+06
+      GoRuntimeType: 2.043904e+06
       GoKind: 22
       Pointee: 1027 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
@@ -11611,7 +11611,7 @@ Types:
       ID: 917
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.065888e+06
+      GoRuntimeType: 1.065984e+06
       GoKind: 22
       Pointee: 918 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
@@ -11660,7 +11660,7 @@ Types:
       ID: 1092
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.056416e+06
+      GoRuntimeType: 1.056512e+06
       GoKind: 22
       Pointee: 1093 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -11681,7 +11681,7 @@ Types:
       ID: 901
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.052576e+06
+      GoRuntimeType: 1.052672e+06
       GoKind: 22
       Pointee: 902 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
@@ -11716,7 +11716,7 @@ Types:
       ID: 1234
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.330496e+06
+      GoRuntimeType: 2.330752e+06
       GoKind: 22
       Pointee: 1235 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
@@ -11730,7 +11730,7 @@ Types:
       ID: 1100
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.068192e+06
+      GoRuntimeType: 1.068288e+06
       GoKind: 22
       Pointee: 1101 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
@@ -11758,7 +11758,7 @@ Types:
       ID: 868
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1.036832e+06
+      GoRuntimeType: 1.036928e+06
       GoKind: 22
       Pointee: 869 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -11779,21 +11779,21 @@ Types:
       ID: 1222
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.291936e+06
+      GoRuntimeType: 2.292192e+06
       GoKind: 22
       Pointee: 1223 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 870
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.03696e+06
+      GoRuntimeType: 1.037056e+06
       GoKind: 22
       Pointee: 871 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 872
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.037088e+06
+      GoRuntimeType: 1.037184e+06
       GoKind: 22
       Pointee: 873 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -11878,14 +11878,14 @@ Types:
       ID: 1112
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.223712e+06
+      GoRuntimeType: 1.223808e+06
       GoKind: 22
       Pointee: 1113 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1200
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 2.08912e+06
+      GoRuntimeType: 2.089376e+06
       GoKind: 22
       Pointee: 1201 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
@@ -11899,14 +11899,14 @@ Types:
       ID: 983
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.227168e+06
+      GoRuntimeType: 1.227264e+06
       GoKind: 22
       Pointee: 984 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1230
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.310464e+06
+      GoRuntimeType: 2.31072e+06
       GoKind: 22
       Pointee: 1231 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
@@ -12058,7 +12058,7 @@ Types:
       ID: 1153
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.830656e+06
+      GoRuntimeType: 1.830912e+06
       GoKind: 22
       Pointee: 1154 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
@@ -12072,21 +12072,21 @@ Types:
       ID: 1132
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.580576e+06
+      GoRuntimeType: 1.580832e+06
       GoKind: 22
       Pointee: 1133 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 1088
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.055264e+06
+      GoRuntimeType: 1.05536e+06
       GoKind: 22
       Pointee: 1089 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1122
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.441024e+06
+      GoRuntimeType: 1.44112e+06
       GoKind: 22
       Pointee: 1123 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
@@ -12100,28 +12100,28 @@ Types:
       ID: 1188
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 2.007232e+06
+      GoRuntimeType: 2.007488e+06
       GoKind: 22
       Pointee: 1189 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1207
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.165568e+06
+      GoRuntimeType: 2.165824e+06
       GoKind: 22
       Pointee: 1202 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1206
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.165184e+06
+      GoRuntimeType: 2.16544e+06
       GoKind: 22
       Pointee: 1205 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 1090
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.055392e+06
+      GoRuntimeType: 1.055488e+06
       GoKind: 22
       Pointee: 1091 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
@@ -12142,70 +12142,70 @@ Types:
       ID: 1155
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.832448e+06
+      GoRuntimeType: 1.832704e+06
       GoKind: 22
       Pointee: 1156 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1196
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.04336e+06
+      GoRuntimeType: 2.043616e+06
       GoKind: 22
       Pointee: 1197 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1198
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.074432e+06
+      GoRuntimeType: 2.074688e+06
       GoKind: 22
       Pointee: 1199 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 1014
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.456544e+06
+      GoRuntimeType: 1.45664e+06
       GoKind: 22
       Pointee: 1015 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 927
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.079968e+06
+      GoRuntimeType: 1.080064e+06
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 925
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.07984e+06
+      GoRuntimeType: 1.079936e+06
       GoKind: 22
       Pointee: 926 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 929
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.083936e+06
+      GoRuntimeType: 1.084032e+06
       GoKind: 22
       Pointee: 930 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 931
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.084064e+06
+      GoRuntimeType: 1.08416e+06
       GoKind: 22
       Pointee: 932 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 1143
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.695904e+06
+      GoRuntimeType: 1.69616e+06
       GoKind: 22
       Pointee: 1144 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 919
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.0664e+06
+      GoRuntimeType: 1.066496e+06
       GoKind: 22
       Pointee: 920 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
@@ -12219,112 +12219,112 @@ Types:
       ID: 1246
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.385824e+06
+      GoRuntimeType: 2.38608e+06
       GoKind: 22
       Pointee: 1247 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 985
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.236256e+06
+      GoRuntimeType: 1.236352e+06
       GoKind: 22
       Pointee: 986 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 958
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.214752e+06
+      GoRuntimeType: 1.214848e+06
       GoKind: 22
       Pointee: 959 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 952
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.214368e+06
+      GoRuntimeType: 1.214464e+06
       GoKind: 22
       Pointee: 953 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 887
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.046432e+06
+      GoRuntimeType: 1.046528e+06
       GoKind: 22
       Pointee: 888 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 964
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.215136e+06
+      GoRuntimeType: 1.215232e+06
       GoKind: 22
       Pointee: 965 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 886
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1.046304e+06
+      GoRuntimeType: 1.0464e+06
       GoKind: 22
       Pointee: 865 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 956
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.214624e+06
+      GoRuntimeType: 1.21472e+06
       GoKind: 22
       Pointee: 957 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 954
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.214496e+06
+      GoRuntimeType: 1.214592e+06
       GoKind: 22
       Pointee: 955 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 962
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.215008e+06
+      GoRuntimeType: 1.215104e+06
       GoKind: 22
       Pointee: 963 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 960
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.21488e+06
+      GoRuntimeType: 1.214976e+06
       GoKind: 22
       Pointee: 961 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1250
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.400064e+06
+      GoRuntimeType: 2.40032e+06
       GoKind: 22
       Pointee: 1251 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 968
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.21552e+06
+      GoRuntimeType: 1.215616e+06
       GoKind: 22
       Pointee: 969 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 891
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1.046688e+06
+      GoRuntimeType: 1.046784e+06
       GoKind: 22
       Pointee: 892 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 889
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1.04656e+06
+      GoRuntimeType: 1.046656e+06
       GoKind: 22
       Pointee: 890 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 966
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.215392e+06
+      GoRuntimeType: 1.215488e+06
       GoKind: 22
       Pointee: 967 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -12387,35 +12387,35 @@ Types:
       ID: 1029
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.694368e+06
+      GoRuntimeType: 1.694624e+06
       GoKind: 22
       Pointee: 1030 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 935
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.098784e+06
+      GoRuntimeType: 1.09888e+06
       GoKind: 22
       Pointee: 936 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 1118
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.277088e+06
+      GoRuntimeType: 1.277184e+06
       GoKind: 22
       Pointee: 1119 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1212
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.18016e+06
+      GoRuntimeType: 2.180416e+06
       GoKind: 22
       Pointee: 1213 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 1106
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.101088e+06
+      GoRuntimeType: 1.101184e+06
       GoKind: 22
       Pointee: 1107 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
@@ -12429,7 +12429,7 @@ Types:
       ID: 993
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.278752e+06
+      GoRuntimeType: 1.278848e+06
       GoKind: 22
       Pointee: 994 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
@@ -12491,7 +12491,7 @@ Types:
       ID: 1210
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.17824e+06
+      GoRuntimeType: 2.178496e+06
       GoKind: 22
       Pointee: 1211 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -12519,14 +12519,14 @@ Types:
       ID: 991
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.275808e+06
+      GoRuntimeType: 1.275904e+06
       GoKind: 22
       Pointee: 992 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 1016
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.463904e+06
+      GoRuntimeType: 1.464e+06
       GoKind: 22
       Pointee: 1017 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
@@ -12540,21 +12540,21 @@ Types:
       ID: 1161
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.838272e+06
+      GoRuntimeType: 1.838528e+06
       GoKind: 22
       Pointee: 1162 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 1116
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.272352e+06
+      GoRuntimeType: 1.272448e+06
       GoKind: 22
       Pointee: 1117 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 933
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.093024e+06
+      GoRuntimeType: 1.09312e+06
       GoKind: 22
       Pointee: 934 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
@@ -12575,21 +12575,21 @@ Types:
       ID: 921
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.069728e+06
+      GoRuntimeType: 1.069824e+06
       GoKind: 22
       Pointee: 922 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 989
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.24304e+06
+      GoRuntimeType: 1.243136e+06
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 987
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.242784e+06
+      GoRuntimeType: 1.24288e+06
       GoKind: 22
       Pointee: 988 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
@@ -12617,7 +12617,7 @@ Types:
       ID: 1165
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.929248e+06
+      GoRuntimeType: 1.929504e+06
       GoKind: 22
       Pointee: 1166 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
@@ -12673,7 +12673,7 @@ Types:
       ID: 1018
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 2.227328e+06
+      GoRuntimeType: 2.227584e+06
       GoKind: 22
       Pointee: 1019 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
@@ -12701,21 +12701,21 @@ Types:
       ID: 950
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.2136e+06
+      GoRuntimeType: 1.213696e+06
       GoKind: 22
       Pointee: 951 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1252
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.405728e+06
+      GoRuntimeType: 2.405984e+06
       GoKind: 22
       Pointee: 1253 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 948
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.213472e+06
+      GoRuntimeType: 1.213568e+06
       GoKind: 22
       Pointee: 949 StructureType internal/poll.errNetClosing
     - __kind: PointerType
@@ -12729,7 +12729,7 @@ Types:
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
       ByteSize: 8
-      GoRuntimeType: 1.596256e+06
+      GoRuntimeType: 1.596512e+06
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
@@ -12748,7 +12748,7 @@ Types:
       ID: 905
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.057312e+06
+      GoRuntimeType: 1.057408e+06
       GoKind: 22
       Pointee: 906 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
@@ -12762,35 +12762,35 @@ Types:
       ID: 1110
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.204768e+06
+      GoRuntimeType: 1.204864e+06
       GoKind: 22
       Pointee: 1111 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1108
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.204384e+06
+      GoRuntimeType: 1.20448e+06
       GoKind: 22
       Pointee: 1109 StructureType io.discard
     - __kind: PointerType
       ID: 1082
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.037856e+06
+      GoRuntimeType: 1.037952e+06
       GoKind: 22
       Pointee: 1083 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 946
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.21296e+06
+      GoRuntimeType: 1.213056e+06
       GoKind: 22
       Pointee: 947 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 1157
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.832672e+06
+      GoRuntimeType: 1.832928e+06
       GoKind: 22
       Pointee: 1158 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13191,63 +13191,63 @@ Types:
       ID: 977
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.221536e+06
+      GoRuntimeType: 1.221632e+06
       GoKind: 22
       Pointee: 978 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1003
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.439264e+06
+      GoRuntimeType: 1.43936e+06
       GoKind: 22
       Pointee: 1004 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1216
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.266048e+06
+      GoRuntimeType: 2.266304e+06
       GoKind: 22
       Pointee: 1217 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 1001
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.438944e+06
+      GoRuntimeType: 1.43904e+06
       GoKind: 22
       Pointee: 1002 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 979
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.221664e+06
+      GoRuntimeType: 1.22176e+06
       GoKind: 22
       Pointee: 980 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1226
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.29296e+06
+      GoRuntimeType: 2.293216e+06
       GoKind: 22
       Pointee: 1227 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1236
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.33808e+06
+      GoRuntimeType: 2.338336e+06
       GoKind: 22
       Pointee: 1237 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1224
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.292448e+06
+      GoRuntimeType: 2.292704e+06
       GoKind: 22
       Pointee: 1225 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 976
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.220768e+06
+      GoRuntimeType: 1.220864e+06
       GoKind: 22
       Pointee: 939 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13259,28 +13259,28 @@ Types:
       ID: 903
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.053472e+06
+      GoRuntimeType: 1.053568e+06
       GoKind: 22
       Pointee: 904 StructureType net.canceledError
     - __kind: PointerType
       ID: 1194
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2.04048e+06
+      GoRuntimeType: 2.040736e+06
       GoKind: 22
       Pointee: 1195 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1047
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.876352e+06
+      GoRuntimeType: 1.876608e+06
       GoKind: 22
       Pointee: 1048 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1238
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.342336e+06
+      GoRuntimeType: 2.342592e+06
       GoKind: 22
       Pointee: 1239 UnresolvedPointeeType net.netFD
     - __kind: PointerType
@@ -13301,35 +13301,35 @@ Types:
       ID: 1220
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.278976e+06
+      GoRuntimeType: 2.279232e+06
       GoKind: 22
       Pointee: 1221 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1218
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.278496e+06
+      GoRuntimeType: 2.278752e+06
       GoKind: 22
       Pointee: 1219 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 981
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.222304e+06
+      GoRuntimeType: 1.2224e+06
       GoKind: 22
       Pointee: 982 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1005
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.439424e+06
+      GoRuntimeType: 1.43952e+06
       GoKind: 22
       Pointee: 1006 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 893
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1.049248e+06
+      GoRuntimeType: 1.049344e+06
       GoKind: 22
       Pointee: 894 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
@@ -13357,7 +13357,7 @@ Types:
       ID: 997
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.434944e+06
+      GoRuntimeType: 1.43504e+06
       GoKind: 22
       Pointee: 998 StructureType net/http.http2StreamError
     - __kind: PointerType
@@ -13371,7 +13371,7 @@ Types:
       ID: 1128
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.576736e+06
+      GoRuntimeType: 1.576992e+06
       GoKind: 22
       Pointee: 1129 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
@@ -13414,21 +13414,21 @@ Types:
       ID: 972
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.21744e+06
+      GoRuntimeType: 1.217536e+06
       GoKind: 22
       Pointee: 973 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 899
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1.04976e+06
+      GoRuntimeType: 1.049856e+06
       GoKind: 22
       Pointee: 900 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1183
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.981664e+06
+      GoRuntimeType: 1.98192e+06
       GoKind: 22
       Pointee: 1184 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
@@ -13454,28 +13454,28 @@ Types:
       ID: 895
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1.049504e+06
+      GoRuntimeType: 1.0496e+06
       GoKind: 22
       Pointee: 896 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1130
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.22816e+06
+      GoRuntimeType: 2.228416e+06
       GoKind: 22
       Pointee: 1131 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1086
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1.049376e+06
+      GoRuntimeType: 1.049472e+06
       GoKind: 22
       Pointee: 1087 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 1120
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.435104e+06
+      GoRuntimeType: 1.4352e+06
       GoKind: 22
       Pointee: 1121 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
@@ -13489,28 +13489,28 @@ Types:
       ID: 999
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.436224e+06
+      GoRuntimeType: 1.43632e+06
       GoKind: 22
       Pointee: 1000 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 970
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.217312e+06
+      GoRuntimeType: 1.217408e+06
       GoKind: 22
       Pointee: 971 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 897
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1.049632e+06
+      GoRuntimeType: 1.049728e+06
       GoKind: 22
       Pointee: 898 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1163
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1.872544e+06
+      GoRuntimeType: 1.8728e+06
       GoKind: 22
       Pointee: 1164 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
@@ -13524,14 +13524,14 @@ Types:
       ID: 1185
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.983456e+06
+      GoRuntimeType: 1.983712e+06
       GoKind: 22
       Pointee: 1186 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 1096
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.061664e+06
+      GoRuntimeType: 1.06176e+06
       GoKind: 22
       Pointee: 1097 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
@@ -13552,14 +13552,14 @@ Types:
       ID: 1136
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 2.149984e+06
+      GoRuntimeType: 2.15024e+06
       GoKind: 22
       Pointee: 1137 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 1098
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.066016e+06
+      GoRuntimeType: 1.066112e+06
       GoKind: 22
       Pointee: 1099 StructureType net/smtp.dataCloser
     - __kind: PointerType
@@ -13585,14 +13585,14 @@ Types:
       ID: 1094
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.061152e+06
+      GoRuntimeType: 1.061248e+06
       GoKind: 22
       Pointee: 1095 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 1007
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.439744e+06
+      GoRuntimeType: 1.43984e+06
       GoKind: 22
       Pointee: 1008 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
@@ -13758,63 +13758,63 @@ Types:
       ID: 1244
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.380448e+06
+      GoRuntimeType: 2.380704e+06
       GoKind: 22
       Pointee: 1245 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 876
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 1.040544e+06
+      GoRuntimeType: 1.04064e+06
       GoKind: 22
       Pointee: 877 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 942
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.206048e+06
+      GoRuntimeType: 1.206144e+06
       GoKind: 22
       Pointee: 943 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1242
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.379712e+06
+      GoRuntimeType: 2.379968e+06
       GoKind: 22
       Pointee: 1243 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1240
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.378976e+06
+      GoRuntimeType: 2.379232e+06
       GoKind: 22
       Pointee: 1241 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 907
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.057696e+06
+      GoRuntimeType: 1.057792e+06
       GoKind: 22
       Pointee: 908 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 1050
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 2.120896e+06
+      GoRuntimeType: 2.121152e+06
       GoKind: 22
       Pointee: 1051 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 1114
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.228576e+06
+      GoRuntimeType: 1.228672e+06
       GoKind: 22
       Pointee: 1115 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 909
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.057824e+06
+      GoRuntimeType: 1.05792e+06
       GoKind: 22
       Pointee: 910 StructureType os/exec.wrappedError
     - __kind: PointerType
@@ -13854,14 +13854,14 @@ Types:
       ID: 880
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1.04336e+06
+      GoRuntimeType: 1.043456e+06
       GoKind: 22
       Pointee: 881 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 884
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1.044e+06
+      GoRuntimeType: 1.044096e+06
       GoKind: 22
       Pointee: 885 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
@@ -13875,14 +13875,14 @@ Types:
       ID: 25
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.432864e+06
+      GoRuntimeType: 1.43296e+06
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 882
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1.043488e+06
+      GoRuntimeType: 1.043584e+06
       GoKind: 22
       Pointee: 883 StructureType runtime.boundsError
     - __kind: PointerType
@@ -13903,14 +13903,14 @@ Types:
       ID: 944
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.211936e+06
+      GoRuntimeType: 1.212032e+06
       GoKind: 22
       Pointee: 945 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 878
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1.041696e+06
+      GoRuntimeType: 1.041792e+06
       GoKind: 22
       Pointee: 859 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -13922,28 +13922,28 @@ Types:
       ID: 59
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 1.210656e+06
+      GoRuntimeType: 1.210752e+06
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.433504e+06
+      GoRuntimeType: 1.4336e+06
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 68
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.043104e+06
+      GoRuntimeType: 1.0432e+06
       GoKind: 22
       Pointee: 367 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 879
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1.041824e+06
+      GoRuntimeType: 1.04192e+06
       GoKind: 22
       Pointee: 862 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -13962,7 +13962,7 @@ Types:
       ID: 50
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.574016e+06
+      GoRuntimeType: 1.574272e+06
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
@@ -13976,14 +13976,14 @@ Types:
       ID: 45
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.08592e+06
+      GoRuntimeType: 2.086176e+06
       GoKind: 22
       Pointee: 46 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 83
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.645216e+06
+      GoRuntimeType: 1.645472e+06
       GoKind: 22
       Pointee: 84 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -13997,7 +13997,7 @@ Types:
       ID: 874
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 1.039904e+06
+      GoRuntimeType: 1.04e+06
       GoKind: 22
       Pointee: 875 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
@@ -14016,21 +14016,21 @@ Types:
       ID: 1179
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.97936e+06
+      GoRuntimeType: 1.979616e+06
       GoKind: 22
       Pointee: 1180 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 1084
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 1.040032e+06
+      GoRuntimeType: 1.040128e+06
       GoKind: 22
       Pointee: 1085 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
       ID: 1080
       Name: '*struct { io.Writer }'
       ByteSize: 8
-      GoRuntimeType: 985952
+      GoRuntimeType: 986048
       GoKind: 22
       Pointee: 1081 StructureType struct { io.Writer }
     - __kind: PointerType
@@ -14044,7 +14044,7 @@ Types:
       ID: 996
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.434464e+06
+      GoRuntimeType: 1.43456e+06
       GoKind: 22
       Pointee: 995 BaseType syscall.Errno
     - __kind: PointerType
@@ -14186,21 +14186,21 @@ Types:
       ID: 1214
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.192384e+06
+      GoRuntimeType: 2.19264e+06
       GoKind: 22
       Pointee: 1215 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 937
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.102624e+06
+      GoRuntimeType: 1.10272e+06
       GoKind: 22
       Pointee: 938 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 1012
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.649824e+06
+      GoRuntimeType: 1.65008e+06
       GoKind: 22
       Pointee: 1013 UnresolvedPointeeType time.Location
     - __kind: PointerType
@@ -14282,7 +14282,7 @@ Types:
       ID: 1208
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.167872e+06
+      GoRuntimeType: 2.168128e+06
       GoKind: 22
       Pointee: 1209 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -14303,14 +14303,14 @@ Types:
       ID: 914
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.061408e+06
+      GoRuntimeType: 1.061504e+06
       GoKind: 22
       Pointee: 915 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 916
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.061536e+06
+      GoRuntimeType: 1.061632e+06
       GoKind: 22
       Pointee: 867 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -24587,7 +24587,7 @@ Types:
     - __kind: StructureType
       ID: 1077
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.134752e+06
+      GoRuntimeType: 1.134848e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24598,7 +24598,7 @@ Types:
       ID: 1103
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.587936e+06
+      GoRuntimeType: 1.588192e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -24688,7 +24688,7 @@ Types:
     - __kind: StructureType
       ID: 975
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.500416e+06
+      GoRuntimeType: 1.500672e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -24716,7 +24716,7 @@ Types:
     - __kind: StructureType
       ID: 924
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
-      GoRuntimeType: 1.30672e+06
+      GoRuntimeType: 1.306816e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24779,7 +24779,7 @@ Types:
       ID: 744
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.757856e+06
+      GoRuntimeType: 1.758112e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24795,7 +24795,7 @@ Types:
       ID: 866
       Name: crypto/tls.alert
       ByteSize: 1
-      GoRuntimeType: 1.007648e+06
+      GoRuntimeType: 1.007744e+06
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1135
@@ -24821,7 +24821,7 @@ Types:
       ID: 815
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.760736e+06
+      GoRuntimeType: 1.760992e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -24836,14 +24836,14 @@ Types:
     - __kind: StructureType
       ID: 809
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.132192e+06
+      GoRuntimeType: 1.132288e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 811
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.623168e+06
+      GoRuntimeType: 1.623424e+06
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -24868,7 +24868,7 @@ Types:
       ID: 918
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.583776e+06
+      GoRuntimeType: 1.584032e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -24877,14 +24877,14 @@ Types:
     - __kind: StructureType
       ID: 817
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.132448e+06
+      GoRuntimeType: 1.132544e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 813
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.760544e+06
+      GoRuntimeType: 1.7608e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -24900,7 +24900,7 @@ Types:
       ID: 831
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.454784e+06
+      GoRuntimeType: 1.45488e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24910,7 +24910,7 @@ Types:
       ID: 835
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.454944e+06
+      GoRuntimeType: 1.45504e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24968,7 +24968,7 @@ Types:
       ID: 704
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.437984e+06
+      GoRuntimeType: 1.43808e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -24986,7 +24986,7 @@ Types:
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.041568e+06
+      GoRuntimeType: 1.041664e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25080,7 +25080,7 @@ Types:
       ID: 713
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.756704e+06
+      GoRuntimeType: 1.75696e+06
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25103,7 +25103,7 @@ Types:
     - __kind: StructureType
       ID: 719
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.12848e+06
+      GoRuntimeType: 1.128576e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25133,7 +25133,7 @@ Types:
       ID: 1035
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.252416e+06
+      GoRuntimeType: 2.252672e+06
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25249,7 +25249,7 @@ Types:
     - __kind: StructureType
       ID: 764
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.131424e+06
+      GoRuntimeType: 1.13152e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25261,14 +25261,14 @@ Types:
     - __kind: StructureType
       ID: 762
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.131296e+06
+      GoRuntimeType: 1.131392e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 760
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.621088e+06
+      GoRuntimeType: 1.621344e+06
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25281,7 +25281,7 @@ Types:
       ID: 780
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.621888e+06
+      GoRuntimeType: 1.622144e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25294,7 +25294,7 @@ Types:
       ID: 784
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.759968e+06
+      GoRuntimeType: 1.760224e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25310,7 +25310,7 @@ Types:
       ID: 782
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.447744e+06
+      GoRuntimeType: 1.44784e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25320,7 +25320,7 @@ Types:
       ID: 778
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.447424e+06
+      GoRuntimeType: 1.44752e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25330,14 +25330,14 @@ Types:
       ID: 1021
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.521216e+06
+      GoRuntimeType: 1.521472e+06
       GoKind: 21
       HeaderType: 1023 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 1044
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.064992e+06
+      GoRuntimeType: 1.065088e+06
       GoKind: 23
       RawFields:
         - Name: array
@@ -25360,7 +25360,7 @@ Types:
       ID: 792
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.622208e+06
+      GoRuntimeType: 1.622464e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25373,7 +25373,7 @@ Types:
       ID: 786
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.447904e+06
+      GoRuntimeType: 1.448e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25383,7 +25383,7 @@ Types:
       ID: 790
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.76016e+06
+      GoRuntimeType: 1.760416e+06
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25399,7 +25399,7 @@ Types:
       ID: 788
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.622048e+06
+      GoRuntimeType: 1.622304e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25412,7 +25412,7 @@ Types:
       ID: 794
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.448064e+06
+      GoRuntimeType: 1.44816e+06
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25422,7 +25422,7 @@ Types:
       ID: 800
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.622528e+06
+      GoRuntimeType: 1.622784e+06
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25435,7 +25435,7 @@ Types:
       ID: 802
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.448384e+06
+      GoRuntimeType: 1.44848e+06
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25445,7 +25445,7 @@ Types:
       ID: 798
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.622368e+06
+      GoRuntimeType: 1.622624e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25458,7 +25458,7 @@ Types:
       ID: 796
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.448224e+06
+      GoRuntimeType: 1.44832e+06
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25468,7 +25468,7 @@ Types:
       ID: 804
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.622688e+06
+      GoRuntimeType: 1.622944e+06
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25481,7 +25481,7 @@ Types:
       ID: 721
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.440224e+06
+      GoRuntimeType: 1.44032e+06
       GoKind: 25
       RawFields:
         - Name: message
@@ -25495,7 +25495,7 @@ Types:
       ID: 723
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.440384e+06
+      GoRuntimeType: 1.44048e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25517,7 +25517,7 @@ Types:
       ID: 727
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.440704e+06
+      GoRuntimeType: 1.4408e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25531,7 +25531,7 @@ Types:
       ID: 1202
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 2.138752e+06
+      GoRuntimeType: 2.139008e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25544,7 +25544,7 @@ Types:
       ID: 1205
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.1648e+06
+      GoRuntimeType: 2.165056e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25564,7 +25564,7 @@ Types:
       ID: 725
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.440544e+06
+      GoRuntimeType: 1.44064e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25574,7 +25574,7 @@ Types:
       ID: 729
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.440864e+06
+      GoRuntimeType: 1.44096e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25624,7 +25624,7 @@ Types:
       ID: 735
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.441824e+06
+      GoRuntimeType: 1.44192e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -25639,7 +25639,7 @@ Types:
       ID: 959
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.870752e+06
+      GoRuntimeType: 1.871008e+06
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -25659,7 +25659,7 @@ Types:
       ID: 888
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.729408e+06
+      GoRuntimeType: 1.729664e+06
       GoKind: 25
       RawFields:
         - Name: Got
@@ -25672,7 +25672,7 @@ Types:
       ID: 965
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.8712e+06
+      GoRuntimeType: 1.871456e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25688,13 +25688,13 @@ Types:
       ID: 865
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 1.00496e+06
+      GoRuntimeType: 1.005056e+06
       GoKind: 8
     - __kind: StructureType
       ID: 957
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.870528e+06
+      GoRuntimeType: 1.870784e+06
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -25716,7 +25716,7 @@ Types:
       ID: 955
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.870304e+06
+      GoRuntimeType: 1.87056e+06
       GoKind: 25
       RawFields:
         - Name: Method
@@ -25732,7 +25732,7 @@ Types:
       ID: 963
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.784864e+06
+      GoRuntimeType: 1.78512e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25745,7 +25745,7 @@ Types:
       ID: 961
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.870976e+06
+      GoRuntimeType: 1.871232e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25765,7 +25765,7 @@ Types:
       ID: 969
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.650784e+06
+      GoRuntimeType: 1.65104e+06
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -25774,20 +25774,20 @@ Types:
     - __kind: StructureType
       ID: 892
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.300192e+06
+      GoRuntimeType: 1.300288e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 890
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.300064e+06
+      GoRuntimeType: 1.30016e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 967
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.785056e+06
+      GoRuntimeType: 1.785312e+06
       GoKind: 25
       RawFields:
         - Name: cause
@@ -25911,7 +25911,7 @@ Types:
       ID: 936
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.466624e+06
+      GoRuntimeType: 1.46672e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -25921,7 +25921,7 @@ Types:
       ID: 1119
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.704736e+06
+      GoRuntimeType: 1.704992e+06
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -25935,7 +25935,7 @@ Types:
       ID: 1145
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.142304e+06
+      GoRuntimeType: 1.1424e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25948,7 +25948,7 @@ Types:
       ID: 1107
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.593056e+06
+      GoRuntimeType: 1.593312e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -25964,13 +25964,13 @@ Types:
       ID: 1028
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.018208e+06
+      GoRuntimeType: 1.018304e+06
       GoKind: 10
     - __kind: StructureType
       ID: 994
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.908832e+06
+      GoRuntimeType: 1.909088e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -25986,7 +25986,7 @@ Types:
       ID: 851
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.630208e+06
+      GoRuntimeType: 1.630464e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26079,7 +26079,7 @@ Types:
       ID: 855
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.467264e+06
+      GoRuntimeType: 1.46736e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26095,7 +26095,7 @@ Types:
       ID: 843
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.462304e+06
+      GoRuntimeType: 1.4624e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26109,7 +26109,7 @@ Types:
       ID: 1017
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.937696e+06
+      GoRuntimeType: 1.937952e+06
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26125,7 +26125,7 @@ Types:
       ID: 845
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.629728e+06
+      GoRuntimeType: 1.629984e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26138,7 +26138,7 @@ Types:
       ID: 1162
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.997024e+06
+      GoRuntimeType: 1.99728e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26155,7 +26155,7 @@ Types:
       ID: 934
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.590656e+06
+      GoRuntimeType: 1.590912e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26180,14 +26180,14 @@ Types:
     - __kind: StructureType
       ID: 988
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.532736e+06
+      GoRuntimeType: 1.532992e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 837
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.455584e+06
+      GoRuntimeType: 1.45568e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26197,7 +26197,7 @@ Types:
       ID: 839
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.455744e+06
+      GoRuntimeType: 1.45584e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26654,7 +26654,7 @@ Types:
       ID: 92
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.879264e+06
+      GoRuntimeType: 1.87952e+06
       GoKind: 25
       RawFields:
         - Name: buf
@@ -26691,7 +26691,7 @@ Types:
     - __kind: StructureType
       ID: 949
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.497216e+06
+      GoRuntimeType: 1.497472e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -26702,7 +26702,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.227936e+06
+      GoRuntimeType: 1.228032e+06
       GoKind: 25
       RawFields:
         - Name: u
@@ -26712,7 +26712,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.665184e+06
+      GoRuntimeType: 1.66544e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26732,7 +26732,7 @@ Types:
       ID: 33
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.510976e+06
+      GoRuntimeType: 1.511232e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26745,7 +26745,7 @@ Types:
       ID: 37
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.510816e+06
+      GoRuntimeType: 1.511072e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26757,13 +26757,13 @@ Types:
     - __kind: StructureType
       ID: 77
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 1.00736e+06
+      GoRuntimeType: 1.007456e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 34
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 1.007264e+06
+      GoRuntimeType: 1.00736e+06
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
@@ -26789,7 +26789,7 @@ Types:
       ID: 906
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
-      GoRuntimeType: 1.581536e+06
+      GoRuntimeType: 1.581792e+06
       GoKind: 25
       RawFields:
         - Name: typ
@@ -26805,7 +26805,7 @@ Types:
       ID: 1265
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.494176e+06
+      GoRuntimeType: 1.494432e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -26822,7 +26822,7 @@ Types:
       ID: 1152
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.204512e+06
+      GoRuntimeType: 1.204608e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26835,7 +26835,7 @@ Types:
       ID: 1187
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.037984e+06
+      GoRuntimeType: 1.03808e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26848,7 +26848,7 @@ Types:
       ID: 1138
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.124768e+06
+      GoRuntimeType: 1.124864e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26861,7 +26861,7 @@ Types:
       ID: 137
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.037728e+06
+      GoRuntimeType: 1.037824e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26873,7 +26873,7 @@ Types:
     - __kind: StructureType
       ID: 1109
       Name: io.discard
-      GoRuntimeType: 1.482976e+06
+      GoRuntimeType: 1.483232e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -26943,7 +26943,7 @@ Types:
       ID: 168
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.036576e+06
+      GoRuntimeType: 1.036672e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26956,7 +26956,7 @@ Types:
       ID: 134
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.637344e+06
+      GoRuntimeType: 1.6376e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -26972,7 +26972,7 @@ Types:
       ID: 149
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.2008e+06
+      GoRuntimeType: 1.200896e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26982,7 +26982,7 @@ Types:
       ID: 382
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.200672e+06
+      GoRuntimeType: 1.200768e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -26996,7 +26996,7 @@ Types:
       ID: 156
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.200032e+06
+      GoRuntimeType: 1.200128e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27006,7 +27006,7 @@ Types:
       ID: 1331
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.199904e+06
+      GoRuntimeType: 1.2e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27016,7 +27016,7 @@ Types:
       ID: 1346
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.199776e+06
+      GoRuntimeType: 1.199872e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27026,7 +27026,7 @@ Types:
       ID: 138
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.201952e+06
+      GoRuntimeType: 1.202048e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27036,7 +27036,7 @@ Types:
       ID: 140
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.201824e+06
+      GoRuntimeType: 1.20192e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27050,7 +27050,7 @@ Types:
       ID: 142
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.201184e+06
+      GoRuntimeType: 1.20128e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27060,7 +27060,7 @@ Types:
       ID: 1301
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.201056e+06
+      GoRuntimeType: 1.201152e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27070,7 +27070,7 @@ Types:
       ID: 1303
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.200928e+06
+      GoRuntimeType: 1.201024e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27080,7 +27080,7 @@ Types:
       ID: 143
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.203104e+06
+      GoRuntimeType: 1.2032e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27090,7 +27090,7 @@ Types:
       ID: 372
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.202976e+06
+      GoRuntimeType: 1.203072e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27104,7 +27104,7 @@ Types:
       ID: 148
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.202336e+06
+      GoRuntimeType: 1.202432e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27114,7 +27114,7 @@ Types:
       ID: 1307
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.202208e+06
+      GoRuntimeType: 1.202304e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27124,7 +27124,7 @@ Types:
       ID: 1313
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.20208e+06
+      GoRuntimeType: 1.202176e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27139,7 +27139,7 @@ Types:
       ID: 166
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.862912e+06
+      GoRuntimeType: 1.863168e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27161,7 +27161,7 @@ Types:
       ID: 161
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.998592e+06
+      GoRuntimeType: 1.998848e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -27189,7 +27189,7 @@ Types:
       ID: 360
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.430784e+06
+      GoRuntimeType: 1.43088e+06
       GoKind: 25
       RawFields:
         - Name: s
@@ -27316,7 +27316,7 @@ Types:
       ID: 129
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.482016e+06
+      GoRuntimeType: 1.482272e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -27329,7 +27329,7 @@ Types:
       ID: 252
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.481696e+06
+      GoRuntimeType: 1.481952e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -27351,14 +27351,14 @@ Types:
       ID: 1275
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.430944e+06
+      GoRuntimeType: 1.43104e+06
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 164
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.036704e+06
+      GoRuntimeType: 1.0368e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27411,7 +27411,7 @@ Types:
       ID: 170
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.19952e+06
+      GoRuntimeType: 1.199616e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27481,7 +27481,7 @@ Types:
       ID: 171
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.199648e+06
+      GoRuntimeType: 1.199744e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -28595,119 +28595,119 @@ Types:
       ID: 229
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.144352e+06
+      GoRuntimeType: 1.144448e+06
       GoKind: 21
       HeaderType: 231 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 224
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.14448e+06
+      GoRuntimeType: 1.144576e+06
       GoKind: 21
       HeaderType: 226 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 192
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.144608e+06
+      GoRuntimeType: 1.144704e+06
       GoKind: 21
       HeaderType: 194 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 204
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.144736e+06
+      GoRuntimeType: 1.144832e+06
       GoKind: 21
       HeaderType: 206 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 150
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.144224e+06
+      GoRuntimeType: 1.14432e+06
       GoKind: 21
       HeaderType: 152 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1285
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.144096e+06
+      GoRuntimeType: 1.144192e+06
       GoKind: 21
       HeaderType: 1287 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1319
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.143456e+06
+      GoRuntimeType: 1.143552e+06
       GoKind: 21
       HeaderType: 1321 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1334
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.143328e+06
+      GoRuntimeType: 1.143424e+06
       GoKind: 21
       HeaderType: 1336 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 172
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.142688e+06
+      GoRuntimeType: 1.142784e+06
       GoKind: 21
       HeaderType: 174 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 1349
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.1432e+06
+      GoRuntimeType: 1.143296e+06
       GoKind: 21
       HeaderType: 1351 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 239
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.144864e+06
+      GoRuntimeType: 1.14496e+06
       GoKind: 21
       HeaderType: 241 GoSwissMapHeaderType map<int,struct {}>
     - __kind: GoMapType
       ID: 209
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.144992e+06
+      GoRuntimeType: 1.145088e+06
       GoKind: 21
       HeaderType: 211 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 199
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.14512e+06
+      GoRuntimeType: 1.145216e+06
       GoKind: 21
       HeaderType: 201 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 187
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.145248e+06
+      GoRuntimeType: 1.145344e+06
       GoKind: 21
       HeaderType: 189 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 182
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.145376e+06
+      GoRuntimeType: 1.145472e+06
       GoKind: 21
       HeaderType: 184 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 177
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.145504e+06
+      GoRuntimeType: 1.1456e+06
       GoKind: 21
       HeaderType: 179 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 234
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 1.145632e+06
+      GoRuntimeType: 1.145728e+06
       GoKind: 21
       HeaderType: 236 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
@@ -28750,28 +28750,28 @@ Types:
       ID: 244
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.14576e+06
+      GoRuntimeType: 1.145856e+06
       GoKind: 21
       HeaderType: 246 GoSwissMapHeaderType map<struct {},struct {}>
     - __kind: GoMapType
       ID: 219
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.145888e+06
+      GoRuntimeType: 1.145984e+06
       GoKind: 21
       HeaderType: 221 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 214
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.146016e+06
+      GoRuntimeType: 1.146112e+06
       GoKind: 21
       HeaderType: 216 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
       ID: 776
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.446944e+06
+      GoRuntimeType: 1.44704e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -28781,7 +28781,7 @@ Types:
       ID: 1073
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.443904e+06
+      GoRuntimeType: 1.444e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -28795,7 +28795,7 @@ Types:
       ID: 1043
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.619808e+06
+      GoRuntimeType: 1.620064e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -28836,7 +28836,7 @@ Types:
       ID: 939
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.128096e+06
+      GoRuntimeType: 1.128192e+06
       GoKind: 24
       RawFields:
         - Name: str
@@ -28854,7 +28854,7 @@ Types:
     - __kind: StructureType
       ID: 904
       Name: net.canceledError
-      GoRuntimeType: 1.301472e+06
+      GoRuntimeType: 1.301568e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28865,7 +28865,7 @@ Types:
       ID: 1048
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 2.138048e+06
+      GoRuntimeType: 2.138304e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -28887,13 +28887,13 @@ Types:
     - __kind: StructureType
       ID: 1233
       Name: net.noReadFrom
-      GoRuntimeType: 1.128352e+06
+      GoRuntimeType: 1.128448e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1232
       Name: net.noWriteTo
-      GoRuntimeType: 1.128224e+06
+      GoRuntimeType: 1.12832e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28904,7 +28904,7 @@ Types:
       ID: 708
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.756512e+06
+      GoRuntimeType: 1.756768e+06
       GoKind: 25
       RawFields:
         - Name: p
@@ -28920,7 +28920,7 @@ Types:
       ID: 1221
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.320224e+06
+      GoRuntimeType: 2.32048e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -28933,7 +28933,7 @@ Types:
       ID: 1219
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.31968e+06
+      GoRuntimeType: 2.319936e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -28958,7 +28958,7 @@ Types:
       ID: 1067
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.435424e+06
+      GoRuntimeType: 1.43552e+06
       GoKind: 25
       RawFields:
         - Name: w
@@ -28974,13 +28974,13 @@ Types:
       ID: 1020
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.005056e+06
+      GoRuntimeType: 1.005152e+06
       GoKind: 10
     - __kind: StructureType
       ID: 684
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.754016e+06
+      GoRuntimeType: 1.754272e+06
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -28996,7 +28996,7 @@ Types:
       ID: 998
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.926944e+06
+      GoRuntimeType: 1.9272e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -29012,7 +29012,7 @@ Types:
       ID: 688
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.619328e+06
+      GoRuntimeType: 1.619584e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29089,7 +29089,7 @@ Types:
     - __kind: StructureType
       ID: 900
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.300704e+06
+      GoRuntimeType: 1.3008e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29119,7 +29119,7 @@ Types:
       ID: 1069
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
-      GoRuntimeType: 1.754784e+06
+      GoRuntimeType: 1.75504e+06
       GoKind: 25
       RawFields:
         - Name: conn
@@ -29142,7 +29142,7 @@ Types:
       ID: 896
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.577536e+06
+      GoRuntimeType: 1.577792e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -29156,7 +29156,7 @@ Types:
       ID: 1087
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.577376e+06
+      GoRuntimeType: 1.577632e+06
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29166,7 +29166,7 @@ Types:
       ID: 1121
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.828192e+06
+      GoRuntimeType: 1.828448e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -29182,7 +29182,7 @@ Types:
       ID: 692
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.436384e+06
+      GoRuntimeType: 1.43648e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -29195,14 +29195,14 @@ Types:
     - __kind: StructureType
       ID: 971
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.500096e+06
+      GoRuntimeType: 1.500352e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 898
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.577696e+06
+      GoRuntimeType: 1.577952e+06
       GoKind: 25
       RawFields:
         - Name: err
@@ -29212,7 +29212,7 @@ Types:
       ID: 1164
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2.057728e+06
+      GoRuntimeType: 2.057984e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29229,7 +29229,7 @@ Types:
       ID: 1186
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 2.073472e+06
+      GoRuntimeType: 2.073728e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29243,7 +29243,7 @@ Types:
       ID: 768
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.759584e+06
+      GoRuntimeType: 1.75984e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29259,7 +29259,7 @@ Types:
       ID: 766
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.621248e+06
+      GoRuntimeType: 1.621504e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29276,7 +29276,7 @@ Types:
       ID: 1099
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.623488e+06
+      GoRuntimeType: 1.623744e+06
       GoKind: 25
       RawFields:
         - Name: c
@@ -29594,7 +29594,7 @@ Types:
       ID: 480
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.312992e+06
+      GoRuntimeType: 1.313088e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29607,7 +29607,7 @@ Types:
       ID: 472
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.313248e+06
+      GoRuntimeType: 1.313344e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29620,7 +29620,7 @@ Types:
       ID: 420
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.313504e+06
+      GoRuntimeType: 1.3136e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29633,7 +29633,7 @@ Types:
       ID: 439
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.31376e+06
+      GoRuntimeType: 1.313856e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29646,7 +29646,7 @@ Types:
       ID: 378
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.312736e+06
+      GoRuntimeType: 1.312832e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29659,7 +29659,7 @@ Types:
       ID: 1293
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.31248e+06
+      GoRuntimeType: 1.312576e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29672,7 +29672,7 @@ Types:
       ID: 1327
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.3112e+06
+      GoRuntimeType: 1.311296e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29685,7 +29685,7 @@ Types:
       ID: 1342
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.310944e+06
+      GoRuntimeType: 1.31104e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29698,7 +29698,7 @@ Types:
       ID: 388
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.309664e+06
+      GoRuntimeType: 1.30976e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29711,7 +29711,7 @@ Types:
       ID: 1357
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.310688e+06
+      GoRuntimeType: 1.310784e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29724,7 +29724,7 @@ Types:
       ID: 496
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
-      GoRuntimeType: 1.314016e+06
+      GoRuntimeType: 1.314112e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29737,7 +29737,7 @@ Types:
       ID: 447
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.314272e+06
+      GoRuntimeType: 1.314368e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29750,7 +29750,7 @@ Types:
       ID: 429
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.314528e+06
+      GoRuntimeType: 1.314624e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29763,7 +29763,7 @@ Types:
       ID: 412
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.314784e+06
+      GoRuntimeType: 1.31488e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29776,7 +29776,7 @@ Types:
       ID: 1055
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
-      GoRuntimeType: 1.376224e+06
+      GoRuntimeType: 1.37632e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29789,7 +29789,7 @@ Types:
       ID: 404
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.31504e+06
+      GoRuntimeType: 1.315136e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29802,7 +29802,7 @@ Types:
       ID: 396
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.315296e+06
+      GoRuntimeType: 1.315392e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29815,7 +29815,7 @@ Types:
       ID: 488
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
-      GoRuntimeType: 1.315552e+06
+      GoRuntimeType: 1.315648e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29900,7 +29900,7 @@ Types:
       ID: 504
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
-      GoRuntimeType: 1.315808e+06
+      GoRuntimeType: 1.315904e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29913,7 +29913,7 @@ Types:
       ID: 463
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.316064e+06
+      GoRuntimeType: 1.31616e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29926,7 +29926,7 @@ Types:
       ID: 455
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.31632e+06
+      GoRuntimeType: 1.316416e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29939,7 +29939,7 @@ Types:
       ID: 482
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.312864e+06
+      GoRuntimeType: 1.31296e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29952,7 +29952,7 @@ Types:
       ID: 474
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.31312e+06
+      GoRuntimeType: 1.313216e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29965,7 +29965,7 @@ Types:
       ID: 422
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.313376e+06
+      GoRuntimeType: 1.313472e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29978,7 +29978,7 @@ Types:
       ID: 441
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.313632e+06
+      GoRuntimeType: 1.313728e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -29991,7 +29991,7 @@ Types:
       ID: 380
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.312608e+06
+      GoRuntimeType: 1.312704e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30004,7 +30004,7 @@ Types:
       ID: 1295
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.312352e+06
+      GoRuntimeType: 1.312448e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30017,7 +30017,7 @@ Types:
       ID: 1329
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.311072e+06
+      GoRuntimeType: 1.311168e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30030,7 +30030,7 @@ Types:
       ID: 1344
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.310816e+06
+      GoRuntimeType: 1.310912e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30043,7 +30043,7 @@ Types:
       ID: 390
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.309536e+06
+      GoRuntimeType: 1.309632e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30056,7 +30056,7 @@ Types:
       ID: 1359
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.31056e+06
+      GoRuntimeType: 1.310656e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30069,7 +30069,7 @@ Types:
       ID: 498
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
-      GoRuntimeType: 1.313888e+06
+      GoRuntimeType: 1.313984e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30082,7 +30082,7 @@ Types:
       ID: 449
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.314144e+06
+      GoRuntimeType: 1.31424e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30095,7 +30095,7 @@ Types:
       ID: 431
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.3144e+06
+      GoRuntimeType: 1.314496e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30108,7 +30108,7 @@ Types:
       ID: 414
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.314656e+06
+      GoRuntimeType: 1.314752e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30121,7 +30121,7 @@ Types:
       ID: 1057
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
-      GoRuntimeType: 1.376096e+06
+      GoRuntimeType: 1.376192e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30134,7 +30134,7 @@ Types:
       ID: 406
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.314912e+06
+      GoRuntimeType: 1.315008e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30147,7 +30147,7 @@ Types:
       ID: 398
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.315168e+06
+      GoRuntimeType: 1.315264e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30160,7 +30160,7 @@ Types:
       ID: 490
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
-      GoRuntimeType: 1.315424e+06
+      GoRuntimeType: 1.31552e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30244,7 +30244,7 @@ Types:
     - __kind: StructureType
       ID: 506
       Name: noalg.struct { key struct {}; elem struct {} }
-      GoRuntimeType: 1.31568e+06
+      GoRuntimeType: 1.315776e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30257,7 +30257,7 @@ Types:
       ID: 465
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.315936e+06
+      GoRuntimeType: 1.316032e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30270,7 +30270,7 @@ Types:
       ID: 457
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.316192e+06
+      GoRuntimeType: 1.316288e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30295,7 +30295,7 @@ Types:
       ID: 1243
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.390624e+06
+      GoRuntimeType: 2.39088e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -30308,7 +30308,7 @@ Types:
       ID: 1241
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.389824e+06
+      GoRuntimeType: 2.39008e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -30320,13 +30320,13 @@ Types:
     - __kind: StructureType
       ID: 1249
       Name: os.noReadFrom
-      GoRuntimeType: 1.125792e+06
+      GoRuntimeType: 1.125888e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1248
       Name: os.noWriteTo
-      GoRuntimeType: 1.125664e+06
+      GoRuntimeType: 1.12576e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -30345,7 +30345,7 @@ Types:
       ID: 910
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.729984e+06
+      GoRuntimeType: 1.73024e+06
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -30407,7 +30407,7 @@ Types:
       ID: 883
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.916e+06
+      GoRuntimeType: 1.916256e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -30433,14 +30433,14 @@ Types:
     - __kind: StructureType
       ID: 90
       Name: runtime.dlogPerM
-      GoRuntimeType: 1.004192e+06
+      GoRuntimeType: 1.004288e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 945
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.780832e+06
+      GoRuntimeType: 1.781088e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30453,7 +30453,7 @@ Types:
       ID: 859
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 1.003616e+06
+      GoRuntimeType: 1.003712e+06
       GoKind: 24
       RawFields:
         - Name: str
@@ -30472,7 +30472,7 @@ Types:
       ID: 23
       Name: runtime.g
       ByteSize: 456
-      GoRuntimeType: 2.439552e+06
+      GoRuntimeType: 2.439808e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30674,7 +30674,7 @@ Types:
       ID: 55
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.210528e+06
+      GoRuntimeType: 1.210624e+06
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -30684,7 +30684,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.942752e+06
+      GoRuntimeType: 1.943008e+06
       GoKind: 25
       RawFields:
         - Name: sp
@@ -30709,7 +30709,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.489216e+06
+      GoRuntimeType: 1.489472e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -30722,7 +30722,7 @@ Types:
       ID: 60
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.77968e+06
+      GoRuntimeType: 1.779936e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30747,7 +30747,7 @@ Types:
       ID: 96
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.491616e+06
+      GoRuntimeType: 1.491872e+06
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -30760,7 +30760,7 @@ Types:
       ID: 72
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 1.490816e+06
+      GoRuntimeType: 1.491072e+06
       GoKind: 25
       RawFields:
         - Name: prev
@@ -30779,7 +30779,7 @@ Types:
       ID: 30
       Name: runtime.m
       ByteSize: 1824
-      GoRuntimeType: 2.444832e+06
+      GoRuntimeType: 2.445088e+06
       GoKind: 25
       RawFields:
         - Name: g0
@@ -31008,7 +31008,7 @@ Types:
       ID: 75
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.943264e+06
+      GoRuntimeType: 1.94352e+06
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31033,7 +31033,7 @@ Types:
       ID: 91
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.868288e+06
+      GoRuntimeType: 1.868544e+06
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31055,7 +31055,7 @@ Types:
       ID: 80
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 1.94352e+06
+      GoRuntimeType: 1.943776e+06
       GoKind: 25
       RawFields:
         - Name: writing
@@ -31080,7 +31080,7 @@ Types:
       ID: 74
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.491296e+06
+      GoRuntimeType: 1.491552e+06
       GoKind: 25
       RawFields:
         - Name: next
@@ -31093,7 +31093,7 @@ Types:
       ID: 98
       Name: runtime.mWeakPointer
       ByteSize: 8
-      GoRuntimeType: 1.574496e+06
+      GoRuntimeType: 1.574752e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -31109,7 +31109,7 @@ Types:
       ID: 71
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.211552e+06
+      GoRuntimeType: 1.211648e+06
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -31120,7 +31120,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.491456e+06
+      GoRuntimeType: 1.491712e+06
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31133,7 +31133,7 @@ Types:
       ID: 89
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.78064e+06
+      GoRuntimeType: 1.780896e+06
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -31152,7 +31152,7 @@ Types:
       ID: 862
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 1.003712e+06
+      GoRuntimeType: 1.003808e+06
       GoKind: 24
       RawFields:
         - Name: str
@@ -31186,7 +31186,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.487936e+06
+      GoRuntimeType: 1.488192e+06
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31207,7 +31207,7 @@ Types:
       ID: 669
       Name: runtime.synctestDeadlockError
       ByteSize: 24
-      GoRuntimeType: 1.619008e+06
+      GoRuntimeType: 1.619264e+06
       GoKind: 25
       RawFields:
         - Name: reason
@@ -31240,7 +31240,7 @@ Types:
       ID: 56
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.489536e+06
+      GoRuntimeType: 1.489792e+06
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -31253,19 +31253,19 @@ Types:
       ID: 35
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.618688e+06
+      GoRuntimeType: 1.618944e+06
       GoKind: 8
     - __kind: StructureType
       ID: 85
       Name: runtime.winlibcall
-      GoRuntimeType: 1.004096e+06
+      GoRuntimeType: 1.004192e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 52
       Name: runtime.xRegPerG
       ByteSize: 8
-      GoRuntimeType: 1.2104e+06
+      GoRuntimeType: 1.210496e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -31310,7 +31310,7 @@ Types:
       ID: 1081
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.474464e+06
+      GoRuntimeType: 1.47472e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -31326,7 +31326,7 @@ Types:
       ID: 1263
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.483296e+06
+      GoRuntimeType: 1.483552e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31339,7 +31339,7 @@ Types:
       ID: 1266
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.638304e+06
+      GoRuntimeType: 1.63856e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31355,7 +31355,7 @@ Types:
       ID: 1269
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.638112e+06
+      GoRuntimeType: 1.638368e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31370,14 +31370,14 @@ Types:
     - __kind: StructureType
       ID: 1264
       Name: sync.noCopy
-      GoRuntimeType: 1.00256e+06
+      GoRuntimeType: 1.002656e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1267
       Name: sync/atomic.Bool
       ByteSize: 4
-      GoRuntimeType: 1.484416e+06
+      GoRuntimeType: 1.484672e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31390,7 +31390,7 @@ Types:
       ID: 1272
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.484576e+06
+      GoRuntimeType: 1.484832e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31403,7 +31403,7 @@ Types:
       ID: 1270
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.638688e+06
+      GoRuntimeType: 1.638944e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31418,20 +31418,20 @@ Types:
     - __kind: StructureType
       ID: 1271
       Name: sync/atomic.align64
-      GoRuntimeType: 1.002752e+06
+      GoRuntimeType: 1.002848e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1268
       Name: sync/atomic.noCopy
-      GoRuntimeType: 1.002656e+06
+      GoRuntimeType: 1.002752e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 995
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.299808e+06
+      GoRuntimeType: 1.299904e+06
       GoKind: 12
     - __kind: StructureType
       ID: 477
@@ -32089,7 +32089,7 @@ Types:
       ID: 938
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.7344e+06
+      GoRuntimeType: 1.734656e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -32102,7 +32102,7 @@ Types:
       ID: 1148
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.944288e+06
+      GoRuntimeType: 1.944544e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1013
@@ -32116,7 +32116,7 @@ Types:
       ID: 1011
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.404768e+06
+      GoRuntimeType: 2.405024e+06
       GoKind: 25
       RawFields:
         - Name: wall
@@ -32197,7 +32197,7 @@ Types:
       ID: 1031
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 2.09424e+06
+      GoRuntimeType: 2.094496e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -32231,13 +32231,13 @@ Types:
       ID: 1034
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
-      GoRuntimeType: 1.00928e+06
+      GoRuntimeType: 1.009376e+06
       GoKind: 9
     - __kind: StructureType
       ID: 1032
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.955552e+06
+      GoRuntimeType: 1.955808e+06
       GoKind: 25
       RawFields:
         - Name: id
@@ -32276,7 +32276,7 @@ Types:
       ID: 754
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.444064e+06
+      GoRuntimeType: 1.44416e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -32292,7 +32292,7 @@ Types:
       ID: 915
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.730176e+06
+      GoRuntimeType: 1.730432e+06
       GoKind: 25
       RawFields:
         - Name: label
@@ -32305,7 +32305,7 @@ Types:
       ID: 867
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
-      GoRuntimeType: 1.008128e+06
+      GoRuntimeType: 1.008224e+06
       GoKind: 5
 MaxTypeID: 1684
 Issues:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x8947d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8947e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1400 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x89480c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89481c", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1238 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x88f898", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f8a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1239 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x88f8c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f8d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1241 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x88f918", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f928", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1242 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x88f944", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f954", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x89352c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89353c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1371 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8935c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8935d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1188 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0x88d020", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d030", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1184 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0x88cfe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cff0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1186 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0x88d000", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d010", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1250 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x88ff80", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ff90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1185 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0x88cff0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1187 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0x88d010", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1272 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x891670", Frameless: true}]
+              InjectionPoints: [{PC: "0x891680", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1273 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x8916ac", Frameless: true}]
+              InjectionPoints: [{PC: "0x8916bc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1206 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x88d570", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d580", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1207 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0x88d588", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d598", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1173 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0x88cf30", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cf40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1170 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0x88cf00", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cf10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x894b30", Frameless: true}]
+              InjectionPoints: [{PC: "0x894b40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1419 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x894b4c", Frameless: true}]
+              InjectionPoints: [{PC: "0x894b5c", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1479 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x88f138"
+                - PC: "0x88f148"
                   Frameless: false
-                - PC: "0x88f1ac"
+                - PC: "0x88f1bc"
                   Frameless: false
-                - PC: "0x88f2f8"
+                - PC: "0x88f308"
                   Frameless: false
-                - PC: "0x88f374"
+                - PC: "0x88f384"
                   Frameless: false
-                - PC: "0x88f43c"
+                - PC: "0x88f44c"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1480 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x88f138"
+                - PC: "0x88f148"
                   Frameless: false
-                - PC: "0x88f1ac"
+                - PC: "0x88f1bc"
                   Frameless: false
-                - PC: "0x88f2f8"
+                - PC: "0x88f308"
                   Frameless: false
-                - PC: "0x88f374"
+                - PC: "0x88f384"
                   Frameless: false
-                - PC: "0x88f43c"
+                - PC: "0x88f44c"
                   Frameless: false
               Condition:
                 Type: 4 BaseType bool
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 1481 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x88f138"
+                - PC: "0x88f148"
                   Frameless: false
-                - PC: "0x88f1ac"
+                - PC: "0x88f1bc"
                   Frameless: false
-                - PC: "0x88f2f8"
+                - PC: "0x88f308"
                   Frameless: false
-                - PC: "0x88f374"
+                - PC: "0x88f384"
                   Frameless: false
-                - PC: "0x88f43c"
+                - PC: "0x88f44c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -474,7 +474,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1269 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x891410", Frameless: true}]
+              InjectionPoints: [{PC: "0x891420", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -493,7 +493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1270 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x891410", Frameless: true}]
+              InjectionPoints: [{PC: "0x891420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -519,7 +519,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x894be0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894bf0", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -554,7 +554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1274 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x8916b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8916c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -584,7 +584,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1268 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x8913f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -613,11 +613,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1335 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x892728", Frameless: false}]
+              InjectionPoints: [{PC: "0x892738", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1336 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x8927d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8927e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -639,7 +639,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1282 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x891960", Frameless: true}]
+              InjectionPoints: [{PC: "0x891970", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -661,7 +661,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1213 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x88da70", Frameless: true}]
+              InjectionPoints: [{PC: "0x88da80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -683,7 +683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1214 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x88da80", Frameless: true}]
+              InjectionPoints: [{PC: "0x88da90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -705,7 +705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1209 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x88d760", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d770", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -727,7 +727,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1210 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x88d770", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -749,7 +749,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1211 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x88d910", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -771,7 +771,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1212 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x88d920", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d930", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -793,7 +793,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x894400", Frameless: true}]
+              InjectionPoints: [{PC: "0x894410", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -820,7 +820,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x894430", Frameless: true}]
+              InjectionPoints: [{PC: "0x894440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -848,7 +848,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1413 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x8948b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8948c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -870,7 +870,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x894c30", Frameless: true}]
+              InjectionPoints: [{PC: "0x894c40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -891,7 +891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x894c40", Frameless: true}]
+              InjectionPoints: [{PC: "0x894c50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -913,7 +913,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1240 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x88f8f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88f900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -947,7 +947,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1208 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x88d5fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x88d60c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -975,11 +975,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1222 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x88e148", Frameless: false}]
+              InjectionPoints: [{PC: "0x88e158", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1223 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x88e184", Frameless: false}]
+              InjectionPoints: [{PC: "0x88e194", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1001,11 +1001,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1220 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x88e05c", Frameless: false}]
+              InjectionPoints: [{PC: "0x88e06c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1221 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x88e0cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x88e0dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1027,11 +1027,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1232 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x88f5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88f5d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1233 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x88f5c8", Frameless: true}]
+              InjectionPoints: [{PC: "0x88f5d8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1053,11 +1053,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1234 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x88f5dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f5ec", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1235 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x88f618", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f628", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1082,7 +1082,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1236 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x88f5dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f5ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1104,11 +1104,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x896fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896fb0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1466 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x896fa8", Frameless: true}]
+              InjectionPoints: [{PC: "0x896fb8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1122,11 +1122,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x896fc0", Frameless: false}]
+              InjectionPoints: [{PC: "0x896fd0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1468 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x896ffc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89700c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1149,11 +1149,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x896f08", Frameless: false}]
+              InjectionPoints: [{PC: "0x896f18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1462 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x896f18", Frameless: false}]
+              InjectionPoints: [{PC: "0x896f28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1167,11 +1167,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x896f58", Frameless: false}]
+              InjectionPoints: [{PC: "0x896f68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1464 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x896f70", Frameless: false}]
+              InjectionPoints: [{PC: "0x896f80", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1194,14 +1194,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x897010", Frameless: true}]
+              InjectionPoints: [{PC: "0x897020", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1470 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x897038"
+                - PC: "0x897048"
                   Frameless: true
-                - PC: "0x897040"
+                - PC: "0x897050"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1216,14 +1216,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x897068", Frameless: false}]
+              InjectionPoints: [{PC: "0x897078", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1472 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x8970c8"
-                  Frameless: false
                 - PC: "0x8970d8"
+                  Frameless: false
+                - PC: "0x8970e8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1250,7 +1250,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1473 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x897014", Frameless: true}]
+              InjectionPoints: [{PC: "0x897024", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1262,7 +1262,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1474 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x897078", Frameless: false}]
+              InjectionPoints: [{PC: "0x897088", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1283,11 +1283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x896be0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896bf0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1450 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x896be8", Frameless: true}]
+              InjectionPoints: [{PC: "0x896bf8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1301,11 +1301,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x896c70", Frameless: true}]
+              InjectionPoints: [{PC: "0x896c80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1452 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x896c74", Frameless: true}]
+              InjectionPoints: [{PC: "0x896c84", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1329,11 +1329,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x896788", Frameless: false}]
+              InjectionPoints: [{PC: "0x896798", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1438 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x89685c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89686c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1375,11 +1375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x8968b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8968c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1442 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8968c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8968d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1402,11 +1402,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x897120", Frameless: true}]
+              InjectionPoints: [{PC: "0x897130", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1476 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x897128", Frameless: true}]
+              InjectionPoints: [{PC: "0x897138", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1420,11 +1420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x8971c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8971d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1478 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x8971ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x8971fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1447,11 +1447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x8966e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8966f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1434 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8966e4", Frameless: true}]
+              InjectionPoints: [{PC: "0x8966f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1465,11 +1465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x8966f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896700", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1436 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8966fc", Frameless: true}]
+              InjectionPoints: [{PC: "0x89670c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1492,11 +1492,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x896d10", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1454 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x896d18", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d28", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1510,11 +1510,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x896db8", Frameless: false}]
+              InjectionPoints: [{PC: "0x896dc8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1456 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x896de4", Frameless: false}]
+              InjectionPoints: [{PC: "0x896df4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1537,11 +1537,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x896bb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896bc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1444 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x896bb4", Frameless: true}]
+              InjectionPoints: [{PC: "0x896bc4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1555,11 +1555,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x896bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896bd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1446 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x896bc4", Frameless: true}]
+              InjectionPoints: [{PC: "0x896bd4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1573,11 +1573,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x896bd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896be0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1448 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x896bd4", Frameless: true}]
+              InjectionPoints: [{PC: "0x896be4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1600,11 +1600,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x896ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896ed0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1458 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x896ec8", Frameless: true}]
+              InjectionPoints: [{PC: "0x896ed8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1618,11 +1618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x896ed0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896ee0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1460 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x896ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896ef0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1645,11 +1645,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x8966c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8966d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1430 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8966c4", Frameless: true}]
+              InjectionPoints: [{PC: "0x8966d4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1663,11 +1663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x8966d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8966e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1432 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8966dc", Frameless: true}]
+              InjectionPoints: [{PC: "0x8966ec", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1690,11 +1690,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1224 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x88f2d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f2e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1225 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x88f330", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f340", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1721,11 +1721,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1226 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x88f368", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f378", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1227 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x88f3f0", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f400", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1752,11 +1752,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1228 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x88f438", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f448", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1229 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x88f474", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f484", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1778,7 +1778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1485 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x88f3b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f3c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1796,11 +1796,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1230 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x88f4b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f4c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1231 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x88f5a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f5b8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1818,7 +1818,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x88f4bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f4cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1839,7 +1839,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1487 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x88f4bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f4cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1857,7 +1857,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x88f570", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f580", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1878,7 +1878,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1489 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x88f570", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f580", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1899,7 +1899,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x12a824"
                   Frameless: true
-                - PC: "0x88fe58"
+                - PC: "0x88fe68"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1920,20 +1920,20 @@ Probes:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x88f138"
+                - PC: "0x88f148"
                   Frameless: false
-                - PC: "0x88f1ac"
+                - PC: "0x88f1bc"
                   Frameless: false
-                - PC: "0x88f2f8"
+                - PC: "0x88f308"
                   Frameless: false
-                - PC: "0x88f374"
+                - PC: "0x88f384"
                   Frameless: false
-                - PC: "0x88f43c"
+                - PC: "0x88f44c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1483 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x88f170", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f180", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1959,15 +1959,15 @@ Probes:
             - Kind: Line
               Type: 1484 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x88f138"
+                - PC: "0x88f148"
                   Frameless: false
-                - PC: "0x88f1ac"
+                - PC: "0x88f1bc"
                   Frameless: false
-                - PC: "0x88f2f8"
+                - PC: "0x88f308"
                   Frameless: false
-                - PC: "0x88f374"
+                - PC: "0x88f384"
                   Frameless: false
-                - PC: "0x88f43c"
+                - PC: "0x88f44c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1990,7 +1990,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x88f5c4", Frameless: true}]
+              InjectionPoints: [{PC: "0x88f5d4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2015,7 +2015,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1491 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x88f5c4", Frameless: true}]
+              InjectionPoints: [{PC: "0x88f5d4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2039,9 +2039,9 @@ Probes:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x88f5f4"
+                - PC: "0x88f604"
                   Frameless: false
-                - PC: "0x88f68c"
+                - PC: "0x88f69c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2064,7 +2064,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1176 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0x88cf60", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cf70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2086,7 +2086,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1177 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0x88cf70", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cf80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2108,7 +2108,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1178 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0x88cf80", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cf90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2130,7 +2130,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1175 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0x88cf50", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cf60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2152,7 +2152,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1174 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0x88cf40", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cf50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2174,7 +2174,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1237 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x88f870", Frameless: true}]
+              InjectionPoints: [{PC: "0x88f880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2195,11 +2195,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x893350", Frameless: false}]
+              InjectionPoints: [{PC: "0x893360", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1369 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8934a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8934b8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2221,7 +2221,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1276 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x891870", Frameless: true}]
+              InjectionPoints: [{PC: "0x891880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2246,7 +2246,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1217 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x88dacc", Frameless: false}]
+              InjectionPoints: [{PC: "0x88dadc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2268,7 +2268,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1218 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x88db60", Frameless: false}]
+              InjectionPoints: [{PC: "0x88db70", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2290,7 +2290,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1219 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x88dc0c", Frameless: false}]
+              InjectionPoints: [{PC: "0x88dc1c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2333,11 +2333,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x89385c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89386c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1375 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x8939cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8939dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2399,7 +2399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1248 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x88ff60", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ff70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2421,7 +2421,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1255 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x88ffc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ffd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2443,7 +2443,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1265 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x890060", Frameless: true}]
+              InjectionPoints: [{PC: "0x890070", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2465,7 +2465,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1267 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x890080", Frameless: true}]
+              InjectionPoints: [{PC: "0x890090", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2487,7 +2487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1266 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x890070", Frameless: true}]
+              InjectionPoints: [{PC: "0x890080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2509,7 +2509,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1252 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x88ffa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ffb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2531,7 +2531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1264 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x890050", Frameless: true}]
+              InjectionPoints: [{PC: "0x890060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2553,7 +2553,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1263 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x890040", Frameless: true}]
+              InjectionPoints: [{PC: "0x890050", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2577,7 +2577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1253 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x88ffb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ffc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2601,7 +2601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1254 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x88ffb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ffc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2623,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1262 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x890030", Frameless: true}]
+              InjectionPoints: [{PC: "0x890040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2645,7 +2645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1261 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x890020", Frameless: true}]
+              InjectionPoints: [{PC: "0x890030", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2667,7 +2667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1246 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x88ff40", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ff50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2689,7 +2689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1247 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x88ff50", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ff60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2711,7 +2711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1245 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x88ff30", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ff40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2733,7 +2733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1256 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x88ffd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ffe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2755,7 +2755,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1259 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x890000", Frameless: true}]
+              InjectionPoints: [{PC: "0x890010", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2777,7 +2777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1260 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x890010", Frameless: true}]
+              InjectionPoints: [{PC: "0x890020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2799,7 +2799,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1257 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x88ffe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fff0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2823,7 +2823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1258 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x88fff0", Frameless: true}]
+              InjectionPoints: [{PC: "0x890000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2845,7 +2845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x894890", Frameless: true}]
+              InjectionPoints: [{PC: "0x8948a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2868,7 +2868,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1411 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x894890", Frameless: true}]
+              InjectionPoints: [{PC: "0x8948a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2915,11 +2915,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x893a50", Frameless: false}]
+              InjectionPoints: [{PC: "0x893a60", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1377 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x893c00", Frameless: false}]
+              InjectionPoints: [{PC: "0x893c10", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2985,11 +2985,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x893d2c", Frameless: false}]
+              InjectionPoints: [{PC: "0x893d3c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1381 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x893dd0", Frameless: false}]
+              InjectionPoints: [{PC: "0x893de0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3020,11 +3020,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x893600", Frameless: false}]
+              InjectionPoints: [{PC: "0x893610", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1373 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x8937d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8937e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3050,11 +3050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1313 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892588", Frameless: false}]
+              InjectionPoints: [{PC: "0x892598", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1314 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892614", Frameless: false}]
+              InjectionPoints: [{PC: "0x892624", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3090,7 +3090,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1271 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x8914d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8914e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3131,11 +3131,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1307 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x8924e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8924f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1308 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x892548", Frameless: false}]
+              InjectionPoints: [{PC: "0x892558", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3159,11 +3159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1309 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x8924e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8924f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1310 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x892548", Frameless: false}]
+              InjectionPoints: [{PC: "0x892558", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3182,11 +3182,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1315 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892588", Frameless: false}]
+              InjectionPoints: [{PC: "0x892598", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1316 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892614", Frameless: false}]
+              InjectionPoints: [{PC: "0x892624", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3206,11 +3206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1317 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892588", Frameless: false}]
+              InjectionPoints: [{PC: "0x892598", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1318 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892614", Frameless: false}]
+              InjectionPoints: [{PC: "0x892624", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3243,11 +3243,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1311 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x8924e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8924f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1312 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x892548", Frameless: false}]
+              InjectionPoints: [{PC: "0x892558", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3275,7 +3275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x894bd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3300,7 +3300,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x894bd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3331,7 +3331,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1424 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x894bd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3356,7 +3356,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x894bd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3383,7 +3383,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1281 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x891940", Frameless: true}]
+              InjectionPoints: [{PC: "0x891950", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3410,7 +3410,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x894470", Frameless: true}]
+              InjectionPoints: [{PC: "0x894480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3437,7 +3437,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x894440", Frameless: true}]
+              InjectionPoints: [{PC: "0x894450", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3472,7 +3472,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x894460", Frameless: true}]
+              InjectionPoints: [{PC: "0x894470", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3504,7 +3504,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x894880", Frameless: true}]
+              InjectionPoints: [{PC: "0x894890", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3526,7 +3526,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1277 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x891880", Frameless: true}]
+              InjectionPoints: [{PC: "0x891890", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3548,7 +3548,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1251 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x88ff90", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ffa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3570,7 +3570,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1275 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x891860", Frameless: true}]
+              InjectionPoints: [{PC: "0x891870", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3594,11 +3594,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1283 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x891d88", Frameless: false}]
+              InjectionPoints: [{PC: "0x891d98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1284 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x891dcc", Frameless: false}]
+              InjectionPoints: [{PC: "0x891ddc", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3618,11 +3618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1327 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x892658", Frameless: false}]
+              InjectionPoints: [{PC: "0x892668", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1328 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x8926e4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926f4", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3663,11 +3663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1293 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x891ea8", Frameless: false}]
+              InjectionPoints: [{PC: "0x891eb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1294 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x891f40", Frameless: false}]
+              InjectionPoints: [{PC: "0x891f50", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3705,11 +3705,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1285 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x891d88", Frameless: false}]
+              InjectionPoints: [{PC: "0x891d98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1286 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x891dcc", Frameless: false}]
+              InjectionPoints: [{PC: "0x891ddc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3750,11 +3750,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1295 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x891ea8", Frameless: false}]
+              InjectionPoints: [{PC: "0x891eb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1296 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x891f40", Frameless: false}]
+              InjectionPoints: [{PC: "0x891f50", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3794,11 +3794,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1329 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x892658", Frameless: false}]
+              InjectionPoints: [{PC: "0x892668", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1330 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x8926e4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926f4", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3815,11 +3815,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1331 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x892658", Frameless: false}]
+              InjectionPoints: [{PC: "0x892668", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1332 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x8926e4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3841,11 +3841,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1287 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x891d88", Frameless: false}]
+              InjectionPoints: [{PC: "0x891d98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1288 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x891dcc", Frameless: false}]
+              InjectionPoints: [{PC: "0x891ddc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3868,18 +3868,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1303 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x892178", Frameless: false}]
+              InjectionPoints: [{PC: "0x892188", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1304 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x892218"
+                - PC: "0x892228"
                   Frameless: false
-                - PC: "0x892260"
+                - PC: "0x892270"
                   Frameless: false
-                - PC: "0x892324"
+                - PC: "0x892334"
                   Frameless: false
-                - PC: "0x892338"
+                - PC: "0x892348"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3907,18 +3907,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1301 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x891ff8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892008", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1302 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x892064"
+                - PC: "0x892074"
                   Frameless: false
-                - PC: "0x8920b0"
+                - PC: "0x8920c0"
                   Frameless: false
-                - PC: "0x8920f0"
+                - PC: "0x892100"
                   Frameless: false
-                - PC: "0x892130"
+                - PC: "0x892140"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3945,11 +3945,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1346 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x892d5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x892d6c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1347 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x892db0", Frameless: false}]
+              InjectionPoints: [{PC: "0x892dc0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3966,11 +3966,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1348 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x892de8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892df8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1349 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x892e24", Frameless: false}]
+              InjectionPoints: [{PC: "0x892e34", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3987,11 +3987,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1350 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x892e58", Frameless: false}]
+              InjectionPoints: [{PC: "0x892e68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1351 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x892e90", Frameless: false}]
+              InjectionPoints: [{PC: "0x892ea0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4008,11 +4008,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1354 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x892f48", Frameless: false}]
+              InjectionPoints: [{PC: "0x892f58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1355 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x892fac", Frameless: false}]
+              InjectionPoints: [{PC: "0x892fbc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4029,11 +4029,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x8932d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8932e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1367 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x893318", Frameless: false}]
+              InjectionPoints: [{PC: "0x893328", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4050,11 +4050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1342 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x892c08", Frameless: false}]
+              InjectionPoints: [{PC: "0x892c18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1343 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x892c54", Frameless: false}]
+              InjectionPoints: [{PC: "0x892c64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4072,14 +4072,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1299 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x891f78", Frameless: false}]
+              InjectionPoints: [{PC: "0x891f88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1300 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x891fa8"
+                - PC: "0x891fb8"
                   Frameless: false
-                - PC: "0x891fbc"
+                - PC: "0x891fcc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4101,11 +4101,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1289 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x891d88", Frameless: false}]
+              InjectionPoints: [{PC: "0x891d98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1290 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x891dcc", Frameless: false}]
+              InjectionPoints: [{PC: "0x891ddc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4126,11 +4126,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1297 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x891ea8", Frameless: false}]
+              InjectionPoints: [{PC: "0x891eb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1298 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x891f40", Frameless: false}]
+              InjectionPoints: [{PC: "0x891f50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4151,11 +4151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1291 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x891e08", Frameless: false}]
+              InjectionPoints: [{PC: "0x891e18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1292 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x891e6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x891e7c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4177,14 +4177,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1305 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x892378", Frameless: false}]
+              InjectionPoints: [{PC: "0x892388", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1306 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x892448"
+                - PC: "0x892458"
                   Frameless: false
-                - PC: "0x89245c"
+                - PC: "0x89246c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4206,11 +4206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1344 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x892c90", Frameless: false}]
+              InjectionPoints: [{PC: "0x892ca0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1345 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x892d24", Frameless: false}]
+              InjectionPoints: [{PC: "0x892d34", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4227,11 +4227,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1340 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x892b48", Frameless: false}]
+              InjectionPoints: [{PC: "0x892b58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1341 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x892bcc", Frameless: false}]
+              InjectionPoints: [{PC: "0x892bdc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4248,11 +4248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1358 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x8930c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8930d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1359 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x893120", Frameless: false}]
+              InjectionPoints: [{PC: "0x893130", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4269,11 +4269,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1352 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x892ec8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892ed8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1353 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x892f10", Frameless: false}]
+              InjectionPoints: [{PC: "0x892f20", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4290,11 +4290,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1364 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x893258", Frameless: false}]
+              InjectionPoints: [{PC: "0x893268", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1365 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x89329c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8932ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4314,7 +4314,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1337 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x8928d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8928e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4335,11 +4335,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1362 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x8931e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8931f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1363 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x893228", Frameless: false}]
+              InjectionPoints: [{PC: "0x893238", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4356,11 +4356,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1338 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x892ab8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892ac8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1339 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x892b10", Frameless: false}]
+              InjectionPoints: [{PC: "0x892b20", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4377,11 +4377,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1360 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x89315c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89316c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1361 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x8931b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8931c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4398,11 +4398,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1356 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x892ff0", Frameless: false}]
+              InjectionPoints: [{PC: "0x893000", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1357 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x893094", Frameless: false}]
+              InjectionPoints: [{PC: "0x8930a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4420,7 +4420,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1171 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0x88cf10", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cf20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1319 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892588", Frameless: false}]
+              InjectionPoints: [{PC: "0x892598", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1320 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892614", Frameless: false}]
+              InjectionPoints: [{PC: "0x892624", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4505,7 +4505,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1192 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x88d390", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d3a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4527,7 +4527,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1190 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x88d370", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4549,7 +4549,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1203 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x88d440", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d450", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4567,7 +4567,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1204 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x88d450", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1193 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x88d3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d3b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1195 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x88d3c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d3d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4630,7 +4630,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1196 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x88d3d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d3e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4652,7 +4652,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1197 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x88d3e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d3f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4681,7 +4681,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1194 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x88d3b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d3c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4712,7 +4712,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1191 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x88d380", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d390", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4734,7 +4734,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x894830", Frameless: true}]
+              InjectionPoints: [{PC: "0x894840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4756,7 +4756,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1198 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x88d3f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4778,7 +4778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1200 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x88d410", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4800,7 +4800,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1201 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x88d420", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4822,7 +4822,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1202 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x88d430", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4844,7 +4844,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1199 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x88d400", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d410", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4866,7 +4866,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x894490", Frameless: true}]
+              InjectionPoints: [{PC: "0x8944a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4888,7 +4888,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x894410", Frameless: true}]
+              InjectionPoints: [{PC: "0x894420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4910,7 +4910,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1249 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x88ff70", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ff80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4931,11 +4931,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1333 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x892658", Frameless: false}]
+              InjectionPoints: [{PC: "0x892668", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1334 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x8926e4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4956,11 +4956,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x893c88", Frameless: false}]
+              InjectionPoints: [{PC: "0x893c98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1379 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x893cec", Frameless: false}]
+              InjectionPoints: [{PC: "0x893cfc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4982,7 +4982,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1172 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0x88cf20", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cf30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5004,7 +5004,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1280 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x891920", Frameless: true}]
+              InjectionPoints: [{PC: "0x891930", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5026,7 +5026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x894450", Frameless: true}]
+              InjectionPoints: [{PC: "0x894460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5048,7 +5048,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1215 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x88da90", Frameless: true}]
+              InjectionPoints: [{PC: "0x88daa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5070,7 +5070,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1216 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x88daa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88dab0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5092,11 +5092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x894b30", Frameless: true}]
+              InjectionPoints: [{PC: "0x894b40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1421 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x894b4c", Frameless: true}]
+              InjectionPoints: [{PC: "0x894b5c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5123,7 +5123,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x894420", Frameless: true}]
+              InjectionPoints: [{PC: "0x894430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5150,7 +5150,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1243 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x88f970", Frameless: true}]
+              InjectionPoints: [{PC: "0x88f980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5171,11 +5171,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x893e0c", Frameless: false}]
+              InjectionPoints: [{PC: "0x893e1c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1383 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x893e9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x893eac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5197,11 +5197,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x894a40", Frameless: true}]
+              InjectionPoints: [{PC: "0x894a50", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x894a58", Frameless: true}]
+              InjectionPoints: [{PC: "0x894a68", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5222,7 +5222,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x894a30", Frameless: true}]
+              InjectionPoints: [{PC: "0x894a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5249,7 +5249,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1244 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x88ff20", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ff30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5281,7 +5281,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x8944a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8944b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5321,7 +5321,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x8948c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8948d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5354,11 +5354,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1321 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892588", Frameless: false}]
+              InjectionPoints: [{PC: "0x892598", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1322 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892614", Frameless: false}]
+              InjectionPoints: [{PC: "0x892624", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5379,11 +5379,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1323 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892588", Frameless: false}]
+              InjectionPoints: [{PC: "0x892598", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1324 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892614", Frameless: false}]
+              InjectionPoints: [{PC: "0x892624", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5406,11 +5406,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1325 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892588", Frameless: false}]
+              InjectionPoints: [{PC: "0x892598", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1326 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892614", Frameless: false}]
+              InjectionPoints: [{PC: "0x892624", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5439,7 +5439,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1402 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x894840", Frameless: true}]
+              InjectionPoints: [{PC: "0x894850", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5471,11 +5471,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x894850", Frameless: true}]
+              InjectionPoints: [{PC: "0x894860", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1404 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x894868", Frameless: true}]
+              InjectionPoints: [{PC: "0x894878", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5505,11 +5505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x894850", Frameless: true}]
+              InjectionPoints: [{PC: "0x894860", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1406 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x894868", Frameless: true}]
+              InjectionPoints: [{PC: "0x894878", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5541,7 +5541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1407 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x894870", Frameless: true}]
+              InjectionPoints: [{PC: "0x894880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x894870", Frameless: true}]
+              InjectionPoints: [{PC: "0x894880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1205 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x88d460", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d470", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5625,7 +5625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1181 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0x88cfb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cfc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5647,7 +5647,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1182 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0x88cfc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cfd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5669,7 +5669,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1183 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0x88cfd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cfe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5691,7 +5691,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1180 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0x88cfa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cfb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5713,7 +5713,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1179 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0x88cf90", Frameless: true}]
+              InjectionPoints: [{PC: "0x88cfa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5735,7 +5735,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1279 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x8918b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8918c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5757,7 +5757,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x8943f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5779,7 +5779,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x8948a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8948b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5801,7 +5801,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1278 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x891890", Frameless: true}]
+              InjectionPoints: [{PC: "0x8918a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5823,7 +5823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1189 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0x88d040", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d050", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5845,7 +5845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x894480", Frameless: true}]
+              InjectionPoints: [{PC: "0x894490", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5867,7 +5867,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x894480", Frameless: true}]
+              InjectionPoints: [{PC: "0x894490", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5890,14 +5890,14 @@ Probes:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x88f798"
+                - PC: "0x88f7a8"
                   Frameless: false
-                - PC: "0x8972ec"
+                - PC: "0x8972fc"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1494 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x88f7d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f7e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5919,11 +5919,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x893ed8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893ee8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1385 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x893f44", Frameless: false}]
+              InjectionPoints: [{PC: "0x893f54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5940,481 +5940,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x88cf00..0x88cf10]
+      OutOfLinePCRanges: [0x88cf10..0x88cf20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 102 ArrayType [2]uint8
           Locations:
-            - Range: 0x88cf00..0x88cf10
+            - Range: 0x88cf10..0x88cf20
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x88cf10..0x88cf20]
+      OutOfLinePCRanges: [0x88cf20..0x88cf30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 ArrayType [2]int32
           Locations:
-            - Range: 0x88cf10..0x88cf20
+            - Range: 0x88cf20..0x88cf30
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x88cf20..0x88cf30]
+      OutOfLinePCRanges: [0x88cf30..0x88cf40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 104 ArrayType [2]string
           Locations:
-            - Range: 0x88cf20..0x88cf30
+            - Range: 0x88cf30..0x88cf40
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x88cf30..0x88cf40]
+      OutOfLinePCRanges: [0x88cf40..0x88cf50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 ArrayType [2]bool
           Locations:
-            - Range: 0x88cf30..0x88cf40
+            - Range: 0x88cf40..0x88cf50
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x88cf40..0x88cf50]
+      OutOfLinePCRanges: [0x88cf50..0x88cf60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x88cf40..0x88cf50
+            - Range: 0x88cf50..0x88cf60
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x88cf50..0x88cf60]
+      OutOfLinePCRanges: [0x88cf60..0x88cf70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 ArrayType [2]int8
           Locations:
-            - Range: 0x88cf50..0x88cf60
+            - Range: 0x88cf60..0x88cf70
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x88cf60..0x88cf70]
+      OutOfLinePCRanges: [0x88cf70..0x88cf80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]int16
           Locations:
-            - Range: 0x88cf60..0x88cf70
+            - Range: 0x88cf70..0x88cf80
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x88cf70..0x88cf80]
+      OutOfLinePCRanges: [0x88cf80..0x88cf90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 ArrayType [2]int32
           Locations:
-            - Range: 0x88cf70..0x88cf80
+            - Range: 0x88cf80..0x88cf90
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x88cf80..0x88cf90]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 109 ArrayType [2]int64
-          Locations:
-            - Range: 0x88cf80..0x88cf90
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 10
-      Name: main.testUintArray
       OutOfLinePCRanges: [0x88cf90..0x88cfa0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 110 ArrayType [2]uint
+          Type: 109 ArrayType [2]int64
           Locations:
             - Range: 0x88cf90..0x88cfa0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 10
+      Name: main.testUintArray
+      OutOfLinePCRanges: [0x88cfa0..0x88cfb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 110 ArrayType [2]uint
+          Locations:
+            - Range: 0x88cfa0..0x88cfb0
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x88cfa0..0x88cfb0]
+      OutOfLinePCRanges: [0x88cfb0..0x88cfc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 102 ArrayType [2]uint8
           Locations:
-            - Range: 0x88cfa0..0x88cfb0
+            - Range: 0x88cfb0..0x88cfc0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x88cfb0..0x88cfc0]
+      OutOfLinePCRanges: [0x88cfc0..0x88cfd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]uint16
           Locations:
-            - Range: 0x88cfb0..0x88cfc0
+            - Range: 0x88cfc0..0x88cfd0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x88cfc0..0x88cfd0]
+      OutOfLinePCRanges: [0x88cfd0..0x88cfe0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]uint32
           Locations:
-            - Range: 0x88cfc0..0x88cfd0
+            - Range: 0x88cfd0..0x88cfe0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x88cfd0..0x88cfe0]
+      OutOfLinePCRanges: [0x88cfe0..0x88cff0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 52 ArrayType [2]uint64
           Locations:
-            - Range: 0x88cfd0..0x88cfe0
+            - Range: 0x88cfe0..0x88cff0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x88cfe0..0x88cff0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 113 ArrayType [2][2]int
-          Locations:
-            - Range: 0x88cfe0..0x88cff0
-              Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 16
-      Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0x88cff0..0x88d000]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 104 ArrayType [2]string
+          Type: 113 ArrayType [2][2]int
           Locations:
             - Range: 0x88cff0..0x88d000
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 16
+      Name: main.testArrayOfStrings
+      OutOfLinePCRanges: [0x88d000..0x88d010]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 104 ArrayType [2]string
+          Locations:
+            - Range: 0x88d000..0x88d010
+              Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x88d000..0x88d010]
+      OutOfLinePCRanges: [0x88d010..0x88d020]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 114 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x88d000..0x88d010
+            - Range: 0x88d010..0x88d020
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0x88d010..0x88d020]
+      OutOfLinePCRanges: [0x88d020..0x88d030]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 115 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0x88d010..0x88d020
+            - Range: 0x88d020..0x88d030
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0x88d020..0x88d030]
+      OutOfLinePCRanges: [0x88d030..0x88d040]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 117 ArrayType [2]struct {}
           Locations:
-            - Range: 0x88d020..0x88d030
+            - Range: 0x88d030..0x88d040
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x88d040..0x88d050]
+      OutOfLinePCRanges: [0x88d050..0x88d060]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [100]uint
           Locations:
-            - Range: 0x88d040..0x88d050
+            - Range: 0x88d050..0x88d060
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x88d370..0x88d380]
+      OutOfLinePCRanges: [0x88d380..0x88d390]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88d370..0x88d380
+            - Range: 0x88d380..0x88d390
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x88d380..0x88d390]
+      OutOfLinePCRanges: [0x88d390..0x88d3a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88d380..0x88d390
+            - Range: 0x88d390..0x88d3a0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x88d390..0x88d3a0]
+      OutOfLinePCRanges: [0x88d3a0..0x88d3b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x88d390..0x88d3a0
+            - Range: 0x88d3a0..0x88d3b0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x88d3a0..0x88d3b0]
+      OutOfLinePCRanges: [0x88d3b0..0x88d3c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d3a0..0x88d3b0
+            - Range: 0x88d3b0..0x88d3c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x88d3b0..0x88d3c0]
+      OutOfLinePCRanges: [0x88d3c0..0x88d3d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x88d3b0..0x88d3c0
+            - Range: 0x88d3c0..0x88d3d0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x88d3c0..0x88d3d0]
+      OutOfLinePCRanges: [0x88d3d0..0x88d3e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 89 BaseType int16
           Locations:
-            - Range: 0x88d3c0..0x88d3d0
+            - Range: 0x88d3d0..0x88d3e0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x88d3d0..0x88d3e0]
+      OutOfLinePCRanges: [0x88d3e0..0x88d3f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88d3d0..0x88d3e0
+            - Range: 0x88d3e0..0x88d3f0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x88d3e0..0x88d3f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 14 BaseType int64
-          Locations:
-            - Range: 0x88d3e0..0x88d3f0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 29
-      Name: main.testSingleUint
       OutOfLinePCRanges: [0x88d3f0..0x88d400]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 12 BaseType uint
+          Type: 14 BaseType int64
           Locations:
             - Range: 0x88d3f0..0x88d400
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 29
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0x88d400..0x88d410]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 BaseType uint
+          Locations:
+            - Range: 0x88d400..0x88d410
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x88d400..0x88d410]
+      OutOfLinePCRanges: [0x88d410..0x88d420]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88d400..0x88d410
+            - Range: 0x88d410..0x88d420
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x88d410..0x88d420]
+      OutOfLinePCRanges: [0x88d420..0x88d430]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x88d410..0x88d420
+            - Range: 0x88d420..0x88d430
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x88d420..0x88d430]
+      OutOfLinePCRanges: [0x88d430..0x88d440]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x88d420..0x88d430
+            - Range: 0x88d430..0x88d440
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x88d430..0x88d440]
+      OutOfLinePCRanges: [0x88d440..0x88d450]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x88d430..0x88d440
+            - Range: 0x88d440..0x88d450
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x88d440..0x88d450]
+      OutOfLinePCRanges: [0x88d450..0x88d460]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x88d440..0x88d450
+            - Range: 0x88d450..0x88d460
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x88d450..0x88d460]
+      OutOfLinePCRanges: [0x88d460..0x88d470]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x88d450..0x88d460
+            - Range: 0x88d460..0x88d470
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x88d460..0x88d470]
+      OutOfLinePCRanges: [0x88d470..0x88d480]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 120 BaseType main.typeAlias
           Locations:
-            - Range: 0x88d460..0x88d470
+            - Range: 0x88d470..0x88d480
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x88d570..0x88d590]
+      OutOfLinePCRanges: [0x88d580..0x88d5a0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 121 StructureType main.bigStruct
           Locations:
-            - Range: 0x88d570..0x88d590
+            - Range: 0x88d580..0x88d5a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6433,48 +6433,48 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x88d5b0..0x88d6d0]
+      OutOfLinePCRanges: [0x88d5c0..0x88d6e0]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x88d5b0..0x88d5d0
+            - Range: 0x88d5c0..0x88d5e0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x88d5b0..0x88d6d0, Pieces: []}]
+          Locations: [{Range: 0x88d5c0..0x88d6e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 9 BaseType int
-          Locations: [{Range: 0x88d5b0..0x88d6d0, Pieces: []}]
+          Locations: [{Range: 0x88d5c0..0x88d6e0, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x88d5e8..0x88d608
+            - Range: 0x88d5f8..0x88d618
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x88d608..0x88d638
+            - Range: 0x88d618..0x88d648
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88d638..0x88d63c
+            - Range: 0x88d648..0x88d64c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: -64}
-            - Range: 0x88d63c..0x88d6d0
+            - Range: 0x88d64c..0x88d6e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
@@ -6485,39 +6485,39 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x88d760..0x88d770]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 125 StructureType main.deepPtr1
-          Locations:
-            - Range: 0x88d760..0x88d770
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 40
-      Name: main.testDeepPtr7
       OutOfLinePCRanges: [0x88d770..0x88d780]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 128 PointerType *main.deepPtr7
+          Type: 125 StructureType main.deepPtr1
           Locations:
             - Range: 0x88d770..0x88d780
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 40
+      Name: main.testDeepPtr7
+      OutOfLinePCRanges: [0x88d780..0x88d790]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 128 PointerType *main.deepPtr7
+          Locations:
+            - Range: 0x88d780..0x88d790
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x88d910..0x88d920]
+      OutOfLinePCRanges: [0x88d920..0x88d930]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 130 StructureType main.deepSlice1
           Locations:
-            - Range: 0x88d910..0x88d920
+            - Range: 0x88d920..0x88d930
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6530,129 +6530,129 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x88d920..0x88d930]
+      OutOfLinePCRanges: [0x88d930..0x88d940]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 134 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x88d920..0x88d930
+            - Range: 0x88d930..0x88d940
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x88da70..0x88da80]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 136 StructureType main.deepMap1
-          Locations:
-            - Range: 0x88da70..0x88da80
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 44
-      Name: main.testDeepMap7
       OutOfLinePCRanges: [0x88da80..0x88da90]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 144 PointerType *main.deepMap7
+          Type: 136 StructureType main.deepMap1
           Locations:
             - Range: 0x88da80..0x88da90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 45
-      Name: main.testStringType1
+    - ID: 44
+      Name: main.testDeepMap7
       OutOfLinePCRanges: [0x88da90..0x88daa0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 146 PointerType *main.stringType1
+          Type: 144 PointerType *main.deepMap7
           Locations:
             - Range: 0x88da90..0x88daa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 46
-      Name: main.testStringType2
+    - ID: 45
+      Name: main.testStringType1
       OutOfLinePCRanges: [0x88daa0..0x88dab0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 148 PointerType **main.stringType2
+          Type: 146 PointerType *main.stringType1
           Locations:
             - Range: 0x88daa0..0x88dab0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 46
+      Name: main.testStringType2
+      OutOfLinePCRanges: [0x88dab0..0x88dac0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 148 PointerType **main.stringType2
+          Locations:
+            - Range: 0x88dab0..0x88dac0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x88dab0..0x88dcb0]
+      OutOfLinePCRanges: [0x88dac0..0x88dcc0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88db78..0x88db88
+            - Range: 0x88db88..0x88db98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88dc28..0x88dc38
+            - Range: 0x88dc38..0x88dc48
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88db60..0x88db64
+            - Range: 0x88db70..0x88db74
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88db64..0x88db88
+            - Range: 0x88db74..0x88db98
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88db88..0x88dc1c
+            - Range: 0x88db98..0x88dc2c
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x88dc1c..0x88dc24
+            - Range: 0x88dc2c..0x88dc34
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x88dc24..0x88dcb0
+            - Range: 0x88dc34..0x88dcc0
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88db5c..0x88db64
+            - Range: 0x88db6c..0x88db74
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88db64..0x88db64
+            - Range: 0x88db74..0x88db74
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x88db64..0x88db88
+            - Range: 0x88db74..0x88db98
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88db88..0x88dc1c
+            - Range: 0x88db98..0x88dc2c
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x88dc1c..0x88dc20
+            - Range: 0x88dc2c..0x88dc30
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x88dc20..0x88dc24
+            - Range: 0x88dc30..0x88dc34
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x88dc24..0x88dc38
+            - Range: 0x88dc34..0x88dc48
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x88dc38..0x88dcb0
+            - Range: 0x88dc48..0x88dcc0
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x88e040..0x88e130]
+      OutOfLinePCRanges: [0x88e050..0x88e140]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 150 StructureType main.esotericStack
           Locations:
-            - Range: 0x88e040..0x88e088
+            - Range: 0x88e050..0x88e098
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6672,7 +6672,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88e088..0x88e08c
+            - Range: 0x88e098..0x88e09c
               Pieces:
                 - Size: 4
                   Op: null
@@ -6692,7 +6692,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88e08c..0x88e090
+            - Range: 0x88e09c..0x88e0a0
               Pieces:
                 - Size: 4
                   Op: null
@@ -6717,157 +6717,157 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x88e130..0x88e1b0]
+      OutOfLinePCRanges: [0x88e140..0x88e1c0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 154 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x88e130..0x88e168
+            - Range: 0x88e140..0x88e178
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 50
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x88f2c0..0x88f350]
+      OutOfLinePCRanges: [0x88f2d0..0x88f360]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f2c0..0x88f2f8
+            - Range: 0x88f2d0..0x88f308
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 51
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x88f350..0x88f420]
+      OutOfLinePCRanges: [0x88f360..0x88f430]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f350..0x88f36c
+            - Range: 0x88f360..0x88f37c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f350..0x88f37c
+            - Range: 0x88f360..0x88f38c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f36c..0x88f37c
+            - Range: 0x88f37c..0x88f38c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f37c..0x88f420
+            - Range: 0x88f38c..0x88f430
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x88f420..0x88f4a0]
+      OutOfLinePCRanges: [0x88f430..0x88f4b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f420..0x88f444
+            - Range: 0x88f430..0x88f454
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x88f4a0..0x88f5c0]
+      OutOfLinePCRanges: [0x88f4b0..0x88f5d0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f508..0x88f510
+            - Range: 0x88f518..0x88f520
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88f510..0x88f528
+            - Range: 0x88f520..0x88f538
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88f528..0x88f53c
+            - Range: 0x88f538..0x88f54c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f504..0x88f50c
+            - Range: 0x88f514..0x88f51c
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88f50c..0x88f528
+            - Range: 0x88f51c..0x88f538
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88f528..0x88f538
+            - Range: 0x88f538..0x88f548
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x88f5c0..0x88f5d0]
+      OutOfLinePCRanges: [0x88f5d0..0x88f5e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f5c0..0x88f5c8
+            - Range: 0x88f5d0..0x88f5d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f5c0..0x88f5c8
+            - Range: 0x88f5d0..0x88f5d8
               Pieces: []
-            - Range: 0x88f5c8..0x88f5c9
+            - Range: 0x88f5d8..0x88f5d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f5c9..0x88f5d0
+            - Range: 0x88f5d9..0x88f5e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x88f5d0..0x88f630]
+      OutOfLinePCRanges: [0x88f5e0..0x88f640]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x88f5d0..0x88f630
+            - Range: 0x88f5e0..0x88f640
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f5d0..0x88f618
+            - Range: 0x88f5e0..0x88f628
               Pieces: []
-            - Range: 0x88f618..0x88f619
+            - Range: 0x88f628..0x88f629
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f619..0x88f630
+            - Range: 0x88f629..0x88f640
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0x88f870..0x88f880]
+      OutOfLinePCRanges: [0x88f880..0x88f890]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x88f870..0x88f880
+            - Range: 0x88f880..0x88f890
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6878,19 +6878,19 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0x88f880..0x88f8f0]
+      OutOfLinePCRanges: [0x88f890..0x88f900]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x88f880..0x88f8b0
+            - Range: 0x88f890..0x88f8c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88f8b0..0x88f8b4
+            - Range: 0x88f8c0..0x88f8c4
               Pieces:
                 - Size: 8
                   Op: null
@@ -6901,28 +6901,28 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f880..0x88f8c4
+            - Range: 0x88f890..0x88f8d4
               Pieces: []
-            - Range: 0x88f8c4..0x88f8c5
+            - Range: 0x88f8d4..0x88f8d5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88f8c5..0x88f8f0
+            - Range: 0x88f8d5..0x88f900
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0x88f8f0..0x88f900]
+      OutOfLinePCRanges: [0x88f900..0x88f910]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x88f8f0..0x88f900
+            - Range: 0x88f900..0x88f910
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6933,41 +6933,41 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x88f900..0x88f970]
+      OutOfLinePCRanges: [0x88f910..0x88f980]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 158 PointerType *interface {}
           Locations:
-            - Range: 0x88f900..0x88f930
+            - Range: 0x88f910..0x88f940
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f900..0x88f944
+            - Range: 0x88f910..0x88f954
               Pieces: []
-            - Range: 0x88f944..0x88f945
+            - Range: 0x88f954..0x88f955
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88f945..0x88f970
+            - Range: 0x88f955..0x88f980
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x88f970..0x88f980]
+      OutOfLinePCRanges: [0x88f980..0x88f990]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 159 StructureType main.structWithAny
           Locations:
-            - Range: 0x88f970..0x88f980
+            - Range: 0x88f980..0x88f990
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6978,140 +6978,127 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x88ff20..0x88ff30]
+      OutOfLinePCRanges: [0x88ff30..0x88ff40]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 160 StructureType main.structWithMap
-          Locations:
-            - Range: 0x88ff20..0x88ff30
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x88ff30..0x88ff40]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 166 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x88ff30..0x88ff40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 63
-      Name: main.testMapStringToInt
+    - ID: 62
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x88ff40..0x88ff50]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 171 GoMapType map[string]int
+          Type: 166 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x88ff40..0x88ff50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToSlice
+    - ID: 63
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x88ff50..0x88ff60]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 176 GoMapType map[string][]string
+          Type: 171 GoMapType map[string]int
           Locations:
             - Range: 0x88ff50..0x88ff60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 65
-      Name: main.testMapArrayToArray
+    - ID: 64
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x88ff60..0x88ff70]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 181 GoMapType map[[4]string][2]int
+          Type: 176 GoMapType map[string][]string
           Locations:
             - Range: 0x88ff60..0x88ff70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testSmallMap
+    - ID: 65
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x88ff70..0x88ff80]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 171 GoMapType map[string]int
+          Type: 181 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x88ff70..0x88ff80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 66
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x88ff80..0x88ff90]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 171 GoMapType map[string]int
+          Locations:
+            - Range: 0x88ff80..0x88ff90
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 67
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x88ff80..0x88ff90]
+      OutOfLinePCRanges: [0x88ff90..0x88ffa0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 186 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x88ff80..0x88ff90
+            - Range: 0x88ff90..0x88ffa0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 68
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x88ff90..0x88ffa0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 187 PointerType *map[string]int
-          Locations:
-            - Range: 0x88ff90..0x88ffa0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x88ffa0..0x88ffb0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 161 GoMapType map[int]int
+          Type: 187 PointerType *map[string]int
           Locations:
             - Range: 0x88ffa0..0x88ffb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 70
-      Name: main.testMapMassive
+    - ID: 69
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x88ffb0..0x88ffc0]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 188 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 161 GoMapType map[int]int
           Locations:
             - Range: 0x88ffb0..0x88ffc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 71
-      Name: main.testMapEmbeddedMaps
+    - ID: 70
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0x88ffc0..0x88ffd0]
       InlinePCRanges: []
       Variables:
-        - Name: m
+        - Name: redactMyEntries
           Type: 188 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x88ffc0..0x88ffd0
@@ -7119,38 +7106,38 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapWithLinkedList
+    - ID: 71
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x88ffd0..0x88ffe0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 193 GoMapType map[bool]main.node
+          Type: 188 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x88ffd0..0x88ffe0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapWithSmallValue
+    - ID: 72
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x88ffe0..0x88fff0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 198 GoMapType map[int]uint8
+          Type: 193 GoMapType map[bool]main.node
           Locations:
             - Range: 0x88ffe0..0x88fff0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithSmallValueMassive
+    - ID: 73
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x88fff0..0x890000]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
+        - Name: m
           Type: 198 GoMapType map[int]uint8
           Locations:
             - Range: 0x88fff0..0x890000
@@ -7158,21 +7145,21 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 74
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x890000..0x890010]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 203 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 198 GoMapType map[int]uint8
           Locations:
             - Range: 0x890000..0x890010
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 75
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x890010..0x890020]
       InlinePCRanges: []
       Variables:
@@ -7184,8 +7171,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapSmallKeySmallValue
+    - ID: 76
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x890020..0x890030]
       InlinePCRanges: []
       Variables:
@@ -7197,127 +7184,140 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 77
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x890030..0x890040]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 208 GoMapType map[uint8][4]int
+          Type: 203 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x890030..0x890040
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapLargeKeySmallValue
+    - ID: 78
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x890040..0x890050]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 213 GoMapType map[[4]int]uint8
+          Type: 208 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x890040..0x890050
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 79
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x890050..0x890060]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 218 GoMapType map[[4]int][4]int
+          Type: 213 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x890050..0x890060
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapEmptyKey
+    - ID: 80
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x890060..0x890070]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 223 GoMapType map[struct {}]int
+          Type: 218 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x890060..0x890070
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapEmptyValue
+    - ID: 81
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0x890070..0x890080]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 228 GoMapType map[int]struct {}
+          Type: 223 GoMapType map[struct {}]int
           Locations:
             - Range: 0x890070..0x890080
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 82
+      Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0x890080..0x890090]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 233 GoMapType map[struct {}]struct {}
+          Type: 228 GoMapType map[int]struct {}
           Locations:
             - Range: 0x890080..0x890090
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x890090..0x8900a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 233 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x890090..0x8900a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x8913f0..0x891400]
+      OutOfLinePCRanges: [0x891400..0x891410]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8913f0..0x891400
+            - Range: 0x891400..0x891410
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8913f0..0x891400
+            - Range: 0x891400..0x891410
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x8913f0..0x891400
+            - Range: 0x891400..0x891410
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x891410..0x891420]
+      OutOfLinePCRanges: [0x891420..0x891430]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x891410..0x891420
+            - Range: 0x891420..0x891430
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x891410..0x891420
+            - Range: 0x891420..0x891430
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7328,48 +7328,48 @@ Subprograms:
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x891410..0x891420
+            - Range: 0x891420..0x891430
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x8914d0..0x8914e0]
+      OutOfLinePCRanges: [0x8914e0..0x8914f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8914d0..0x8914e0
+            - Range: 0x8914e0..0x8914f0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8914d0..0x8914e0
+            - Range: 0x8914e0..0x8914f0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x8914d0..0x8914e0
+            - Range: 0x8914e0..0x8914f0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x8914d0..0x8914e0
+            - Range: 0x8914e0..0x8914f0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8914d0..0x8914e0
+            - Range: 0x8914e0..0x8914f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7380,63 +7380,63 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x891670..0x8916b0]
+      OutOfLinePCRanges: [0x891680..0x8916c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x891670..0x8916ac
+            - Range: 0x891680..0x8916bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x891670..0x8916ac
+            - Range: 0x891680..0x8916bc
               Pieces: []
-            - Range: 0x8916ac..0x8916ad
+            - Range: 0x8916bc..0x8916bd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8916ad..0x8916b0
+            - Range: 0x8916bd..0x8916c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0x8916b0..0x8916c0]
+      OutOfLinePCRanges: [0x8916c0..0x8916d0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 238 GoChannelType chan bool
           Locations:
-            - Range: 0x8916b0..0x8916c0
+            - Range: 0x8916c0..0x8916d0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x891860..0x891870]
+      OutOfLinePCRanges: [0x891870..0x891880]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x891860..0x891870
+            - Range: 0x891870..0x891880
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x891870..0x891880]
+      OutOfLinePCRanges: [0x891880..0x891890]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 241 StructureType main.node
           Locations:
-            - Range: 0x891870..0x891880
+            - Range: 0x891880..0x891890
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7447,273 +7447,273 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x891880..0x891890]
+      OutOfLinePCRanges: [0x891890..0x8918a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.node
-          Locations:
-            - Range: 0x891880..0x891890
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 92
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x891890..0x8918a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 19 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x891890..0x8918a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 92
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0x8918a0..0x8918b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 19 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0x8918a0..0x8918b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x8918b0..0x8918c0]
+      OutOfLinePCRanges: [0x8918c0..0x8918d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 100 PointerType *uint
           Locations:
-            - Range: 0x8918b0..0x8918c0
+            - Range: 0x8918c0..0x8918d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x891920..0x891930]
+      OutOfLinePCRanges: [0x891930..0x891940]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 88 PointerType *string
           Locations:
-            - Range: 0x891920..0x891930
+            - Range: 0x891930..0x891940
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x891940..0x891950]
+      OutOfLinePCRanges: [0x891950..0x891960]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0x891940..0x891950
+            - Range: 0x891950..0x891960
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x891940..0x891950
+            - Range: 0x891950..0x891960
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0x891960..0x891970]
+      OutOfLinePCRanges: [0x891970..0x891980]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 243 PointerType *main.t
           Locations:
-            - Range: 0x891960..0x891970
+            - Range: 0x891970..0x891980
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x891d70..0x891df0]
+      OutOfLinePCRanges: [0x891d80..0x891e00]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891d70..0x891d8c
+            - Range: 0x891d80..0x891d9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891d70..0x891dcc
+            - Range: 0x891d80..0x891ddc
               Pieces: []
-            - Range: 0x891dcc..0x891dcd
+            - Range: 0x891ddc..0x891ddd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891dcd..0x891df0
+            - Range: 0x891ddd..0x891e00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891d8c..0x891d98
+            - Range: 0x891d9c..0x891da8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891d98..0x891df0
+            - Range: 0x891da8..0x891e00
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x891df0..0x891e90]
+      OutOfLinePCRanges: [0x891e00..0x891ea0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891df0..0x891e14
+            - Range: 0x891e00..0x891e24
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891e14..0x891e90
+            - Range: 0x891e24..0x891ea0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x891df0..0x891e6c
+            - Range: 0x891e00..0x891e7c
               Pieces: []
-            - Range: 0x891e6c..0x891e6d
+            - Range: 0x891e7c..0x891e7d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891e6d..0x891e90
+            - Range: 0x891e7d..0x891ea0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x891e18..0x891e34
+            - Range: 0x891e28..0x891e44
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891e34..0x891e90
+            - Range: 0x891e44..0x891ea0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x891e90..0x891f60]
+      OutOfLinePCRanges: [0x891ea0..0x891f70]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891e90..0x891ee8
+            - Range: 0x891ea0..0x891ef8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891e90..0x891f40
+            - Range: 0x891ea0..0x891f50
               Pieces: []
-            - Range: 0x891f40..0x891f41
+            - Range: 0x891f50..0x891f51
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891f41..0x891f60
+            - Range: 0x891f51..0x891f70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x891e90..0x891f60, Pieces: []}]
+          Locations: [{Range: 0x891ea0..0x891f70, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891eac..0x891eec
+            - Range: 0x891ebc..0x891efc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891eec..0x891f60
+            - Range: 0x891efc..0x891f70
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x891ebc..0x891eec
+            - Range: 0x891ecc..0x891efc
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x891eec..0x891f60
+            - Range: 0x891efc..0x891f70
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x891f60..0x891fe0]
+      OutOfLinePCRanges: [0x891f70..0x891ff0]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x891f60..0x891f84
+            - Range: 0x891f70..0x891f94
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x891f60..0x891fa8
+            - Range: 0x891f70..0x891fb8
               Pieces: []
-            - Range: 0x891fa8..0x891fa9
+            - Range: 0x891fb8..0x891fb9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x891fa9..0x891fbc
+            - Range: 0x891fb9..0x891fcc
               Pieces: []
-            - Range: 0x891fbc..0x891fbd
+            - Range: 0x891fcc..0x891fcd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x891fbd..0x891fe0
+            - Range: 0x891fcd..0x891ff0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x891fe0..0x892160]
+      OutOfLinePCRanges: [0x891ff0..0x892170]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x891fe0..0x892038
+            - Range: 0x891ff0..0x892048
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892038..0x89203c
+            - Range: 0x892048..0x89204c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892094..0x892098
+            - Range: 0x8920a4..0x8920a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x8920c4..0x8920c8
+            - Range: 0x8920d4..0x8920d8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892104..0x892108
+            - Range: 0x892114..0x892118
               Pieces:
                 - Size: 8
                   Op: null
@@ -7724,117 +7724,117 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x891fe0..0x892034
+            - Range: 0x891ff0..0x892044
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x891fe0..0x892064
+            - Range: 0x891ff0..0x892074
               Pieces: []
-            - Range: 0x892064..0x892065
+            - Range: 0x892074..0x892075
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892065..0x8920b0
+            - Range: 0x892075..0x8920c0
               Pieces: []
-            - Range: 0x8920b0..0x8920b1
+            - Range: 0x8920c0..0x8920c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8920b1..0x8920f0
+            - Range: 0x8920c1..0x892100
               Pieces: []
-            - Range: 0x8920f0..0x8920f1
+            - Range: 0x892100..0x892101
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8920f1..0x892130
+            - Range: 0x892101..0x892140
               Pieces: []
-            - Range: 0x892130..0x892131
+            - Range: 0x892140..0x892141
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892131..0x892160
+            - Range: 0x892141..0x892170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x891fe0..0x892064
+            - Range: 0x891ff0..0x892074
               Pieces: []
-            - Range: 0x892064..0x892065
+            - Range: 0x892074..0x892075
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x892065..0x8920b0
+            - Range: 0x892075..0x8920c0
               Pieces: []
-            - Range: 0x8920b0..0x8920b1
+            - Range: 0x8920c0..0x8920c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8920b1..0x8920f0
+            - Range: 0x8920c1..0x892100
               Pieces: []
-            - Range: 0x8920f0..0x8920f1
+            - Range: 0x892100..0x892101
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8920f1..0x892130
+            - Range: 0x892101..0x892140
               Pieces: []
-            - Range: 0x892130..0x892131
+            - Range: 0x892140..0x892141
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x892131..0x892160
+            - Range: 0x892141..0x892170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892094..0x89209c
+            - Range: 0x8920a4..0x8920ac
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x892160..0x892360]
+      OutOfLinePCRanges: [0x892170..0x892370]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x892160..0x8921bc
+            - Range: 0x892170..0x8921cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8921bc..0x8921c0
+            - Range: 0x8921cc..0x8921d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8921c0..0x892360
+            - Range: 0x8921d0..0x892370
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7845,549 +7845,549 @@ Subprograms:
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x892160..0x892218
+            - Range: 0x892170..0x892228
               Pieces: []
-            - Range: 0x892218..0x892219
+            - Range: 0x892228..0x892229
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892219..0x892260
+            - Range: 0x892229..0x892270
               Pieces: []
-            - Range: 0x892260..0x892261
+            - Range: 0x892270..0x892271
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892261..0x892324
+            - Range: 0x892271..0x892334
               Pieces: []
-            - Range: 0x892324..0x892325
+            - Range: 0x892334..0x892335
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892325..0x892338
+            - Range: 0x892335..0x892348
               Pieces: []
-            - Range: 0x892338..0x892339
+            - Range: 0x892348..0x892349
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892339..0x892360
+            - Range: 0x892349..0x892370
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x89224c..0x892254
+            - Range: 0x89225c..0x892264
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x8921fc..0x892218
+            - Range: 0x89220c..0x892228
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x892360..0x8924d0]
+      OutOfLinePCRanges: [0x892370..0x8924e0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x892360..0x89239c
+            - Range: 0x892370..0x8923ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89239c..0x8923fc
+            - Range: 0x8923ac..0x89240c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8923fc..0x892468
+            - Range: 0x89240c..0x892478
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x892468..0x892490
+            - Range: 0x892478..0x8924a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x892490..0x892494
+            - Range: 0x8924a0..0x8924a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x892494..0x8924d0
+            - Range: 0x8924a4..0x8924e0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x892360..0x892448
+            - Range: 0x892370..0x892458
               Pieces: []
-            - Range: 0x892448..0x892449
+            - Range: 0x892458..0x892459
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892449..0x89245c
+            - Range: 0x892459..0x89246c
               Pieces: []
-            - Range: 0x89245c..0x89245d
+            - Range: 0x89246c..0x89246d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89245d..0x8924d0
+            - Range: 0x89246d..0x8924e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x892360..0x89239c
+            - Range: 0x892370..0x8923ac
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89239c..0x8923ec
+            - Range: 0x8923ac..0x8923fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8923ec..0x8923fc
+            - Range: 0x8923fc..0x89240c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8923fc..0x892454
+            - Range: 0x89240c..0x892464
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x892454..0x892458
+            - Range: 0x892464..0x892468
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x892458..0x89245c
+            - Range: 0x892468..0x89246c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x89245c..0x8924d0
+            - Range: 0x89246c..0x8924e0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x8924d0..0x892570]
+      OutOfLinePCRanges: [0x8924e0..0x892580]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8924d0..0x8924ec
+            - Range: 0x8924e0..0x8924fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8924d0..0x892548
+            - Range: 0x8924e0..0x892558
               Pieces: []
-            - Range: 0x892548..0x892549
+            - Range: 0x892558..0x892559
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892549..0x892570
+            - Range: 0x892559..0x892580
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x892570..0x892640]
+      OutOfLinePCRanges: [0x892580..0x892650]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892570..0x8925c0
+            - Range: 0x892580..0x8925d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892570..0x892614
+            - Range: 0x892580..0x892624
               Pieces: []
-            - Range: 0x892614..0x892615
+            - Range: 0x892624..0x892625
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892615..0x892640
+            - Range: 0x892625..0x892650
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892570..0x892614
+            - Range: 0x892580..0x892624
               Pieces: []
-            - Range: 0x892614..0x892615
+            - Range: 0x892624..0x892625
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x892615..0x892640
+            - Range: 0x892625..0x892650
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x892640..0x892710]
+      OutOfLinePCRanges: [0x892650..0x892720]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892640..0x892680
+            - Range: 0x892650..0x892690
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892680..0x892710
+            - Range: 0x892690..0x892720
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892640..0x8926e4
+            - Range: 0x892650..0x8926f4
               Pieces: []
-            - Range: 0x8926e4..0x8926e5
+            - Range: 0x8926f4..0x8926f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8926e5..0x892710
+            - Range: 0x8926f5..0x892720
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892640..0x8926e4
+            - Range: 0x892650..0x8926f4
               Pieces: []
-            - Range: 0x8926e4..0x8926e5
+            - Range: 0x8926f4..0x8926f5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8926e5..0x892710
+            - Range: 0x8926f5..0x892720
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892640..0x8926e4
+            - Range: 0x892650..0x8926f4
               Pieces: []
-            - Range: 0x8926e4..0x8926e5
+            - Range: 0x8926f4..0x8926f5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8926e5..0x892710
+            - Range: 0x8926f5..0x892720
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x892710..0x892800]
+      OutOfLinePCRanges: [0x892720..0x892810]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892710..0x892750
+            - Range: 0x892720..0x892760
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892750..0x892800
+            - Range: 0x892760..0x892810
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892710..0x8927d8
+            - Range: 0x892720..0x8927e8
               Pieces: []
-            - Range: 0x8927d8..0x8927d9
+            - Range: 0x8927e8..0x8927e9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8927d9..0x892800
+            - Range: 0x8927e9..0x892810
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892710..0x8927d8
+            - Range: 0x892720..0x8927e8
               Pieces: []
-            - Range: 0x8927d8..0x8927d9
+            - Range: 0x8927e8..0x8927e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8927d9..0x892800
+            - Range: 0x8927e9..0x892810
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x892800..0x8929c0]
+      OutOfLinePCRanges: [0x892810..0x8929d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892800..0x892864
+            - Range: 0x892810..0x892874
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892864..0x8929c0
+            - Range: 0x892874..0x8929d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x89282c..0x8929c0
+            - Range: 0x89283c..0x8929d0
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892830..0x8929c0
+            - Range: 0x892840..0x8929d0
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x892aa0..0x892b30]
+      OutOfLinePCRanges: [0x892ab0..0x892b40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x892aa0..0x892b10
+            - Range: 0x892ab0..0x892b20
               Pieces: []
-            - Range: 0x892b10..0x892b11
+            - Range: 0x892b20..0x892b21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892b11..0x892b30
+            - Range: 0x892b21..0x892b40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 89 BaseType int16
           Locations:
-            - Range: 0x892aa0..0x892b10
+            - Range: 0x892ab0..0x892b20
               Pieces: []
-            - Range: 0x892b10..0x892b11
+            - Range: 0x892b20..0x892b21
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x892b11..0x892b30
+            - Range: 0x892b21..0x892b40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x892aa0..0x892b10
+            - Range: 0x892ab0..0x892b20
               Pieces: []
-            - Range: 0x892b10..0x892b11
+            - Range: 0x892b20..0x892b21
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x892b11..0x892b30
+            - Range: 0x892b21..0x892b40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x892aa0..0x892b10
+            - Range: 0x892ab0..0x892b20
               Pieces: []
-            - Range: 0x892b10..0x892b11
+            - Range: 0x892b20..0x892b21
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x892b11..0x892b30
+            - Range: 0x892b21..0x892b40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x892aa0..0x892b10
+            - Range: 0x892ab0..0x892b20
               Pieces: []
-            - Range: 0x892b10..0x892b11
+            - Range: 0x892b20..0x892b21
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x892b11..0x892b30
+            - Range: 0x892b21..0x892b40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x892aa0..0x892b10
+            - Range: 0x892ab0..0x892b20
               Pieces: []
-            - Range: 0x892b10..0x892b11
+            - Range: 0x892b20..0x892b21
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x892b11..0x892b30
+            - Range: 0x892b21..0x892b40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x892aa0..0x892b10
+            - Range: 0x892ab0..0x892b20
               Pieces: []
-            - Range: 0x892b10..0x892b11
+            - Range: 0x892b20..0x892b21
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x892b11..0x892b30
+            - Range: 0x892b21..0x892b40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x892aa0..0x892b10
+            - Range: 0x892ab0..0x892b20
               Pieces: []
-            - Range: 0x892b10..0x892b11
+            - Range: 0x892b20..0x892b21
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x892b11..0x892b30
+            - Range: 0x892b21..0x892b40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x892b30..0x892bf0]
+      OutOfLinePCRanges: [0x892b40..0x892c00]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x892b30..0x892bcc
+            - Range: 0x892b40..0x892bdc
               Pieces: []
-            - Range: 0x892bcc..0x892bcd
+            - Range: 0x892bdc..0x892bdd
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x892bcd..0x892bf0
+            - Range: 0x892bdd..0x892c00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x892bf0..0x892c70]
+      OutOfLinePCRanges: [0x892c00..0x892c80]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 90 BaseType complex64
-          Locations: [{Range: 0x892bf0..0x892c70, Pieces: []}]
+          Locations: [{Range: 0x892c00..0x892c80, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 91 BaseType complex128
-          Locations: [{Range: 0x892bf0..0x892c70, Pieces: []}]
+          Locations: [{Range: 0x892c00..0x892c80, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x892c70..0x892d40]
+      OutOfLinePCRanges: [0x892c80..0x892d50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x892c70..0x892d24
+            - Range: 0x892c80..0x892d34
               Pieces: []
-            - Range: 0x892d24..0x892d25
+            - Range: 0x892d34..0x892d35
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8409,193 +8409,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x892d25..0x892d40
+            - Range: 0x892d35..0x892d50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x892d40..0x892dd0]
+      OutOfLinePCRanges: [0x892d50..0x892de0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x892d40..0x892db0
+            - Range: 0x892d50..0x892dc0
               Pieces: []
-            - Range: 0x892db0..0x892db1
+            - Range: 0x892dc0..0x892dc1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x892db1..0x892dd0
+            - Range: 0x892dc1..0x892de0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x892dd0..0x892e40]
+      OutOfLinePCRanges: [0x892de0..0x892e50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 247 ArrayType [1]int
           Locations:
-            - Range: 0x892dd0..0x892e24
+            - Range: 0x892de0..0x892e34
               Pieces: []
-            - Range: 0x892e24..0x892e25
+            - Range: 0x892e34..0x892e35
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892e25..0x892e40
+            - Range: 0x892e35..0x892e50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x892e40..0x892eb0]
+      OutOfLinePCRanges: [0x892e50..0x892ec0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0x892e40..0x892e90
+            - Range: 0x892e50..0x892ea0
               Pieces: []
-            - Range: 0x892e90..0x892e91
+            - Range: 0x892ea0..0x892ea1
               Pieces: []
-            - Range: 0x892e91..0x892eb0
+            - Range: 0x892ea1..0x892ec0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x892eb0..0x892f30]
+      OutOfLinePCRanges: [0x892ec0..0x892f40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 StructureType main.mixedStruct
-          Locations: [{Range: 0x892eb0..0x892f30, Pieces: []}]
+          Locations: [{Range: 0x892ec0..0x892f40, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x892f30..0x892fd0]
+      OutOfLinePCRanges: [0x892f40..0x892fe0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f30..0x892fac
+            - Range: 0x892f40..0x892fbc
               Pieces: []
-            - Range: 0x892fac..0x892fad
+            - Range: 0x892fbc..0x892fbd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892fad..0x892fd0
+            - Range: 0x892fbd..0x892fe0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f30..0x892fac
+            - Range: 0x892f40..0x892fbc
               Pieces: []
-            - Range: 0x892fac..0x892fad
+            - Range: 0x892fbc..0x892fbd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x892fad..0x892fd0
+            - Range: 0x892fbd..0x892fe0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f30..0x892fac
+            - Range: 0x892f40..0x892fbc
               Pieces: []
-            - Range: 0x892fac..0x892fad
+            - Range: 0x892fbc..0x892fbd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x892fad..0x892fd0
+            - Range: 0x892fbd..0x892fe0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f30..0x892fac
+            - Range: 0x892f40..0x892fbc
               Pieces: []
-            - Range: 0x892fac..0x892fad
+            - Range: 0x892fbc..0x892fbd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x892fad..0x892fd0
+            - Range: 0x892fbd..0x892fe0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f30..0x892fac
+            - Range: 0x892f40..0x892fbc
               Pieces: []
-            - Range: 0x892fac..0x892fad
+            - Range: 0x892fbc..0x892fbd
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x892fad..0x892fd0
+            - Range: 0x892fbd..0x892fe0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f30..0x892fac
+            - Range: 0x892f40..0x892fbc
               Pieces: []
-            - Range: 0x892fac..0x892fad
+            - Range: 0x892fbc..0x892fbd
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x892fad..0x892fd0
+            - Range: 0x892fbd..0x892fe0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f30..0x892fac
+            - Range: 0x892f40..0x892fbc
               Pieces: []
-            - Range: 0x892fac..0x892fad
+            - Range: 0x892fbc..0x892fbd
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x892fad..0x892fd0
+            - Range: 0x892fbd..0x892fe0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f30..0x892fac
+            - Range: 0x892f40..0x892fbc
               Pieces: []
-            - Range: 0x892fac..0x892fad
+            - Range: 0x892fbc..0x892fbd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x892fad..0x892fd0
+            - Range: 0x892fbd..0x892fe0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892f30..0x892fac
+            - Range: 0x892f40..0x892fbc
               Pieces: []
-            - Range: 0x892fac..0x892fad
+            - Range: 0x892fbc..0x892fbd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x892fad..0x892fd0
+            - Range: 0x892fbd..0x892fe0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x892fd0..0x8930b0]
+      OutOfLinePCRanges: [0x892fe0..0x8930c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.wideStruct
           Locations:
-            - Range: 0x892fd0..0x893094
+            - Range: 0x892fe0..0x8930a4
               Pieces: []
-            - Range: 0x893094..0x893095
+            - Range: 0x8930a4..0x8930a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8619,145 +8619,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x893095..0x8930b0
+            - Range: 0x8930a5..0x8930c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x8930b0..0x893140]
+      OutOfLinePCRanges: [0x8930c0..0x893150]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8930b0..0x893120
+            - Range: 0x8930c0..0x893130
               Pieces: []
-            - Range: 0x893120..0x893121
+            - Range: 0x893130..0x893131
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893121..0x893140
+            - Range: 0x893131..0x893150
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x8930b0..0x893140, Pieces: []}]
+          Locations: [{Range: 0x8930c0..0x893150, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8930b0..0x893120
+            - Range: 0x8930c0..0x893130
               Pieces: []
-            - Range: 0x893120..0x893121
+            - Range: 0x893130..0x893131
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893121..0x893140
+            - Range: 0x893131..0x893150
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x8930b0..0x893140, Pieces: []}]
+          Locations: [{Range: 0x8930c0..0x893150, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8930b0..0x893120
+            - Range: 0x8930c0..0x893130
               Pieces: []
-            - Range: 0x893120..0x893121
+            - Range: 0x893130..0x893131
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x893121..0x893140
+            - Range: 0x893131..0x893150
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x893140..0x8931d0]
+      OutOfLinePCRanges: [0x893150..0x8931e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x893140..0x8931b0
+            - Range: 0x893150..0x8931c0
               Pieces: []
-            - Range: 0x8931b0..0x8931b1
+            - Range: 0x8931c0..0x8931c1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8931b1..0x8931d0
+            - Range: 0x8931c1..0x8931e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x8931d0..0x893240]
+      OutOfLinePCRanges: [0x8931e0..0x893250]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x8931d0..0x893240, Pieces: []}]
+          Locations: [{Range: 0x8931e0..0x893250, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x893240..0x8932c0]
+      OutOfLinePCRanges: [0x893250..0x8932d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float32
-          Locations: [{Range: 0x893240..0x8932c0, Pieces: []}]
+          Locations: [{Range: 0x893250..0x8932d0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x893240..0x8932c0, Pieces: []}]
+          Locations: [{Range: 0x893250..0x8932d0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x8932c0..0x893330]
+      OutOfLinePCRanges: [0x8932d0..0x893340]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8932c0..0x893318
+            - Range: 0x8932d0..0x893328
               Pieces: []
-            - Range: 0x893318..0x893319
+            - Range: 0x893328..0x893329
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893319..0x893330
+            - Range: 0x893329..0x893340
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x8932c0..0x893318
+            - Range: 0x8932d0..0x893328
               Pieces: []
-            - Range: 0x893318..0x893319
+            - Range: 0x893328..0x893329
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893319..0x893330
+            - Range: 0x893329..0x893340
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x893330..0x893510]
+      OutOfLinePCRanges: [0x893340..0x893520]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x893330..0x89339c
+            - Range: 0x893340..0x8933ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8779,7 +8779,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x89339c..0x8933b0
+            - Range: 0x8933ac..0x8933c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8801,7 +8801,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8933b0..0x8933b4
+            - Range: 0x8933c0..0x8933c4
               Pieces:
                 - Size: 8
                   Op: null
@@ -8828,9 +8828,9 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x893330..0x8934a8
+            - Range: 0x893340..0x8934b8
               Pieces: []
-            - Range: 0x8934a8..0x8934a9
+            - Range: 0x8934b8..0x8934b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8852,44 +8852,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8934a9..0x893510
+            - Range: 0x8934b9..0x893520
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x893510..0x8935e0]
+      OutOfLinePCRanges: [0x893520..0x8935f0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x893510..0x8935e0
+            - Range: 0x893520..0x8935f0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x893510..0x8935c4
+            - Range: 0x893520..0x8935d4
               Pieces: []
-            - Range: 0x8935c4..0x8935c5
+            - Range: 0x8935d4..0x8935d5
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x8935c5..0x8935e0
+            - Range: 0x8935d5..0x8935f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x8935e0..0x893840]
+      OutOfLinePCRanges: [0x8935f0..0x893850]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x8935e0..0x893650
+            - Range: 0x8935f0..0x893660
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8911,7 +8911,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x893650..0x893664
+            - Range: 0x893660..0x893674
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8933,7 +8933,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x893664..0x893668
+            - Range: 0x893674..0x893678
               Pieces:
                 - Size: 8
                   Op: null
@@ -8960,16 +8960,16 @@ Subprograms:
         - Name: s2
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x8935e0..0x893840
+            - Range: 0x8935f0..0x893850
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x8935e0..0x8937d0
+            - Range: 0x8935f0..0x8937e0
               Pieces: []
-            - Range: 0x8937d0..0x8937d1
+            - Range: 0x8937e0..0x8937e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8991,196 +8991,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8937d1..0x893840
+            - Range: 0x8937e1..0x893850
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x893840..0x893a30]
+      OutOfLinePCRanges: [0x893850..0x893a40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893840..0x8938b8
+            - Range: 0x893850..0x8938c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8938b8..0x893a30
+            - Range: 0x8938c8..0x893a40
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893840..0x8938b8
+            - Range: 0x893850..0x8938c8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8938b8..0x893a30
+            - Range: 0x8938c8..0x893a40
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893840..0x8938b8
+            - Range: 0x893850..0x8938c8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8938b8..0x893a30
+            - Range: 0x8938c8..0x893a40
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893840..0x8938b8
+            - Range: 0x893850..0x8938c8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8938b8..0x893a30
+            - Range: 0x8938c8..0x893a40
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893840..0x8938b8
+            - Range: 0x893850..0x8938c8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8938b8..0x893a30
+            - Range: 0x8938c8..0x893a40
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893840..0x8938b8
+            - Range: 0x893850..0x8938c8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8938b8..0x893a30
+            - Range: 0x8938c8..0x893a40
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893840..0x8938b8
+            - Range: 0x893850..0x8938c8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8938b8..0x893a30
+            - Range: 0x8938c8..0x893a40
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893840..0x8938b8
+            - Range: 0x893850..0x8938c8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8938b8..0x893a30
+            - Range: 0x8938c8..0x893a40
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893840..0x8938b8
+            - Range: 0x893850..0x8938c8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x8938b8..0x893a30
+            - Range: 0x8938c8..0x893a40
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x893840..0x8939cc
+            - Range: 0x893850..0x8939dc
               Pieces: []
-            - Range: 0x8939cc..0x8939cd
+            - Range: 0x8939dc..0x8939dd
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x8939cd..0x893a30
+            - Range: 0x8939dd..0x893a40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x893a30..0x893c70]
+      OutOfLinePCRanges: [0x893a40..0x893c80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a30..0x893ab8
+            - Range: 0x893a40..0x893ac8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893ab8..0x893c70
+            - Range: 0x893ac8..0x893c80
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a30..0x893ab8
+            - Range: 0x893a40..0x893ac8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893ab8..0x893c70
+            - Range: 0x893ac8..0x893c80
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a30..0x893ab8
+            - Range: 0x893a40..0x893ac8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x893ab8..0x893c70
+            - Range: 0x893ac8..0x893c80
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a30..0x893ab8
+            - Range: 0x893a40..0x893ac8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x893ab8..0x893c70
+            - Range: 0x893ac8..0x893c80
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a30..0x893ab8
+            - Range: 0x893a40..0x893ac8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x893ab8..0x893c70
+            - Range: 0x893ac8..0x893c80
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a30..0x893ab8
+            - Range: 0x893a40..0x893ac8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x893ab8..0x893c70
+            - Range: 0x893ac8..0x893c80
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a30..0x893ab8
+            - Range: 0x893a40..0x893ac8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x893ab8..0x893c70
+            - Range: 0x893ac8..0x893c80
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a30..0x893ab8
+            - Range: 0x893a40..0x893ac8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x893ab8..0x893c70
+            - Range: 0x893ac8..0x893c80
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x893a30..0x893ab8
+            - Range: 0x893a40..0x893ac8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x893ab8..0x893c70
+            - Range: 0x893ac8..0x893c80
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9191,9 +9191,9 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x893a30..0x893c00
+            - Range: 0x893a40..0x893c10
               Pieces: []
-            - Range: 0x893c00..0x893c01
+            - Range: 0x893c10..0x893c11
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9215,208 +9215,189 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x893c01..0x893c70
+            - Range: 0x893c11..0x893c80
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x893c70..0x893d10]
+      OutOfLinePCRanges: [0x893c80..0x893d20]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x893c70..0x893d10
+            - Range: 0x893c80..0x893d20
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893c70..0x893cec
+            - Range: 0x893c80..0x893cfc
               Pieces: []
-            - Range: 0x893cec..0x893ced
+            - Range: 0x893cfc..0x893cfd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893ced..0x893d10
+            - Range: 0x893cfd..0x893d20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893c70..0x893cec
+            - Range: 0x893c80..0x893cfc
               Pieces: []
-            - Range: 0x893cec..0x893ced
+            - Range: 0x893cfc..0x893cfd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893ced..0x893d10
+            - Range: 0x893cfd..0x893d20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893c70..0x893cec
+            - Range: 0x893c80..0x893cfc
               Pieces: []
-            - Range: 0x893cec..0x893ced
+            - Range: 0x893cfc..0x893cfd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x893ced..0x893d10
+            - Range: 0x893cfd..0x893d20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x893d10..0x893df0]
+      OutOfLinePCRanges: [0x893d20..0x893e00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x893d10..0x893df0
+            - Range: 0x893d20..0x893e00
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x893d10..0x893df0
+            - Range: 0x893d20..0x893e00
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893d10..0x893dd0
+            - Range: 0x893d20..0x893de0
               Pieces: []
-            - Range: 0x893dd0..0x893dd1
+            - Range: 0x893de0..0x893de1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893dd1..0x893df0
+            - Range: 0x893de1..0x893e00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x893d10..0x893dd0
+            - Range: 0x893d20..0x893de0
               Pieces: []
-            - Range: 0x893dd0..0x893dd1
+            - Range: 0x893de0..0x893de1
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x893dd1..0x893df0
+            - Range: 0x893de1..0x893e00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x893df0..0x893ec0]
+      OutOfLinePCRanges: [0x893e00..0x893ed0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x893df0..0x893ec0
+            - Range: 0x893e00..0x893ed0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893df0..0x893e9c
+            - Range: 0x893e00..0x893eac
               Pieces: []
-            - Range: 0x893e9c..0x893e9d
+            - Range: 0x893eac..0x893ead
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893e9d..0x893ec0
+            - Range: 0x893ead..0x893ed0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x893df0..0x893e9c
+            - Range: 0x893e00..0x893eac
               Pieces: []
-            - Range: 0x893e9c..0x893e9d
+            - Range: 0x893eac..0x893ead
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x893e9d..0x893ec0
+            - Range: 0x893ead..0x893ed0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893e70..0x893ec0
+            - Range: 0x893e80..0x893ed0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x893ec0..0x893f70]
+      OutOfLinePCRanges: [0x893ed0..0x893f80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 248 ArrayType [0]int
-          Locations: [{Range: 0x893ec0..0x893f70, Pieces: []}]
+          Locations: [{Range: 0x893ed0..0x893f80, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893ec0..0x893f00
+            - Range: 0x893ed0..0x893f10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893f00..0x893f1c
+            - Range: 0x893f10..0x893f2c
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x893f1c..0x893f38
+            - Range: 0x893f2c..0x893f48
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x893f38..0x893f70
+            - Range: 0x893f48..0x893f80
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893ec0..0x893f44
+            - Range: 0x893ed0..0x893f54
               Pieces: []
-            - Range: 0x893f44..0x893f45
+            - Range: 0x893f54..0x893f55
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893f45..0x893f70
+            - Range: 0x893f55..0x893f80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0x893ec0..0x893f44
+            - Range: 0x893ed0..0x893f54
               Pieces: []
-            - Range: 0x893f44..0x893f45
+            - Range: 0x893f54..0x893f55
               Pieces: []
-            - Range: 0x893f45..0x893f70
+            - Range: 0x893f55..0x893f80
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x8943f0..0x894400]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x8943f0..0x894400
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 134
-      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x894400..0x894410]
       InlinePCRanges: []
       Variables:
@@ -9434,13 +9415,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 135
-      Name: main.testSliceOfSlices
+    - ID: 134
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x894410..0x894420]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 253 GoSliceHeaderType [][]uint
+          Type: 252 GoSliceHeaderType []uint
           Locations:
             - Range: 0x894410..0x894420
               Pieces:
@@ -9453,13 +9434,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 136
-      Name: main.testStructSlice
+    - ID: 135
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x894420..0x894430]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 253 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x894420..0x894430
               Pieces:
@@ -9471,16 +9452,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x894420..0x894430
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 137
-      Name: main.testEmptySliceOfStructs
+    - ID: 136
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0x894430..0x894440]
       InlinePCRanges: []
       Variables:
@@ -9505,8 +9479,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testNilSliceOfStructs
+    - ID: 137
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x894440..0x894450]
       InlinePCRanges: []
       Variables:
@@ -9531,15 +9505,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x894450..0x894460]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x894450..0x894460
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x894450..0x894460
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x894450..0x894460]
+      OutOfLinePCRanges: [0x894460..0x894470]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 258 GoSliceHeaderType []string
           Locations:
-            - Range: 0x894450..0x894460
+            - Range: 0x894460..0x894470
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9552,20 +9552,20 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x894460..0x894470]
+      OutOfLinePCRanges: [0x894470..0x894480]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x894460..0x894470
+            - Range: 0x894470..0x894480
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 259 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x894460..0x894470
+            - Range: 0x894470..0x894480
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9578,37 +9578,18 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x894460..0x894470
+            - Range: 0x894470..0x894480
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x894470..0x894480]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0x894470..0x894480
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 142
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x894480..0x894490]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 252 GoSliceHeaderType []uint
+          Type: 260 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x894480..0x894490
               Pieces:
@@ -9621,13 +9602,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 143
-      Name: main.testSliceEmptyStructs
+    - ID: 142
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x894490..0x8944a0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 261 GoSliceHeaderType []struct {}
+          Type: 252 GoSliceHeaderType []uint
           Locations:
             - Range: 0x894490..0x8944a0
               Pieces:
@@ -9640,15 +9621,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x8944a0..0x8944b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 261 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x8944a0..0x8944b0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x8944a0..0x8944b0]
+      OutOfLinePCRanges: [0x8944b0..0x8944c0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8944a0..0x8944b0
+            - Range: 0x8944b0..0x8944c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9661,7 +9661,7 @@ Subprograms:
         - Name: bs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8944a0..0x8944b0
+            - Range: 0x8944b0..0x8944c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9674,7 +9674,7 @@ Subprograms:
         - Name: cs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8944a0..0x8944b0
+            - Range: 0x8944b0..0x8944c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9687,44 +9687,27 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0x8947c0..0x894830]
+      OutOfLinePCRanges: [0x8947d0..0x894840]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8947c0..0x89480c
+            - Range: 0x8947d0..0x89481c
               Pieces: []
-            - Range: 0x89480c..0x89480d
+            - Range: 0x89481c..0x89481d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89480d..0x894830
+            - Range: 0x89481d..0x894840
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x894830..0x894840]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x894830..0x894840
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 147
-      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x894840..0x894850]
       InlinePCRanges: []
       Variables:
@@ -9739,10 +9722,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 147
+      Name: main.testThreeStrings
+      OutOfLinePCRanges: [0x894850..0x894860]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x894850..0x894860
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894840..0x894850
+            - Range: 0x894850..0x894860
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9753,7 +9753,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894840..0x894850
+            - Range: 0x894850..0x894860
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9764,13 +9764,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x894850..0x894870]
+      OutOfLinePCRanges: [0x894860..0x894880]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 263 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x894850..0x894870
+            - Range: 0x894860..0x894880
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9789,49 +9789,32 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x894870..0x894880]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 264 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x894870..0x894880
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 150
-      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x894880..0x894890]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 265 PointerType *main.oneStringStruct
+          Type: 264 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x894880..0x894890
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 151
-      Name: main.testMassiveString
+    - ID: 150
+      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x894890..0x8948a0]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
+        - Name: a
+          Type: 265 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x894890..0x8948a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 152
-      Name: main.testUnitializedString
+    - ID: 151
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0x8948a0..0x8948b0]
       InlinePCRanges: []
       Variables:
@@ -9847,8 +9830,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 153
-      Name: main.testEmptyString
+    - ID: 152
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0x8948b0..0x8948c0]
       InlinePCRanges: []
       Variables:
@@ -9864,12 +9847,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
-      Name: main.testSubstrings
+    - ID: 153
+      Name: main.testEmptyString
       OutOfLinePCRanges: [0x8948c0..0x8948d0]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x8948c0..0x8948d0
@@ -9880,10 +9863,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 154
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0x8948d0..0x8948e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x8948d0..0x8948e0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8948c0..0x8948d0
+            - Range: 0x8948d0..0x8948e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9894,7 +9894,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8948c0..0x8948d0
+            - Range: 0x8948d0..0x8948e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9905,26 +9905,26 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x894a30..0x894a40]
+      OutOfLinePCRanges: [0x894a40..0x894a50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x894a30..0x894a40
+            - Range: 0x894a40..0x894a50
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x894a40..0x894a60]
+      OutOfLinePCRanges: [0x894a50..0x894a70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x894a40..0x894a60
+            - Range: 0x894a50..0x894a70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9943,13 +9943,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0x894b30..0x894b50]
+      OutOfLinePCRanges: [0x894b40..0x894b60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 311 StructureType main.aStruct
           Locations:
-            - Range: 0x894b30..0x894b50
+            - Range: 0x894b40..0x894b60
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9970,93 +9970,93 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x894bd0..0x894be0]
+      OutOfLinePCRanges: [0x894be0..0x894bf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 312 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x894bd0..0x894be0
+            - Range: 0x894be0..0x894bf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x894be0..0x894bf0]
+      OutOfLinePCRanges: [0x894bf0..0x894c00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.tenStrings
           Locations:
-            - Range: 0x894be0..0x894bf0
+            - Range: 0x894bf0..0x894c00
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x894c30..0x894c40]
+      OutOfLinePCRanges: [0x894c40..0x894c50]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 315 StructureType main.emptyStruct
-          Locations: [{Range: 0x894c30..0x894c40, Pieces: []}]
+          Locations: [{Range: 0x894c40..0x894c50, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x894c40..0x894c50]
+      OutOfLinePCRanges: [0x894c50..0x894c60]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 316 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x894c40..0x894c50
+            - Range: 0x894c50..0x894c60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x8966c0..0x8966d0]
+      OutOfLinePCRanges: [0x8966d0..0x8966e0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x8966c0..0x8966d0
+            - Range: 0x8966d0..0x8966e0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x8966c0..0x8966c4
+            - Range: 0x8966d0..0x8966d4
               Pieces: []
-            - Range: 0x8966c4..0x8966c5
+            - Range: 0x8966d4..0x8966d5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8966c5..0x8966d0
+            - Range: 0x8966d5..0x8966e0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x8966d0..0x8966e0]
+      OutOfLinePCRanges: [0x8966e0..0x8966f0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8966d0..0x8966dc
+            - Range: 0x8966e0..0x8966ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8966dc..0x8966e0
+            - Range: 0x8966ec..0x8966f0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10067,58 +10067,58 @@ Subprograms:
         - Name: ~r0
           Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x8966d0..0x8966dc
+            - Range: 0x8966e0..0x8966ec
               Pieces: []
-            - Range: 0x8966dc..0x8966dd
+            - Range: 0x8966ec..0x8966ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8966dd..0x8966e0
+            - Range: 0x8966ed..0x8966f0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x8966e0..0x8966f0]
+      OutOfLinePCRanges: [0x8966f0..0x896700]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x8966e0..0x8966f0
+            - Range: 0x8966f0..0x896700
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x8966e0..0x8966e4
+            - Range: 0x8966f0..0x8966f4
               Pieces: []
-            - Range: 0x8966e4..0x8966e5
+            - Range: 0x8966f4..0x8966f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8966e5..0x8966f0
+            - Range: 0x8966f5..0x896700
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x8966f0..0x896700]
+      OutOfLinePCRanges: [0x896700..0x896710]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x8966f0..0x8966fc
+            - Range: 0x896700..0x89670c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8966fc..0x896700
+            - Range: 0x89670c..0x896710
               Pieces:
                 - Size: 8
                   Op: null
@@ -10129,28 +10129,28 @@ Subprograms:
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8966f0..0x8966fc
+            - Range: 0x896700..0x89670c
               Pieces: []
-            - Range: 0x8966fc..0x8966fd
+            - Range: 0x89670c..0x89670d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8966fd..0x896700
+            - Range: 0x89670d..0x896710
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x896770..0x8968a0]
+      OutOfLinePCRanges: [0x896780..0x8968b0]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x896770..0x89679c
+            - Range: 0x896780..0x8967ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10158,7 +10158,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x89679c..0x8967ac
+            - Range: 0x8967ac..0x8967bc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10166,7 +10166,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x8967ac..0x8968a0
+            - Range: 0x8967bc..0x8968b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10179,18 +10179,18 @@ Subprograms:
         - Name: pred
           Type: 323 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x896770..0x8967ac
+            - Range: 0x896780..0x8967bc
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8967ac..0x8968a0
+            - Range: 0x8967bc..0x8968b0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x896770..0x89685c
+            - Range: 0x896780..0x89686c
               Pieces: []
-            - Range: 0x89685c..0x89685d
+            - Range: 0x89686c..0x89686d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10198,14 +10198,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89685d..0x8968a0
+            - Range: 0x89686d..0x8968b0
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8967ac..0x8967c8
+            - Range: 0x8967bc..0x8967d8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10213,7 +10213,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8967c8..0x8967cc
+            - Range: 0x8967d8..0x8967dc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10221,7 +10221,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8967cc..0x8967d0
+            - Range: 0x8967dc..0x8967e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10229,7 +10229,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8967d0..0x8967d0
+            - Range: 0x8967e0..0x8967e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10237,7 +10237,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8967d0..0x8967fc
+            - Range: 0x8967e0..0x89680c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10245,7 +10245,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8967fc..0x896850
+            - Range: 0x89680c..0x896860
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10253,7 +10253,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x896850..0x8968a0
+            - Range: 0x896860..0x8968b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10266,86 +10266,62 @@ Subprograms:
         - Name: item
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x8967ec..0x8967fc
+            - Range: 0x8967fc..0x89680c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8967fc..0x896850
+            - Range: 0x89680c..0x896860
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x8968a0..0x896900]
+      OutOfLinePCRanges: [0x8968b0..0x896910]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x8968a0..0x8968c8
+            - Range: 0x8968b0..0x8968d8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 324 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x8968a0..0x8968c8
+            - Range: 0x8968b0..0x8968d8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x8968a0..0x8968c8
+            - Range: 0x8968b0..0x8968d8
               Pieces: []
-            - Range: 0x8968c8..0x8968c9
+            - Range: 0x8968d8..0x8968d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8968c9..0x896900
+            - Range: 0x8968d9..0x896910
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 168
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x896bb0..0x896bc0]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 322 PointerType *go.shape.int
-          Locations:
-            - Range: 0x896bb0..0x896bc0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 322 PointerType *go.shape.int
-          Locations:
-            - Range: 0x896bb0..0x896bb4
-              Pieces: []
-            - Range: 0x896bb4..0x896bb5
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896bb5..0x896bc0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 169
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0x896bc0..0x896bd0]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 325 PointerType *go.shape.struct { Name string }
+          Type: 322 PointerType *go.shape.int
           Locations:
             - Range: 0x896bc0..0x896bd0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 325 PointerType *go.shape.struct { Name string }
+          Type: 322 PointerType *go.shape.int
           Locations:
             - Range: 0x896bc0..0x896bc4
               Pieces: []
@@ -10356,20 +10332,20 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 170
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+    - ID: 169
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0x896bd0..0x896be0]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 327 PointerType *go.shape.struct { X int; Y int }
+          Type: 325 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0x896bd0..0x896be0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 327 PointerType *go.shape.struct { X int; Y int }
+          Type: 325 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0x896bd0..0x896bd4
               Pieces: []
@@ -10380,101 +10356,125 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 170
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0x896be0..0x896bf0]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 327 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x896be0..0x896bf0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 327 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x896be0..0x896be4
+              Pieces: []
+            - Range: 0x896be4..0x896be5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x896be5..0x896bf0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x896be0..0x896bf0]
+      OutOfLinePCRanges: [0x896bf0..0x896c00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x896be0..0x896bf0
+            - Range: 0x896bf0..0x896c00
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896be0..0x896be8
+            - Range: 0x896bf0..0x896bf8
               Pieces: []
-            - Range: 0x896be8..0x896be9
+            - Range: 0x896bf8..0x896bf9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896be9..0x896bf0
+            - Range: 0x896bf9..0x896c00
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x896c70..0x896c80]
+      OutOfLinePCRanges: [0x896c80..0x896c90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 331 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x896c70..0x896c80
+            - Range: 0x896c80..0x896c90
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896c70..0x896c74
+            - Range: 0x896c80..0x896c84
               Pieces: []
-            - Range: 0x896c74..0x896c75
+            - Range: 0x896c84..0x896c85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896c75..0x896c80
+            - Range: 0x896c85..0x896c90
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x896d10..0x896d20]
+      OutOfLinePCRanges: [0x896d20..0x896d30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x896d10..0x896d20
+            - Range: 0x896d20..0x896d30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896d10..0x896d20
+            - Range: 0x896d20..0x896d30
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0x896d10..0x896d20
+            - Range: 0x896d20..0x896d30
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x896da0..0x896e30]
+      OutOfLinePCRanges: [0x896db0..0x896e40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x896da0..0x896e30
+            - Range: 0x896db0..0x896e40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896da0..0x896e30
+            - Range: 0x896db0..0x896e40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10485,20 +10485,20 @@ Subprograms:
         - Name: v
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896da0..0x896e30
+            - Range: 0x896db0..0x896e40
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x896ec0..0x896ed0]
+      OutOfLinePCRanges: [0x896ed0..0x896ee0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896ec0..0x896ed0
+            - Range: 0x896ed0..0x896ee0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10509,59 +10509,59 @@ Subprograms:
         - Name: b
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0x896ec0..0x896ed0
+            - Range: 0x896ed0..0x896ee0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0x896ec0..0x896ec8
+            - Range: 0x896ed0..0x896ed8
               Pieces: []
-            - Range: 0x896ec8..0x896ec9
+            - Range: 0x896ed8..0x896ed9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896ec9..0x896ed0
+            - Range: 0x896ed9..0x896ee0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896ec0..0x896ec8
+            - Range: 0x896ed0..0x896ed8
               Pieces: []
-            - Range: 0x896ec8..0x896ec9
+            - Range: 0x896ed8..0x896ed9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x896ec9..0x896ed0
+            - Range: 0x896ed9..0x896ee0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x896ed0..0x896ef0]
+      OutOfLinePCRanges: [0x896ee0..0x896f00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896ed0..0x896ee0
+            - Range: 0x896ee0..0x896ef0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896ed0..0x896edc
+            - Range: 0x896ee0..0x896eec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x896edc..0x896ef0
+            - Range: 0x896eec..0x896f00
               Pieces:
                 - Size: 8
                   Op: null
@@ -10572,73 +10572,73 @@ Subprograms:
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896ed0..0x896ee0
+            - Range: 0x896ee0..0x896ef0
               Pieces: []
-            - Range: 0x896ee0..0x896ee1
+            - Range: 0x896ef0..0x896ef1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896ee1..0x896ef0
+            - Range: 0x896ef1..0x896f00
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896ed0..0x896ee0
+            - Range: 0x896ee0..0x896ef0
               Pieces: []
-            - Range: 0x896ee0..0x896ee1
+            - Range: 0x896ef0..0x896ef1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x896ee1..0x896ef0
+            - Range: 0x896ef1..0x896f00
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x896ef0..0x896f40]
+      OutOfLinePCRanges: [0x896f00..0x896f50]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 337 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x896ef0..0x896f18
+            - Range: 0x896f00..0x896f28
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x896ef0..0x896f18
+            - Range: 0x896f00..0x896f28
               Pieces: []
-            - Range: 0x896f18..0x896f19
+            - Range: 0x896f28..0x896f29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896f19..0x896f40
+            - Range: 0x896f29..0x896f50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x896f40..0x896fa0]
+      OutOfLinePCRanges: [0x896f50..0x896fb0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 338 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x896f40..0x896f6c
+            - Range: 0x896f50..0x896f7c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x896f6c..0x896f70
+            - Range: 0x896f7c..0x896f80
               Pieces:
                 - Size: 8
                   Op: null
@@ -10649,65 +10649,65 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x896f40..0x896f70
+            - Range: 0x896f50..0x896f80
               Pieces: []
-            - Range: 0x896f70..0x896f71
+            - Range: 0x896f80..0x896f81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896f71..0x896fa0
+            - Range: 0x896f81..0x896fb0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x896fa0..0x896fb0]
+      OutOfLinePCRanges: [0x896fb0..0x896fc0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 339 PointerType *go.shape.string
           Locations:
-            - Range: 0x896fa0..0x896fa8
+            - Range: 0x896fb0..0x896fb8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896fa0..0x896fa8
+            - Range: 0x896fb0..0x896fb8
               Pieces: []
-            - Range: 0x896fa8..0x896fa9
+            - Range: 0x896fb8..0x896fb9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896fa9..0x896fb0
+            - Range: 0x896fb9..0x896fc0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x896fb0..0x897010]
+      OutOfLinePCRanges: [0x896fc0..0x897020]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 340 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x896fb0..0x896fec
+            - Range: 0x896fc0..0x896ffc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 341 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x896fb0..0x896ffc
+            - Range: 0x896fc0..0x89700c
               Pieces: []
-            - Range: 0x896ffc..0x896ffd
+            - Range: 0x89700c..0x89700d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10721,20 +10721,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x896ffd..0x897010
+            - Range: 0x89700d..0x897020
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x897010..0x897050]
+      OutOfLinePCRanges: [0x897020..0x897060]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x897010..0x89701c
+            - Range: 0x897020..0x89702c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10742,7 +10742,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x89701c..0x897050
+            - Range: 0x89702c..0x897060
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10755,42 +10755,42 @@ Subprograms:
         - Name: needle
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x897010..0x897050
+            - Range: 0x897020..0x897060
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x897010..0x897038
+            - Range: 0x897020..0x897048
               Pieces: []
-            - Range: 0x897038..0x897039
+            - Range: 0x897048..0x897049
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897039..0x897040
+            - Range: 0x897049..0x897050
               Pieces: []
-            - Range: 0x897040..0x897041
+            - Range: 0x897050..0x897051
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897041..0x897050
+            - Range: 0x897051..0x897060
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x89702c..0x89703c
+            - Range: 0x89703c..0x89704c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x897050..0x897120]
+      OutOfLinePCRanges: [0x897060..0x897130]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 342 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x897050..0x897074
+            - Range: 0x897060..0x897084
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10798,7 +10798,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x897074..0x897078
+            - Range: 0x897084..0x897088
               Pieces:
                 - Size: 8
                   Op: null
@@ -10811,13 +10811,13 @@ Subprograms:
         - Name: needle
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x897050..0x8970ac
+            - Range: 0x897060..0x8970bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8970ac..0x897120
+            - Range: 0x8970bc..0x897130
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10828,28 +10828,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x897050..0x8970c8
-              Pieces: []
-            - Range: 0x8970c8..0x8970c9
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8970c9..0x8970d8
+            - Range: 0x897060..0x8970d8
               Pieces: []
             - Range: 0x8970d8..0x8970d9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8970d9..0x897120
+            - Range: 0x8970d9..0x8970e8
+              Pieces: []
+            - Range: 0x8970e8..0x8970e9
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8970e9..0x897130
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89708c..0x8970a0
+            - Range: 0x89709c..0x8970b0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8970a0..0x8970ac
+            - Range: 0x8970b0..0x8970bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10860,56 +10860,56 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x897120..0x897130]
+      OutOfLinePCRanges: [0x897130..0x897140]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 343 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x897120..0x897128
+            - Range: 0x897130..0x897138
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x897120..0x897130
+            - Range: 0x897130..0x897140
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x897120..0x897128
+            - Range: 0x897130..0x897138
               Pieces: []
-            - Range: 0x897128..0x897129
+            - Range: 0x897138..0x897139
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897129..0x897130
+            - Range: 0x897139..0x897140
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x8971b0..0x897230]
+      OutOfLinePCRanges: [0x8971c0..0x897240]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 344 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x8971b0..0x8971dc
+            - Range: 0x8971c0..0x8971ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8971dc..0x8971e8
+            - Range: 0x8971ec..0x8971f8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8971e8..0x8971ec
+            - Range: 0x8971f8..0x8971fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10920,7 +10920,7 @@ Subprograms:
         - Name: value
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8971b0..0x8971ec
+            - Range: 0x8971c0..0x8971fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10931,11 +10931,11 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8971b0..0x8971ec
+            - Range: 0x8971c0..0x8971fc
               Pieces: []
-            - Range: 0x8971ec..0x8971ed
+            - Range: 0x8971fc..0x8971fd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8971ed..0x897230
+            - Range: 0x8971fd..0x897240
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11073,31 +11073,31 @@ Subprograms:
       DictRegister: 0
     - ID: 186
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x88f120..0x88f190]
+      OutOfLinePCRanges: [0x88f130..0x88f1a0]
       InlinePCRanges:
-        - Ranges: [0x88f1ac..0x88f1e4]
-          RootRanges: [0x88f190..0x88f210]
-        - Ranges: [0x88f2f8..0x88f330]
-          RootRanges: [0x88f2c0..0x88f350]
-        - Ranges: [0x88f374..0x88f3ac]
-          RootRanges: [0x88f350..0x88f420]
-        - Ranges: [0x88f43c..0x88f474]
-          RootRanges: [0x88f420..0x88f4a0]
+        - Ranges: [0x88f1bc..0x88f1f4]
+          RootRanges: [0x88f1a0..0x88f220]
+        - Ranges: [0x88f308..0x88f340]
+          RootRanges: [0x88f2d0..0x88f360]
+        - Ranges: [0x88f384..0x88f3bc]
+          RootRanges: [0x88f360..0x88f430]
+        - Ranges: [0x88f44c..0x88f484]
+          RootRanges: [0x88f430..0x88f4b0]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f120..0x88f140
+            - Range: 0x88f130..0x88f150
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f1ac..0x88f1b4
+            - Range: 0x88f1bc..0x88f1c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f2f8..0x88f300
+            - Range: 0x88f308..0x88f310
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f36c..0x88f37c
+            - Range: 0x88f37c..0x88f38c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f37c..0x88f420
+            - Range: 0x88f38c..0x88f430
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x88f420..0x88f444
+            - Range: 0x88f430..0x88f454
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11106,37 +11106,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88f3b8..0x88f3f0]
-          RootRanges: [0x88f350..0x88f420]
+        - Ranges: [0x88f3c8..0x88f400]
+          RootRanges: [0x88f360..0x88f430]
       Variables: []
       DictRegister: null
     - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88f4bc..0x88f500]
-          RootRanges: [0x88f4a0..0x88f5c0]
+        - Ranges: [0x88f4cc..0x88f510]
+          RootRanges: [0x88f4b0..0x88f5d0]
       Variables: []
       DictRegister: null
     - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88f570..0x88f5a8]
-          RootRanges: [0x88f4a0..0x88f5c0]
+        - Ranges: [0x88f580..0x88f5b8]
+          RootRanges: [0x88f4b0..0x88f5d0]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88f5c4..0x88f5c8]
-          RootRanges: [0x88f5c0..0x88f5d0]
+        - Ranges: [0x88f5d4..0x88f5d8]
+          RootRanges: [0x88f5d0..0x88f5e0]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f5c0..0x88f5c8
+            - Range: 0x88f5d0..0x88f5d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11145,38 +11145,38 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88f5f4..0x88f618]
-          RootRanges: [0x88f5d0..0x88f630]
-        - Ranges: [0x88f68c..0x88f6b4]
-          RootRanges: [0x88f630..0x88f780]
+        - Ranges: [0x88f604..0x88f628]
+          RootRanges: [0x88f5e0..0x88f640]
+        - Ranges: [0x88f69c..0x88f6c4]
+          RootRanges: [0x88f640..0x88f790]
       Variables:
         - Name: a
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x88f5e0..0x88f630
+            - Range: 0x88f5f0..0x88f640
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x88f678..0x88f780
+            - Range: 0x88f688..0x88f790
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 192
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x88f780..0x88f800]
+      OutOfLinePCRanges: [0x88f790..0x88f810]
       InlinePCRanges:
-        - Ranges: [0x8972ec..0x897320]
-          RootRanges: [0x8972c0..0x897370]
+        - Ranges: [0x8972fc..0x897330]
+          RootRanges: [0x8972d0..0x897380]
       Variables:
         - Name: b
           Type: 349 StructureType main.firstBehavior
           Locations:
-            - Range: 0x88f780..0x88f7ac
+            - Range: 0x88f790..0x88f7bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88f7ac..0x88f7b0
+            - Range: 0x88f7bc..0x88f7c0
               Pieces:
                 - Size: 8
                   Op: null
@@ -11187,15 +11187,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f780..0x88f7d0
+            - Range: 0x88f790..0x88f7e0
               Pieces: []
-            - Range: 0x88f7d0..0x88f7d1
+            - Range: 0x88f7e0..0x88f7e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88f7d1..0x88f800
+            - Range: 0x88f7e1..0x88f810
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11204,8 +11204,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88fe58..0x88fe64, 0x88fe68..0x88fe70]
-          RootRanges: [0x88fd40..0x88feb0]
+        - Ranges: [0x88fe68..0x88fe74, 0x88fe78..0x88fe80]
+          RootRanges: [0x88fd50..0x88fec0]
         - Ranges: [0x12a824..0x12a828, 0x12a82c..0x12a834]
           RootRanges: [0x12a810..0x12a840]
       Variables: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x8947e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894938", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1400 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x89481c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89496c", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1238 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x88f8a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f9f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1239 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x88f8d4", Frameless: false}]
+              InjectionPoints: [{PC: "0x88fa24", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1241 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x88f928", Frameless: false}]
+              InjectionPoints: [{PC: "0x88fa78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1242 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x88f954", Frameless: false}]
+              InjectionPoints: [{PC: "0x88faa4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x89353c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89368c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1371 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8935d4", Frameless: false}]
+              InjectionPoints: [{PC: "0x893724", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1188 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0x88d030", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1184 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0x88cff0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1186 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0x88d010", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1250 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x88ff90", Frameless: true}]
+              InjectionPoints: [{PC: "0x8900e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1185 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0x88d000", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1187 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0x88d020", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d170", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1272 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x891680", Frameless: true}]
+              InjectionPoints: [{PC: "0x8917d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1273 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x8916bc", Frameless: true}]
+              InjectionPoints: [{PC: "0x89180c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1206 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x88d580", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d6d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1207 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0x88d598", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d6e8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1173 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0x88cf40", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d090", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1170 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0x88cf10", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x894b40", Frameless: true}]
+              InjectionPoints: [{PC: "0x894c90", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1419 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x894b5c", Frameless: true}]
+              InjectionPoints: [{PC: "0x894cac", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1479 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x88f148"
+                - PC: "0x88f298"
                   Frameless: false
-                - PC: "0x88f1bc"
+                - PC: "0x88f30c"
                   Frameless: false
-                - PC: "0x88f308"
+                - PC: "0x88f458"
                   Frameless: false
-                - PC: "0x88f384"
+                - PC: "0x88f4d4"
                   Frameless: false
-                - PC: "0x88f44c"
+                - PC: "0x88f59c"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1480 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x88f148"
+                - PC: "0x88f298"
                   Frameless: false
-                - PC: "0x88f1bc"
+                - PC: "0x88f30c"
                   Frameless: false
-                - PC: "0x88f308"
+                - PC: "0x88f458"
                   Frameless: false
-                - PC: "0x88f384"
+                - PC: "0x88f4d4"
                   Frameless: false
-                - PC: "0x88f44c"
+                - PC: "0x88f59c"
                   Frameless: false
               Condition:
                 Type: 4 BaseType bool
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 1481 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x88f148"
+                - PC: "0x88f298"
                   Frameless: false
-                - PC: "0x88f1bc"
+                - PC: "0x88f30c"
                   Frameless: false
-                - PC: "0x88f308"
+                - PC: "0x88f458"
                   Frameless: false
-                - PC: "0x88f384"
+                - PC: "0x88f4d4"
                   Frameless: false
-                - PC: "0x88f44c"
+                - PC: "0x88f59c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -474,7 +474,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1269 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x891420", Frameless: true}]
+              InjectionPoints: [{PC: "0x891570", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -493,7 +493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1270 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x891420", Frameless: true}]
+              InjectionPoints: [{PC: "0x891570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -519,7 +519,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x894bf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894d40", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -554,7 +554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1274 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x8916c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891810", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -584,7 +584,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1268 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x891400", Frameless: true}]
+              InjectionPoints: [{PC: "0x891550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -613,11 +613,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1335 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x892738", Frameless: false}]
+              InjectionPoints: [{PC: "0x892888", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1336 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x8927e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892938", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -639,7 +639,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1282 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x891970", Frameless: true}]
+              InjectionPoints: [{PC: "0x891ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -661,7 +661,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1213 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x88da80", Frameless: true}]
+              InjectionPoints: [{PC: "0x88dbd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -683,7 +683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1214 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x88da90", Frameless: true}]
+              InjectionPoints: [{PC: "0x88dbe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -705,7 +705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1209 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x88d770", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d8c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -727,7 +727,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1210 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x88d780", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d8d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -749,7 +749,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1211 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x88d920", Frameless: true}]
+              InjectionPoints: [{PC: "0x88da70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -771,7 +771,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1212 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x88d930", Frameless: true}]
+              InjectionPoints: [{PC: "0x88da80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -793,7 +793,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x894410", Frameless: true}]
+              InjectionPoints: [{PC: "0x894560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -820,7 +820,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x894440", Frameless: true}]
+              InjectionPoints: [{PC: "0x894590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -848,7 +848,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1413 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x8948c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894a10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -870,7 +870,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x894c40", Frameless: true}]
+              InjectionPoints: [{PC: "0x894d90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -891,7 +891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x894c50", Frameless: true}]
+              InjectionPoints: [{PC: "0x894da0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -913,7 +913,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1240 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x88f900", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fa50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -947,7 +947,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1208 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x88d60c", Frameless: false}]
+              InjectionPoints: [{PC: "0x88d75c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -975,11 +975,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1222 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x88e158", Frameless: false}]
+              InjectionPoints: [{PC: "0x88e2a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1223 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x88e194", Frameless: false}]
+              InjectionPoints: [{PC: "0x88e2e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1001,11 +1001,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1220 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x88e06c", Frameless: false}]
+              InjectionPoints: [{PC: "0x88e1bc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1221 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x88e0dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x88e22c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1027,11 +1027,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1232 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x88f5d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88f720", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1233 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x88f5d8", Frameless: true}]
+              InjectionPoints: [{PC: "0x88f728", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1053,11 +1053,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1234 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x88f5ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f73c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1235 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x88f628", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f778", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1082,7 +1082,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1236 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x88f5ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f73c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1104,11 +1104,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x896fb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x897100", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1466 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x896fb8", Frameless: true}]
+              InjectionPoints: [{PC: "0x897108", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1122,11 +1122,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x896fd0", Frameless: false}]
+              InjectionPoints: [{PC: "0x897120", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1468 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x89700c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89715c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1149,11 +1149,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x896f18", Frameless: false}]
+              InjectionPoints: [{PC: "0x897068", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1462 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x896f28", Frameless: false}]
+              InjectionPoints: [{PC: "0x897078", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1167,11 +1167,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x896f68", Frameless: false}]
+              InjectionPoints: [{PC: "0x8970b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1464 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x896f80", Frameless: false}]
+              InjectionPoints: [{PC: "0x8970d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1194,14 +1194,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x897020", Frameless: true}]
+              InjectionPoints: [{PC: "0x897170", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1470 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x897048"
+                - PC: "0x897198"
                   Frameless: true
-                - PC: "0x897050"
+                - PC: "0x8971a0"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1216,14 +1216,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x897078", Frameless: false}]
+              InjectionPoints: [{PC: "0x8971c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1472 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x8970d8"
+                - PC: "0x897228"
                   Frameless: false
-                - PC: "0x8970e8"
+                - PC: "0x897238"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1250,7 +1250,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1473 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x897024", Frameless: true}]
+              InjectionPoints: [{PC: "0x897174", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1262,7 +1262,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1474 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x897088", Frameless: false}]
+              InjectionPoints: [{PC: "0x8971d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1283,11 +1283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x896bf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1450 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x896bf8", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d48", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1301,11 +1301,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x896c80", Frameless: true}]
+              InjectionPoints: [{PC: "0x896dd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1452 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x896c84", Frameless: true}]
+              InjectionPoints: [{PC: "0x896dd4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1329,11 +1329,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x896798", Frameless: false}]
+              InjectionPoints: [{PC: "0x8968e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1438 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x89686c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8969bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1375,11 +1375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x8968c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x896a18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1442 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8968d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x896a28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1402,11 +1402,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x897130", Frameless: true}]
+              InjectionPoints: [{PC: "0x897280", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1476 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x897138", Frameless: true}]
+              InjectionPoints: [{PC: "0x897288", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1420,11 +1420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x8971d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x897328", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1478 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x8971fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89734c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1447,11 +1447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x8966f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896840", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1434 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8966f4", Frameless: true}]
+              InjectionPoints: [{PC: "0x896844", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1465,11 +1465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x896700", Frameless: true}]
+              InjectionPoints: [{PC: "0x896850", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1436 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x89670c", Frameless: true}]
+              InjectionPoints: [{PC: "0x89685c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1492,11 +1492,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x896d20", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e70", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1454 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x896d28", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e78", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1510,11 +1510,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x896dc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x896f18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1456 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x896df4", Frameless: false}]
+              InjectionPoints: [{PC: "0x896f44", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1537,11 +1537,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x896bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d10", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1444 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x896bc4", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d14", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1555,11 +1555,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x896bd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1446 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x896bd4", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d24", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1573,11 +1573,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x896be0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d30", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1448 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x896be4", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d34", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1600,11 +1600,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x896ed0", Frameless: true}]
+              InjectionPoints: [{PC: "0x897020", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1458 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x896ed8", Frameless: true}]
+              InjectionPoints: [{PC: "0x897028", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1618,11 +1618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x896ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0x897030", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1460 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x896ef0", Frameless: true}]
+              InjectionPoints: [{PC: "0x897040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1645,11 +1645,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x8966d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896820", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1430 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8966d4", Frameless: true}]
+              InjectionPoints: [{PC: "0x896824", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1663,11 +1663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x8966e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896830", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1432 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8966ec", Frameless: true}]
+              InjectionPoints: [{PC: "0x89683c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1690,11 +1690,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1224 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x88f2e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f438", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1225 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x88f340", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f490", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1721,11 +1721,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1226 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x88f378", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f4c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1227 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x88f400", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f550", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1752,11 +1752,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1228 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x88f448", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f598", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1229 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x88f484", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f5d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1778,7 +1778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1485 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x88f3c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f518", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1796,11 +1796,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1230 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x88f4c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f618", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1231 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x88f5b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f708", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1818,7 +1818,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x88f4cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f61c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1839,7 +1839,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1487 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x88f4cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f61c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1857,7 +1857,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x88f580", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f6d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1878,7 +1878,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1489 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x88f580", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f6d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1899,7 +1899,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x12a824"
                   Frameless: true
-                - PC: "0x88fe68"
+                - PC: "0x88ffbc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1920,20 +1920,20 @@ Probes:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x88f148"
+                - PC: "0x88f298"
                   Frameless: false
-                - PC: "0x88f1bc"
+                - PC: "0x88f30c"
                   Frameless: false
-                - PC: "0x88f308"
+                - PC: "0x88f458"
                   Frameless: false
-                - PC: "0x88f384"
+                - PC: "0x88f4d4"
                   Frameless: false
-                - PC: "0x88f44c"
+                - PC: "0x88f59c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1483 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x88f180", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f2d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1959,15 +1959,15 @@ Probes:
             - Kind: Line
               Type: 1484 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x88f148"
+                - PC: "0x88f298"
                   Frameless: false
-                - PC: "0x88f1bc"
+                - PC: "0x88f30c"
                   Frameless: false
-                - PC: "0x88f308"
+                - PC: "0x88f458"
                   Frameless: false
-                - PC: "0x88f384"
+                - PC: "0x88f4d4"
                   Frameless: false
-                - PC: "0x88f44c"
+                - PC: "0x88f59c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1990,7 +1990,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x88f5d4", Frameless: true}]
+              InjectionPoints: [{PC: "0x88f724", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2015,7 +2015,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1491 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x88f5d4", Frameless: true}]
+              InjectionPoints: [{PC: "0x88f724", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2039,9 +2039,9 @@ Probes:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x88f604"
+                - PC: "0x88f754"
                   Frameless: false
-                - PC: "0x88f69c"
+                - PC: "0x88f7ec"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2064,7 +2064,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1176 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0x88cf70", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d0c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2086,7 +2086,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1177 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0x88cf80", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d0d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2108,7 +2108,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1178 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0x88cf90", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d0e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2130,7 +2130,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1175 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0x88cf60", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d0b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2152,7 +2152,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1174 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0x88cf50", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d0a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2174,7 +2174,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1237 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x88f880", Frameless: true}]
+              InjectionPoints: [{PC: "0x88f9d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2195,11 +2195,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x893360", Frameless: false}]
+              InjectionPoints: [{PC: "0x8934b0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1369 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8934b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893608", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2221,7 +2221,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1276 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x891880", Frameless: true}]
+              InjectionPoints: [{PC: "0x8919d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2246,7 +2246,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1217 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x88dadc", Frameless: false}]
+              InjectionPoints: [{PC: "0x88dc2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2268,7 +2268,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1218 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x88db70", Frameless: false}]
+              InjectionPoints: [{PC: "0x88dcc0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2290,7 +2290,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1219 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x88dc1c", Frameless: false}]
+              InjectionPoints: [{PC: "0x88dd6c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2333,11 +2333,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x89386c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8939bc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1375 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x8939dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x893b2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2399,7 +2399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1248 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x88ff70", Frameless: true}]
+              InjectionPoints: [{PC: "0x8900c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2421,7 +2421,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1255 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x88ffd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x890120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2443,7 +2443,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1265 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x890070", Frameless: true}]
+              InjectionPoints: [{PC: "0x8901c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2465,7 +2465,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1267 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x890090", Frameless: true}]
+              InjectionPoints: [{PC: "0x8901e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2487,7 +2487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1266 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x890080", Frameless: true}]
+              InjectionPoints: [{PC: "0x8901d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2509,7 +2509,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1252 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x88ffb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x890100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2531,7 +2531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1264 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x890060", Frameless: true}]
+              InjectionPoints: [{PC: "0x8901b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2553,7 +2553,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1263 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x890050", Frameless: true}]
+              InjectionPoints: [{PC: "0x8901a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2577,7 +2577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1253 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x88ffc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x890110", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2601,7 +2601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1254 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x88ffc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x890110", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2623,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1262 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x890040", Frameless: true}]
+              InjectionPoints: [{PC: "0x890190", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2645,7 +2645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1261 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x890030", Frameless: true}]
+              InjectionPoints: [{PC: "0x890180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2667,7 +2667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1246 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x88ff50", Frameless: true}]
+              InjectionPoints: [{PC: "0x8900a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2689,7 +2689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1247 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x88ff60", Frameless: true}]
+              InjectionPoints: [{PC: "0x8900b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2711,7 +2711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1245 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x88ff40", Frameless: true}]
+              InjectionPoints: [{PC: "0x890090", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2733,7 +2733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1256 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x88ffe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x890130", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2755,7 +2755,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1259 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x890010", Frameless: true}]
+              InjectionPoints: [{PC: "0x890160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2777,7 +2777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1260 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x890020", Frameless: true}]
+              InjectionPoints: [{PC: "0x890170", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2799,7 +2799,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1257 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x88fff0", Frameless: true}]
+              InjectionPoints: [{PC: "0x890140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2823,7 +2823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1258 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x890000", Frameless: true}]
+              InjectionPoints: [{PC: "0x890150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2845,7 +2845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x8948a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8949f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2868,7 +2868,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1411 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x8948a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8949f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2915,11 +2915,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x893a60", Frameless: false}]
+              InjectionPoints: [{PC: "0x893bb0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1377 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x893c10", Frameless: false}]
+              InjectionPoints: [{PC: "0x893d60", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2985,11 +2985,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x893d3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x893e8c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1381 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x893de0", Frameless: false}]
+              InjectionPoints: [{PC: "0x893f30", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3020,11 +3020,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x893610", Frameless: false}]
+              InjectionPoints: [{PC: "0x893760", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1373 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x8937e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x893930", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3050,11 +3050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1313 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892598", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1314 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892624", Frameless: false}]
+              InjectionPoints: [{PC: "0x892774", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3090,7 +3090,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1271 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x8914e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891630", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3131,11 +3131,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1307 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x8924f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892648", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1308 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x892558", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3159,11 +3159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1309 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x8924f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892648", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1310 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x892558", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926a8", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3182,11 +3182,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1315 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892598", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1316 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892624", Frameless: false}]
+              InjectionPoints: [{PC: "0x892774", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3206,11 +3206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1317 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892598", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1318 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892624", Frameless: false}]
+              InjectionPoints: [{PC: "0x892774", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3243,11 +3243,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1311 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x8924f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892648", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1312 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x892558", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3275,7 +3275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x894be0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894d30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3300,7 +3300,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x894be0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894d30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3331,7 +3331,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1424 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x894be0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894d30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3356,7 +3356,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x894be0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894d30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3383,7 +3383,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1281 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x891950", Frameless: true}]
+              InjectionPoints: [{PC: "0x891aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3410,7 +3410,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x894480", Frameless: true}]
+              InjectionPoints: [{PC: "0x8945d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3437,7 +3437,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x894450", Frameless: true}]
+              InjectionPoints: [{PC: "0x8945a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3472,7 +3472,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x894470", Frameless: true}]
+              InjectionPoints: [{PC: "0x8945c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3504,7 +3504,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x894890", Frameless: true}]
+              InjectionPoints: [{PC: "0x8949e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3526,7 +3526,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1277 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x891890", Frameless: true}]
+              InjectionPoints: [{PC: "0x8919e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3548,7 +3548,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1251 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x88ffa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8900f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3570,7 +3570,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1275 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x891870", Frameless: true}]
+              InjectionPoints: [{PC: "0x8919c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3594,11 +3594,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1283 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x891d98", Frameless: false}]
+              InjectionPoints: [{PC: "0x891ee8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1284 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x891ddc", Frameless: false}]
+              InjectionPoints: [{PC: "0x891f2c", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3618,11 +3618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1327 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x892668", Frameless: false}]
+              InjectionPoints: [{PC: "0x8927b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1328 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x8926f4", Frameless: false}]
+              InjectionPoints: [{PC: "0x892844", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3663,11 +3663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1293 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x891eb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892008", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1294 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x891f50", Frameless: false}]
+              InjectionPoints: [{PC: "0x8920a0", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3705,11 +3705,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1285 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x891d98", Frameless: false}]
+              InjectionPoints: [{PC: "0x891ee8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1286 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x891ddc", Frameless: false}]
+              InjectionPoints: [{PC: "0x891f2c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3750,11 +3750,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1295 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x891eb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892008", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1296 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x891f50", Frameless: false}]
+              InjectionPoints: [{PC: "0x8920a0", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3794,11 +3794,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1329 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x892668", Frameless: false}]
+              InjectionPoints: [{PC: "0x8927b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1330 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x8926f4", Frameless: false}]
+              InjectionPoints: [{PC: "0x892844", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3815,11 +3815,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1331 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x892668", Frameless: false}]
+              InjectionPoints: [{PC: "0x8927b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1332 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x8926f4", Frameless: false}]
+              InjectionPoints: [{PC: "0x892844", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3841,11 +3841,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1287 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x891d98", Frameless: false}]
+              InjectionPoints: [{PC: "0x891ee8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1288 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x891ddc", Frameless: false}]
+              InjectionPoints: [{PC: "0x891f2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3868,18 +3868,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1303 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x892188", Frameless: false}]
+              InjectionPoints: [{PC: "0x8922d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1304 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x892228"
+                - PC: "0x892378"
                   Frameless: false
-                - PC: "0x892270"
+                - PC: "0x8923c0"
                   Frameless: false
-                - PC: "0x892334"
+                - PC: "0x892484"
                   Frameless: false
-                - PC: "0x892348"
+                - PC: "0x892498"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3907,18 +3907,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1301 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x892008", Frameless: false}]
+              InjectionPoints: [{PC: "0x892158", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1302 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x892074"
+                - PC: "0x8921c4"
                   Frameless: false
-                - PC: "0x8920c0"
+                - PC: "0x892210"
                   Frameless: false
-                - PC: "0x892100"
+                - PC: "0x892250"
                   Frameless: false
-                - PC: "0x892140"
+                - PC: "0x892290"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3945,11 +3945,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1346 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x892d6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x892ebc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1347 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x892dc0", Frameless: false}]
+              InjectionPoints: [{PC: "0x892f10", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3966,11 +3966,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1348 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x892df8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892f48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1349 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x892e34", Frameless: false}]
+              InjectionPoints: [{PC: "0x892f84", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3987,11 +3987,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1350 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x892e68", Frameless: false}]
+              InjectionPoints: [{PC: "0x892fb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1351 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x892ea0", Frameless: false}]
+              InjectionPoints: [{PC: "0x892ff0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4008,11 +4008,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1354 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x892f58", Frameless: false}]
+              InjectionPoints: [{PC: "0x8930a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1355 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x892fbc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89310c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4029,11 +4029,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x8932e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893438", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1367 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x893328", Frameless: false}]
+              InjectionPoints: [{PC: "0x893478", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4050,11 +4050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1342 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x892c18", Frameless: false}]
+              InjectionPoints: [{PC: "0x892d68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1343 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x892c64", Frameless: false}]
+              InjectionPoints: [{PC: "0x892db4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4072,14 +4072,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1299 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x891f88", Frameless: false}]
+              InjectionPoints: [{PC: "0x8920d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1300 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x891fb8"
+                - PC: "0x892108"
                   Frameless: false
-                - PC: "0x891fcc"
+                - PC: "0x89211c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4101,11 +4101,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1289 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x891d98", Frameless: false}]
+              InjectionPoints: [{PC: "0x891ee8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1290 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x891ddc", Frameless: false}]
+              InjectionPoints: [{PC: "0x891f2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4126,11 +4126,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1297 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x891eb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892008", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1298 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x891f50", Frameless: false}]
+              InjectionPoints: [{PC: "0x8920a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4151,11 +4151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1291 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x891e18", Frameless: false}]
+              InjectionPoints: [{PC: "0x891f68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1292 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x891e7c", Frameless: false}]
+              InjectionPoints: [{PC: "0x891fcc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4177,14 +4177,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1305 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x892388", Frameless: false}]
+              InjectionPoints: [{PC: "0x8924d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1306 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x892458"
+                - PC: "0x8925a8"
                   Frameless: false
-                - PC: "0x89246c"
+                - PC: "0x8925bc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4206,11 +4206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1344 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x892ca0", Frameless: false}]
+              InjectionPoints: [{PC: "0x892df0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1345 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x892d34", Frameless: false}]
+              InjectionPoints: [{PC: "0x892e84", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4227,11 +4227,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1340 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x892b58", Frameless: false}]
+              InjectionPoints: [{PC: "0x892ca8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1341 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x892bdc", Frameless: false}]
+              InjectionPoints: [{PC: "0x892d2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4248,11 +4248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1358 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x8930d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893228", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1359 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x893130", Frameless: false}]
+              InjectionPoints: [{PC: "0x893280", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4269,11 +4269,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1352 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x892ed8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1353 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x892f20", Frameless: false}]
+              InjectionPoints: [{PC: "0x893070", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4290,11 +4290,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1364 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x893268", Frameless: false}]
+              InjectionPoints: [{PC: "0x8933b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1365 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x8932ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x8933fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4314,7 +4314,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1337 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x8928e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892a38", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4335,11 +4335,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1362 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x8931f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893348", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1363 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x893238", Frameless: false}]
+              InjectionPoints: [{PC: "0x893388", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4356,11 +4356,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1338 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x892ac8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892c18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1339 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x892b20", Frameless: false}]
+              InjectionPoints: [{PC: "0x892c70", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4377,11 +4377,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1360 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x89316c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8932bc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1361 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x8931c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x893310", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4398,11 +4398,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1356 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x893000", Frameless: false}]
+              InjectionPoints: [{PC: "0x893150", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1357 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x8930a4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8931f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4420,7 +4420,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1171 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0x88cf20", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d070", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1319 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892598", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1320 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892624", Frameless: false}]
+              InjectionPoints: [{PC: "0x892774", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4505,7 +4505,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1192 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x88d3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d4f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4527,7 +4527,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1190 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x88d380", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d4d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4549,7 +4549,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1203 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x88d450", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4567,7 +4567,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1204 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x88d460", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d5b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1193 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x88d3b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1195 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x88d3d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4630,7 +4630,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1196 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x88d3e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4652,7 +4652,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1197 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x88d3f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4681,7 +4681,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1194 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x88d3c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4712,7 +4712,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1191 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x88d390", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4734,7 +4734,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x894840", Frameless: true}]
+              InjectionPoints: [{PC: "0x894990", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4756,7 +4756,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1198 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x88d400", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4778,7 +4778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1200 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x88d420", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4800,7 +4800,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1201 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x88d430", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4822,7 +4822,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1202 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x88d440", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4844,7 +4844,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1199 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x88d410", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4866,7 +4866,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x8944a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8945f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4888,7 +4888,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x894420", Frameless: true}]
+              InjectionPoints: [{PC: "0x894570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4910,7 +4910,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1249 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x88ff80", Frameless: true}]
+              InjectionPoints: [{PC: "0x8900d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4931,11 +4931,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1333 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x892668", Frameless: false}]
+              InjectionPoints: [{PC: "0x8927b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1334 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x8926f4", Frameless: false}]
+              InjectionPoints: [{PC: "0x892844", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4956,11 +4956,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x893c98", Frameless: false}]
+              InjectionPoints: [{PC: "0x893de8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1379 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x893cfc", Frameless: false}]
+              InjectionPoints: [{PC: "0x893e4c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4982,7 +4982,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1172 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0x88cf30", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5004,7 +5004,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1280 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x891930", Frameless: true}]
+              InjectionPoints: [{PC: "0x891a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5026,7 +5026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x894460", Frameless: true}]
+              InjectionPoints: [{PC: "0x8945b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5048,7 +5048,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1215 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x88daa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88dbf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5070,7 +5070,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1216 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x88dab0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88dc00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5092,11 +5092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x894b40", Frameless: true}]
+              InjectionPoints: [{PC: "0x894c90", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1421 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x894b5c", Frameless: true}]
+              InjectionPoints: [{PC: "0x894cac", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5123,7 +5123,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x894430", Frameless: true}]
+              InjectionPoints: [{PC: "0x894580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5150,7 +5150,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1243 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x88f980", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fad0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5171,11 +5171,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x893e1c", Frameless: false}]
+              InjectionPoints: [{PC: "0x893f6c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1383 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x893eac", Frameless: false}]
+              InjectionPoints: [{PC: "0x893ffc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5197,11 +5197,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x894a50", Frameless: true}]
+              InjectionPoints: [{PC: "0x894ba0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x894a68", Frameless: true}]
+              InjectionPoints: [{PC: "0x894bb8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5222,7 +5222,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x894a40", Frameless: true}]
+              InjectionPoints: [{PC: "0x894b90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5249,7 +5249,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1244 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x88ff30", Frameless: true}]
+              InjectionPoints: [{PC: "0x890080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5281,7 +5281,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x8944b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5321,7 +5321,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x8948d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5354,11 +5354,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1321 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892598", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1322 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892624", Frameless: false}]
+              InjectionPoints: [{PC: "0x892774", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5379,11 +5379,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1323 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892598", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1324 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892624", Frameless: false}]
+              InjectionPoints: [{PC: "0x892774", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5406,11 +5406,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1325 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x892598", Frameless: false}]
+              InjectionPoints: [{PC: "0x8926e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1326 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x892624", Frameless: false}]
+              InjectionPoints: [{PC: "0x892774", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5439,7 +5439,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1402 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x894850", Frameless: true}]
+              InjectionPoints: [{PC: "0x8949a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5471,11 +5471,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x894860", Frameless: true}]
+              InjectionPoints: [{PC: "0x8949b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1404 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x894878", Frameless: true}]
+              InjectionPoints: [{PC: "0x8949c8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5505,11 +5505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x894860", Frameless: true}]
+              InjectionPoints: [{PC: "0x8949b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1406 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x894878", Frameless: true}]
+              InjectionPoints: [{PC: "0x8949c8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5541,7 +5541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1407 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x894880", Frameless: true}]
+              InjectionPoints: [{PC: "0x8949d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x894880", Frameless: true}]
+              InjectionPoints: [{PC: "0x8949d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1205 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x88d470", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5625,7 +5625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1181 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0x88cfc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d110", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5647,7 +5647,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1182 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0x88cfd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5669,7 +5669,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1183 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0x88cfe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d130", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5691,7 +5691,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1180 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0x88cfb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5713,7 +5713,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1179 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0x88cfa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d0f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5735,7 +5735,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1279 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x8918c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891a10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5757,7 +5757,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x894400", Frameless: true}]
+              InjectionPoints: [{PC: "0x894550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5779,7 +5779,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x8948b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5801,7 +5801,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1278 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x8918a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8919f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5823,7 +5823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1189 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0x88d050", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d1a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5845,7 +5845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x894490", Frameless: true}]
+              InjectionPoints: [{PC: "0x8945e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5867,7 +5867,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x894490", Frameless: true}]
+              InjectionPoints: [{PC: "0x8945e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5890,14 +5890,14 @@ Probes:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x88f7a8"
+                - PC: "0x88f8f8"
                   Frameless: false
-                - PC: "0x8972fc"
+                - PC: "0x89744c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1494 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x88f7e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x88f930", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5919,11 +5919,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x893ee8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894038", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1385 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x893f54", Frameless: false}]
+              InjectionPoints: [{PC: "0x8940a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5940,481 +5940,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x88cf10..0x88cf20]
+      OutOfLinePCRanges: [0x88d060..0x88d070]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 102 ArrayType [2]uint8
           Locations:
-            - Range: 0x88cf10..0x88cf20
+            - Range: 0x88d060..0x88d070
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x88cf20..0x88cf30]
+      OutOfLinePCRanges: [0x88d070..0x88d080]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 ArrayType [2]int32
           Locations:
-            - Range: 0x88cf20..0x88cf30
+            - Range: 0x88d070..0x88d080
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x88cf30..0x88cf40]
+      OutOfLinePCRanges: [0x88d080..0x88d090]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 104 ArrayType [2]string
           Locations:
-            - Range: 0x88cf30..0x88cf40
+            - Range: 0x88d080..0x88d090
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x88cf40..0x88cf50]
+      OutOfLinePCRanges: [0x88d090..0x88d0a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 ArrayType [2]bool
           Locations:
-            - Range: 0x88cf40..0x88cf50
+            - Range: 0x88d090..0x88d0a0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x88cf50..0x88cf60]
+      OutOfLinePCRanges: [0x88d0a0..0x88d0b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x88cf50..0x88cf60
+            - Range: 0x88d0a0..0x88d0b0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x88cf60..0x88cf70]
+      OutOfLinePCRanges: [0x88d0b0..0x88d0c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 ArrayType [2]int8
           Locations:
-            - Range: 0x88cf60..0x88cf70
+            - Range: 0x88d0b0..0x88d0c0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x88cf70..0x88cf80]
+      OutOfLinePCRanges: [0x88d0c0..0x88d0d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]int16
           Locations:
-            - Range: 0x88cf70..0x88cf80
+            - Range: 0x88d0c0..0x88d0d0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x88cf80..0x88cf90]
+      OutOfLinePCRanges: [0x88d0d0..0x88d0e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 ArrayType [2]int32
           Locations:
-            - Range: 0x88cf80..0x88cf90
+            - Range: 0x88d0d0..0x88d0e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x88cf90..0x88cfa0]
+      OutOfLinePCRanges: [0x88d0e0..0x88d0f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]int64
           Locations:
-            - Range: 0x88cf90..0x88cfa0
+            - Range: 0x88d0e0..0x88d0f0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x88cfa0..0x88cfb0]
+      OutOfLinePCRanges: [0x88d0f0..0x88d100]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]uint
           Locations:
-            - Range: 0x88cfa0..0x88cfb0
+            - Range: 0x88d0f0..0x88d100
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x88cfb0..0x88cfc0]
+      OutOfLinePCRanges: [0x88d100..0x88d110]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 102 ArrayType [2]uint8
           Locations:
-            - Range: 0x88cfb0..0x88cfc0
+            - Range: 0x88d100..0x88d110
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x88cfc0..0x88cfd0]
+      OutOfLinePCRanges: [0x88d110..0x88d120]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]uint16
           Locations:
-            - Range: 0x88cfc0..0x88cfd0
+            - Range: 0x88d110..0x88d120
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x88cfd0..0x88cfe0]
+      OutOfLinePCRanges: [0x88d120..0x88d130]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]uint32
           Locations:
-            - Range: 0x88cfd0..0x88cfe0
+            - Range: 0x88d120..0x88d130
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x88cfe0..0x88cff0]
+      OutOfLinePCRanges: [0x88d130..0x88d140]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 52 ArrayType [2]uint64
           Locations:
-            - Range: 0x88cfe0..0x88cff0
+            - Range: 0x88d130..0x88d140
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x88cff0..0x88d000]
+      OutOfLinePCRanges: [0x88d140..0x88d150]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 113 ArrayType [2][2]int
           Locations:
-            - Range: 0x88cff0..0x88d000
+            - Range: 0x88d140..0x88d150
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x88d000..0x88d010]
+      OutOfLinePCRanges: [0x88d150..0x88d160]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 104 ArrayType [2]string
           Locations:
-            - Range: 0x88d000..0x88d010
+            - Range: 0x88d150..0x88d160
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x88d010..0x88d020]
+      OutOfLinePCRanges: [0x88d160..0x88d170]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 114 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x88d010..0x88d020
+            - Range: 0x88d160..0x88d170
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0x88d020..0x88d030]
+      OutOfLinePCRanges: [0x88d170..0x88d180]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 115 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0x88d020..0x88d030
+            - Range: 0x88d170..0x88d180
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0x88d030..0x88d040]
+      OutOfLinePCRanges: [0x88d180..0x88d190]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 117 ArrayType [2]struct {}
           Locations:
-            - Range: 0x88d030..0x88d040
+            - Range: 0x88d180..0x88d190
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x88d050..0x88d060]
+      OutOfLinePCRanges: [0x88d1a0..0x88d1b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [100]uint
           Locations:
-            - Range: 0x88d050..0x88d060
+            - Range: 0x88d1a0..0x88d1b0
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x88d380..0x88d390]
+      OutOfLinePCRanges: [0x88d4d0..0x88d4e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88d380..0x88d390
+            - Range: 0x88d4d0..0x88d4e0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x88d390..0x88d3a0]
+      OutOfLinePCRanges: [0x88d4e0..0x88d4f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88d390..0x88d3a0
+            - Range: 0x88d4e0..0x88d4f0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x88d3a0..0x88d3b0]
+      OutOfLinePCRanges: [0x88d4f0..0x88d500]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x88d3a0..0x88d3b0
+            - Range: 0x88d4f0..0x88d500
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x88d3b0..0x88d3c0]
+      OutOfLinePCRanges: [0x88d500..0x88d510]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d3b0..0x88d3c0
+            - Range: 0x88d500..0x88d510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x88d3c0..0x88d3d0]
+      OutOfLinePCRanges: [0x88d510..0x88d520]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x88d3c0..0x88d3d0
+            - Range: 0x88d510..0x88d520
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x88d3d0..0x88d3e0]
+      OutOfLinePCRanges: [0x88d520..0x88d530]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 89 BaseType int16
           Locations:
-            - Range: 0x88d3d0..0x88d3e0
+            - Range: 0x88d520..0x88d530
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x88d3e0..0x88d3f0]
+      OutOfLinePCRanges: [0x88d530..0x88d540]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88d3e0..0x88d3f0
+            - Range: 0x88d530..0x88d540
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x88d3f0..0x88d400]
+      OutOfLinePCRanges: [0x88d540..0x88d550]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x88d3f0..0x88d400
+            - Range: 0x88d540..0x88d550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x88d400..0x88d410]
+      OutOfLinePCRanges: [0x88d550..0x88d560]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88d400..0x88d410
+            - Range: 0x88d550..0x88d560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x88d410..0x88d420]
+      OutOfLinePCRanges: [0x88d560..0x88d570]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88d410..0x88d420
+            - Range: 0x88d560..0x88d570
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x88d420..0x88d430]
+      OutOfLinePCRanges: [0x88d570..0x88d580]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x88d420..0x88d430
+            - Range: 0x88d570..0x88d580
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x88d430..0x88d440]
+      OutOfLinePCRanges: [0x88d580..0x88d590]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x88d430..0x88d440
+            - Range: 0x88d580..0x88d590
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x88d440..0x88d450]
+      OutOfLinePCRanges: [0x88d590..0x88d5a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x88d440..0x88d450
+            - Range: 0x88d590..0x88d5a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x88d450..0x88d460]
+      OutOfLinePCRanges: [0x88d5a0..0x88d5b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x88d450..0x88d460
+            - Range: 0x88d5a0..0x88d5b0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x88d460..0x88d470]
+      OutOfLinePCRanges: [0x88d5b0..0x88d5c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x88d460..0x88d470
+            - Range: 0x88d5b0..0x88d5c0
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x88d470..0x88d480]
+      OutOfLinePCRanges: [0x88d5c0..0x88d5d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 120 BaseType main.typeAlias
           Locations:
-            - Range: 0x88d470..0x88d480
+            - Range: 0x88d5c0..0x88d5d0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x88d580..0x88d5a0]
+      OutOfLinePCRanges: [0x88d6d0..0x88d6f0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 121 StructureType main.bigStruct
           Locations:
-            - Range: 0x88d580..0x88d5a0
+            - Range: 0x88d6d0..0x88d6f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6433,48 +6433,48 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x88d5c0..0x88d6e0]
+      OutOfLinePCRanges: [0x88d710..0x88d830]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x88d5c0..0x88d5e0
+            - Range: 0x88d710..0x88d730
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x88d5c0..0x88d6e0, Pieces: []}]
+          Locations: [{Range: 0x88d710..0x88d830, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 9 BaseType int
-          Locations: [{Range: 0x88d5c0..0x88d6e0, Pieces: []}]
+          Locations: [{Range: 0x88d710..0x88d830, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x88d5f8..0x88d618
+            - Range: 0x88d748..0x88d768
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x88d618..0x88d648
+            - Range: 0x88d768..0x88d798
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88d648..0x88d64c
+            - Range: 0x88d798..0x88d79c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: -64}
-            - Range: 0x88d64c..0x88d6e0
+            - Range: 0x88d79c..0x88d830
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
@@ -6485,39 +6485,39 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x88d770..0x88d780]
+      OutOfLinePCRanges: [0x88d8c0..0x88d8d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 125 StructureType main.deepPtr1
           Locations:
-            - Range: 0x88d770..0x88d780
+            - Range: 0x88d8c0..0x88d8d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x88d780..0x88d790]
+      OutOfLinePCRanges: [0x88d8d0..0x88d8e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 128 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x88d780..0x88d790
+            - Range: 0x88d8d0..0x88d8e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x88d920..0x88d930]
+      OutOfLinePCRanges: [0x88da70..0x88da80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 130 StructureType main.deepSlice1
           Locations:
-            - Range: 0x88d920..0x88d930
+            - Range: 0x88da70..0x88da80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6530,129 +6530,129 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x88d930..0x88d940]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 134 PointerType *main.deepSlice7
-          Locations:
-            - Range: 0x88d930..0x88d940
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 43
-      Name: main.testDeepMap1
       OutOfLinePCRanges: [0x88da80..0x88da90]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 136 StructureType main.deepMap1
+          Type: 134 PointerType *main.deepSlice7
           Locations:
             - Range: 0x88da80..0x88da90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 43
+      Name: main.testDeepMap1
+      OutOfLinePCRanges: [0x88dbd0..0x88dbe0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 136 StructureType main.deepMap1
+          Locations:
+            - Range: 0x88dbd0..0x88dbe0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x88da90..0x88daa0]
+      OutOfLinePCRanges: [0x88dbe0..0x88dbf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 PointerType *main.deepMap7
           Locations:
-            - Range: 0x88da90..0x88daa0
+            - Range: 0x88dbe0..0x88dbf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x88daa0..0x88dab0]
+      OutOfLinePCRanges: [0x88dbf0..0x88dc00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 146 PointerType *main.stringType1
           Locations:
-            - Range: 0x88daa0..0x88dab0
+            - Range: 0x88dbf0..0x88dc00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x88dab0..0x88dac0]
+      OutOfLinePCRanges: [0x88dc00..0x88dc10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 148 PointerType **main.stringType2
           Locations:
-            - Range: 0x88dab0..0x88dac0
+            - Range: 0x88dc00..0x88dc10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x88dac0..0x88dcc0]
+      OutOfLinePCRanges: [0x88dc10..0x88de10]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88db88..0x88db98
+            - Range: 0x88dcd8..0x88dce8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88dc38..0x88dc48
+            - Range: 0x88dd88..0x88dd98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88db70..0x88db74
+            - Range: 0x88dcc0..0x88dcc4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88db74..0x88db98
+            - Range: 0x88dcc4..0x88dce8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88db98..0x88dc2c
+            - Range: 0x88dce8..0x88dd7c
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x88dc2c..0x88dc34
+            - Range: 0x88dd7c..0x88dd84
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x88dc34..0x88dcc0
+            - Range: 0x88dd84..0x88de10
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88db6c..0x88db74
+            - Range: 0x88dcbc..0x88dcc4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88db74..0x88db74
+            - Range: 0x88dcc4..0x88dcc4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x88db74..0x88db98
+            - Range: 0x88dcc4..0x88dce8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88db98..0x88dc2c
+            - Range: 0x88dce8..0x88dd7c
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x88dc2c..0x88dc30
+            - Range: 0x88dd7c..0x88dd80
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x88dc30..0x88dc34
+            - Range: 0x88dd80..0x88dd84
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x88dc34..0x88dc48
+            - Range: 0x88dd84..0x88dd98
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x88dc48..0x88dcc0
+            - Range: 0x88dd98..0x88de10
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x88e050..0x88e140]
+      OutOfLinePCRanges: [0x88e1a0..0x88e290]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 150 StructureType main.esotericStack
           Locations:
-            - Range: 0x88e050..0x88e098
+            - Range: 0x88e1a0..0x88e1e8
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6672,7 +6672,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88e098..0x88e09c
+            - Range: 0x88e1e8..0x88e1ec
               Pieces:
                 - Size: 4
                   Op: null
@@ -6692,7 +6692,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88e09c..0x88e0a0
+            - Range: 0x88e1ec..0x88e1f0
               Pieces:
                 - Size: 4
                   Op: null
@@ -6717,157 +6717,157 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x88e140..0x88e1c0]
+      OutOfLinePCRanges: [0x88e290..0x88e310]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 154 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x88e140..0x88e178
+            - Range: 0x88e290..0x88e2c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 50
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x88f2d0..0x88f360]
+      OutOfLinePCRanges: [0x88f420..0x88f4b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f2d0..0x88f308
+            - Range: 0x88f420..0x88f458
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 51
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x88f360..0x88f430]
+      OutOfLinePCRanges: [0x88f4b0..0x88f580]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f360..0x88f37c
+            - Range: 0x88f4b0..0x88f4cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f360..0x88f38c
+            - Range: 0x88f4b0..0x88f4dc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f37c..0x88f38c
+            - Range: 0x88f4cc..0x88f4dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f38c..0x88f430
+            - Range: 0x88f4dc..0x88f580
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x88f430..0x88f4b0]
+      OutOfLinePCRanges: [0x88f580..0x88f600]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f430..0x88f454
+            - Range: 0x88f580..0x88f5a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x88f4b0..0x88f5d0]
+      OutOfLinePCRanges: [0x88f600..0x88f720]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f518..0x88f520
+            - Range: 0x88f668..0x88f670
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88f520..0x88f538
+            - Range: 0x88f670..0x88f688
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88f538..0x88f54c
+            - Range: 0x88f688..0x88f69c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f514..0x88f51c
+            - Range: 0x88f664..0x88f66c
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88f51c..0x88f538
+            - Range: 0x88f66c..0x88f688
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88f538..0x88f548
+            - Range: 0x88f688..0x88f698
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x88f5d0..0x88f5e0]
+      OutOfLinePCRanges: [0x88f720..0x88f730]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f5d0..0x88f5d8
+            - Range: 0x88f720..0x88f728
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f5d0..0x88f5d8
+            - Range: 0x88f720..0x88f728
               Pieces: []
-            - Range: 0x88f5d8..0x88f5d9
+            - Range: 0x88f728..0x88f729
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f5d9..0x88f5e0
+            - Range: 0x88f729..0x88f730
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x88f5e0..0x88f640]
+      OutOfLinePCRanges: [0x88f730..0x88f790]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x88f5e0..0x88f640
+            - Range: 0x88f730..0x88f790
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f5e0..0x88f628
+            - Range: 0x88f730..0x88f778
               Pieces: []
-            - Range: 0x88f628..0x88f629
+            - Range: 0x88f778..0x88f779
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f629..0x88f640
+            - Range: 0x88f779..0x88f790
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0x88f880..0x88f890]
+      OutOfLinePCRanges: [0x88f9d0..0x88f9e0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x88f880..0x88f890
+            - Range: 0x88f9d0..0x88f9e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6878,19 +6878,19 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0x88f890..0x88f900]
+      OutOfLinePCRanges: [0x88f9e0..0x88fa50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x88f890..0x88f8c0
+            - Range: 0x88f9e0..0x88fa10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88f8c0..0x88f8c4
+            - Range: 0x88fa10..0x88fa14
               Pieces:
                 - Size: 8
                   Op: null
@@ -6901,28 +6901,28 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f890..0x88f8d4
+            - Range: 0x88f9e0..0x88fa24
               Pieces: []
-            - Range: 0x88f8d4..0x88f8d5
+            - Range: 0x88fa24..0x88fa25
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88f8d5..0x88f900
+            - Range: 0x88fa25..0x88fa50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0x88f900..0x88f910]
+      OutOfLinePCRanges: [0x88fa50..0x88fa60]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x88f900..0x88f910
+            - Range: 0x88fa50..0x88fa60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6933,41 +6933,41 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x88f910..0x88f980]
+      OutOfLinePCRanges: [0x88fa60..0x88fad0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 158 PointerType *interface {}
           Locations:
-            - Range: 0x88f910..0x88f940
+            - Range: 0x88fa60..0x88fa90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f910..0x88f954
+            - Range: 0x88fa60..0x88faa4
               Pieces: []
-            - Range: 0x88f954..0x88f955
+            - Range: 0x88faa4..0x88faa5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88f955..0x88f980
+            - Range: 0x88faa5..0x88fad0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x88f980..0x88f990]
+      OutOfLinePCRanges: [0x88fad0..0x88fae0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 159 StructureType main.structWithAny
           Locations:
-            - Range: 0x88f980..0x88f990
+            - Range: 0x88fad0..0x88fae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6978,346 +6978,346 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x88ff30..0x88ff40]
+      OutOfLinePCRanges: [0x890080..0x890090]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 160 StructureType main.structWithMap
-          Locations:
-            - Range: 0x88ff30..0x88ff40
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x88ff40..0x88ff50]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 166 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x88ff40..0x88ff50
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 63
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x88ff50..0x88ff60]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 171 GoMapType map[string]int
-          Locations:
-            - Range: 0x88ff50..0x88ff60
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x88ff60..0x88ff70]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 176 GoMapType map[string][]string
-          Locations:
-            - Range: 0x88ff60..0x88ff70
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x88ff70..0x88ff80]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 181 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0x88ff70..0x88ff80
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 66
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0x88ff80..0x88ff90]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 171 GoMapType map[string]int
-          Locations:
-            - Range: 0x88ff80..0x88ff90
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x88ff90..0x88ffa0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 186 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0x88ff90..0x88ffa0
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x88ffa0..0x88ffb0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 187 PointerType *map[string]int
-          Locations:
-            - Range: 0x88ffa0..0x88ffb0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x88ffb0..0x88ffc0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 161 GoMapType map[int]int
-          Locations:
-            - Range: 0x88ffb0..0x88ffc0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0x88ffc0..0x88ffd0]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 188 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x88ffc0..0x88ffd0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 71
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x88ffd0..0x88ffe0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 188 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x88ffd0..0x88ffe0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 72
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x88ffe0..0x88fff0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 193 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0x88ffe0..0x88fff0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 73
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x88fff0..0x890000]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 198 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x88fff0..0x890000
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 74
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x890000..0x890010]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 198 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x890000..0x890010
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x890010..0x890020]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 203 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x890010..0x890020
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x890020..0x890030]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 203 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x890020..0x890030
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 77
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x890030..0x890040]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 203 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x890030..0x890040
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 78
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x890040..0x890050]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 208 GoMapType map[uint8][4]int
-          Locations:
-            - Range: 0x890040..0x890050
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 79
-      Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x890050..0x890060]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 213 GoMapType map[[4]int]uint8
-          Locations:
-            - Range: 0x890050..0x890060
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 80
-      Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x890060..0x890070]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 218 GoMapType map[[4]int][4]int
-          Locations:
-            - Range: 0x890060..0x890070
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 81
-      Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x890070..0x890080]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 223 GoMapType map[struct {}]int
-          Locations:
-            - Range: 0x890070..0x890080
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 82
-      Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x890080..0x890090]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 228 GoMapType map[int]struct {}
           Locations:
             - Range: 0x890080..0x890090
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 62
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x890090..0x8900a0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 233 GoMapType map[struct {}]struct {}
+          Type: 166 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x890090..0x8900a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 63
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0x8900a0..0x8900b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 171 GoMapType map[string]int
+          Locations:
+            - Range: 0x8900a0..0x8900b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 64
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0x8900b0..0x8900c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 176 GoMapType map[string][]string
+          Locations:
+            - Range: 0x8900b0..0x8900c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 65
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0x8900c0..0x8900d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 181 GoMapType map[[4]string][2]int
+          Locations:
+            - Range: 0x8900c0..0x8900d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 66
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x8900d0..0x8900e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 171 GoMapType map[string]int
+          Locations:
+            - Range: 0x8900d0..0x8900e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 67
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x8900e0..0x8900f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 186 ArrayType [2]map[string]int
+          Locations:
+            - Range: 0x8900e0..0x8900f0
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 68
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x8900f0..0x890100]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 187 PointerType *map[string]int
+          Locations:
+            - Range: 0x8900f0..0x890100
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 69
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x890100..0x890110]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 161 GoMapType map[int]int
+          Locations:
+            - Range: 0x890100..0x890110
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 70
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x890110..0x890120]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 188 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x890110..0x890120
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 71
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x890120..0x890130]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 188 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x890120..0x890130
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 72
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x890130..0x890140]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 193 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0x890130..0x890140
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x890140..0x890150]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 198 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x890140..0x890150
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x890150..0x890160]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 198 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x890150..0x890160
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 75
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x890160..0x890170]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 203 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x890160..0x890170
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 76
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x890170..0x890180]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 203 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x890170..0x890180
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x890180..0x890190]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 203 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x890180..0x890190
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 78
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x890190..0x8901a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x890190..0x8901a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 79
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x8901a0..0x8901b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 213 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x8901a0..0x8901b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 80
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x8901b0..0x8901c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 218 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x8901b0..0x8901c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 81
+      Name: main.testMapEmptyKey
+      OutOfLinePCRanges: [0x8901c0..0x8901d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 223 GoMapType map[struct {}]int
+          Locations:
+            - Range: 0x8901c0..0x8901d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 82
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0x8901d0..0x8901e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 228 GoMapType map[int]struct {}
+          Locations:
+            - Range: 0x8901d0..0x8901e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x8901e0..0x8901f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 233 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x8901e0..0x8901f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x891400..0x891410]
+      OutOfLinePCRanges: [0x891550..0x891560]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x891400..0x891410
+            - Range: 0x891550..0x891560
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x891400..0x891410
+            - Range: 0x891550..0x891560
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x891400..0x891410
+            - Range: 0x891550..0x891560
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x891420..0x891430]
+      OutOfLinePCRanges: [0x891570..0x891580]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x891420..0x891430
+            - Range: 0x891570..0x891580
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x891420..0x891430
+            - Range: 0x891570..0x891580
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7328,48 +7328,48 @@ Subprograms:
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x891420..0x891430
+            - Range: 0x891570..0x891580
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x8914e0..0x8914f0]
+      OutOfLinePCRanges: [0x891630..0x891640]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8914e0..0x8914f0
+            - Range: 0x891630..0x891640
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8914e0..0x8914f0
+            - Range: 0x891630..0x891640
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x8914e0..0x8914f0
+            - Range: 0x891630..0x891640
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x8914e0..0x8914f0
+            - Range: 0x891630..0x891640
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8914e0..0x8914f0
+            - Range: 0x891630..0x891640
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7380,63 +7380,63 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x891680..0x8916c0]
+      OutOfLinePCRanges: [0x8917d0..0x891810]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x891680..0x8916bc
+            - Range: 0x8917d0..0x89180c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x891680..0x8916bc
+            - Range: 0x8917d0..0x89180c
               Pieces: []
-            - Range: 0x8916bc..0x8916bd
+            - Range: 0x89180c..0x89180d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8916bd..0x8916c0
+            - Range: 0x89180d..0x891810
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0x8916c0..0x8916d0]
+      OutOfLinePCRanges: [0x891810..0x891820]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 238 GoChannelType chan bool
           Locations:
-            - Range: 0x8916c0..0x8916d0
+            - Range: 0x891810..0x891820
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x891870..0x891880]
+      OutOfLinePCRanges: [0x8919c0..0x8919d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x891870..0x891880
+            - Range: 0x8919c0..0x8919d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x891880..0x891890]
+      OutOfLinePCRanges: [0x8919d0..0x8919e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 241 StructureType main.node
           Locations:
-            - Range: 0x891880..0x891890
+            - Range: 0x8919d0..0x8919e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7447,273 +7447,273 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x891890..0x8918a0]
+      OutOfLinePCRanges: [0x8919e0..0x8919f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.node
           Locations:
-            - Range: 0x891890..0x8918a0
+            - Range: 0x8919e0..0x8919f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x8918a0..0x8918b0]
+      OutOfLinePCRanges: [0x8919f0..0x891a00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x8918a0..0x8918b0
+            - Range: 0x8919f0..0x891a00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x8918c0..0x8918d0]
+      OutOfLinePCRanges: [0x891a10..0x891a20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 100 PointerType *uint
           Locations:
-            - Range: 0x8918c0..0x8918d0
+            - Range: 0x891a10..0x891a20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x891930..0x891940]
+      OutOfLinePCRanges: [0x891a80..0x891a90]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 88 PointerType *string
           Locations:
-            - Range: 0x891930..0x891940
+            - Range: 0x891a80..0x891a90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x891950..0x891960]
+      OutOfLinePCRanges: [0x891aa0..0x891ab0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0x891950..0x891960
+            - Range: 0x891aa0..0x891ab0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x891950..0x891960
+            - Range: 0x891aa0..0x891ab0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0x891970..0x891980]
+      OutOfLinePCRanges: [0x891ac0..0x891ad0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 243 PointerType *main.t
           Locations:
-            - Range: 0x891970..0x891980
+            - Range: 0x891ac0..0x891ad0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x891d80..0x891e00]
+      OutOfLinePCRanges: [0x891ed0..0x891f50]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891d80..0x891d9c
+            - Range: 0x891ed0..0x891eec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891d80..0x891ddc
+            - Range: 0x891ed0..0x891f2c
               Pieces: []
-            - Range: 0x891ddc..0x891ddd
+            - Range: 0x891f2c..0x891f2d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891ddd..0x891e00
+            - Range: 0x891f2d..0x891f50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891d9c..0x891da8
+            - Range: 0x891eec..0x891ef8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891da8..0x891e00
+            - Range: 0x891ef8..0x891f50
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x891e00..0x891ea0]
+      OutOfLinePCRanges: [0x891f50..0x891ff0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891e00..0x891e24
+            - Range: 0x891f50..0x891f74
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891e24..0x891ea0
+            - Range: 0x891f74..0x891ff0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x891e00..0x891e7c
+            - Range: 0x891f50..0x891fcc
               Pieces: []
-            - Range: 0x891e7c..0x891e7d
+            - Range: 0x891fcc..0x891fcd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891e7d..0x891ea0
+            - Range: 0x891fcd..0x891ff0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x891e28..0x891e44
+            - Range: 0x891f78..0x891f94
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891e44..0x891ea0
+            - Range: 0x891f94..0x891ff0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x891ea0..0x891f70]
+      OutOfLinePCRanges: [0x891ff0..0x8920c0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891ea0..0x891ef8
+            - Range: 0x891ff0..0x892048
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891ea0..0x891f50
+            - Range: 0x891ff0..0x8920a0
               Pieces: []
-            - Range: 0x891f50..0x891f51
+            - Range: 0x8920a0..0x8920a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891f51..0x891f70
+            - Range: 0x8920a1..0x8920c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x891ea0..0x891f70, Pieces: []}]
+          Locations: [{Range: 0x891ff0..0x8920c0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891ebc..0x891efc
+            - Range: 0x89200c..0x89204c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891efc..0x891f70
+            - Range: 0x89204c..0x8920c0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x891ecc..0x891efc
+            - Range: 0x89201c..0x89204c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x891efc..0x891f70
+            - Range: 0x89204c..0x8920c0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x891f70..0x891ff0]
+      OutOfLinePCRanges: [0x8920c0..0x892140]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x891f70..0x891f94
+            - Range: 0x8920c0..0x8920e4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x891f70..0x891fb8
+            - Range: 0x8920c0..0x892108
               Pieces: []
-            - Range: 0x891fb8..0x891fb9
+            - Range: 0x892108..0x892109
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x891fb9..0x891fcc
+            - Range: 0x892109..0x89211c
               Pieces: []
-            - Range: 0x891fcc..0x891fcd
+            - Range: 0x89211c..0x89211d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x891fcd..0x891ff0
+            - Range: 0x89211d..0x892140
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x891ff0..0x892170]
+      OutOfLinePCRanges: [0x892140..0x8922c0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x891ff0..0x892048
+            - Range: 0x892140..0x892198
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892048..0x89204c
+            - Range: 0x892198..0x89219c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8920a4..0x8920a8
+            - Range: 0x8921f4..0x8921f8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x8920d4..0x8920d8
+            - Range: 0x892224..0x892228
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892114..0x892118
+            - Range: 0x892264..0x892268
               Pieces:
                 - Size: 8
                   Op: null
@@ -7724,117 +7724,117 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x891ff0..0x892044
+            - Range: 0x892140..0x892194
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x891ff0..0x892074
+            - Range: 0x892140..0x8921c4
               Pieces: []
-            - Range: 0x892074..0x892075
+            - Range: 0x8921c4..0x8921c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892075..0x8920c0
+            - Range: 0x8921c5..0x892210
               Pieces: []
-            - Range: 0x8920c0..0x8920c1
+            - Range: 0x892210..0x892211
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8920c1..0x892100
+            - Range: 0x892211..0x892250
               Pieces: []
-            - Range: 0x892100..0x892101
+            - Range: 0x892250..0x892251
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892101..0x892140
+            - Range: 0x892251..0x892290
               Pieces: []
-            - Range: 0x892140..0x892141
+            - Range: 0x892290..0x892291
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892141..0x892170
+            - Range: 0x892291..0x8922c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x891ff0..0x892074
+            - Range: 0x892140..0x8921c4
               Pieces: []
-            - Range: 0x892074..0x892075
+            - Range: 0x8921c4..0x8921c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x892075..0x8920c0
+            - Range: 0x8921c5..0x892210
               Pieces: []
-            - Range: 0x8920c0..0x8920c1
+            - Range: 0x892210..0x892211
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8920c1..0x892100
+            - Range: 0x892211..0x892250
               Pieces: []
-            - Range: 0x892100..0x892101
+            - Range: 0x892250..0x892251
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x892101..0x892140
+            - Range: 0x892251..0x892290
               Pieces: []
-            - Range: 0x892140..0x892141
+            - Range: 0x892290..0x892291
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x892141..0x892170
+            - Range: 0x892291..0x8922c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8920a4..0x8920ac
+            - Range: 0x8921f4..0x8921fc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x892170..0x892370]
+      OutOfLinePCRanges: [0x8922c0..0x8924c0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x892170..0x8921cc
+            - Range: 0x8922c0..0x89231c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8921cc..0x8921d0
+            - Range: 0x89231c..0x892320
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8921d0..0x892370
+            - Range: 0x892320..0x8924c0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7845,549 +7845,549 @@ Subprograms:
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x892170..0x892228
+            - Range: 0x8922c0..0x892378
               Pieces: []
-            - Range: 0x892228..0x892229
+            - Range: 0x892378..0x892379
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892229..0x892270
+            - Range: 0x892379..0x8923c0
               Pieces: []
-            - Range: 0x892270..0x892271
+            - Range: 0x8923c0..0x8923c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892271..0x892334
+            - Range: 0x8923c1..0x892484
               Pieces: []
-            - Range: 0x892334..0x892335
+            - Range: 0x892484..0x892485
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892335..0x892348
+            - Range: 0x892485..0x892498
               Pieces: []
-            - Range: 0x892348..0x892349
+            - Range: 0x892498..0x892499
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892349..0x892370
+            - Range: 0x892499..0x8924c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x89225c..0x892264
+            - Range: 0x8923ac..0x8923b4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x89220c..0x892228
+            - Range: 0x89235c..0x892378
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x892370..0x8924e0]
+      OutOfLinePCRanges: [0x8924c0..0x892630]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x892370..0x8923ac
+            - Range: 0x8924c0..0x8924fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8923ac..0x89240c
+            - Range: 0x8924fc..0x89255c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x89240c..0x892478
+            - Range: 0x89255c..0x8925c8
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x892478..0x8924a0
+            - Range: 0x8925c8..0x8925f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8924a0..0x8924a4
+            - Range: 0x8925f0..0x8925f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8924a4..0x8924e0
+            - Range: 0x8925f4..0x892630
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x892370..0x892458
+            - Range: 0x8924c0..0x8925a8
               Pieces: []
-            - Range: 0x892458..0x892459
+            - Range: 0x8925a8..0x8925a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x892459..0x89246c
+            - Range: 0x8925a9..0x8925bc
               Pieces: []
-            - Range: 0x89246c..0x89246d
+            - Range: 0x8925bc..0x8925bd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89246d..0x8924e0
+            - Range: 0x8925bd..0x892630
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x892370..0x8923ac
+            - Range: 0x8924c0..0x8924fc
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8923ac..0x8923fc
+            - Range: 0x8924fc..0x89254c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8923fc..0x89240c
+            - Range: 0x89254c..0x89255c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x89240c..0x892464
+            - Range: 0x89255c..0x8925b4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x892464..0x892468
+            - Range: 0x8925b4..0x8925b8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x892468..0x89246c
+            - Range: 0x8925b8..0x8925bc
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x89246c..0x8924e0
+            - Range: 0x8925bc..0x892630
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x8924e0..0x892580]
+      OutOfLinePCRanges: [0x892630..0x8926d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8924e0..0x8924fc
+            - Range: 0x892630..0x89264c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8924e0..0x892558
+            - Range: 0x892630..0x8926a8
               Pieces: []
-            - Range: 0x892558..0x892559
+            - Range: 0x8926a8..0x8926a9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892559..0x892580
+            - Range: 0x8926a9..0x8926d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x892580..0x892650]
+      OutOfLinePCRanges: [0x8926d0..0x8927a0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892580..0x8925d0
+            - Range: 0x8926d0..0x892720
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892580..0x892624
+            - Range: 0x8926d0..0x892774
               Pieces: []
-            - Range: 0x892624..0x892625
+            - Range: 0x892774..0x892775
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892625..0x892650
+            - Range: 0x892775..0x8927a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892580..0x892624
+            - Range: 0x8926d0..0x892774
               Pieces: []
-            - Range: 0x892624..0x892625
+            - Range: 0x892774..0x892775
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x892625..0x892650
+            - Range: 0x892775..0x8927a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x892650..0x892720]
+      OutOfLinePCRanges: [0x8927a0..0x892870]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892650..0x892690
+            - Range: 0x8927a0..0x8927e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892690..0x892720
+            - Range: 0x8927e0..0x892870
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892650..0x8926f4
+            - Range: 0x8927a0..0x892844
               Pieces: []
-            - Range: 0x8926f4..0x8926f5
+            - Range: 0x892844..0x892845
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8926f5..0x892720
+            - Range: 0x892845..0x892870
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892650..0x8926f4
+            - Range: 0x8927a0..0x892844
               Pieces: []
-            - Range: 0x8926f4..0x8926f5
+            - Range: 0x892844..0x892845
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8926f5..0x892720
+            - Range: 0x892845..0x892870
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892650..0x8926f4
+            - Range: 0x8927a0..0x892844
               Pieces: []
-            - Range: 0x8926f4..0x8926f5
+            - Range: 0x892844..0x892845
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8926f5..0x892720
+            - Range: 0x892845..0x892870
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x892720..0x892810]
+      OutOfLinePCRanges: [0x892870..0x892960]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892720..0x892760
+            - Range: 0x892870..0x8928b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892760..0x892810
+            - Range: 0x8928b0..0x892960
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892720..0x8927e8
+            - Range: 0x892870..0x892938
               Pieces: []
-            - Range: 0x8927e8..0x8927e9
+            - Range: 0x892938..0x892939
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8927e9..0x892810
+            - Range: 0x892939..0x892960
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892720..0x8927e8
+            - Range: 0x892870..0x892938
               Pieces: []
-            - Range: 0x8927e8..0x8927e9
+            - Range: 0x892938..0x892939
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8927e9..0x892810
+            - Range: 0x892939..0x892960
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x892810..0x8929d0]
+      OutOfLinePCRanges: [0x892960..0x892b20]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892810..0x892874
+            - Range: 0x892960..0x8929c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892874..0x8929d0
+            - Range: 0x8929c4..0x892b20
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x89283c..0x8929d0
+            - Range: 0x89298c..0x892b20
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892840..0x8929d0
+            - Range: 0x892990..0x892b20
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x892ab0..0x892b40]
+      OutOfLinePCRanges: [0x892c00..0x892c90]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x892ab0..0x892b20
+            - Range: 0x892c00..0x892c70
               Pieces: []
-            - Range: 0x892b20..0x892b21
+            - Range: 0x892c70..0x892c71
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892b21..0x892b40
+            - Range: 0x892c71..0x892c90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 89 BaseType int16
           Locations:
-            - Range: 0x892ab0..0x892b20
+            - Range: 0x892c00..0x892c70
               Pieces: []
-            - Range: 0x892b20..0x892b21
+            - Range: 0x892c70..0x892c71
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x892b21..0x892b40
+            - Range: 0x892c71..0x892c90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x892ab0..0x892b20
+            - Range: 0x892c00..0x892c70
               Pieces: []
-            - Range: 0x892b20..0x892b21
+            - Range: 0x892c70..0x892c71
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x892b21..0x892b40
+            - Range: 0x892c71..0x892c90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x892ab0..0x892b20
+            - Range: 0x892c00..0x892c70
               Pieces: []
-            - Range: 0x892b20..0x892b21
+            - Range: 0x892c70..0x892c71
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x892b21..0x892b40
+            - Range: 0x892c71..0x892c90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x892ab0..0x892b20
+            - Range: 0x892c00..0x892c70
               Pieces: []
-            - Range: 0x892b20..0x892b21
+            - Range: 0x892c70..0x892c71
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x892b21..0x892b40
+            - Range: 0x892c71..0x892c90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x892ab0..0x892b20
+            - Range: 0x892c00..0x892c70
               Pieces: []
-            - Range: 0x892b20..0x892b21
+            - Range: 0x892c70..0x892c71
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x892b21..0x892b40
+            - Range: 0x892c71..0x892c90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x892ab0..0x892b20
+            - Range: 0x892c00..0x892c70
               Pieces: []
-            - Range: 0x892b20..0x892b21
+            - Range: 0x892c70..0x892c71
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x892b21..0x892b40
+            - Range: 0x892c71..0x892c90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x892ab0..0x892b20
+            - Range: 0x892c00..0x892c70
               Pieces: []
-            - Range: 0x892b20..0x892b21
+            - Range: 0x892c70..0x892c71
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x892b21..0x892b40
+            - Range: 0x892c71..0x892c90
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x892b40..0x892c00]
+      OutOfLinePCRanges: [0x892c90..0x892d50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892b40..0x892c00, Pieces: []}]
+          Locations: [{Range: 0x892c90..0x892d50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x892b40..0x892bdc
+            - Range: 0x892c90..0x892d2c
               Pieces: []
-            - Range: 0x892bdc..0x892bdd
+            - Range: 0x892d2c..0x892d2d
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x892bdd..0x892c00
+            - Range: 0x892d2d..0x892d50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x892c00..0x892c80]
+      OutOfLinePCRanges: [0x892d50..0x892dd0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 90 BaseType complex64
-          Locations: [{Range: 0x892c00..0x892c80, Pieces: []}]
+          Locations: [{Range: 0x892d50..0x892dd0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 91 BaseType complex128
-          Locations: [{Range: 0x892c00..0x892c80, Pieces: []}]
+          Locations: [{Range: 0x892d50..0x892dd0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x892c80..0x892d50]
+      OutOfLinePCRanges: [0x892dd0..0x892ea0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x892c80..0x892d34
+            - Range: 0x892dd0..0x892e84
               Pieces: []
-            - Range: 0x892d34..0x892d35
+            - Range: 0x892e84..0x892e85
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8409,193 +8409,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x892d35..0x892d50
+            - Range: 0x892e85..0x892ea0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x892d50..0x892de0]
+      OutOfLinePCRanges: [0x892ea0..0x892f30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x892d50..0x892dc0
+            - Range: 0x892ea0..0x892f10
               Pieces: []
-            - Range: 0x892dc0..0x892dc1
+            - Range: 0x892f10..0x892f11
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x892dc1..0x892de0
+            - Range: 0x892f11..0x892f30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x892de0..0x892e50]
+      OutOfLinePCRanges: [0x892f30..0x892fa0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 247 ArrayType [1]int
           Locations:
-            - Range: 0x892de0..0x892e34
+            - Range: 0x892f30..0x892f84
               Pieces: []
-            - Range: 0x892e34..0x892e35
+            - Range: 0x892f84..0x892f85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892e35..0x892e50
+            - Range: 0x892f85..0x892fa0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x892e50..0x892ec0]
+      OutOfLinePCRanges: [0x892fa0..0x893010]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0x892e50..0x892ea0
+            - Range: 0x892fa0..0x892ff0
               Pieces: []
-            - Range: 0x892ea0..0x892ea1
+            - Range: 0x892ff0..0x892ff1
               Pieces: []
-            - Range: 0x892ea1..0x892ec0
+            - Range: 0x892ff1..0x893010
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x892ec0..0x892f40]
+      OutOfLinePCRanges: [0x893010..0x893090]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 StructureType main.mixedStruct
-          Locations: [{Range: 0x892ec0..0x892f40, Pieces: []}]
+          Locations: [{Range: 0x893010..0x893090, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x892f40..0x892fe0]
+      OutOfLinePCRanges: [0x893090..0x893130]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f40..0x892fbc
+            - Range: 0x893090..0x89310c
               Pieces: []
-            - Range: 0x892fbc..0x892fbd
+            - Range: 0x89310c..0x89310d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892fbd..0x892fe0
+            - Range: 0x89310d..0x893130
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f40..0x892fbc
+            - Range: 0x893090..0x89310c
               Pieces: []
-            - Range: 0x892fbc..0x892fbd
+            - Range: 0x89310c..0x89310d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x892fbd..0x892fe0
+            - Range: 0x89310d..0x893130
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f40..0x892fbc
+            - Range: 0x893090..0x89310c
               Pieces: []
-            - Range: 0x892fbc..0x892fbd
+            - Range: 0x89310c..0x89310d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x892fbd..0x892fe0
+            - Range: 0x89310d..0x893130
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f40..0x892fbc
+            - Range: 0x893090..0x89310c
               Pieces: []
-            - Range: 0x892fbc..0x892fbd
+            - Range: 0x89310c..0x89310d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x892fbd..0x892fe0
+            - Range: 0x89310d..0x893130
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f40..0x892fbc
+            - Range: 0x893090..0x89310c
               Pieces: []
-            - Range: 0x892fbc..0x892fbd
+            - Range: 0x89310c..0x89310d
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x892fbd..0x892fe0
+            - Range: 0x89310d..0x893130
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f40..0x892fbc
+            - Range: 0x893090..0x89310c
               Pieces: []
-            - Range: 0x892fbc..0x892fbd
+            - Range: 0x89310c..0x89310d
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x892fbd..0x892fe0
+            - Range: 0x89310d..0x893130
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f40..0x892fbc
+            - Range: 0x893090..0x89310c
               Pieces: []
-            - Range: 0x892fbc..0x892fbd
+            - Range: 0x89310c..0x89310d
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x892fbd..0x892fe0
+            - Range: 0x89310d..0x893130
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892f40..0x892fbc
+            - Range: 0x893090..0x89310c
               Pieces: []
-            - Range: 0x892fbc..0x892fbd
+            - Range: 0x89310c..0x89310d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x892fbd..0x892fe0
+            - Range: 0x89310d..0x893130
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892f40..0x892fbc
+            - Range: 0x893090..0x89310c
               Pieces: []
-            - Range: 0x892fbc..0x892fbd
+            - Range: 0x89310c..0x89310d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x892fbd..0x892fe0
+            - Range: 0x89310d..0x893130
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x892fe0..0x8930c0]
+      OutOfLinePCRanges: [0x893130..0x893210]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.wideStruct
           Locations:
-            - Range: 0x892fe0..0x8930a4
+            - Range: 0x893130..0x8931f4
               Pieces: []
-            - Range: 0x8930a4..0x8930a5
+            - Range: 0x8931f4..0x8931f5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8619,145 +8619,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x8930a5..0x8930c0
+            - Range: 0x8931f5..0x893210
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x8930c0..0x893150]
+      OutOfLinePCRanges: [0x893210..0x8932a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8930c0..0x893130
+            - Range: 0x893210..0x893280
               Pieces: []
-            - Range: 0x893130..0x893131
+            - Range: 0x893280..0x893281
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893131..0x893150
+            - Range: 0x893281..0x8932a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x8930c0..0x893150, Pieces: []}]
+          Locations: [{Range: 0x893210..0x8932a0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8930c0..0x893130
+            - Range: 0x893210..0x893280
               Pieces: []
-            - Range: 0x893130..0x893131
+            - Range: 0x893280..0x893281
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893131..0x893150
+            - Range: 0x893281..0x8932a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x8930c0..0x893150, Pieces: []}]
+          Locations: [{Range: 0x893210..0x8932a0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8930c0..0x893130
+            - Range: 0x893210..0x893280
               Pieces: []
-            - Range: 0x893130..0x893131
+            - Range: 0x893280..0x893281
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x893131..0x893150
+            - Range: 0x893281..0x8932a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x893150..0x8931e0]
+      OutOfLinePCRanges: [0x8932a0..0x893330]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x893150..0x8931c0
+            - Range: 0x8932a0..0x893310
               Pieces: []
-            - Range: 0x8931c0..0x8931c1
+            - Range: 0x893310..0x893311
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8931c1..0x8931e0
+            - Range: 0x893311..0x893330
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x8931e0..0x893250]
+      OutOfLinePCRanges: [0x893330..0x8933a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x8931e0..0x893250, Pieces: []}]
+          Locations: [{Range: 0x893330..0x8933a0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x893250..0x8932d0]
+      OutOfLinePCRanges: [0x8933a0..0x893420]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float32
-          Locations: [{Range: 0x893250..0x8932d0, Pieces: []}]
+          Locations: [{Range: 0x8933a0..0x893420, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x893250..0x8932d0, Pieces: []}]
+          Locations: [{Range: 0x8933a0..0x893420, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x8932d0..0x893340]
+      OutOfLinePCRanges: [0x893420..0x893490]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8932d0..0x893328
+            - Range: 0x893420..0x893478
               Pieces: []
-            - Range: 0x893328..0x893329
+            - Range: 0x893478..0x893479
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893329..0x893340
+            - Range: 0x893479..0x893490
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x8932d0..0x893328
+            - Range: 0x893420..0x893478
               Pieces: []
-            - Range: 0x893328..0x893329
+            - Range: 0x893478..0x893479
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893329..0x893340
+            - Range: 0x893479..0x893490
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x893340..0x893520]
+      OutOfLinePCRanges: [0x893490..0x893670]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x893340..0x8933ac
+            - Range: 0x893490..0x8934fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8779,7 +8779,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8933ac..0x8933c0
+            - Range: 0x8934fc..0x893510
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8801,7 +8801,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8933c0..0x8933c4
+            - Range: 0x893510..0x893514
               Pieces:
                 - Size: 8
                   Op: null
@@ -8828,9 +8828,9 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x893340..0x8934b8
+            - Range: 0x893490..0x893608
               Pieces: []
-            - Range: 0x8934b8..0x8934b9
+            - Range: 0x893608..0x893609
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8852,44 +8852,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8934b9..0x893520
+            - Range: 0x893609..0x893670
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x893520..0x8935f0]
+      OutOfLinePCRanges: [0x893670..0x893740]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x893520..0x8935f0
+            - Range: 0x893670..0x893740
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x893520..0x8935d4
+            - Range: 0x893670..0x893724
               Pieces: []
-            - Range: 0x8935d4..0x8935d5
+            - Range: 0x893724..0x893725
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x8935d5..0x8935f0
+            - Range: 0x893725..0x893740
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x8935f0..0x893850]
+      OutOfLinePCRanges: [0x893740..0x8939a0]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x8935f0..0x893660
+            - Range: 0x893740..0x8937b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8911,7 +8911,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x893660..0x893674
+            - Range: 0x8937b0..0x8937c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8933,7 +8933,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x893674..0x893678
+            - Range: 0x8937c4..0x8937c8
               Pieces:
                 - Size: 8
                   Op: null
@@ -8960,16 +8960,16 @@ Subprograms:
         - Name: s2
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x8935f0..0x893850
+            - Range: 0x893740..0x8939a0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x8935f0..0x8937e0
+            - Range: 0x893740..0x893930
               Pieces: []
-            - Range: 0x8937e0..0x8937e1
+            - Range: 0x893930..0x893931
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8991,196 +8991,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8937e1..0x893850
+            - Range: 0x893931..0x8939a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x893850..0x893a40]
+      OutOfLinePCRanges: [0x8939a0..0x893b90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893850..0x8938c8
+            - Range: 0x8939a0..0x893a18
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8938c8..0x893a40
+            - Range: 0x893a18..0x893b90
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893850..0x8938c8
+            - Range: 0x8939a0..0x893a18
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8938c8..0x893a40
+            - Range: 0x893a18..0x893b90
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893850..0x8938c8
+            - Range: 0x8939a0..0x893a18
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8938c8..0x893a40
+            - Range: 0x893a18..0x893b90
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893850..0x8938c8
+            - Range: 0x8939a0..0x893a18
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8938c8..0x893a40
+            - Range: 0x893a18..0x893b90
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893850..0x8938c8
+            - Range: 0x8939a0..0x893a18
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8938c8..0x893a40
+            - Range: 0x893a18..0x893b90
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893850..0x8938c8
+            - Range: 0x8939a0..0x893a18
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8938c8..0x893a40
+            - Range: 0x893a18..0x893b90
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893850..0x8938c8
+            - Range: 0x8939a0..0x893a18
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8938c8..0x893a40
+            - Range: 0x893a18..0x893b90
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893850..0x8938c8
+            - Range: 0x8939a0..0x893a18
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8938c8..0x893a40
+            - Range: 0x893a18..0x893b90
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893850..0x8938c8
+            - Range: 0x8939a0..0x893a18
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x8938c8..0x893a40
+            - Range: 0x893a18..0x893b90
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x893850..0x8939dc
+            - Range: 0x8939a0..0x893b2c
               Pieces: []
-            - Range: 0x8939dc..0x8939dd
+            - Range: 0x893b2c..0x893b2d
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x8939dd..0x893a40
+            - Range: 0x893b2d..0x893b90
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x893a40..0x893c80]
+      OutOfLinePCRanges: [0x893b90..0x893dd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a40..0x893ac8
+            - Range: 0x893b90..0x893c18
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893ac8..0x893c80
+            - Range: 0x893c18..0x893dd0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a40..0x893ac8
+            - Range: 0x893b90..0x893c18
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893ac8..0x893c80
+            - Range: 0x893c18..0x893dd0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a40..0x893ac8
+            - Range: 0x893b90..0x893c18
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x893ac8..0x893c80
+            - Range: 0x893c18..0x893dd0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a40..0x893ac8
+            - Range: 0x893b90..0x893c18
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x893ac8..0x893c80
+            - Range: 0x893c18..0x893dd0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a40..0x893ac8
+            - Range: 0x893b90..0x893c18
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x893ac8..0x893c80
+            - Range: 0x893c18..0x893dd0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a40..0x893ac8
+            - Range: 0x893b90..0x893c18
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x893ac8..0x893c80
+            - Range: 0x893c18..0x893dd0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a40..0x893ac8
+            - Range: 0x893b90..0x893c18
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x893ac8..0x893c80
+            - Range: 0x893c18..0x893dd0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a40..0x893ac8
+            - Range: 0x893b90..0x893c18
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x893ac8..0x893c80
+            - Range: 0x893c18..0x893dd0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x893a40..0x893ac8
+            - Range: 0x893b90..0x893c18
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x893ac8..0x893c80
+            - Range: 0x893c18..0x893dd0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9191,9 +9191,9 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x893a40..0x893c10
+            - Range: 0x893b90..0x893d60
               Pieces: []
-            - Range: 0x893c10..0x893c11
+            - Range: 0x893d60..0x893d61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9215,196 +9215,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x893c11..0x893c80
+            - Range: 0x893d61..0x893dd0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x893c80..0x893d20]
+      OutOfLinePCRanges: [0x893dd0..0x893e70]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x893c80..0x893d20
+            - Range: 0x893dd0..0x893e70
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893c80..0x893cfc
+            - Range: 0x893dd0..0x893e4c
               Pieces: []
-            - Range: 0x893cfc..0x893cfd
+            - Range: 0x893e4c..0x893e4d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893cfd..0x893d20
+            - Range: 0x893e4d..0x893e70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893c80..0x893cfc
+            - Range: 0x893dd0..0x893e4c
               Pieces: []
-            - Range: 0x893cfc..0x893cfd
+            - Range: 0x893e4c..0x893e4d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893cfd..0x893d20
+            - Range: 0x893e4d..0x893e70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893c80..0x893cfc
+            - Range: 0x893dd0..0x893e4c
               Pieces: []
-            - Range: 0x893cfc..0x893cfd
+            - Range: 0x893e4c..0x893e4d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x893cfd..0x893d20
+            - Range: 0x893e4d..0x893e70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x893d20..0x893e00]
+      OutOfLinePCRanges: [0x893e70..0x893f50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x893d20..0x893e00
+            - Range: 0x893e70..0x893f50
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x893d20..0x893e00
+            - Range: 0x893e70..0x893f50
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893d20..0x893de0
+            - Range: 0x893e70..0x893f30
               Pieces: []
-            - Range: 0x893de0..0x893de1
+            - Range: 0x893f30..0x893f31
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893de1..0x893e00
+            - Range: 0x893f31..0x893f50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x893d20..0x893de0
+            - Range: 0x893e70..0x893f30
               Pieces: []
-            - Range: 0x893de0..0x893de1
+            - Range: 0x893f30..0x893f31
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x893de1..0x893e00
+            - Range: 0x893f31..0x893f50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x893e00..0x893ed0]
+      OutOfLinePCRanges: [0x893f50..0x894020]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x893e00..0x893ed0
+            - Range: 0x893f50..0x894020
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893e00..0x893eac
+            - Range: 0x893f50..0x893ffc
               Pieces: []
-            - Range: 0x893eac..0x893ead
+            - Range: 0x893ffc..0x893ffd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893ead..0x893ed0
+            - Range: 0x893ffd..0x894020
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x893e00..0x893eac
+            - Range: 0x893f50..0x893ffc
               Pieces: []
-            - Range: 0x893eac..0x893ead
+            - Range: 0x893ffc..0x893ffd
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x893ead..0x893ed0
+            - Range: 0x893ffd..0x894020
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893e80..0x893ed0
+            - Range: 0x893fd0..0x894020
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x893ed0..0x893f80]
+      OutOfLinePCRanges: [0x894020..0x8940d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 248 ArrayType [0]int
-          Locations: [{Range: 0x893ed0..0x893f80, Pieces: []}]
+          Locations: [{Range: 0x894020..0x8940d0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893ed0..0x893f10
+            - Range: 0x894020..0x894060
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893f10..0x893f2c
+            - Range: 0x894060..0x89407c
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x893f2c..0x893f48
+            - Range: 0x89407c..0x894098
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x893f48..0x893f80
+            - Range: 0x894098..0x8940d0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893ed0..0x893f54
+            - Range: 0x894020..0x8940a4
               Pieces: []
-            - Range: 0x893f54..0x893f55
+            - Range: 0x8940a4..0x8940a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893f55..0x893f80
+            - Range: 0x8940a5..0x8940d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0x893ed0..0x893f54
+            - Range: 0x894020..0x8940a4
               Pieces: []
-            - Range: 0x893f54..0x893f55
+            - Range: 0x8940a4..0x8940a5
               Pieces: []
-            - Range: 0x893f55..0x893f80
+            - Range: 0x8940a5..0x8940d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x894400..0x894410]
+      OutOfLinePCRanges: [0x894550..0x894560]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x894400..0x894410
+            - Range: 0x894550..0x894560
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9417,13 +9417,13 @@ Subprograms:
       DictRegister: null
     - ID: 134
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x894410..0x894420]
+      OutOfLinePCRanges: [0x894560..0x894570]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x894410..0x894420
+            - Range: 0x894560..0x894570
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9436,13 +9436,13 @@ Subprograms:
       DictRegister: null
     - ID: 135
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x894420..0x894430]
+      OutOfLinePCRanges: [0x894570..0x894580]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 253 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x894420..0x894430
+            - Range: 0x894570..0x894580
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9455,13 +9455,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x894430..0x894440]
+      OutOfLinePCRanges: [0x894580..0x894590]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x894430..0x894440
+            - Range: 0x894580..0x894590
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9474,20 +9474,20 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x894430..0x894440
+            - Range: 0x894580..0x894590
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 137
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x894440..0x894450]
+      OutOfLinePCRanges: [0x894590..0x8945a0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x894440..0x894450
+            - Range: 0x894590..0x8945a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9500,20 +9500,20 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x894440..0x894450
+            - Range: 0x894590..0x8945a0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 138
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x894450..0x894460]
+      OutOfLinePCRanges: [0x8945a0..0x8945b0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x894450..0x894460
+            - Range: 0x8945a0..0x8945b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9526,20 +9526,20 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x894450..0x894460
+            - Range: 0x8945a0..0x8945b0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x894460..0x894470]
+      OutOfLinePCRanges: [0x8945b0..0x8945c0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 258 GoSliceHeaderType []string
           Locations:
-            - Range: 0x894460..0x894470
+            - Range: 0x8945b0..0x8945c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9552,20 +9552,20 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x894470..0x894480]
+      OutOfLinePCRanges: [0x8945c0..0x8945d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x894470..0x894480
+            - Range: 0x8945c0..0x8945d0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 259 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x894470..0x894480
+            - Range: 0x8945c0..0x8945d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9578,20 +9578,20 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x894470..0x894480
+            - Range: 0x8945c0..0x8945d0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x894480..0x894490]
+      OutOfLinePCRanges: [0x8945d0..0x8945e0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x894480..0x894490
+            - Range: 0x8945d0..0x8945e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9604,13 +9604,13 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x894490..0x8944a0]
+      OutOfLinePCRanges: [0x8945e0..0x8945f0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x894490..0x8944a0
+            - Range: 0x8945e0..0x8945f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9623,13 +9623,13 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x8944a0..0x8944b0]
+      OutOfLinePCRanges: [0x8945f0..0x894600]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 261 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x8944a0..0x8944b0
+            - Range: 0x8945f0..0x894600
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9642,13 +9642,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x8944b0..0x8944c0]
+      OutOfLinePCRanges: [0x894600..0x894610]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8944b0..0x8944c0
+            - Range: 0x894600..0x894610
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9661,7 +9661,7 @@ Subprograms:
         - Name: bs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8944b0..0x8944c0
+            - Range: 0x894600..0x894610
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9674,7 +9674,7 @@ Subprograms:
         - Name: cs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8944b0..0x8944c0
+            - Range: 0x894600..0x894610
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9687,34 +9687,34 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0x8947d0..0x894840]
+      OutOfLinePCRanges: [0x894920..0x894990]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8947d0..0x89481c
+            - Range: 0x894920..0x89496c
               Pieces: []
-            - Range: 0x89481c..0x89481d
+            - Range: 0x89496c..0x89496d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89481d..0x894840
+            - Range: 0x89496d..0x894990
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x894840..0x894850]
+      OutOfLinePCRanges: [0x894990..0x8949a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894840..0x894850
+            - Range: 0x894990..0x8949a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9725,13 +9725,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x894850..0x894860]
+      OutOfLinePCRanges: [0x8949a0..0x8949b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894850..0x894860
+            - Range: 0x8949a0..0x8949b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9742,7 +9742,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894850..0x894860
+            - Range: 0x8949a0..0x8949b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9753,7 +9753,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894850..0x894860
+            - Range: 0x8949a0..0x8949b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9764,13 +9764,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x894860..0x894880]
+      OutOfLinePCRanges: [0x8949b0..0x8949d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 263 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x894860..0x894880
+            - Range: 0x8949b0..0x8949d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9789,39 +9789,39 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x894880..0x894890]
+      OutOfLinePCRanges: [0x8949d0..0x8949e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x894880..0x894890
+            - Range: 0x8949d0..0x8949e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x894890..0x8948a0]
+      OutOfLinePCRanges: [0x8949e0..0x8949f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 265 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x894890..0x8948a0
+            - Range: 0x8949e0..0x8949f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x8948a0..0x8948b0]
+      OutOfLinePCRanges: [0x8949f0..0x894a00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8948a0..0x8948b0
+            - Range: 0x8949f0..0x894a00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9832,13 +9832,13 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x8948b0..0x8948c0]
+      OutOfLinePCRanges: [0x894a00..0x894a10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8948b0..0x8948c0
+            - Range: 0x894a00..0x894a10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9849,13 +9849,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x8948c0..0x8948d0]
+      OutOfLinePCRanges: [0x894a10..0x894a20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8948c0..0x8948d0
+            - Range: 0x894a10..0x894a20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9866,13 +9866,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x8948d0..0x8948e0]
+      OutOfLinePCRanges: [0x894a20..0x894a30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8948d0..0x8948e0
+            - Range: 0x894a20..0x894a30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9883,7 +9883,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8948d0..0x8948e0
+            - Range: 0x894a20..0x894a30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9894,7 +9894,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8948d0..0x8948e0
+            - Range: 0x894a20..0x894a30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9905,26 +9905,26 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x894a40..0x894a50]
+      OutOfLinePCRanges: [0x894b90..0x894ba0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x894a40..0x894a50
+            - Range: 0x894b90..0x894ba0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x894a50..0x894a70]
+      OutOfLinePCRanges: [0x894ba0..0x894bc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x894a50..0x894a70
+            - Range: 0x894ba0..0x894bc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9943,13 +9943,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0x894b40..0x894b60]
+      OutOfLinePCRanges: [0x894c90..0x894cb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 311 StructureType main.aStruct
           Locations:
-            - Range: 0x894b40..0x894b60
+            - Range: 0x894c90..0x894cb0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9970,93 +9970,93 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x894be0..0x894bf0]
+      OutOfLinePCRanges: [0x894d30..0x894d40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 312 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x894be0..0x894bf0
+            - Range: 0x894d30..0x894d40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x894bf0..0x894c00]
+      OutOfLinePCRanges: [0x894d40..0x894d50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.tenStrings
           Locations:
-            - Range: 0x894bf0..0x894c00
+            - Range: 0x894d40..0x894d50
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x894c40..0x894c50]
+      OutOfLinePCRanges: [0x894d90..0x894da0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 315 StructureType main.emptyStruct
-          Locations: [{Range: 0x894c40..0x894c50, Pieces: []}]
+          Locations: [{Range: 0x894d90..0x894da0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x894c50..0x894c60]
+      OutOfLinePCRanges: [0x894da0..0x894db0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 316 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x894c50..0x894c60
+            - Range: 0x894da0..0x894db0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x8966d0..0x8966e0]
+      OutOfLinePCRanges: [0x896820..0x896830]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x8966d0..0x8966e0
+            - Range: 0x896820..0x896830
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x8966d0..0x8966d4
+            - Range: 0x896820..0x896824
               Pieces: []
-            - Range: 0x8966d4..0x8966d5
+            - Range: 0x896824..0x896825
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8966d5..0x8966e0
+            - Range: 0x896825..0x896830
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x8966e0..0x8966f0]
+      OutOfLinePCRanges: [0x896830..0x896840]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8966e0..0x8966ec
+            - Range: 0x896830..0x89683c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8966ec..0x8966f0
+            - Range: 0x89683c..0x896840
               Pieces:
                 - Size: 8
                   Op: null
@@ -10067,58 +10067,58 @@ Subprograms:
         - Name: ~r0
           Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x8966e0..0x8966ec
+            - Range: 0x896830..0x89683c
               Pieces: []
-            - Range: 0x8966ec..0x8966ed
+            - Range: 0x89683c..0x89683d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8966ed..0x8966f0
+            - Range: 0x89683d..0x896840
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x8966f0..0x896700]
+      OutOfLinePCRanges: [0x896840..0x896850]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x8966f0..0x896700
+            - Range: 0x896840..0x896850
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x8966f0..0x8966f4
+            - Range: 0x896840..0x896844
               Pieces: []
-            - Range: 0x8966f4..0x8966f5
+            - Range: 0x896844..0x896845
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8966f5..0x896700
+            - Range: 0x896845..0x896850
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x896700..0x896710]
+      OutOfLinePCRanges: [0x896850..0x896860]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x896700..0x89670c
+            - Range: 0x896850..0x89685c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89670c..0x896710
+            - Range: 0x89685c..0x896860
               Pieces:
                 - Size: 8
                   Op: null
@@ -10129,28 +10129,28 @@ Subprograms:
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896700..0x89670c
+            - Range: 0x896850..0x89685c
               Pieces: []
-            - Range: 0x89670c..0x89670d
+            - Range: 0x89685c..0x89685d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89670d..0x896710
+            - Range: 0x89685d..0x896860
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x896780..0x8968b0]
+      OutOfLinePCRanges: [0x8968d0..0x896a00]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x896780..0x8967ac
+            - Range: 0x8968d0..0x8968fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10158,7 +10158,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8967ac..0x8967bc
+            - Range: 0x8968fc..0x89690c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10166,7 +10166,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x8967bc..0x8968b0
+            - Range: 0x89690c..0x896a00
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10179,18 +10179,18 @@ Subprograms:
         - Name: pred
           Type: 323 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x896780..0x8967bc
+            - Range: 0x8968d0..0x89690c
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8967bc..0x8968b0
+            - Range: 0x89690c..0x896a00
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x896780..0x89686c
+            - Range: 0x8968d0..0x8969bc
               Pieces: []
-            - Range: 0x89686c..0x89686d
+            - Range: 0x8969bc..0x8969bd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10198,14 +10198,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89686d..0x8968b0
+            - Range: 0x8969bd..0x896a00
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8967bc..0x8967d8
+            - Range: 0x89690c..0x896928
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10213,7 +10213,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8967d8..0x8967dc
+            - Range: 0x896928..0x89692c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10221,7 +10221,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8967dc..0x8967e0
+            - Range: 0x89692c..0x896930
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10229,7 +10229,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8967e0..0x8967e0
+            - Range: 0x896930..0x896930
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10237,7 +10237,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8967e0..0x89680c
+            - Range: 0x896930..0x89695c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10245,7 +10245,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x89680c..0x896860
+            - Range: 0x89695c..0x8969b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10253,7 +10253,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x896860..0x8968b0
+            - Range: 0x8969b0..0x896a00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10266,215 +10266,215 @@ Subprograms:
         - Name: item
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x8967fc..0x89680c
+            - Range: 0x89694c..0x89695c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89680c..0x896860
+            - Range: 0x89695c..0x8969b0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x8968b0..0x896910]
+      OutOfLinePCRanges: [0x896a00..0x896a60]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x8968b0..0x8968d8
+            - Range: 0x896a00..0x896a28
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 324 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x8968b0..0x8968d8
+            - Range: 0x896a00..0x896a28
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x8968b0..0x8968d8
+            - Range: 0x896a00..0x896a28
               Pieces: []
-            - Range: 0x8968d8..0x8968d9
+            - Range: 0x896a28..0x896a29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8968d9..0x896910
+            - Range: 0x896a29..0x896a60
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 168
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x896bc0..0x896bd0]
+      OutOfLinePCRanges: [0x896d10..0x896d20]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 322 PointerType *go.shape.int
           Locations:
-            - Range: 0x896bc0..0x896bd0
+            - Range: 0x896d10..0x896d20
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 PointerType *go.shape.int
           Locations:
-            - Range: 0x896bc0..0x896bc4
+            - Range: 0x896d10..0x896d14
               Pieces: []
-            - Range: 0x896bc4..0x896bc5
+            - Range: 0x896d14..0x896d15
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896bc5..0x896bd0
+            - Range: 0x896d15..0x896d20
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x896bd0..0x896be0]
+      OutOfLinePCRanges: [0x896d20..0x896d30]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 325 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x896bd0..0x896be0
+            - Range: 0x896d20..0x896d30
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 325 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x896bd0..0x896bd4
+            - Range: 0x896d20..0x896d24
               Pieces: []
-            - Range: 0x896bd4..0x896bd5
+            - Range: 0x896d24..0x896d25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896bd5..0x896be0
+            - Range: 0x896d25..0x896d30
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x896be0..0x896bf0]
+      OutOfLinePCRanges: [0x896d30..0x896d40]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 327 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x896be0..0x896bf0
+            - Range: 0x896d30..0x896d40
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 327 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x896be0..0x896be4
+            - Range: 0x896d30..0x896d34
               Pieces: []
-            - Range: 0x896be4..0x896be5
+            - Range: 0x896d34..0x896d35
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896be5..0x896bf0
+            - Range: 0x896d35..0x896d40
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x896bf0..0x896c00]
+      OutOfLinePCRanges: [0x896d40..0x896d50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x896bf0..0x896c00
+            - Range: 0x896d40..0x896d50
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896bf0..0x896bf8
+            - Range: 0x896d40..0x896d48
               Pieces: []
-            - Range: 0x896bf8..0x896bf9
+            - Range: 0x896d48..0x896d49
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896bf9..0x896c00
+            - Range: 0x896d49..0x896d50
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x896c80..0x896c90]
+      OutOfLinePCRanges: [0x896dd0..0x896de0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 331 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x896c80..0x896c90
+            - Range: 0x896dd0..0x896de0
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896c80..0x896c84
+            - Range: 0x896dd0..0x896dd4
               Pieces: []
-            - Range: 0x896c84..0x896c85
+            - Range: 0x896dd4..0x896dd5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896c85..0x896c90
+            - Range: 0x896dd5..0x896de0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x896d20..0x896d30]
+      OutOfLinePCRanges: [0x896e70..0x896e80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x896d20..0x896d30
+            - Range: 0x896e70..0x896e80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896d20..0x896d30
+            - Range: 0x896e70..0x896e80
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0x896d20..0x896d30
+            - Range: 0x896e70..0x896e80
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x896db0..0x896e40]
+      OutOfLinePCRanges: [0x896f00..0x896f90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x896db0..0x896e40
+            - Range: 0x896f00..0x896f90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896db0..0x896e40
+            - Range: 0x896f00..0x896f90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10485,20 +10485,20 @@ Subprograms:
         - Name: v
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896db0..0x896e40
+            - Range: 0x896f00..0x896f90
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x896ed0..0x896ee0]
+      OutOfLinePCRanges: [0x897020..0x897030]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896ed0..0x896ee0
+            - Range: 0x897020..0x897030
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10509,59 +10509,59 @@ Subprograms:
         - Name: b
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0x896ed0..0x896ee0
+            - Range: 0x897020..0x897030
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0x896ed0..0x896ed8
+            - Range: 0x897020..0x897028
               Pieces: []
-            - Range: 0x896ed8..0x896ed9
+            - Range: 0x897028..0x897029
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896ed9..0x896ee0
+            - Range: 0x897029..0x897030
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896ed0..0x896ed8
+            - Range: 0x897020..0x897028
               Pieces: []
-            - Range: 0x896ed8..0x896ed9
+            - Range: 0x897028..0x897029
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x896ed9..0x896ee0
+            - Range: 0x897029..0x897030
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x896ee0..0x896f00]
+      OutOfLinePCRanges: [0x897030..0x897050]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896ee0..0x896ef0
+            - Range: 0x897030..0x897040
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896ee0..0x896eec
+            - Range: 0x897030..0x89703c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x896eec..0x896f00
+            - Range: 0x89703c..0x897050
               Pieces:
                 - Size: 8
                   Op: null
@@ -10572,73 +10572,73 @@ Subprograms:
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896ee0..0x896ef0
+            - Range: 0x897030..0x897040
               Pieces: []
-            - Range: 0x896ef0..0x896ef1
+            - Range: 0x897040..0x897041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896ef1..0x896f00
+            - Range: 0x897041..0x897050
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896ee0..0x896ef0
+            - Range: 0x897030..0x897040
               Pieces: []
-            - Range: 0x896ef0..0x896ef1
+            - Range: 0x897040..0x897041
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x896ef1..0x896f00
+            - Range: 0x897041..0x897050
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x896f00..0x896f50]
+      OutOfLinePCRanges: [0x897050..0x8970a0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 337 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x896f00..0x896f28
+            - Range: 0x897050..0x897078
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x896f00..0x896f28
+            - Range: 0x897050..0x897078
               Pieces: []
-            - Range: 0x896f28..0x896f29
+            - Range: 0x897078..0x897079
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896f29..0x896f50
+            - Range: 0x897079..0x8970a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x896f50..0x896fb0]
+      OutOfLinePCRanges: [0x8970a0..0x897100]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 338 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x896f50..0x896f7c
+            - Range: 0x8970a0..0x8970cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x896f7c..0x896f80
+            - Range: 0x8970cc..0x8970d0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10649,65 +10649,65 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x896f50..0x896f80
+            - Range: 0x8970a0..0x8970d0
               Pieces: []
-            - Range: 0x896f80..0x896f81
+            - Range: 0x8970d0..0x8970d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896f81..0x896fb0
+            - Range: 0x8970d1..0x897100
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x896fb0..0x896fc0]
+      OutOfLinePCRanges: [0x897100..0x897110]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 339 PointerType *go.shape.string
           Locations:
-            - Range: 0x896fb0..0x896fb8
+            - Range: 0x897100..0x897108
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896fb0..0x896fb8
+            - Range: 0x897100..0x897108
               Pieces: []
-            - Range: 0x896fb8..0x896fb9
+            - Range: 0x897108..0x897109
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896fb9..0x896fc0
+            - Range: 0x897109..0x897110
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x896fc0..0x897020]
+      OutOfLinePCRanges: [0x897110..0x897170]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 340 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x896fc0..0x896ffc
+            - Range: 0x897110..0x89714c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 341 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x896fc0..0x89700c
+            - Range: 0x897110..0x89715c
               Pieces: []
-            - Range: 0x89700c..0x89700d
+            - Range: 0x89715c..0x89715d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10721,20 +10721,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x89700d..0x897020
+            - Range: 0x89715d..0x897170
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x897020..0x897060]
+      OutOfLinePCRanges: [0x897170..0x8971b0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x897020..0x89702c
+            - Range: 0x897170..0x89717c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10742,7 +10742,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x89702c..0x897060
+            - Range: 0x89717c..0x8971b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10755,42 +10755,42 @@ Subprograms:
         - Name: needle
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x897020..0x897060
+            - Range: 0x897170..0x8971b0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x897020..0x897048
+            - Range: 0x897170..0x897198
               Pieces: []
-            - Range: 0x897048..0x897049
+            - Range: 0x897198..0x897199
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897049..0x897050
+            - Range: 0x897199..0x8971a0
               Pieces: []
-            - Range: 0x897050..0x897051
+            - Range: 0x8971a0..0x8971a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897051..0x897060
+            - Range: 0x8971a1..0x8971b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x89703c..0x89704c
+            - Range: 0x89718c..0x89719c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x897060..0x897130]
+      OutOfLinePCRanges: [0x8971b0..0x897280]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 342 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x897060..0x897084
+            - Range: 0x8971b0..0x8971d4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10798,7 +10798,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x897084..0x897088
+            - Range: 0x8971d4..0x8971d8
               Pieces:
                 - Size: 8
                   Op: null
@@ -10811,13 +10811,13 @@ Subprograms:
         - Name: needle
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x897060..0x8970bc
+            - Range: 0x8971b0..0x89720c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8970bc..0x897130
+            - Range: 0x89720c..0x897280
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10828,28 +10828,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x897060..0x8970d8
+            - Range: 0x8971b0..0x897228
               Pieces: []
-            - Range: 0x8970d8..0x8970d9
+            - Range: 0x897228..0x897229
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8970d9..0x8970e8
+            - Range: 0x897229..0x897238
               Pieces: []
-            - Range: 0x8970e8..0x8970e9
+            - Range: 0x897238..0x897239
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8970e9..0x897130
+            - Range: 0x897239..0x897280
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89709c..0x8970b0
+            - Range: 0x8971ec..0x897200
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8970b0..0x8970bc
+            - Range: 0x897200..0x89720c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10860,56 +10860,56 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x897130..0x897140]
+      OutOfLinePCRanges: [0x897280..0x897290]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 343 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x897130..0x897138
+            - Range: 0x897280..0x897288
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x897130..0x897140
+            - Range: 0x897280..0x897290
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x897130..0x897138
+            - Range: 0x897280..0x897288
               Pieces: []
-            - Range: 0x897138..0x897139
+            - Range: 0x897288..0x897289
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897139..0x897140
+            - Range: 0x897289..0x897290
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x8971c0..0x897240]
+      OutOfLinePCRanges: [0x897310..0x897390]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 344 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x8971c0..0x8971ec
+            - Range: 0x897310..0x89733c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8971ec..0x8971f8
+            - Range: 0x89733c..0x897348
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8971f8..0x8971fc
+            - Range: 0x897348..0x89734c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10920,7 +10920,7 @@ Subprograms:
         - Name: value
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8971c0..0x8971fc
+            - Range: 0x897310..0x89734c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10931,11 +10931,11 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8971c0..0x8971fc
+            - Range: 0x897310..0x89734c
               Pieces: []
-            - Range: 0x8971fc..0x8971fd
+            - Range: 0x89734c..0x89734d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8971fd..0x897240
+            - Range: 0x89734d..0x897390
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11073,31 +11073,31 @@ Subprograms:
       DictRegister: 0
     - ID: 186
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x88f130..0x88f1a0]
+      OutOfLinePCRanges: [0x88f280..0x88f2f0]
       InlinePCRanges:
-        - Ranges: [0x88f1bc..0x88f1f4]
-          RootRanges: [0x88f1a0..0x88f220]
-        - Ranges: [0x88f308..0x88f340]
-          RootRanges: [0x88f2d0..0x88f360]
-        - Ranges: [0x88f384..0x88f3bc]
-          RootRanges: [0x88f360..0x88f430]
-        - Ranges: [0x88f44c..0x88f484]
-          RootRanges: [0x88f430..0x88f4b0]
+        - Ranges: [0x88f30c..0x88f344]
+          RootRanges: [0x88f2f0..0x88f370]
+        - Ranges: [0x88f458..0x88f490]
+          RootRanges: [0x88f420..0x88f4b0]
+        - Ranges: [0x88f4d4..0x88f50c]
+          RootRanges: [0x88f4b0..0x88f580]
+        - Ranges: [0x88f59c..0x88f5d4]
+          RootRanges: [0x88f580..0x88f600]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f130..0x88f150
+            - Range: 0x88f280..0x88f2a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f1bc..0x88f1c4
+            - Range: 0x88f30c..0x88f314
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f308..0x88f310
+            - Range: 0x88f458..0x88f460
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f37c..0x88f38c
+            - Range: 0x88f4cc..0x88f4dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88f38c..0x88f430
+            - Range: 0x88f4dc..0x88f580
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x88f430..0x88f454
+            - Range: 0x88f580..0x88f5a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11106,37 +11106,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88f3c8..0x88f400]
-          RootRanges: [0x88f360..0x88f430]
+        - Ranges: [0x88f518..0x88f550]
+          RootRanges: [0x88f4b0..0x88f580]
       Variables: []
       DictRegister: null
     - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88f4cc..0x88f510]
-          RootRanges: [0x88f4b0..0x88f5d0]
+        - Ranges: [0x88f61c..0x88f660]
+          RootRanges: [0x88f600..0x88f720]
       Variables: []
       DictRegister: null
     - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88f580..0x88f5b8]
-          RootRanges: [0x88f4b0..0x88f5d0]
+        - Ranges: [0x88f6d0..0x88f708]
+          RootRanges: [0x88f600..0x88f720]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88f5d4..0x88f5d8]
-          RootRanges: [0x88f5d0..0x88f5e0]
+        - Ranges: [0x88f724..0x88f728]
+          RootRanges: [0x88f720..0x88f730]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88f5d0..0x88f5d8
+            - Range: 0x88f720..0x88f728
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11145,38 +11145,38 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88f604..0x88f628]
-          RootRanges: [0x88f5e0..0x88f640]
-        - Ranges: [0x88f69c..0x88f6c4]
-          RootRanges: [0x88f640..0x88f790]
+        - Ranges: [0x88f754..0x88f778]
+          RootRanges: [0x88f730..0x88f790]
+        - Ranges: [0x88f7ec..0x88f814]
+          RootRanges: [0x88f790..0x88f8e0]
       Variables:
         - Name: a
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x88f5f0..0x88f640
+            - Range: 0x88f740..0x88f790
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x88f688..0x88f790
+            - Range: 0x88f7d8..0x88f8e0
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 192
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x88f790..0x88f810]
+      OutOfLinePCRanges: [0x88f8e0..0x88f960]
       InlinePCRanges:
-        - Ranges: [0x8972fc..0x897330]
-          RootRanges: [0x8972d0..0x897380]
+        - Ranges: [0x89744c..0x897480]
+          RootRanges: [0x897420..0x8974d0]
       Variables:
         - Name: b
           Type: 349 StructureType main.firstBehavior
           Locations:
-            - Range: 0x88f790..0x88f7bc
+            - Range: 0x88f8e0..0x88f90c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88f7bc..0x88f7c0
+            - Range: 0x88f90c..0x88f910
               Pieces:
                 - Size: 8
                   Op: null
@@ -11187,15 +11187,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f790..0x88f7e0
+            - Range: 0x88f8e0..0x88f930
               Pieces: []
-            - Range: 0x88f7e0..0x88f7e1
+            - Range: 0x88f930..0x88f931
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88f7e1..0x88f810
+            - Range: 0x88f931..0x88f960
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11204,8 +11204,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88fe68..0x88fe74, 0x88fe78..0x88fe80]
-          RootRanges: [0x88fd50..0x88fec0]
+        - Ranges: [0x88ffbc..0x88ffc8, 0x88ffcc..0x88ffd4]
+          RootRanges: [0x88fea0..0x890010]
         - Ranges: [0x12a824..0x12a828, 0x12a82c..0x12a834]
           RootRanges: [0x12a810..0x12a840]
       Variables: []
@@ -11246,7 +11246,7 @@ Types:
       ID: 123
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 492800
+      GoRuntimeType: 492832
       GoKind: 22
       Pointee: 88 PointerType *string
     - __kind: PointerType
@@ -11378,7 +11378,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 458400
+      GoRuntimeType: 458432
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11420,14 +11420,14 @@ Types:
       ID: 1022
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.858016e+06
+      GoRuntimeType: 1.858304e+06
       GoKind: 22
       Pointee: 1023 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
       ID: 674
       Name: '*archive/tar.headerError'
       ByteSize: 8
-      GoRuntimeType: 861792
+      GoRuntimeType: 861824
       GoKind: 22
       Pointee: 675 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
@@ -11439,49 +11439,49 @@ Types:
       ID: 962
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.259008e+06
+      GoRuntimeType: 1.259136e+06
       GoKind: 22
       Pointee: 963 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
       ID: 910
       Name: '*archive/zip.countWriter'
       ByteSize: 8
-      GoRuntimeType: 861984
+      GoRuntimeType: 862016
       GoKind: 22
       Pointee: 911 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
       ID: 912
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
-      GoRuntimeType: 862080
+      GoRuntimeType: 862112
       GoKind: 22
       Pointee: 913 StructureType archive/zip.dirWriter
     - __kind: PointerType
       ID: 1009
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.782304e+06
+      GoRuntimeType: 1.782592e+06
       GoKind: 22
       Pointee: 1010 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 938
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.021248e+06
+      GoRuntimeType: 1.021376e+06
       GoKind: 22
       Pointee: 939 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 940
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.021504e+06
+      GoRuntimeType: 1.021632e+06
       GoKind: 22
       Pointee: 941 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 365536
+      GoRuntimeType: 365568
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
@@ -11623,35 +11623,35 @@ Types:
       ID: 986
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.0392e+06
+      GoRuntimeType: 2.039488e+06
       GoKind: 22
       Pointee: 987 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1013
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.824256e+06
+      GoRuntimeType: 1.824544e+06
       GoKind: 22
       Pointee: 1014 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1058
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.13216e+06
+      GoRuntimeType: 2.132448e+06
       GoKind: 22
       Pointee: 1059 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
       ID: 587
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 844416
+      GoRuntimeType: 844448
       GoKind: 22
       Pointee: 482 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
       ID: 588
       Name: '*compress/flate.InternalError'
       ByteSize: 8
-      GoRuntimeType: 844512
+      GoRuntimeType: 844544
       GoKind: 22
       Pointee: 483 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
@@ -11663,329 +11663,329 @@ Types:
       ID: 960
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.249248e+06
+      GoRuntimeType: 1.249376e+06
       GoKind: 22
       Pointee: 961 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
       ID: 906
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
-      GoRuntimeType: 844608
+      GoRuntimeType: 844640
       GoKind: 22
       Pointee: 907 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
       ID: 982
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.608928e+06
+      GoRuntimeType: 1.609216e+06
       GoKind: 22
       Pointee: 983 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 818
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.123424e+06
+      GoRuntimeType: 1.123552e+06
       GoKind: 22
       Pointee: 819 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 667
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 856704
+      GoRuntimeType: 856736
       GoKind: 22
       Pointee: 496 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
       ID: 668
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 856896
+      GoRuntimeType: 856928
       GoKind: 22
       Pointee: 497 BaseType crypto/des.KeySizeError
     - __kind: PointerType
       ID: 972
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
-      GoRuntimeType: 1.38064e+06
+      GoRuntimeType: 1.380928e+06
       GoKind: 22
       Pointee: 973 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
       ID: 997
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.687936e+06
+      GoRuntimeType: 1.688224e+06
       GoKind: 22
       Pointee: 998 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
       ID: 669
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 857184
+      GoRuntimeType: 857216
       GoKind: 22
       Pointee: 498 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
       ID: 1005
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 1.779488e+06
+      GoRuntimeType: 1.779776e+06
       GoKind: 22
       Pointee: 1006 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 999
       Name: '*crypto/sha256.digest'
       ByteSize: 8
-      GoRuntimeType: 1.688384e+06
+      GoRuntimeType: 1.688672e+06
       GoKind: 22
       Pointee: 1000 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
       ID: 1001
       Name: '*crypto/sha512.digest'
       ByteSize: 8
-      GoRuntimeType: 1.688832e+06
+      GoRuntimeType: 1.68912e+06
       GoKind: 22
       Pointee: 1002 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
       ID: 593
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
-      GoRuntimeType: 846048
+      GoRuntimeType: 846080
       GoKind: 22
       Pointee: 486 BaseType crypto/tls.AlertError
     - __kind: PointerType
       ID: 758
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.009088e+06
+      GoRuntimeType: 1.009216e+06
       GoKind: 22
       Pointee: 759 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1084
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.24128e+06
+      GoRuntimeType: 2.241568e+06
       GoKind: 22
       Pointee: 1085 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
       ID: 591
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
-      GoRuntimeType: 845856
+      GoRuntimeType: 845888
       GoKind: 22
       Pointee: 592 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
       ID: 589
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
-      GoRuntimeType: 845760
+      GoRuntimeType: 845792
       GoKind: 22
       Pointee: 590 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
       ID: 757
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.007424e+06
+      GoRuntimeType: 1.007552e+06
       GoKind: 22
       Pointee: 714 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 970
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.37776e+06
+      GoRuntimeType: 1.378048e+06
       GoKind: 22
       Pointee: 971 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
       ID: 977
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.458304e+06
+      GoRuntimeType: 1.458592e+06
       GoKind: 22
       Pointee: 978 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 853
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.249568e+06
+      GoRuntimeType: 1.249696e+06
       GoKind: 22
       Pointee: 854 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 868
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 1.915168e+06
+      GoRuntimeType: 1.915456e+06
       GoKind: 22
       Pointee: 869 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
       ID: 663
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
-      GoRuntimeType: 855648
+      GoRuntimeType: 855680
       GoKind: 22
       Pointee: 664 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
       ID: 657
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
-      GoRuntimeType: 855168
+      GoRuntimeType: 855200
       GoKind: 22
       Pointee: 658 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
       ID: 659
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
-      GoRuntimeType: 855264
+      GoRuntimeType: 855296
       GoKind: 22
       Pointee: 660 StructureType crypto/x509.HostnameError
     - __kind: PointerType
       ID: 656
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
-      GoRuntimeType: 855072
+      GoRuntimeType: 855104
       GoKind: 22
       Pointee: 495 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
       ID: 763
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.014976e+06
+      GoRuntimeType: 1.015104e+06
       GoKind: 22
       Pointee: 764 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
       ID: 665
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
-      GoRuntimeType: 855744
+      GoRuntimeType: 855776
       GoKind: 22
       Pointee: 666 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
       ID: 661
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
-      GoRuntimeType: 855552
+      GoRuntimeType: 855584
       GoKind: 22
       Pointee: 662 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
       ID: 678
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
-      GoRuntimeType: 862272
+      GoRuntimeType: 862304
       GoKind: 22
       Pointee: 679 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
       ID: 682
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 862464
+      GoRuntimeType: 862496
       GoKind: 22
       Pointee: 683 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
       ID: 680
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 862368
+      GoRuntimeType: 862400
       GoKind: 22
       Pointee: 681 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
       ID: 579
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 842976
+      GoRuntimeType: 843008
       GoKind: 22
       Pointee: 480 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 928
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.004608e+06
+      GoRuntimeType: 1.004736e+06
       GoKind: 22
       Pointee: 929 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
       ID: 582
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
-      GoRuntimeType: 843840
+      GoRuntimeType: 843872
       GoKind: 22
       Pointee: 481 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
       ID: 550
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 837696
+      GoRuntimeType: 837728
       GoKind: 22
       Pointee: 551 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 749
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.000256e+06
+      GoRuntimeType: 1.000384e+06
       GoKind: 22
       Pointee: 750 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 542
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 837312
+      GoRuntimeType: 837344
       GoKind: 22
       Pointee: 543 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 548
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 837600
+      GoRuntimeType: 837632
       GoKind: 22
       Pointee: 549 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 546
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
-      GoRuntimeType: 837504
+      GoRuntimeType: 837536
       GoKind: 22
       Pointee: 547 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
       ID: 544
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 837408
+      GoRuntimeType: 837440
       GoKind: 22
       Pointee: 545 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1064
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.157728e+06
+      GoRuntimeType: 2.158016e+06
       GoKind: 22
       Pointee: 1065 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
       ID: 552
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 838080
+      GoRuntimeType: 838112
       GoKind: 22
       Pointee: 553 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 936
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.017792e+06
+      GoRuntimeType: 1.01792e+06
       GoKind: 22
       Pointee: 937 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
       ID: 651
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 854112
+      GoRuntimeType: 854144
       GoKind: 22
       Pointee: 652 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 649
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
-      GoRuntimeType: 854016
+      GoRuntimeType: 854048
       GoKind: 22
       Pointee: 650 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
       ID: 653
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 854208
+      GoRuntimeType: 854240
       GoKind: 22
       Pointee: 492 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
@@ -11997,119 +11997,119 @@ Types:
       ID: 654
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
-      GoRuntimeType: 854304
+      GoRuntimeType: 854336
       GoKind: 22
       Pointee: 655 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 1042
       Name: '*encoding/xml.printer'
       ByteSize: 8
-      GoRuntimeType: 2.02768e+06
+      GoRuntimeType: 2.027968e+06
       GoKind: 22
       Pointee: 1043 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 99
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 364448
+      GoRuntimeType: 364480
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 520
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 827712
+      GoRuntimeType: 827744
       GoKind: 22
       Pointee: 521 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 716
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 984512
+      GoRuntimeType: 984640
       GoKind: 22
       Pointee: 717 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 101
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 365408
+      GoRuntimeType: 365440
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 92
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 365472
+      GoRuntimeType: 365504
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
       ID: 1052
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.123456e+06
+      GoRuntimeType: 2.123744e+06
       GoKind: 22
       Pointee: 1053 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 718
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 984640
+      GoRuntimeType: 984768
       GoKind: 22
       Pointee: 719 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 720
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 984768
+      GoRuntimeType: 984896
       GoKind: 22
       Pointee: 721 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
       ID: 580
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 843360
+      GoRuntimeType: 843392
       GoKind: 22
       Pointee: 581 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 561
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 840480
+      GoRuntimeType: 840512
       GoKind: 22
       Pointee: 562 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
       ID: 563
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 840576
+      GoRuntimeType: 840608
       GoKind: 22
       Pointee: 564 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 880
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 840288
+      GoRuntimeType: 840320
       GoKind: 22
       Pointee: 881 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
       ID: 567
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 840864
+      GoRuntimeType: 840896
       GoKind: 22
       Pointee: 568 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 882
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 840384
+      GoRuntimeType: 840416
       GoKind: 22
       Pointee: 883 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
       ID: 565
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 840672
+      GoRuntimeType: 840704
       GoKind: 22
       Pointee: 474 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -12121,7 +12121,7 @@ Types:
       ID: 560
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 840192
+      GoRuntimeType: 840224
       GoKind: 22
       Pointee: 471 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -12133,7 +12133,7 @@ Types:
       ID: 566
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 840768
+      GoRuntimeType: 840800
       GoKind: 22
       Pointee: 477 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -12145,98 +12145,98 @@ Types:
       ID: 950
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.129184e+06
+      GoRuntimeType: 1.129312e+06
       GoKind: 22
       Pointee: 951 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1030
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 1.930496e+06
+      GoRuntimeType: 1.930784e+06
       GoKind: 22
       Pointee: 1031 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
       ID: 672
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
-      GoRuntimeType: 860736
+      GoRuntimeType: 860768
       GoKind: 22
       Pointee: 673 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 827
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.132512e+06
+      GoRuntimeType: 1.13264e+06
       GoKind: 22
       Pointee: 828 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1060
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.133696e+06
+      GoRuntimeType: 2.133984e+06
       GoKind: 22
       Pointee: 1061 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
       ID: 600
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
-      GoRuntimeType: 849600
+      GoRuntimeType: 849632
       GoKind: 22
       Pointee: 601 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
       ID: 607
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
-      GoRuntimeType: 850656
+      GoRuntimeType: 850688
       GoKind: 22
       Pointee: 608 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
       ID: 602
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
-      GoRuntimeType: 850368
+      GoRuntimeType: 850400
       GoKind: 22
       Pointee: 491 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
       ID: 605
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
-      GoRuntimeType: 850560
+      GoRuntimeType: 850592
       GoKind: 22
       Pointee: 606 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
       ID: 603
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
-      GoRuntimeType: 850464
+      GoRuntimeType: 850496
       GoKind: 22
       Pointee: 604 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
       ID: 623
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
-      GoRuntimeType: 852576
+      GoRuntimeType: 852608
       GoKind: 22
       Pointee: 624 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
       ID: 627
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
-      GoRuntimeType: 852768
+      GoRuntimeType: 852800
       GoKind: 22
       Pointee: 628 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
       ID: 625
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
-      GoRuntimeType: 852672
+      GoRuntimeType: 852704
       GoKind: 22
       Pointee: 626 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
       ID: 621
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
-      GoRuntimeType: 852480
+      GoRuntimeType: 852512
       GoKind: 22
       Pointee: 622 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
@@ -12248,357 +12248,357 @@ Types:
       ID: 635
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
-      GoRuntimeType: 853152
+      GoRuntimeType: 853184
       GoKind: 22
       Pointee: 636 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
       ID: 629
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
-      GoRuntimeType: 852864
+      GoRuntimeType: 852896
       GoKind: 22
       Pointee: 630 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
       ID: 633
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
-      GoRuntimeType: 853056
+      GoRuntimeType: 853088
       GoKind: 22
       Pointee: 634 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
       ID: 631
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
-      GoRuntimeType: 852960
+      GoRuntimeType: 852992
       GoKind: 22
       Pointee: 632 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
       ID: 637
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
-      GoRuntimeType: 853248
+      GoRuntimeType: 853280
       GoKind: 22
       Pointee: 638 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
       ID: 643
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
-      GoRuntimeType: 853536
+      GoRuntimeType: 853568
       GoKind: 22
       Pointee: 644 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
       ID: 645
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
-      GoRuntimeType: 853632
+      GoRuntimeType: 853664
       GoKind: 22
       Pointee: 646 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
       ID: 641
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
-      GoRuntimeType: 853440
+      GoRuntimeType: 853472
       GoKind: 22
       Pointee: 642 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
       ID: 639
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
-      GoRuntimeType: 853344
+      GoRuntimeType: 853376
       GoKind: 22
       Pointee: 640 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
       ID: 647
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
-      GoRuntimeType: 853824
+      GoRuntimeType: 853856
       GoKind: 22
       Pointee: 648 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 569
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 842016
+      GoRuntimeType: 842048
       GoKind: 22
       Pointee: 570 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 989
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.685024e+06
+      GoRuntimeType: 1.685312e+06
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
       ID: 571
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 842112
+      GoRuntimeType: 842144
       GoKind: 22
       Pointee: 572 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 968
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.37664e+06
+      GoRuntimeType: 1.376928e+06
       GoKind: 22
       Pointee: 969 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 924
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.003584e+06
+      GoRuntimeType: 1.003712e+06
       GoKind: 22
       Pointee: 925 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 958
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.247328e+06
+      GoRuntimeType: 1.247456e+06
       GoKind: 22
       Pointee: 959 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 575
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 842304
+      GoRuntimeType: 842336
       GoKind: 22
       Pointee: 576 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1020
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.848512e+06
+      GoRuntimeType: 1.8488e+06
       GoKind: 22
       Pointee: 1021 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1035
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.00272e+06
+      GoRuntimeType: 2.003008e+06
       GoKind: 22
       Pointee: 1032 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1034
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.002336e+06
+      GoRuntimeType: 2.002624e+06
       GoKind: 22
       Pointee: 1033 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 926
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.003712e+06
+      GoRuntimeType: 1.00384e+06
       GoKind: 22
       Pointee: 927 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 573
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 842208
+      GoRuntimeType: 842240
       GoKind: 22
       Pointee: 574 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
       ID: 577
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 842400
+      GoRuntimeType: 842432
       GoKind: 22
       Pointee: 578 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 993
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.686592e+06
+      GoRuntimeType: 1.68688e+06
       GoKind: 22
       Pointee: 994 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1026
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.884096e+06
+      GoRuntimeType: 1.884384e+06
       GoKind: 22
       Pointee: 1027 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1028
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.914848e+06
+      GoRuntimeType: 1.915136e+06
       GoKind: 22
       Pointee: 1029 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 858
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.261408e+06
+      GoRuntimeType: 1.261536e+06
       GoKind: 22
       Pointee: 859 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 771
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.029184e+06
+      GoRuntimeType: 1.029312e+06
       GoKind: 22
       Pointee: 772 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 769
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.029056e+06
+      GoRuntimeType: 1.029184e+06
       GoKind: 22
       Pointee: 770 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 773
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.033152e+06
+      GoRuntimeType: 1.03328e+06
       GoKind: 22
       Pointee: 774 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 775
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.03328e+06
+      GoRuntimeType: 1.033408e+06
       GoKind: 22
       Pointee: 776 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 979
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.485952e+06
+      GoRuntimeType: 1.48624e+06
       GoKind: 22
       Pointee: 980 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 765
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.015744e+06
+      GoRuntimeType: 1.015872e+06
       GoKind: 22
       Pointee: 766 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 583
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
-      GoRuntimeType: 844032
+      GoRuntimeType: 844064
       GoKind: 22
       Pointee: 584 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
       ID: 1076
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.220384e+06
+      GoRuntimeType: 2.220672e+06
       GoKind: 22
       Pointee: 1077 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 829
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.140704e+06
+      GoRuntimeType: 1.140832e+06
       GoKind: 22
       Pointee: 830 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 802
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.119584e+06
+      GoRuntimeType: 1.119712e+06
       GoKind: 22
       Pointee: 803 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 796
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.1192e+06
+      GoRuntimeType: 1.119328e+06
       GoKind: 22
       Pointee: 797 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 735
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 994112
+      GoRuntimeType: 994240
       GoKind: 22
       Pointee: 736 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 808
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.119968e+06
+      GoRuntimeType: 1.120096e+06
       GoKind: 22
       Pointee: 809 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 734
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 993984
+      GoRuntimeType: 994112
       GoKind: 22
       Pointee: 713 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 800
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.119456e+06
+      GoRuntimeType: 1.119584e+06
       GoKind: 22
       Pointee: 801 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 798
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.119328e+06
+      GoRuntimeType: 1.119456e+06
       GoKind: 22
       Pointee: 799 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 806
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.11984e+06
+      GoRuntimeType: 1.119968e+06
       GoKind: 22
       Pointee: 807 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 804
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.119712e+06
+      GoRuntimeType: 1.11984e+06
       GoKind: 22
       Pointee: 805 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1080
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.231424e+06
+      GoRuntimeType: 2.231712e+06
       GoKind: 22
       Pointee: 1081 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 812
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.120352e+06
+      GoRuntimeType: 1.12048e+06
       GoKind: 22
       Pointee: 813 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 739
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 994368
+      GoRuntimeType: 994496
       GoKind: 22
       Pointee: 740 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 737
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 994240
+      GoRuntimeType: 994368
       GoKind: 22
       Pointee: 738 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 810
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.120224e+06
+      GoRuntimeType: 1.120352e+06
       GoKind: 22
       Pointee: 811 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
       ID: 694
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
-      GoRuntimeType: 874368
+      GoRuntimeType: 874400
       GoKind: 22
       Pointee: 503 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
@@ -12610,21 +12610,21 @@ Types:
       ID: 346
       Name: '*go.shape.float64'
       ByteSize: 8
-      GoRuntimeType: 450336
+      GoRuntimeType: 450368
       GoKind: 22
       Pointee: 347 BaseType go.shape.float64
     - __kind: PointerType
       ID: 322
       Name: '*go.shape.int'
       ByteSize: 8
-      GoRuntimeType: 449952
+      GoRuntimeType: 449984
       GoKind: 22
       Pointee: 317 BaseType go.shape.int
     - __kind: PointerType
       ID: 339
       Name: '*go.shape.string'
       ByteSize: 8
-      GoRuntimeType: 450016
+      GoRuntimeType: 450048
       GoKind: 22
       Pointee: 319 GoStringHeaderType go.shape.string
     - __kind: PointerType
@@ -12654,63 +12654,63 @@ Types:
       ID: 871
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.484416e+06
+      GoRuntimeType: 1.484704e+06
       GoKind: 22
       Pointee: 872 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 779
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.048128e+06
+      GoRuntimeType: 1.048256e+06
       GoKind: 22
       Pointee: 780 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 956
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.179616e+06
+      GoRuntimeType: 1.179744e+06
       GoKind: 22
       Pointee: 957 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1040
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.017312e+06
+      GoRuntimeType: 2.0176e+06
       GoKind: 22
       Pointee: 1041 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 942
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.050432e+06
+      GoRuntimeType: 1.05056e+06
       GoKind: 22
       Pointee: 943 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
       ID: 695
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 875616
+      GoRuntimeType: 875648
       GoKind: 22
       Pointee: 506 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
       ID: 837
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.18128e+06
+      GoRuntimeType: 1.181408e+06
       GoKind: 22
       Pointee: 838 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
       ID: 698
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
-      GoRuntimeType: 875904
+      GoRuntimeType: 875936
       GoKind: 22
       Pointee: 699 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
       ID: 697
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 875808
+      GoRuntimeType: 875840
       GoKind: 22
       Pointee: 510 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
@@ -12722,7 +12722,7 @@ Types:
       ID: 701
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 876096
+      GoRuntimeType: 876128
       GoKind: 22
       Pointee: 516 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
@@ -12734,7 +12734,7 @@ Types:
       ID: 700
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 876000
+      GoRuntimeType: 876032
       GoKind: 22
       Pointee: 513 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
@@ -12746,7 +12746,7 @@ Types:
       ID: 696
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 875712
+      GoRuntimeType: 875744
       GoKind: 22
       Pointee: 507 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
@@ -12758,133 +12758,133 @@ Types:
       ID: 1038
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.015392e+06
+      GoRuntimeType: 2.01568e+06
       GoKind: 22
       Pointee: 1039 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
       ID: 702
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
-      GoRuntimeType: 876192
+      GoRuntimeType: 876224
       GoKind: 22
       Pointee: 703 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
       ID: 704
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
-      GoRuntimeType: 876288
+      GoRuntimeType: 876320
       GoKind: 22
       Pointee: 519 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
       ID: 690
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
-      GoRuntimeType: 869760
+      GoRuntimeType: 869792
       GoKind: 22
       Pointee: 691 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
       ID: 835
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.178208e+06
+      GoRuntimeType: 1.178336e+06
       GoKind: 22
       Pointee: 836 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 860
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.268768e+06
+      GoRuntimeType: 1.268896e+06
       GoKind: 22
       Pointee: 861 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
       ID: 692
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
-      GoRuntimeType: 872640
+      GoRuntimeType: 872672
       GoKind: 22
       Pointee: 693 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 1003
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.693312e+06
+      GoRuntimeType: 1.6936e+06
       GoKind: 22
       Pointee: 1004 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 954
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.174752e+06
+      GoRuntimeType: 1.17488e+06
       GoKind: 22
       Pointee: 955 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 777
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.042368e+06
+      GoRuntimeType: 1.042496e+06
       GoKind: 22
       Pointee: 778 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 914
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
-      GoRuntimeType: 872736
+      GoRuntimeType: 872768
       GoKind: 22
       Pointee: 915 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
       ID: 670
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
-      GoRuntimeType: 858624
+      GoRuntimeType: 858656
       GoKind: 22
       Pointee: 671 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
       ID: 767
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.0192e+06
+      GoRuntimeType: 1.019328e+06
       GoKind: 22
       Pointee: 768 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 833
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.146464e+06
+      GoRuntimeType: 1.146592e+06
       GoKind: 22
       Pointee: 834 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 831
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.146208e+06
+      GoRuntimeType: 1.146336e+06
       GoKind: 22
       Pointee: 832 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
       ID: 684
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
-      GoRuntimeType: 863328
+      GoRuntimeType: 863360
       GoKind: 22
       Pointee: 685 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
       ID: 686
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
-      GoRuntimeType: 863424
+      GoRuntimeType: 863456
       GoKind: 22
       Pointee: 687 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
       ID: 615
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
-      GoRuntimeType: 851040
+      GoRuntimeType: 851072
       GoKind: 22
       Pointee: 616 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
       ID: 991
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.685696e+06
+      GoRuntimeType: 1.685984e+06
       GoKind: 22
       Pointee: 992 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
@@ -13026,126 +13026,126 @@ Types:
       ID: 705
       Name: '*html/template.Error'
       ByteSize: 8
-      GoRuntimeType: 877056
+      GoRuntimeType: 877088
       GoKind: 22
       Pointee: 706 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 94
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 365088
+      GoRuntimeType: 365120
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 97
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 364704
+      GoRuntimeType: 364736
       GoKind: 22
       Pointee: 89 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 364832
+      GoRuntimeType: 364864
       GoKind: 22
       Pointee: 13 BaseType int32
     - __kind: PointerType
       ID: 93
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 364960
+      GoRuntimeType: 364992
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
       ID: 98
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 364576
+      GoRuntimeType: 364608
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
       ID: 158
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 365664
+      GoRuntimeType: 365696
       GoKind: 22
       Pointee: 152 GoEmptyInterfaceType interface {}
     - __kind: PointerType
       ID: 585
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 844128
+      GoRuntimeType: 844160
       GoKind: 22
       Pointee: 586 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 900
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 832608
+      GoRuntimeType: 832640
       GoKind: 22
       Pointee: 901 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
       ID: 794
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.118432e+06
+      GoRuntimeType: 1.11856e+06
       GoKind: 22
       Pointee: 795 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1082
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.236096e+06
+      GoRuntimeType: 2.236384e+06
       GoKind: 22
       Pointee: 1083 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 792
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.118304e+06
+      GoRuntimeType: 1.118432e+06
       GoKind: 22
       Pointee: 793 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 522
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 831456
+      GoRuntimeType: 831488
       GoKind: 22
       Pointee: 523 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 946
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.109728e+06
+      GoRuntimeType: 1.109856e+06
       GoKind: 22
       Pointee: 947 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 944
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.109344e+06
+      GoRuntimeType: 1.109472e+06
       GoKind: 22
       Pointee: 945 StructureType io.discard
     - __kind: PointerType
       ID: 918
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 985536
+      GoRuntimeType: 985664
       GoKind: 22
       Pointee: 919 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 790
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.118048e+06
+      GoRuntimeType: 1.118176e+06
       GoKind: 22
       Pointee: 791 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 995
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.686816e+06
+      GoRuntimeType: 1.687104e+06
       GoKind: 22
       Pointee: 996 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13170,105 +13170,105 @@ Types:
       ID: 364
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 357920
+      GoRuntimeType: 357952
       GoKind: 22
       Pointee: 365 StructureType main.deepMap2
     - __kind: PointerType
       ID: 1120
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 357856
+      GoRuntimeType: 357888
       GoKind: 22
       Pointee: 1121 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 144
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 357600
+      GoRuntimeType: 357632
       GoKind: 22
       Pointee: 145 StructureType main.deepMap7
     - __kind: PointerType
       ID: 1148
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 357536
+      GoRuntimeType: 357568
       GoKind: 22
       Pointee: 1149 StructureType main.deepMap8
     - __kind: PointerType
       ID: 1157
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 357472
+      GoRuntimeType: 357504
       GoKind: 22
       Pointee: 1158 StructureType main.deepMap9
     - __kind: PointerType
       ID: 126
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 358496
+      GoRuntimeType: 358528
       GoKind: 22
       Pointee: 127 StructureType main.deepPtr2
     - __kind: PointerType
       ID: 1086
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 358432
+      GoRuntimeType: 358464
       GoKind: 22
       Pointee: 1087 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 128
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 358176
+      GoRuntimeType: 358208
       GoKind: 22
       Pointee: 129 StructureType main.deepPtr7
     - __kind: PointerType
       ID: 1123
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 358112
+      GoRuntimeType: 358144
       GoKind: 22
       Pointee: 1124 StructureType main.deepPtr8
     - __kind: PointerType
       ID: 1125
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 358048
+      GoRuntimeType: 358080
       GoKind: 22
       Pointee: 1126 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 133
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 359072
+      GoRuntimeType: 359104
       GoKind: 22
       Pointee: 358 StructureType main.deepSlice2
     - __kind: PointerType
       ID: 1110
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 359008
+      GoRuntimeType: 359040
       GoKind: 22
       Pointee: 1111 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 134
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 358752
+      GoRuntimeType: 358784
       GoKind: 22
       Pointee: 135 StructureType main.deepSlice7
     - __kind: PointerType
       ID: 1129
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 358688
+      GoRuntimeType: 358720
       GoKind: 22
       Pointee: 1130 StructureType main.deepSlice8
     - __kind: PointerType
       ID: 1135
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 358624
+      GoRuntimeType: 358656
       GoKind: 22
       Pointee: 1136 StructureType main.deepSlice9
     - __kind: PointerType
@@ -13281,28 +13281,28 @@ Types:
       ID: 154
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 359200
+      GoRuntimeType: 359232
       GoKind: 22
       Pointee: 155 StructureType main.esotericHeap
     - __kind: PointerType
       ID: 1102
       Name: '*main.firstBehavior'
       ByteSize: 8
-      GoRuntimeType: 827424
+      GoRuntimeType: 827456
       GoKind: 22
       Pointee: 349 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 1167
       Name: '*main.nestedStruct'
       ByteSize: 8
-      GoRuntimeType: 359456
+      GoRuntimeType: 359488
       GoKind: 22
       Pointee: 116 StructureType main.nestedStruct
     - __kind: PointerType
       ID: 242
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 359264
+      GoRuntimeType: 359296
       GoKind: 22
       Pointee: 241 StructureType main.node
     - __kind: PointerType
@@ -13315,14 +13315,14 @@ Types:
       ID: 1103
       Name: '*main.secondBehavior'
       ByteSize: 8
-      GoRuntimeType: 827520
+      GoRuntimeType: 827552
       GoKind: 22
       Pointee: 1104 StructureType main.secondBehavior
     - __kind: PointerType
       ID: 1091
       Name: '*main.somethingImpl'
       ByteSize: 8
-      GoRuntimeType: 827616
+      GoRuntimeType: 827648
       GoKind: 22
       Pointee: 1092 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
@@ -13356,7 +13356,7 @@ Types:
       ID: 381
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 357408
+      GoRuntimeType: 357440
       GoKind: 22
       Pointee: 160 StructureType main.structWithMap
     - __kind: PointerType
@@ -13397,77 +13397,77 @@ Types:
       ID: 619
       Name: '*math/big.ErrNaN'
       ByteSize: 8
-      GoRuntimeType: 851904
+      GoRuntimeType: 851936
       GoKind: 22
       Pointee: 620 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 908
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
-      GoRuntimeType: 846528
+      GoRuntimeType: 846560
       GoKind: 22
       Pointee: 909 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
       ID: 821
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.126752e+06
+      GoRuntimeType: 1.12688e+06
       GoKind: 22
       Pointee: 822 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 847
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.245568e+06
+      GoRuntimeType: 1.245696e+06
       GoKind: 22
       Pointee: 848 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1046
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.095648e+06
+      GoRuntimeType: 2.095936e+06
       GoKind: 22
       Pointee: 1047 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 845
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.245248e+06
+      GoRuntimeType: 1.245376e+06
       GoKind: 22
       Pointee: 846 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 823
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.12688e+06
+      GoRuntimeType: 1.127008e+06
       GoKind: 22
       Pointee: 824 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1056
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.125504e+06
+      GoRuntimeType: 2.125792e+06
       GoKind: 22
       Pointee: 1057 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1066
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.170464e+06
+      GoRuntimeType: 2.170752e+06
       GoKind: 22
       Pointee: 1067 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1054
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.124992e+06
+      GoRuntimeType: 2.12528e+06
       GoKind: 22
       Pointee: 1055 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 820
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.125984e+06
+      GoRuntimeType: 1.126112e+06
       GoKind: 22
       Pointee: 783 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13479,126 +13479,126 @@ Types:
       ID: 751
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.001024e+06
+      GoRuntimeType: 1.001152e+06
       GoKind: 22
       Pointee: 752 StructureType net.canceledError
     - __kind: PointerType
       ID: 1024
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 1.881792e+06
+      GoRuntimeType: 1.88208e+06
       GoKind: 22
       Pointee: 1025 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 889
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.726464e+06
+      GoRuntimeType: 1.726752e+06
       GoKind: 22
       Pointee: 890 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1068
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.17472e+06
+      GoRuntimeType: 2.175008e+06
       GoKind: 22
       Pointee: 1069 UnresolvedPointeeType net.netFD
     - __kind: PointerType
       ID: 554
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 839040
+      GoRuntimeType: 839072
       GoKind: 22
       Pointee: 555 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 556
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 839712
+      GoRuntimeType: 839744
       GoKind: 22
       Pointee: 557 StructureType net.result·2
     - __kind: PointerType
       ID: 1050
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.110016e+06
+      GoRuntimeType: 2.110304e+06
       GoKind: 22
       Pointee: 1051 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1048
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.109536e+06
+      GoRuntimeType: 2.109824e+06
       GoKind: 22
       Pointee: 1049 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 825
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.12752e+06
+      GoRuntimeType: 1.127648e+06
       GoKind: 22
       Pointee: 826 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 849
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.245728e+06
+      GoRuntimeType: 1.245856e+06
       GoKind: 22
       Pointee: 850 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 741
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 996800
+      GoRuntimeType: 996928
       GoKind: 22
       Pointee: 742 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 902
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 834912
+      GoRuntimeType: 834944
       GoKind: 22
       Pointee: 903 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 531
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 835584
+      GoRuntimeType: 835616
       GoKind: 22
       Pointee: 452 BaseType net/http.http2ConnectionError
     - __kind: PointerType
       ID: 532
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 835680
+      GoRuntimeType: 835712
       GoKind: 22
       Pointee: 533 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 841
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.241408e+06
+      GoRuntimeType: 1.241536e+06
       GoKind: 22
       Pointee: 842 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 536
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 836160
+      GoRuntimeType: 836192
       GoKind: 22
       Pointee: 537 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 964
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.37328e+06
+      GoRuntimeType: 1.373568e+06
       GoKind: 22
       Pointee: 965 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
       ID: 535
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 836064
+      GoRuntimeType: 836096
       GoKind: 22
       Pointee: 456 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -13610,7 +13610,7 @@ Types:
       ID: 539
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 836352
+      GoRuntimeType: 836384
       GoKind: 22
       Pointee: 462 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -13622,7 +13622,7 @@ Types:
       ID: 538
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 836256
+      GoRuntimeType: 836288
       GoKind: 22
       Pointee: 459 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -13634,28 +13634,28 @@ Types:
       ID: 816
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.122528e+06
+      GoRuntimeType: 1.122656e+06
       GoKind: 22
       Pointee: 817 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 747
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 997440
+      GoRuntimeType: 997568
       GoKind: 22
       Pointee: 748 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1015
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.825792e+06
+      GoRuntimeType: 1.82608e+06
       GoKind: 22
       Pointee: 1016 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
       ID: 534
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 835968
+      GoRuntimeType: 836000
       GoKind: 22
       Pointee: 453 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -13667,126 +13667,126 @@ Types:
       ID: 904
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 836448
+      GoRuntimeType: 836480
       GoKind: 22
       Pointee: 905 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 743
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 997056
+      GoRuntimeType: 997184
       GoKind: 22
       Pointee: 744 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 966
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.040864e+06
+      GoRuntimeType: 2.041152e+06
       GoKind: 22
       Pointee: 967 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 922
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 996928
+      GoRuntimeType: 997056
       GoKind: 22
       Pointee: 923 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 948
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.121504e+06
+      GoRuntimeType: 1.121632e+06
       GoKind: 22
       Pointee: 949 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
       ID: 540
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 836544
+      GoRuntimeType: 836576
       GoKind: 22
       Pointee: 541 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 843
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.242528e+06
+      GoRuntimeType: 1.242656e+06
       GoKind: 22
       Pointee: 844 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 814
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.1224e+06
+      GoRuntimeType: 1.122528e+06
       GoKind: 22
       Pointee: 815 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 745
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 997184
+      GoRuntimeType: 997312
       GoKind: 22
       Pointee: 746 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 529
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 834816
+      GoRuntimeType: 834848
       GoKind: 22
       Pointee: 530 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 1017
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.827328e+06
+      GoRuntimeType: 1.827616e+06
       GoKind: 22
       Pointee: 1018 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 932
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.010112e+06
+      GoRuntimeType: 1.01024e+06
       GoKind: 22
       Pointee: 933 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
       ID: 611
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
-      GoRuntimeType: 850848
+      GoRuntimeType: 850880
       GoKind: 22
       Pointee: 612 StructureType net/netip.parseAddrError
     - __kind: PointerType
       ID: 609
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
-      GoRuntimeType: 850752
+      GoRuntimeType: 850784
       GoKind: 22
       Pointee: 610 StructureType net/netip.parsePrefixError
     - __kind: PointerType
       ID: 974
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 1.990112e+06
+      GoRuntimeType: 1.9904e+06
       GoKind: 22
       Pointee: 975 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 934
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.015232e+06
+      GoRuntimeType: 1.01536e+06
       GoKind: 22
       Pointee: 935 StructureType net/smtp.dataCloser
     - __kind: PointerType
       ID: 595
       Name: '*net/textproto.Error'
       ByteSize: 8
-      GoRuntimeType: 846720
+      GoRuntimeType: 846752
       GoKind: 22
       Pointee: 596 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
       ID: 594
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 846624
+      GoRuntimeType: 846656
       GoKind: 22
       Pointee: 487 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
@@ -13798,21 +13798,21 @@ Types:
       ID: 930
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.009472e+06
+      GoRuntimeType: 1.0096e+06
       GoKind: 22
       Pointee: 931 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 851
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.246048e+06
+      GoRuntimeType: 1.246176e+06
       GoKind: 22
       Pointee: 852 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
       ID: 558
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 839808
+      GoRuntimeType: 839840
       GoKind: 22
       Pointee: 465 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -13824,7 +13824,7 @@ Types:
       ID: 559
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 839904
+      GoRuntimeType: 839936
       GoKind: 22
       Pointee: 468 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -13836,70 +13836,70 @@ Types:
       ID: 1074
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.211968e+06
+      GoRuntimeType: 2.212256e+06
       GoKind: 22
       Pointee: 1075 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 724
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 988224
+      GoRuntimeType: 988352
       GoKind: 22
       Pointee: 725 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 786
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.111136e+06
+      GoRuntimeType: 1.111264e+06
       GoKind: 22
       Pointee: 787 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1072
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.209024e+06
+      GoRuntimeType: 2.209312e+06
       GoKind: 22
       Pointee: 1073 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1070
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.208288e+06
+      GoRuntimeType: 2.208576e+06
       GoKind: 22
       Pointee: 1071 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 753
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.006144e+06
+      GoRuntimeType: 1.006272e+06
       GoKind: 22
       Pointee: 754 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 892
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 1.961376e+06
+      GoRuntimeType: 1.961664e+06
       GoKind: 22
       Pointee: 893 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 952
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.133536e+06
+      GoRuntimeType: 1.133664e+06
       GoKind: 22
       Pointee: 953 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 755
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.006272e+06
+      GoRuntimeType: 1.0064e+06
       GoKind: 22
       Pointee: 756 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 689
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
-      GoRuntimeType: 867840
+      GoRuntimeType: 867872
       GoKind: 22
       Pointee: 500 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
@@ -13911,84 +13911,84 @@ Types:
       ID: 688
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
-      GoRuntimeType: 867744
+      GoRuntimeType: 867776
       GoKind: 22
       Pointee: 499 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
       ID: 524
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 832224
+      GoRuntimeType: 832256
       GoKind: 22
       Pointee: 525 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 617
       Name: '*regexp/syntax.Error'
       ByteSize: 8
-      GoRuntimeType: 851520
+      GoRuntimeType: 851552
       GoKind: 22
       Pointee: 618 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
       ID: 727
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 989760
+      GoRuntimeType: 989888
       GoKind: 22
       Pointee: 728 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 732
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 991680
+      GoRuntimeType: 991808
       GoKind: 22
       Pointee: 733 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 365728
+      GoRuntimeType: 365760
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.239648e+06
+      GoRuntimeType: 1.239776e+06
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 729
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 989888
+      GoRuntimeType: 990016
       GoKind: 22
       Pointee: 730 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 366368
+      GoRuntimeType: 366400
       GoKind: 22
       Pointee: 61 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 366432
+      GoRuntimeType: 366464
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 788
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.116512e+06
+      GoRuntimeType: 1.11664e+06
       GoKind: 22
       Pointee: 789 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 726
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 989504
+      GoRuntimeType: 989632
       GoKind: 22
       Pointee: 707 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14000,28 +14000,28 @@ Types:
       ID: 53
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 830688
+      GoRuntimeType: 830720
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 991040
+      GoRuntimeType: 991168
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 142
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 368416
+      GoRuntimeType: 368448
       GoKind: 22
       Pointee: 143 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 731
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 991424
+      GoRuntimeType: 991552
       GoKind: 22
       Pointee: 710 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14033,35 +14033,35 @@ Types:
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 367136
+      GoRuntimeType: 367168
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 1.926656e+06
+      GoRuntimeType: 1.926944e+06
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.435648e+06
+      GoRuntimeType: 1.435936e+06
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 722
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 987584
+      GoRuntimeType: 987712
       GoKind: 22
       Pointee: 723 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 88
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 364512
+      GoRuntimeType: 364544
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
@@ -14073,21 +14073,21 @@ Types:
       ID: 1011
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.823744e+06
+      GoRuntimeType: 1.824032e+06
       GoKind: 22
       Pointee: 1012 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 920
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 987712
+      GoRuntimeType: 987840
       GoKind: 22
       Pointee: 921 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
       ID: 916
       Name: '*struct { io.Writer }'
       ByteSize: 8
-      GoRuntimeType: 924608
+      GoRuntimeType: 924736
       GoKind: 22
       Pointee: 917 StructureType struct { io.Writer }
     - __kind: PointerType
@@ -14099,42 +14099,42 @@ Types:
       ID: 840
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.240768e+06
+      GoRuntimeType: 1.240896e+06
       GoKind: 22
       Pointee: 839 BaseType syscall.Errno
     - __kind: PointerType
       ID: 1044
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.028064e+06
+      GoRuntimeType: 2.028352e+06
       GoKind: 22
       Pointee: 1045 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 781
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.051968e+06
+      GoRuntimeType: 1.052096e+06
       GoKind: 22
       Pointee: 782 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 856
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.441216e+06
+      GoRuntimeType: 1.441504e+06
       GoKind: 22
       Pointee: 857 UnresolvedPointeeType time.Location
     - __kind: PointerType
       ID: 527
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 833376
+      GoRuntimeType: 833408
       GoKind: 22
       Pointee: 528 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 526
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 833280
+      GoRuntimeType: 833312
       GoKind: 22
       Pointee: 449 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -14146,91 +14146,91 @@ Types:
       ID: 100
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 365152
+      GoRuntimeType: 365184
       GoKind: 22
       Pointee: 12 BaseType uint
     - __kind: PointerType
       ID: 96
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 364768
+      GoRuntimeType: 364800
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 364896
+      GoRuntimeType: 364928
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 95
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 365024
+      GoRuntimeType: 365056
       GoKind: 22
       Pointee: 10 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 364640
+      GoRuntimeType: 364672
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 365216
+      GoRuntimeType: 365248
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
       ID: 1007
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
-      GoRuntimeType: 1.780768e+06
+      GoRuntimeType: 1.781056e+06
       GoKind: 22
       Pointee: 1008 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
       ID: 613
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
-      GoRuntimeType: 850944
+      GoRuntimeType: 850976
       GoKind: 22
       Pointee: 614 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
       ID: 1036
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.00464e+06
+      GoRuntimeType: 2.004928e+06
       GoKind: 22
       Pointee: 1037 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
       ID: 597
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
-      GoRuntimeType: 847104
+      GoRuntimeType: 847136
       GoKind: 22
       Pointee: 598 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
       ID: 599
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
-      GoRuntimeType: 847200
+      GoRuntimeType: 847232
       GoKind: 22
       Pointee: 490 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
       ID: 760
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.009856e+06
+      GoRuntimeType: 1.009984e+06
       GoKind: 22
       Pointee: 761 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 762
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.009984e+06
+      GoRuntimeType: 1.010112e+06
       GoKind: 22
       Pointee: 715 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -23240,7 +23240,7 @@ Types:
       ID: 85
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 642528
+      GoRuntimeType: 642560
       GoKind: 17
       Count: 10
       HasCount: true
@@ -23249,7 +23249,7 @@ Types:
       ID: 330
       Name: '[16]uint8'
       ByteSize: 16
-      GoRuntimeType: 623072
+      GoRuntimeType: 623104
       GoKind: 17
       Count: 16
       HasCount: true
@@ -23258,7 +23258,7 @@ Types:
       ID: 247
       Name: '[1]int'
       ByteSize: 8
-      GoRuntimeType: 629216
+      GoRuntimeType: 629248
       GoKind: 17
       Count: 1
       HasCount: true
@@ -23267,7 +23267,7 @@ Types:
       ID: 71
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 642240
+      GoRuntimeType: 642272
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23292,7 +23292,7 @@ Types:
       ID: 77
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 642432
+      GoRuntimeType: 642464
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23309,7 +23309,7 @@ Types:
       ID: 106
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 626336
+      GoRuntimeType: 626368
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23326,7 +23326,7 @@ Types:
       ID: 103
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 627488
+      GoRuntimeType: 627520
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23367,7 +23367,7 @@ Types:
       ID: 104
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 627584
+      GoRuntimeType: 627616
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23407,7 +23407,7 @@ Types:
       ID: 52
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 627680
+      GoRuntimeType: 627712
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23416,7 +23416,7 @@ Types:
       ID: 102
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 627392
+      GoRuntimeType: 627424
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23425,7 +23425,7 @@ Types:
       ID: 83
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 675136
+      GoRuntimeType: 675168
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23434,7 +23434,7 @@ Types:
       ID: 63
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 642048
+      GoRuntimeType: 642080
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23443,7 +23443,7 @@ Types:
       ID: 246
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 627776
+      GoRuntimeType: 627808
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23452,7 +23452,7 @@ Types:
       ID: 51
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 641760
+      GoRuntimeType: 641792
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23461,7 +23461,7 @@ Types:
       ID: 391
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 625952
+      GoRuntimeType: 625984
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23470,7 +23470,7 @@ Types:
       ID: 376
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 626240
+      GoRuntimeType: 626272
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23479,7 +23479,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 634304
+      GoRuntimeType: 634336
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23496,7 +23496,7 @@ Types:
       ID: 884
       Name: '[5]uint8'
       ByteSize: 5
-      GoRuntimeType: 627296
+      GoRuntimeType: 627328
       GoKind: 17
       Count: 5
       HasCount: true
@@ -23505,7 +23505,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 628736
+      GoRuntimeType: 628768
       GoKind: 17
       Count: 6
       HasCount: true
@@ -23514,7 +23514,7 @@ Types:
       ID: 78
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 642336
+      GoRuntimeType: 642368
       GoKind: 17
       Count: 8
       HasCount: true
@@ -23523,7 +23523,7 @@ Types:
       ID: 361
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 623168
+      GoRuntimeType: 623200
       GoKind: 17
       Count: 8
       HasCount: true
@@ -23532,7 +23532,7 @@ Types:
       ID: 131
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 448800
+      GoRuntimeType: 448832
       GoKind: 23
       RawFields:
         - Name: array
@@ -23555,7 +23555,7 @@ Types:
       ID: 1108
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 448736
+      GoRuntimeType: 448768
       GoKind: 23
       RawFields:
         - Name: array
@@ -23578,7 +23578,7 @@ Types:
       ID: 1127
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 448416
+      GoRuntimeType: 448448
       GoKind: 23
       RawFields:
         - Name: array
@@ -23601,7 +23601,7 @@ Types:
       ID: 1133
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 448352
+      GoRuntimeType: 448384
       GoKind: 23
       RawFields:
         - Name: array
@@ -23624,7 +23624,7 @@ Types:
       ID: 122
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 447328
+      GoRuntimeType: 447360
       GoKind: 23
       RawFields:
         - Name: array
@@ -23779,7 +23779,7 @@ Types:
       ID: 259
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 456608
+      GoRuntimeType: 456640
       GoKind: 23
       RawFields:
         - Name: array
@@ -23964,7 +23964,7 @@ Types:
       ID: 879
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 456480
+      GoRuntimeType: 456512
       GoKind: 23
       RawFields:
         - Name: array
@@ -23987,7 +23987,7 @@ Types:
       ID: 345
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 452128
+      GoRuntimeType: 452160
       GoKind: 23
       RawFields:
         - Name: array
@@ -24032,7 +24032,7 @@ Types:
       ID: 342
       Name: '[]go.shape.string'
       ByteSize: 24
-      GoRuntimeType: 450144
+      GoRuntimeType: 450176
       GoKind: 23
       RawFields:
         - Name: array
@@ -24055,7 +24055,7 @@ Types:
       ID: 1139
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 456928
+      GoRuntimeType: 456960
       GoKind: 23
       RawFields:
         - Name: array
@@ -24148,7 +24148,7 @@ Types:
       ID: 380
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 449376
+      GoRuntimeType: 449408
       GoKind: 23
       RawFields:
         - Name: array
@@ -24197,7 +24197,7 @@ Types:
       ID: 258
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 456736
+      GoRuntimeType: 456768
       GoKind: 23
       RawFields:
         - Name: array
@@ -24220,7 +24220,7 @@ Types:
       ID: 261
       Name: '[]struct {}'
       ByteSize: 24
-      GoRuntimeType: 449696
+      GoRuntimeType: 449728
       GoKind: 23
       RawFields:
         - Name: array
@@ -24242,7 +24242,7 @@ Types:
       ID: 252
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 456224
+      GoRuntimeType: 456256
       GoKind: 23
       RawFields:
         - Name: array
@@ -24265,7 +24265,7 @@ Types:
       ID: 260
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 455584
+      GoRuntimeType: 455616
       GoKind: 23
       RawFields:
         - Name: array
@@ -24288,7 +24288,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 455456
+      GoRuntimeType: 455488
       GoKind: 23
       RawFields:
         - Name: array
@@ -24311,7 +24311,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 456288
+      GoRuntimeType: 456320
       GoKind: 23
       RawFields:
         - Name: array
@@ -24484,7 +24484,7 @@ Types:
       ID: 675
       Name: archive/tar.headerError
       ByteSize: 24
-      GoRuntimeType: 861888
+      GoRuntimeType: 861920
       GoKind: 23
       RawFields:
         - Name: array
@@ -24514,7 +24514,7 @@ Types:
     - __kind: StructureType
       ID: 913
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.083968e+06
+      GoRuntimeType: 1.084096e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24525,7 +24525,7 @@ Types:
       ID: 939
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.38336e+06
+      GoRuntimeType: 1.383648e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -24539,7 +24539,7 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 534912
+      GoRuntimeType: 534944
       GoKind: 1
     - __kind: GoHMapBucketType
       ID: 222
@@ -25069,36 +25069,36 @@ Types:
     - __kind: GoChannelType
       ID: 238
       Name: chan bool
-      GoRuntimeType: 546496
+      GoRuntimeType: 546528
       GoKind: 18
     - __kind: GoChannelType
       ID: 151
       Name: chan struct {}
-      GoRuntimeType: 545536
+      GoRuntimeType: 545568
       GoKind: 18
     - __kind: BaseType
       ID: 91
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 534720
+      GoRuntimeType: 534752
       GoKind: 16
     - __kind: BaseType
       ID: 90
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 534656
+      GoRuntimeType: 534688
       GoKind: 15
     - __kind: BaseType
       ID: 482
       Name: compress/flate.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 767712
+      GoRuntimeType: 767744
       GoKind: 6
     - __kind: GoStringHeaderType
       ID: 483
       Name: compress/flate.InternalError
       ByteSize: 16
-      GoRuntimeType: 767808
+      GoRuntimeType: 767840
       GoKind: 24
       RawFields:
         - Name: str
@@ -25128,20 +25128,20 @@ Types:
     - __kind: StructureType
       ID: 819
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.303296e+06
+      GoRuntimeType: 1.303584e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 496
       Name: crypto/aes.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 770304
+      GoRuntimeType: 770336
       GoKind: 2
     - __kind: BaseType
       ID: 497
       Name: crypto/des.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 770400
+      GoRuntimeType: 770432
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 973
@@ -25155,7 +25155,7 @@ Types:
       ID: 498
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 770496
+      GoRuntimeType: 770528
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1006
@@ -25173,7 +25173,7 @@ Types:
       ID: 486
       Name: crypto/tls.AlertError
       ByteSize: 1
-      GoRuntimeType: 768288
+      GoRuntimeType: 768320
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 759
@@ -25191,7 +25191,7 @@ Types:
       ID: 590
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.614112e+06
+      GoRuntimeType: 1.6144e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25207,7 +25207,7 @@ Types:
       ID: 714
       Name: crypto/tls.alert
       ByteSize: 1
-      GoRuntimeType: 956096
+      GoRuntimeType: 956224
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 971
@@ -25229,7 +25229,7 @@ Types:
       ID: 664
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.617184e+06
+      GoRuntimeType: 1.617472e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25244,14 +25244,14 @@ Types:
     - __kind: StructureType
       ID: 658
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.08128e+06
+      GoRuntimeType: 1.081408e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 660
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.415712e+06
+      GoRuntimeType: 1.416e+06
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -25264,19 +25264,19 @@ Types:
       ID: 495
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
-      GoRuntimeType: 769920
+      GoRuntimeType: 769952
       GoKind: 2
     - __kind: BaseType
       ID: 887
       Name: crypto/x509.InvalidReason
       ByteSize: 8
-      GoRuntimeType: 540160
+      GoRuntimeType: 540192
       GoKind: 2
     - __kind: StructureType
       ID: 764
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.37968e+06
+      GoRuntimeType: 1.379968e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -25285,14 +25285,14 @@ Types:
     - __kind: StructureType
       ID: 666
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.081536e+06
+      GoRuntimeType: 1.081664e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 662
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.616992e+06
+      GoRuntimeType: 1.61728e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25308,7 +25308,7 @@ Types:
       ID: 679
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.259648e+06
+      GoRuntimeType: 1.259776e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25318,7 +25318,7 @@ Types:
       ID: 683
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.259808e+06
+      GoRuntimeType: 1.259936e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25332,7 +25332,7 @@ Types:
       ID: 480
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 767424
+      GoRuntimeType: 767456
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 929
@@ -25342,7 +25342,7 @@ Types:
       ID: 481
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
-      GoRuntimeType: 767616
+      GoRuntimeType: 767648
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 551
@@ -25376,7 +25376,7 @@ Types:
       ID: 553
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.244288e+06
+      GoRuntimeType: 1.244416e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -25398,7 +25398,7 @@ Types:
       ID: 492
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
-      GoRuntimeType: 769824
+      GoRuntimeType: 769856
       GoKind: 24
       RawFields:
         - Name: str
@@ -25425,7 +25425,7 @@ Types:
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 989376
+      GoRuntimeType: 989504
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25446,13 +25446,13 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 534784
+      GoRuntimeType: 534816
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 534848
+      GoRuntimeType: 534880
       GoKind: 14
     - __kind: UnresolvedPointeeType
       ID: 1053
@@ -25470,13 +25470,13 @@ Types:
       ID: 57
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 447072
+      GoRuntimeType: 447104
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 67
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 781536
+      GoRuntimeType: 781568
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 348
@@ -25519,7 +25519,7 @@ Types:
       ID: 562
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.612384e+06
+      GoRuntimeType: 1.612672e+06
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25542,7 +25542,7 @@ Types:
     - __kind: StructureType
       ID: 568
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.077696e+06
+      GoRuntimeType: 1.077824e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25553,7 +25553,7 @@ Types:
       ID: 474
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 766848
+      GoRuntimeType: 766880
       GoKind: 24
       RawFields:
         - Name: str
@@ -25572,7 +25572,7 @@ Types:
       ID: 877
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.083904e+06
+      GoRuntimeType: 2.084192e+06
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25621,13 +25621,13 @@ Types:
       ID: 878
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 537152
+      GoRuntimeType: 537184
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 471
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 766752
+      GoRuntimeType: 766784
       GoKind: 24
       RawFields:
         - Name: str
@@ -25646,7 +25646,7 @@ Types:
       ID: 477
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 766944
+      GoRuntimeType: 766976
       GoKind: 24
       RawFields:
         - Name: str
@@ -25688,26 +25688,26 @@ Types:
     - __kind: StructureType
       ID: 608
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.080512e+06
+      GoRuntimeType: 1.08064e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 491
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
-      GoRuntimeType: 768960
+      GoRuntimeType: 768992
       GoKind: 2
     - __kind: StructureType
       ID: 606
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.080384e+06
+      GoRuntimeType: 1.080512e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 604
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.413792e+06
+      GoRuntimeType: 1.41408e+06
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25720,7 +25720,7 @@ Types:
       ID: 624
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.414592e+06
+      GoRuntimeType: 1.41488e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25733,7 +25733,7 @@ Types:
       ID: 628
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.616416e+06
+      GoRuntimeType: 1.616704e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25749,7 +25749,7 @@ Types:
       ID: 626
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.254048e+06
+      GoRuntimeType: 1.254176e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25759,7 +25759,7 @@ Types:
       ID: 622
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.253728e+06
+      GoRuntimeType: 1.253856e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25769,14 +25769,14 @@ Types:
       ID: 863
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.14096e+06
+      GoRuntimeType: 1.141088e+06
       GoKind: 21
       HeaderType: 865 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 886
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.013568e+06
+      GoRuntimeType: 1.013696e+06
       GoKind: 23
       RawFields:
         - Name: array
@@ -25799,7 +25799,7 @@ Types:
       ID: 636
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.414912e+06
+      GoRuntimeType: 1.4152e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25812,7 +25812,7 @@ Types:
       ID: 630
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.254208e+06
+      GoRuntimeType: 1.254336e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25822,7 +25822,7 @@ Types:
       ID: 634
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.616608e+06
+      GoRuntimeType: 1.616896e+06
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25838,7 +25838,7 @@ Types:
       ID: 632
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.414752e+06
+      GoRuntimeType: 1.41504e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25851,7 +25851,7 @@ Types:
       ID: 638
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.254368e+06
+      GoRuntimeType: 1.254496e+06
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25861,7 +25861,7 @@ Types:
       ID: 644
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.415232e+06
+      GoRuntimeType: 1.41552e+06
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25874,7 +25874,7 @@ Types:
       ID: 646
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.254688e+06
+      GoRuntimeType: 1.254816e+06
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25884,7 +25884,7 @@ Types:
       ID: 642
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.415072e+06
+      GoRuntimeType: 1.41536e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25897,7 +25897,7 @@ Types:
       ID: 640
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.254528e+06
+      GoRuntimeType: 1.254656e+06
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25907,7 +25907,7 @@ Types:
       ID: 648
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.415392e+06
+      GoRuntimeType: 1.41568e+06
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25920,7 +25920,7 @@ Types:
       ID: 570
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.246528e+06
+      GoRuntimeType: 1.246656e+06
       GoKind: 25
       RawFields:
         - Name: message
@@ -25934,7 +25934,7 @@ Types:
       ID: 572
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.246688e+06
+      GoRuntimeType: 1.246816e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25956,7 +25956,7 @@ Types:
       ID: 576
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.247008e+06
+      GoRuntimeType: 1.247136e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25970,7 +25970,7 @@ Types:
       ID: 1032
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 1.978176e+06
+      GoRuntimeType: 1.978464e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25983,7 +25983,7 @@ Types:
       ID: 1033
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.001952e+06
+      GoRuntimeType: 2.00224e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -26003,7 +26003,7 @@ Types:
       ID: 574
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.246848e+06
+      GoRuntimeType: 1.246976e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -26013,7 +26013,7 @@ Types:
       ID: 578
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.247168e+06
+      GoRuntimeType: 1.247296e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -26063,7 +26063,7 @@ Types:
       ID: 584
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.248128e+06
+      GoRuntimeType: 1.248256e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -26078,7 +26078,7 @@ Types:
       ID: 803
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.721536e+06
+      GoRuntimeType: 1.721824e+06
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -26098,7 +26098,7 @@ Types:
       ID: 736
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.51792e+06
+      GoRuntimeType: 1.518208e+06
       GoKind: 25
       RawFields:
         - Name: Got
@@ -26111,7 +26111,7 @@ Types:
       ID: 809
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.721984e+06
+      GoRuntimeType: 1.722272e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26127,13 +26127,13 @@ Types:
       ID: 713
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 953504
+      GoRuntimeType: 953632
       GoKind: 8
     - __kind: StructureType
       ID: 801
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.721312e+06
+      GoRuntimeType: 1.7216e+06
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -26149,13 +26149,13 @@ Types:
       ID: 888
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 765024
+      GoRuntimeType: 765056
       GoKind: 8
     - __kind: StructureType
       ID: 799
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.721088e+06
+      GoRuntimeType: 1.721376e+06
       GoKind: 25
       RawFields:
         - Name: Method
@@ -26171,7 +26171,7 @@ Types:
       ID: 807
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.64e+06
+      GoRuntimeType: 1.640288e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26184,7 +26184,7 @@ Types:
       ID: 805
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.72176e+06
+      GoRuntimeType: 1.722048e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26204,7 +26204,7 @@ Types:
       ID: 813
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.442176e+06
+      GoRuntimeType: 1.442464e+06
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -26213,20 +26213,20 @@ Types:
     - __kind: StructureType
       ID: 740
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.201056e+06
+      GoRuntimeType: 1.201184e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 738
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.200928e+06
+      GoRuntimeType: 1.201056e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 811
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.640192e+06
+      GoRuntimeType: 1.64048e+06
       GoKind: 25
       RawFields:
         - Name: cause
@@ -26239,7 +26239,7 @@ Types:
       ID: 503
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
-      GoRuntimeType: 772320
+      GoRuntimeType: 772352
       GoKind: 24
       RawFields:
         - Name: str
@@ -26258,25 +26258,25 @@ Types:
       ID: 334
       Name: go.shape.bool
       ByteSize: 1
-      GoRuntimeType: 546688
+      GoRuntimeType: 546720
       GoKind: 1
     - __kind: BaseType
       ID: 347
       Name: go.shape.float64
       ByteSize: 8
-      GoRuntimeType: 546752
+      GoRuntimeType: 546784
       GoKind: 14
     - __kind: BaseType
       ID: 317
       Name: go.shape.int
       ByteSize: 8
-      GoRuntimeType: 546560
+      GoRuntimeType: 546592
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 319
       Name: go.shape.string
       ByteSize: 16
-      GoRuntimeType: 546624
+      GoRuntimeType: 546656
       GoKind: 24
       RawFields:
         - Name: str
@@ -26350,7 +26350,7 @@ Types:
       ID: 780
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.271488e+06
+      GoRuntimeType: 1.271616e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26360,7 +26360,7 @@ Types:
       ID: 957
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.494784e+06
+      GoRuntimeType: 1.495072e+06
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -26374,7 +26374,7 @@ Types:
       ID: 981
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.091392e+06
+      GoRuntimeType: 1.09152e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26387,7 +26387,7 @@ Types:
       ID: 943
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.38816e+06
+      GoRuntimeType: 1.388448e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -26397,19 +26397,19 @@ Types:
       ID: 506
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
-      GoRuntimeType: 772896
+      GoRuntimeType: 772928
       GoKind: 10
     - __kind: BaseType
       ID: 870
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 966752
+      GoRuntimeType: 966880
       GoKind: 10
     - __kind: StructureType
       ID: 838
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.759616e+06
+      GoRuntimeType: 1.759904e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26425,7 +26425,7 @@ Types:
       ID: 699
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.422592e+06
+      GoRuntimeType: 1.42288e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26438,7 +26438,7 @@ Types:
       ID: 510
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 773088
+      GoRuntimeType: 773120
       GoKind: 24
       RawFields:
         - Name: str
@@ -26457,7 +26457,7 @@ Types:
       ID: 516
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 773280
+      GoRuntimeType: 773312
       GoKind: 24
       RawFields:
         - Name: str
@@ -26476,7 +26476,7 @@ Types:
       ID: 513
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 773184
+      GoRuntimeType: 773216
       GoKind: 24
       RawFields:
         - Name: str
@@ -26495,7 +26495,7 @@ Types:
       ID: 507
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 772992
+      GoRuntimeType: 773024
       GoKind: 24
       RawFields:
         - Name: str
@@ -26518,7 +26518,7 @@ Types:
       ID: 703
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.272128e+06
+      GoRuntimeType: 1.272256e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26528,13 +26528,13 @@ Types:
       ID: 519
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
-      GoRuntimeType: 773376
+      GoRuntimeType: 773408
       GoKind: 2
     - __kind: StructureType
       ID: 691
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.267168e+06
+      GoRuntimeType: 1.267296e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26548,7 +26548,7 @@ Types:
       ID: 861
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.785376e+06
+      GoRuntimeType: 1.785664e+06
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26564,7 +26564,7 @@ Types:
       ID: 693
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.422112e+06
+      GoRuntimeType: 1.4224e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26577,7 +26577,7 @@ Types:
       ID: 1004
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.838848e+06
+      GoRuntimeType: 1.839136e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26594,7 +26594,7 @@ Types:
       ID: 778
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.38576e+06
+      GoRuntimeType: 1.386048e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26619,14 +26619,14 @@ Types:
     - __kind: StructureType
       ID: 832
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.332576e+06
+      GoRuntimeType: 1.332864e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 685
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.260448e+06
+      GoRuntimeType: 1.260576e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26636,7 +26636,7 @@ Types:
       ID: 687
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.260608e+06
+      GoRuntimeType: 1.260736e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -27576,37 +27576,37 @@ Types:
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 534464
+      GoRuntimeType: 534496
       GoKind: 2
     - __kind: BaseType
       ID: 89
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 534080
+      GoRuntimeType: 534112
       GoKind: 4
     - __kind: BaseType
       ID: 13
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 534208
+      GoRuntimeType: 534240
       GoKind: 5
     - __kind: BaseType
       ID: 14
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 534336
+      GoRuntimeType: 534368
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 533952
+      GoRuntimeType: 533984
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 152
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 781248
+      GoRuntimeType: 781280
       GoKind: 20
       RawFields:
         - Name: _type
@@ -27623,7 +27623,7 @@ Types:
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.7296e+06
+      GoRuntimeType: 1.729888e+06
       GoKind: 25
       RawFields:
         - Name: buf
@@ -27656,7 +27656,7 @@ Types:
     - __kind: StructureType
       ID: 793
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.300256e+06
+      GoRuntimeType: 1.300544e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27667,7 +27667,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.133152e+06
+      GoRuntimeType: 1.13328e+06
       GoKind: 25
       RawFields:
         - Name: u
@@ -27677,7 +27677,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.456384e+06
+      GoRuntimeType: 1.456672e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27693,7 +27693,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.313536e+06
+      GoRuntimeType: 1.313824e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27706,7 +27706,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.313376e+06
+      GoRuntimeType: 1.313664e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27719,7 +27719,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.313696e+06
+      GoRuntimeType: 1.313984e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27731,13 +27731,13 @@ Types:
     - __kind: StructureType
       ID: 66
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 955808
+      GoRuntimeType: 955936
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 955712
+      GoRuntimeType: 955840
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27748,7 +27748,7 @@ Types:
       ID: 988
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.109472e+06
+      GoRuntimeType: 1.1096e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27761,7 +27761,7 @@ Types:
       ID: 1019
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 985664
+      GoRuntimeType: 985792
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27774,7 +27774,7 @@ Types:
       ID: 976
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.074112e+06
+      GoRuntimeType: 1.07424e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27787,7 +27787,7 @@ Types:
       ID: 124
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 985408
+      GoRuntimeType: 985536
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27799,7 +27799,7 @@ Types:
     - __kind: StructureType
       ID: 945
       Name: io.discard
-      GoRuntimeType: 1.287616e+06
+      GoRuntimeType: 1.287904e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27869,7 +27869,7 @@ Types:
       ID: 157
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 984256
+      GoRuntimeType: 984384
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27882,7 +27882,7 @@ Types:
       ID: 121
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.428928e+06
+      GoRuntimeType: 1.429216e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -27898,7 +27898,7 @@ Types:
       ID: 136
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.10576e+06
+      GoRuntimeType: 1.105888e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27908,7 +27908,7 @@ Types:
       ID: 365
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.105632e+06
+      GoRuntimeType: 1.10576e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27922,7 +27922,7 @@ Types:
       ID: 145
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.104992e+06
+      GoRuntimeType: 1.10512e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27932,7 +27932,7 @@ Types:
       ID: 1149
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.104864e+06
+      GoRuntimeType: 1.104992e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27942,7 +27942,7 @@ Types:
       ID: 1158
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.104736e+06
+      GoRuntimeType: 1.104864e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27952,7 +27952,7 @@ Types:
       ID: 125
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.106912e+06
+      GoRuntimeType: 1.10704e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27962,7 +27962,7 @@ Types:
       ID: 127
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.106784e+06
+      GoRuntimeType: 1.106912e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27976,7 +27976,7 @@ Types:
       ID: 129
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.106144e+06
+      GoRuntimeType: 1.106272e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27986,7 +27986,7 @@ Types:
       ID: 1124
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.106016e+06
+      GoRuntimeType: 1.106144e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27996,7 +27996,7 @@ Types:
       ID: 1126
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.105888e+06
+      GoRuntimeType: 1.106016e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -28006,7 +28006,7 @@ Types:
       ID: 130
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.108064e+06
+      GoRuntimeType: 1.108192e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -28016,7 +28016,7 @@ Types:
       ID: 358
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.107936e+06
+      GoRuntimeType: 1.108064e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -28030,7 +28030,7 @@ Types:
       ID: 135
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.107296e+06
+      GoRuntimeType: 1.107424e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -28040,7 +28040,7 @@ Types:
       ID: 1130
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.107168e+06
+      GoRuntimeType: 1.107296e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -28050,7 +28050,7 @@ Types:
       ID: 1136
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.10704e+06
+      GoRuntimeType: 1.107168e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -28065,7 +28065,7 @@ Types:
       ID: 155
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.713696e+06
+      GoRuntimeType: 1.713984e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -28087,7 +28087,7 @@ Types:
       ID: 150
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.84016e+06
+      GoRuntimeType: 1.840448e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -28115,7 +28115,7 @@ Types:
       ID: 349
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.237568e+06
+      GoRuntimeType: 1.237696e+06
       GoKind: 25
       RawFields:
         - Name: s
@@ -28242,7 +28242,7 @@ Types:
       ID: 116
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.286656e+06
+      GoRuntimeType: 1.286944e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -28255,7 +28255,7 @@ Types:
       ID: 241
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.286336e+06
+      GoRuntimeType: 1.286624e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -28277,14 +28277,14 @@ Types:
       ID: 1104
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.237728e+06
+      GoRuntimeType: 1.237856e+06
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 9 BaseType int}]
     - __kind: GoInterfaceType
       ID: 153
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 984384
+      GoRuntimeType: 984512
       GoKind: 20
       RawFields:
         - Name: tab
@@ -28337,7 +28337,7 @@ Types:
       ID: 159
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.10448e+06
+      GoRuntimeType: 1.104608e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -28407,7 +28407,7 @@ Types:
       ID: 160
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.104608e+06
+      GoRuntimeType: 1.104736e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -28576,119 +28576,119 @@ Types:
       ID: 218
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 884256
+      GoRuntimeType: 884288
       GoKind: 21
       HeaderType: 220 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
       ID: 213
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 884352
+      GoRuntimeType: 884384
       GoKind: 21
       HeaderType: 215 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
       ID: 181
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 884448
+      GoRuntimeType: 884480
       GoKind: 21
       HeaderType: 183 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoMapType
       ID: 193
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 884544
+      GoRuntimeType: 884576
       GoKind: 21
       HeaderType: 195 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
       ID: 137
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 884160
+      GoRuntimeType: 884192
       GoKind: 21
       HeaderType: 139 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1114
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 884064
+      GoRuntimeType: 884096
       GoKind: 21
       HeaderType: 1116 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1142
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 883584
+      GoRuntimeType: 883616
       GoKind: 21
       HeaderType: 1144 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1151
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 883488
+      GoRuntimeType: 883520
       GoKind: 21
       HeaderType: 1153 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 161
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 882336
+      GoRuntimeType: 882368
       GoKind: 21
       HeaderType: 163 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
       ID: 1160
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 883392
+      GoRuntimeType: 883424
       GoKind: 21
       HeaderType: 1162 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 228
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 884640
+      GoRuntimeType: 884672
       GoKind: 21
       HeaderType: 230 GoHMapHeaderType hash<int,struct {}>
     - __kind: GoMapType
       ID: 198
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 884736
+      GoRuntimeType: 884768
       GoKind: 21
       HeaderType: 200 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
       ID: 188
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 884832
+      GoRuntimeType: 884864
       GoKind: 21
       HeaderType: 190 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 176
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 884928
+      GoRuntimeType: 884960
       GoKind: 21
       HeaderType: 178 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
       ID: 171
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 885024
+      GoRuntimeType: 885056
       GoKind: 21
       HeaderType: 173 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 166
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 885120
+      GoRuntimeType: 885152
       GoKind: 21
       HeaderType: 168 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 223
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 885216
+      GoRuntimeType: 885248
       GoKind: 21
       HeaderType: 225 GoHMapHeaderType hash<struct {},int>
     - __kind: GoMapType
@@ -28731,28 +28731,28 @@ Types:
       ID: 233
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 885312
+      GoRuntimeType: 885344
       GoKind: 21
       HeaderType: 235 GoHMapHeaderType hash<struct {},struct {}>
     - __kind: GoMapType
       ID: 208
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 885408
+      GoRuntimeType: 885440
       GoKind: 21
       HeaderType: 210 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoMapType
       ID: 203
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 885504
+      GoRuntimeType: 885536
       GoKind: 21
       HeaderType: 205 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
       ID: 620
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.253408e+06
+      GoRuntimeType: 1.253536e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -28762,7 +28762,7 @@ Types:
       ID: 909
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.250208e+06
+      GoRuntimeType: 1.250336e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -28776,7 +28776,7 @@ Types:
       ID: 885
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.412512e+06
+      GoRuntimeType: 1.4128e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -28817,7 +28817,7 @@ Types:
       ID: 783
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.077312e+06
+      GoRuntimeType: 1.07744e+06
       GoKind: 24
       RawFields:
         - Name: str
@@ -28835,7 +28835,7 @@ Types:
     - __kind: StructureType
       ID: 752
       Name: net.canceledError
-      GoRuntimeType: 1.201952e+06
+      GoRuntimeType: 1.20208e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28846,7 +28846,7 @@ Types:
       ID: 890
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 1.977472e+06
+      GoRuntimeType: 1.97776e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -28868,13 +28868,13 @@ Types:
     - __kind: StructureType
       ID: 1063
       Name: net.noReadFrom
-      GoRuntimeType: 1.077568e+06
+      GoRuntimeType: 1.077696e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1062
       Name: net.noWriteTo
-      GoRuntimeType: 1.07744e+06
+      GoRuntimeType: 1.077568e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28885,7 +28885,7 @@ Types:
       ID: 557
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.612192e+06
+      GoRuntimeType: 1.61248e+06
       GoKind: 25
       RawFields:
         - Name: p
@@ -28901,7 +28901,7 @@ Types:
       ID: 1051
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.153792e+06
+      GoRuntimeType: 2.15408e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -28914,7 +28914,7 @@ Types:
       ID: 1049
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.153248e+06
+      GoRuntimeType: 2.153536e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -28939,7 +28939,7 @@ Types:
       ID: 903
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.241728e+06
+      GoRuntimeType: 1.241856e+06
       GoKind: 25
       RawFields:
         - Name: w
@@ -28949,19 +28949,19 @@ Types:
       ID: 452
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 765504
+      GoRuntimeType: 765536
       GoKind: 10
     - __kind: BaseType
       ID: 862
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 953600
+      GoRuntimeType: 953728
       GoKind: 10
     - __kind: StructureType
       ID: 533
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.610272e+06
+      GoRuntimeType: 1.61056e+06
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -28977,7 +28977,7 @@ Types:
       ID: 842
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.775648e+06
+      GoRuntimeType: 1.775936e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -28993,7 +28993,7 @@ Types:
       ID: 537
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.412032e+06
+      GoRuntimeType: 1.41232e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29010,7 +29010,7 @@ Types:
       ID: 456
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 765696
+      GoRuntimeType: 765728
       GoKind: 24
       RawFields:
         - Name: str
@@ -29029,7 +29029,7 @@ Types:
       ID: 462
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 765888
+      GoRuntimeType: 765920
       GoKind: 24
       RawFields:
         - Name: str
@@ -29048,7 +29048,7 @@ Types:
       ID: 459
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 765792
+      GoRuntimeType: 765824
       GoKind: 24
       RawFields:
         - Name: str
@@ -29070,7 +29070,7 @@ Types:
     - __kind: StructureType
       ID: 748
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.201312e+06
+      GoRuntimeType: 1.20144e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29081,7 +29081,7 @@ Types:
       ID: 453
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 765600
+      GoRuntimeType: 765632
       GoKind: 24
       RawFields:
         - Name: str
@@ -29100,7 +29100,7 @@ Types:
       ID: 905
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
-      GoRuntimeType: 1.61104e+06
+      GoRuntimeType: 1.611328e+06
       GoKind: 25
       RawFields:
         - Name: conn
@@ -29115,7 +29115,7 @@ Types:
     - __kind: ArrayType
       ID: 985
       Name: net/http.incomparable
-      GoRuntimeType: 834624
+      GoRuntimeType: 834656
       GoKind: 17
       HasCount: true
       Element: 57 GoSubroutineType func()
@@ -29123,7 +29123,7 @@ Types:
       ID: 744
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.37392e+06
+      GoRuntimeType: 1.374208e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -29137,7 +29137,7 @@ Types:
       ID: 923
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.37376e+06
+      GoRuntimeType: 1.374048e+06
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29147,7 +29147,7 @@ Types:
       ID: 949
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.682336e+06
+      GoRuntimeType: 1.682624e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -29163,7 +29163,7 @@ Types:
       ID: 541
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.242688e+06
+      GoRuntimeType: 1.242816e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -29176,14 +29176,14 @@ Types:
     - __kind: StructureType
       ID: 815
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.302976e+06
+      GoRuntimeType: 1.303264e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 746
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.37408e+06
+      GoRuntimeType: 1.374368e+06
       GoKind: 25
       RawFields:
         - Name: err
@@ -29197,7 +29197,7 @@ Types:
       ID: 1018
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 1.913888e+06
+      GoRuntimeType: 1.914176e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29211,7 +29211,7 @@ Types:
       ID: 612
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.616032e+06
+      GoRuntimeType: 1.61632e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29227,7 +29227,7 @@ Types:
       ID: 610
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.413952e+06
+      GoRuntimeType: 1.41424e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29244,7 +29244,7 @@ Types:
       ID: 935
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.415872e+06
+      GoRuntimeType: 1.41616e+06
       GoKind: 25
       RawFields:
         - Name: c
@@ -29261,7 +29261,7 @@ Types:
       ID: 487
       Name: net/textproto.ProtocolError
       ByteSize: 16
-      GoRuntimeType: 768384
+      GoRuntimeType: 768416
       GoKind: 24
       RawFields:
         - Name: str
@@ -29288,7 +29288,7 @@ Types:
       ID: 465
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 766464
+      GoRuntimeType: 766496
       GoKind: 24
       RawFields:
         - Name: str
@@ -29307,7 +29307,7 @@ Types:
       ID: 468
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 766560
+      GoRuntimeType: 766592
       GoKind: 24
       RawFields:
         - Name: str
@@ -29338,7 +29338,7 @@ Types:
       ID: 1073
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.221984e+06
+      GoRuntimeType: 2.222272e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29351,7 +29351,7 @@ Types:
       ID: 1071
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.221184e+06
+      GoRuntimeType: 2.221472e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29363,13 +29363,13 @@ Types:
     - __kind: StructureType
       ID: 1079
       Name: os.noReadFrom
-      GoRuntimeType: 1.075136e+06
+      GoRuntimeType: 1.075264e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1078
       Name: os.noWriteTo
-      GoRuntimeType: 1.075008e+06
+      GoRuntimeType: 1.075136e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29388,7 +29388,7 @@ Types:
       ID: 756
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.518496e+06
+      GoRuntimeType: 1.518784e+06
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -29401,7 +29401,7 @@ Types:
       ID: 500
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
-      GoRuntimeType: 771552
+      GoRuntimeType: 771584
       GoKind: 24
       RawFields:
         - Name: str
@@ -29420,7 +29420,7 @@ Types:
       ID: 499
       Name: os/user.UnknownUserIdError
       ByteSize: 8
-      GoRuntimeType: 771456
+      GoRuntimeType: 771488
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 525
@@ -29450,7 +29450,7 @@ Types:
       ID: 730
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.765216e+06
+      GoRuntimeType: 1.765504e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -29469,7 +29469,7 @@ Types:
       ID: 891
       Name: runtime.boundsErrorCode
       ByteSize: 1
-      GoRuntimeType: 535040
+      GoRuntimeType: 535072
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 61
@@ -29482,14 +29482,14 @@ Types:
     - __kind: StructureType
       ID: 80
       Name: runtime.dlogPerM
-      GoRuntimeType: 952832
+      GoRuntimeType: 952960
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 789
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.63616e+06
+      GoRuntimeType: 1.636448e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -29502,7 +29502,7 @@ Types:
       ID: 707
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 952448
+      GoRuntimeType: 952576
       GoKind: 24
       RawFields:
         - Name: str
@@ -29521,7 +29521,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 2.265216e+06
+      GoRuntimeType: 2.265504e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -29696,7 +29696,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.116256e+06
+      GoRuntimeType: 1.116384e+06
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -29706,7 +29706,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.842464e+06
+      GoRuntimeType: 1.842752e+06
       GoKind: 25
       RawFields:
         - Name: sp
@@ -29734,7 +29734,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.295296e+06
+      GoRuntimeType: 1.295584e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -29747,7 +29747,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.6352e+06
+      GoRuntimeType: 1.635488e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -29766,13 +29766,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 764256
+      GoRuntimeType: 764288
       GoKind: 12
     - __kind: StructureType
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.295136e+06
+      GoRuntimeType: 1.295424e+06
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -29785,7 +29785,7 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.79072e+06
+      GoRuntimeType: 1.791008e+06
       GoKind: 25
       RawFields:
         - Name: fn
@@ -29810,13 +29810,13 @@ Types:
       ID: 87
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 764160
+      GoRuntimeType: 764192
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 2.271328e+06
+      GoRuntimeType: 2.271616e+06
       GoKind: 25
       RawFields:
         - Name: g0
@@ -30036,7 +30036,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.790464e+06
+      GoRuntimeType: 1.790752e+06
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -30061,7 +30061,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 1.436032e+06
+      GoRuntimeType: 1.43632e+06
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -30077,7 +30077,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 1.43584e+06
+      GoRuntimeType: 1.436128e+06
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -30097,20 +30097,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 763872
+      GoRuntimeType: 763904
       GoKind: 12
     - __kind: StructureType
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.115872e+06
+      GoRuntimeType: 1.116e+06
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.294976e+06
+      GoRuntimeType: 1.295264e+06
       GoKind: 25
       RawFields:
         - Name: entries
@@ -30123,7 +30123,7 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.635968e+06
+      GoRuntimeType: 1.636256e+06
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -30142,7 +30142,7 @@ Types:
       ID: 710
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 953024
+      GoRuntimeType: 953152
       GoKind: 24
       RawFields:
         - Name: str
@@ -30161,13 +30161,13 @@ Types:
       ID: 58
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 764064
+      GoRuntimeType: 764096
       GoKind: 12
     - __kind: ArrayType
       ID: 55
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 830304
+      GoRuntimeType: 830336
       GoKind: 17
       Count: 2
       HasCount: true
@@ -30176,7 +30176,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.293376e+06
+      GoRuntimeType: 1.293664e+06
       GoKind: 25
       RawFields:
         - Name: lo
@@ -30193,7 +30193,7 @@ Types:
       ID: 59
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 535168
+      GoRuntimeType: 535200
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -30203,7 +30203,7 @@ Types:
       ID: 68
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 535232
+      GoRuntimeType: 535264
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 73
@@ -30213,7 +30213,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.294336e+06
+      GoRuntimeType: 1.294624e+06
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -30226,12 +30226,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.07552e+06
+      GoRuntimeType: 1.075648e+06
       GoKind: 8
     - __kind: StructureType
       ID: 75
       Name: runtime.winlibcall
-      GoRuntimeType: 952736
+      GoRuntimeType: 952864
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -30242,7 +30242,7 @@ Types:
       ID: 11
       Name: string
       ByteSize: 16
-      GoRuntimeType: 533888
+      GoRuntimeType: 533920
       GoKind: 24
       RawFields:
         - Name: str
@@ -30269,7 +30269,7 @@ Types:
       ID: 917
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.279136e+06
+      GoRuntimeType: 1.279424e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -30278,14 +30278,14 @@ Types:
     - __kind: StructureType
       ID: 118
       Name: struct {}
-      GoRuntimeType: 775200
+      GoRuntimeType: 775232
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1093
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.287936e+06
+      GoRuntimeType: 1.288224e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -30298,7 +30298,7 @@ Types:
       ID: 1094
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.289056e+06
+      GoRuntimeType: 1.289344e+06
       GoKind: 25
       RawFields:
         - Name: done
@@ -30311,7 +30311,7 @@ Types:
       ID: 1097
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.429696e+06
+      GoRuntimeType: 1.429984e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -30326,14 +30326,14 @@ Types:
     - __kind: StructureType
       ID: 1098
       Name: sync.noCopy
-      GoRuntimeType: 951392
+      GoRuntimeType: 951520
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1101
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.289376e+06
+      GoRuntimeType: 1.289664e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -30346,7 +30346,7 @@ Types:
       ID: 1095
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.289536e+06
+      GoRuntimeType: 1.289824e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -30359,7 +30359,7 @@ Types:
       ID: 1099
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.43008e+06
+      GoRuntimeType: 1.430368e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -30374,20 +30374,20 @@ Types:
     - __kind: StructureType
       ID: 1100
       Name: sync/atomic.align64
-      GoRuntimeType: 951584
+      GoRuntimeType: 951712
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1096
       Name: sync/atomic.noCopy
-      GoRuntimeType: 951488
+      GoRuntimeType: 951616
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 839
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.200544e+06
+      GoRuntimeType: 1.200672e+06
       GoKind: 12
     - __kind: UnresolvedPointeeType
       ID: 1045
@@ -30397,7 +30397,7 @@ Types:
       ID: 782
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.522912e+06
+      GoRuntimeType: 1.5232e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -30410,7 +30410,7 @@ Types:
       ID: 984
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.791488e+06
+      GoRuntimeType: 1.791776e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 857
@@ -30424,7 +30424,7 @@ Types:
       ID: 855
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.234208e+06
+      GoRuntimeType: 2.234496e+06
       GoKind: 25
       RawFields:
         - Name: wall
@@ -30440,7 +30440,7 @@ Types:
       ID: 449
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 764640
+      GoRuntimeType: 764672
       GoKind: 24
       RawFields:
         - Name: str
@@ -30459,43 +30459,43 @@ Types:
       ID: 12
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 534528
+      GoRuntimeType: 534560
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 534144
+      GoRuntimeType: 534176
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 534272
+      GoRuntimeType: 534304
       GoKind: 10
     - __kind: BaseType
       ID: 10
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 534400
+      GoRuntimeType: 534432
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 534016
+      GoRuntimeType: 534048
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 534592
+      GoRuntimeType: 534624
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 534976
+      GoRuntimeType: 535008
       GoKind: 26
     - __kind: UnresolvedPointeeType
       ID: 1008
@@ -30505,7 +30505,7 @@ Types:
       ID: 873
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 1.935616e+06
+      GoRuntimeType: 1.935904e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30539,13 +30539,13 @@ Types:
       ID: 876
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
-      GoRuntimeType: 957728
+      GoRuntimeType: 957856
       GoKind: 9
     - __kind: StructureType
       ID: 874
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.801984e+06
+      GoRuntimeType: 1.802272e+06
       GoKind: 25
       RawFields:
         - Name: id
@@ -30574,7 +30574,7 @@ Types:
       ID: 875
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
-      GoRuntimeType: 538624
+      GoRuntimeType: 538656
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1037
@@ -30584,7 +30584,7 @@ Types:
       ID: 598
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.250528e+06
+      GoRuntimeType: 1.250656e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -30594,13 +30594,13 @@ Types:
       ID: 490
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
-      GoRuntimeType: 768480
+      GoRuntimeType: 768512
       GoKind: 2
     - __kind: StructureType
       ID: 761
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.518688e+06
+      GoRuntimeType: 1.518976e+06
       GoKind: 25
       RawFields:
         - Name: label
@@ -30613,7 +30613,7 @@ Types:
       ID: 715
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
-      GoRuntimeType: 956576
+      GoRuntimeType: 956704
       GoKind: 5
 MaxTypeID: 1495
 Issues:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1574 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x851d48", Frameless: false}]
+              InjectionPoints: [{PC: "0x851d58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1575 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x851d7c", Frameless: false}]
+              InjectionPoints: [{PC: "0x851d8c", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1413 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x84cf08", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cf18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1414 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x84cf34", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cf44", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x84cf88", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cf98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x84cfb4", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cfc4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1545 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x850b3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x850b4c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1546 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x850bd4", Frameless: false}]
+              InjectionPoints: [{PC: "0x850be4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1363 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0x84a6d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a6e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1359 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0x84a690", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a6a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1361 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0x84a6b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a6c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x84d5f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1360 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0x84a6a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a6b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1362 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0x84a6c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a6d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x84ed90", Frameless: true}]
+              InjectionPoints: [{PC: "0x84eda0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1448 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x84edcc", Frameless: true}]
+              InjectionPoints: [{PC: "0x84eddc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x84ac20", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ac30", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1382 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0x84ac38", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ac48", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1348 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0x84a5e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a5f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1345 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0x84a5b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x8520a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8520b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1594 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x8520bc", Frameless: true}]
+              InjectionPoints: [{PC: "0x8520cc", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1654 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x84c7c8"
+                - PC: "0x84c7d8"
                   Frameless: false
-                - PC: "0x84c83c"
+                - PC: "0x84c84c"
                   Frameless: false
-                - PC: "0x84c988"
+                - PC: "0x84c998"
                   Frameless: false
-                - PC: "0x84ca04"
+                - PC: "0x84ca14"
                   Frameless: false
-                - PC: "0x84cabc"
+                - PC: "0x84cacc"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1655 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x84c7c8"
+                - PC: "0x84c7d8"
                   Frameless: false
-                - PC: "0x84c83c"
+                - PC: "0x84c84c"
                   Frameless: false
-                - PC: "0x84c988"
+                - PC: "0x84c998"
                   Frameless: false
-                - PC: "0x84ca04"
+                - PC: "0x84ca14"
                   Frameless: false
-                - PC: "0x84cabc"
+                - PC: "0x84cacc"
                   Frameless: false
               Condition:
                 Type: 4 BaseType bool
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 1656 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x84c7c8"
+                - PC: "0x84c7d8"
                   Frameless: false
-                - PC: "0x84c83c"
+                - PC: "0x84c84c"
                   Frameless: false
-                - PC: "0x84c988"
+                - PC: "0x84c998"
                   Frameless: false
-                - PC: "0x84ca04"
+                - PC: "0x84ca14"
                   Frameless: false
-                - PC: "0x84cabc"
+                - PC: "0x84cacc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -474,7 +474,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x84eb30", Frameless: true}]
+              InjectionPoints: [{PC: "0x84eb40", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -493,7 +493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x84eb30", Frameless: true}]
+              InjectionPoints: [{PC: "0x84eb40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -519,7 +519,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1601 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x852150", Frameless: true}]
+              InjectionPoints: [{PC: "0x852160", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -554,7 +554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x84edd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ede0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -584,7 +584,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x84eb10", Frameless: true}]
+              InjectionPoints: [{PC: "0x84eb20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -613,11 +613,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1510 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x84fd58", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fd68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1511 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x84fe04", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fe14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -639,7 +639,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x84f080", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f090", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -661,7 +661,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x84b120", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b130", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -683,7 +683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x84b130", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -705,7 +705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x84ae10", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ae20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -727,7 +727,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x84ae20", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ae30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -749,7 +749,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x84afc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84afd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -771,7 +771,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x84afd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84afe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -793,7 +793,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1562 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x851970", Frameless: true}]
+              InjectionPoints: [{PC: "0x851980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -820,7 +820,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1565 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x8519a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8519b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -848,7 +848,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x851e20", Frameless: true}]
+              InjectionPoints: [{PC: "0x851e30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -870,7 +870,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x8521a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8521b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -891,7 +891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x8521b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8521c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -913,7 +913,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x84cf60", Frameless: true}]
+              InjectionPoints: [{PC: "0x84cf70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -947,7 +947,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1383 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x84acac", Frameless: false}]
+              InjectionPoints: [{PC: "0x84acbc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -975,11 +975,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x84b7d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b7e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1398 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x84b814", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b824", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1001,11 +1001,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x84b70c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b71c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1396 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x84b77c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b78c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1027,11 +1027,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1407 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x84cc40", Frameless: true}]
+              InjectionPoints: [{PC: "0x84cc50", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1408 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x84cc48", Frameless: true}]
+              InjectionPoints: [{PC: "0x84cc58", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1053,11 +1053,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x84cc5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cc6c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1410 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x84cc98", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cca8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1082,7 +1082,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1411 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x84cc5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cc6c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1104,11 +1104,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1640 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x854310", Frameless: true}]
+              InjectionPoints: [{PC: "0x854320", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1641 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x854318", Frameless: true}]
+              InjectionPoints: [{PC: "0x854328", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1122,11 +1122,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1642 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x854330", Frameless: false}]
+              InjectionPoints: [{PC: "0x854340", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1643 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x85436c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85437c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1149,11 +1149,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1636 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x854278", Frameless: false}]
+              InjectionPoints: [{PC: "0x854288", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1637 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x854288", Frameless: false}]
+              InjectionPoints: [{PC: "0x854298", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1167,11 +1167,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1638 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x8542c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8542d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1639 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x8542e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8542f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1194,14 +1194,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1644 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x854380", Frameless: true}]
+              InjectionPoints: [{PC: "0x854390", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1645 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x8543a8"
+                - PC: "0x8543b8"
                   Frameless: true
-                - PC: "0x8543b0"
+                - PC: "0x8543c0"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1216,14 +1216,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1646 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x8543d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8543e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1647 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x854438"
-                  Frameless: false
                 - PC: "0x854448"
+                  Frameless: false
+                - PC: "0x854458"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1250,7 +1250,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1648 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x854384", Frameless: true}]
+              InjectionPoints: [{PC: "0x854394", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1262,7 +1262,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1649 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x8543e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8543f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1283,11 +1283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x853f70", Frameless: true}]
+              InjectionPoints: [{PC: "0x853f80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1625 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x853f78", Frameless: true}]
+              InjectionPoints: [{PC: "0x853f88", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1301,11 +1301,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1626 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x854000", Frameless: true}]
+              InjectionPoints: [{PC: "0x854010", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1627 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x854004", Frameless: true}]
+              InjectionPoints: [{PC: "0x854014", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1329,11 +1329,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x853b78", Frameless: false}]
+              InjectionPoints: [{PC: "0x853b88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1613 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x853c4c", Frameless: false}]
+              InjectionPoints: [{PC: "0x853c5c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1375,11 +1375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x853c98", Frameless: false}]
+              InjectionPoints: [{PC: "0x853ca8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1617 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x853ca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x853cb8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1402,11 +1402,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1650 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x854480", Frameless: true}]
+              InjectionPoints: [{PC: "0x854490", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1651 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x854488", Frameless: true}]
+              InjectionPoints: [{PC: "0x854498", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1420,11 +1420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1652 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x854518", Frameless: false}]
+              InjectionPoints: [{PC: "0x854528", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1653 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x85453c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85454c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1447,11 +1447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x853ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853af0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1609 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x853ae4", Frameless: true}]
+              InjectionPoints: [{PC: "0x853af4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1465,11 +1465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x853af0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853b00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1611 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x853afc", Frameless: true}]
+              InjectionPoints: [{PC: "0x853b0c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1492,11 +1492,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1628 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x8540a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8540b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1629 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x8540a8", Frameless: true}]
+              InjectionPoints: [{PC: "0x8540b8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1510,11 +1510,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1630 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x854148", Frameless: false}]
+              InjectionPoints: [{PC: "0x854158", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1631 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x854174", Frameless: false}]
+              InjectionPoints: [{PC: "0x854184", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1537,11 +1537,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1618 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x853f40", Frameless: true}]
+              InjectionPoints: [{PC: "0x853f50", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1619 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x853f44", Frameless: true}]
+              InjectionPoints: [{PC: "0x853f54", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1555,11 +1555,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1620 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x853f50", Frameless: true}]
+              InjectionPoints: [{PC: "0x853f60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1621 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x853f54", Frameless: true}]
+              InjectionPoints: [{PC: "0x853f64", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1573,11 +1573,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1622 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x853f60", Frameless: true}]
+              InjectionPoints: [{PC: "0x853f70", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1623 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x853f64", Frameless: true}]
+              InjectionPoints: [{PC: "0x853f74", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1600,11 +1600,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1632 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x854230", Frameless: true}]
+              InjectionPoints: [{PC: "0x854240", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1633 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x854238", Frameless: true}]
+              InjectionPoints: [{PC: "0x854248", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1618,11 +1618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1634 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x854240", Frameless: true}]
+              InjectionPoints: [{PC: "0x854250", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1635 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x854250", Frameless: true}]
+              InjectionPoints: [{PC: "0x854260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1645,11 +1645,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x853ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853ad0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1605 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x853ac4", Frameless: true}]
+              InjectionPoints: [{PC: "0x853ad4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1663,11 +1663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x853ad0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853ae0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1607 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x853adc", Frameless: true}]
+              InjectionPoints: [{PC: "0x853aec", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1690,11 +1690,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x84c968", Frameless: false}]
+              InjectionPoints: [{PC: "0x84c978", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1400 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x84c9c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x84c9d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1721,11 +1721,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x84c9f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ca08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1402 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x84ca80", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ca90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1752,11 +1752,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x84cab8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cac8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1404 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x84caf4", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cb04", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1778,7 +1778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1660 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x84ca48", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ca58", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1796,11 +1796,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x84cb38", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cb48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1406 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x84cc28", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cc38", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1818,7 +1818,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1661 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x84cb3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cb4c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1839,7 +1839,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1662 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x84cb3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cb4c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1857,7 +1857,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1663 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x84cbf0", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cc00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1878,7 +1878,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1664 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x84cbf0", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cc00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1899,7 +1899,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x129ba8"
                   Frameless: true
-                - PC: "0x84d4c8"
+                - PC: "0x84d4d8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1920,20 +1920,20 @@ Probes:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x84c7c8"
+                - PC: "0x84c7d8"
                   Frameless: false
-                - PC: "0x84c83c"
+                - PC: "0x84c84c"
                   Frameless: false
-                - PC: "0x84c988"
+                - PC: "0x84c998"
                   Frameless: false
-                - PC: "0x84ca04"
+                - PC: "0x84ca14"
                   Frameless: false
-                - PC: "0x84cabc"
+                - PC: "0x84cacc"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x84c800", Frameless: false}]
+              InjectionPoints: [{PC: "0x84c810", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1959,15 +1959,15 @@ Probes:
             - Kind: Line
               Type: 1659 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x84c7c8"
+                - PC: "0x84c7d8"
                   Frameless: false
-                - PC: "0x84c83c"
+                - PC: "0x84c84c"
                   Frameless: false
-                - PC: "0x84c988"
+                - PC: "0x84c998"
                   Frameless: false
-                - PC: "0x84ca04"
+                - PC: "0x84ca14"
                   Frameless: false
-                - PC: "0x84cabc"
+                - PC: "0x84cacc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1990,7 +1990,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1665 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x84cc44", Frameless: true}]
+              InjectionPoints: [{PC: "0x84cc54", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2015,7 +2015,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1666 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x84cc44", Frameless: true}]
+              InjectionPoints: [{PC: "0x84cc54", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2039,9 +2039,9 @@ Probes:
             - Kind: Entry
               Type: 1667 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x84cc74"
+                - PC: "0x84cc84"
                   Frameless: false
-                - PC: "0x84cd0c"
+                - PC: "0x84cd1c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2064,7 +2064,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1351 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0x84a610", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2086,7 +2086,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1352 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0x84a620", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a630", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2108,7 +2108,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1353 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0x84a630", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2130,7 +2130,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1350 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0x84a600", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a610", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2152,7 +2152,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1349 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0x84a5f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2174,7 +2174,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x84cee0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84cef0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2195,11 +2195,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1543 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x850980", Frameless: false}]
+              InjectionPoints: [{PC: "0x850990", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1544 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x850ad8", Frameless: false}]
+              InjectionPoints: [{PC: "0x850ae8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2221,7 +2221,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x84ef90", Frameless: true}]
+              InjectionPoints: [{PC: "0x84efa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2246,7 +2246,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1392 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x84b17c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b18c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2268,7 +2268,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1393 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x84b20c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b21c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2290,7 +2290,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1394 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x84b2b4", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b2c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2333,11 +2333,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1549 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x850e3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x850e4c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1550 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x850fa8", Frameless: false}]
+              InjectionPoints: [{PC: "0x850fb8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2399,7 +2399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2421,7 +2421,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1430 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x84d630", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2443,7 +2443,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x84d6d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d6e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2465,7 +2465,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x84d6f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2487,7 +2487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x84d6e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d6f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2509,7 +2509,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x84d610", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2531,7 +2531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x84d6c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d6d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2553,7 +2553,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x84d6b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d6c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2577,7 +2577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x84d620", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d630", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2601,7 +2601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x84d620", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d630", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2623,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x84d6a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d6b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2645,7 +2645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1436 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x84d690", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d6a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2667,7 +2667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1421 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x84d5b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2689,7 +2689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x84d5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2711,7 +2711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x84d5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d5b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2733,7 +2733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x84d640", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d650", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2755,7 +2755,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x84d670", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2777,7 +2777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x84d680", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d690", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2799,7 +2799,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x84d650", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2823,7 +2823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x84d660", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d670", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2845,7 +2845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x851e00", Frameless: true}]
+              InjectionPoints: [{PC: "0x851e10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2868,7 +2868,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1586 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x851e00", Frameless: true}]
+              InjectionPoints: [{PC: "0x851e10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2915,11 +2915,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1551 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x851010", Frameless: false}]
+              InjectionPoints: [{PC: "0x851020", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1552 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x8511bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8511cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2985,11 +2985,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1555 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x8512bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8512cc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1556 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x851364", Frameless: false}]
+              InjectionPoints: [{PC: "0x851374", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3020,11 +3020,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1547 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x850c10", Frameless: false}]
+              InjectionPoints: [{PC: "0x850c20", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1548 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x850de0", Frameless: false}]
+              InjectionPoints: [{PC: "0x850df0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3050,11 +3050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1489 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc54", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3090,7 +3090,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x84ebf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ec00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3131,11 +3131,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x84fb28", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fb38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1483 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fb88", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fb98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3159,11 +3159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x84fb28", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fb38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fb88", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fb98", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3182,11 +3182,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1491 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc54", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3206,11 +3206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1493 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc54", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3243,11 +3243,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x84fb28", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fb38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1487 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fb88", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fb98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3275,7 +3275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x852140", Frameless: true}]
+              InjectionPoints: [{PC: "0x852150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3300,7 +3300,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x852140", Frameless: true}]
+              InjectionPoints: [{PC: "0x852150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3331,7 +3331,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x852140", Frameless: true}]
+              InjectionPoints: [{PC: "0x852150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3356,7 +3356,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x852140", Frameless: true}]
+              InjectionPoints: [{PC: "0x852150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3383,7 +3383,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x84f060", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f070", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3410,7 +3410,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x8519e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8519f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3437,7 +3437,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1566 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x8519b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8519c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3472,7 +3472,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1568 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x8519d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8519e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3504,7 +3504,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1584 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x851df0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3526,7 +3526,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x84efa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84efb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3548,7 +3548,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x84d600", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d610", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3570,7 +3570,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x84ef80", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ef90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3594,11 +3594,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x84f3d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f3e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1459 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x84f41c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3618,11 +3618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1502 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x84fc98", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fca8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1503 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fd20", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fd30", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3663,11 +3663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x84f4f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f508", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1469 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x84f590", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f5a0", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3705,11 +3705,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x84f3d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f3e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1461 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x84f41c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3750,11 +3750,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x84f4f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f508", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1471 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x84f590", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f5a0", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3794,11 +3794,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1504 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x84fc98", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fca8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1505 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fd20", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fd30", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3815,11 +3815,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1506 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x84fc98", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fca8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1507 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fd20", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fd30", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3841,11 +3841,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x84f3d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f3e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1463 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x84f41c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3868,18 +3868,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x84f7c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f7d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1479 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x84f864"
+                - PC: "0x84f874"
                   Frameless: false
-                - PC: "0x84f8ac"
+                - PC: "0x84f8bc"
                   Frameless: false
-                - PC: "0x84f970"
+                - PC: "0x84f980"
                   Frameless: false
-                - PC: "0x84f984"
+                - PC: "0x84f994"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3907,18 +3907,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x84f648", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f658", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1477 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x84f69c"
+                - PC: "0x84f6ac"
                   Frameless: false
-                - PC: "0x84f700"
+                - PC: "0x84f710"
                   Frameless: false
-                - PC: "0x84f740"
+                - PC: "0x84f750"
                   Frameless: false
-                - PC: "0x84f780"
+                - PC: "0x84f790"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3945,11 +3945,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1521 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x85038c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85039c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1522 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x8503e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8503f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3966,11 +3966,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1523 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x850418", Frameless: false}]
+              InjectionPoints: [{PC: "0x850428", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1524 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x850454", Frameless: false}]
+              InjectionPoints: [{PC: "0x850464", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3987,11 +3987,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1525 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x850488", Frameless: false}]
+              InjectionPoints: [{PC: "0x850498", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1526 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x8504c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8504d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4008,11 +4008,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1529 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x850578", Frameless: false}]
+              InjectionPoints: [{PC: "0x850588", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1530 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x8505dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8505ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4029,11 +4029,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1541 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x850908", Frameless: false}]
+              InjectionPoints: [{PC: "0x850918", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1542 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x850948", Frameless: false}]
+              InjectionPoints: [{PC: "0x850958", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4050,11 +4050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1517 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x850238", Frameless: false}]
+              InjectionPoints: [{PC: "0x850248", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1518 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x850284", Frameless: false}]
+              InjectionPoints: [{PC: "0x850294", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4072,14 +4072,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1474 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x84f5c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f5d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1475 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x84f5f8"
+                - PC: "0x84f608"
                   Frameless: false
-                - PC: "0x84f60c"
+                - PC: "0x84f61c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4101,11 +4101,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x84f3d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f3e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1465 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x84f41c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4126,11 +4126,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x84f4f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f508", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1473 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x84f590", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f5a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4151,11 +4151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x84f458", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f468", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1467 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x84f4b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f4c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4177,14 +4177,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1480 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x84f9c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f9d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1481 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x84fa94"
+                - PC: "0x84faa4"
                   Frameless: false
-                - PC: "0x84faa8"
+                - PC: "0x84fab8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4206,11 +4206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1519 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x8502c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8502d0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1520 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x850354", Frameless: false}]
+              InjectionPoints: [{PC: "0x850364", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4227,11 +4227,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1515 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x850178", Frameless: false}]
+              InjectionPoints: [{PC: "0x850188", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1516 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x8501fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x85020c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4248,11 +4248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1533 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x8506f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x850708", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1534 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x850750", Frameless: false}]
+              InjectionPoints: [{PC: "0x850760", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4269,11 +4269,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1527 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x8504f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x850508", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1528 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x850540", Frameless: false}]
+              InjectionPoints: [{PC: "0x850550", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4290,11 +4290,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1539 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x850888", Frameless: false}]
+              InjectionPoints: [{PC: "0x850898", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1540 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x8508cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8508dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4314,7 +4314,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1512 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x84ff08", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ff18", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4335,11 +4335,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1537 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x850818", Frameless: false}]
+              InjectionPoints: [{PC: "0x850828", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1538 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x850858", Frameless: false}]
+              InjectionPoints: [{PC: "0x850868", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4356,11 +4356,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1513 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x8500e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8500f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1514 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x850140", Frameless: false}]
+              InjectionPoints: [{PC: "0x850150", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4377,11 +4377,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1535 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x85078c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85079c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1536 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x8507e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8507f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4398,11 +4398,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1531 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x850620", Frameless: false}]
+              InjectionPoints: [{PC: "0x850630", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1532 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x8506c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8506d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4420,7 +4420,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1346 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0x84a5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a5d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1494 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1495 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc54", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4505,7 +4505,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x84aa40", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aa50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4527,7 +4527,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x84aa20", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aa30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4549,7 +4549,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x84aaf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ab00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4567,7 +4567,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x84ab00", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ab10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x84aa50", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aa60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x84aa70", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aa80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4630,7 +4630,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x84aa80", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aa90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4652,7 +4652,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x84aa90", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aaa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4681,7 +4681,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x84aa60", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aa70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4712,7 +4712,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x84aa30", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aa40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4734,7 +4734,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1576 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x851da0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851db0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4756,7 +4756,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x84aaa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aab0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4778,7 +4778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x84aac0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aad0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4800,7 +4800,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x84aad0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4822,7 +4822,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x84aae0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aaf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4844,7 +4844,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x84aab0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4866,7 +4866,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1572 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x851a00", Frameless: true}]
+              InjectionPoints: [{PC: "0x851a10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4888,7 +4888,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1563 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x851980", Frameless: true}]
+              InjectionPoints: [{PC: "0x851990", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4910,7 +4910,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1424 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x84d5e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d5f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4931,11 +4931,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1508 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x84fc98", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fca8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1509 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fd20", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fd30", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4956,11 +4956,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1553 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x851218", Frameless: false}]
+              InjectionPoints: [{PC: "0x851228", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1554 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x85127c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85128c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4982,7 +4982,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1347 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0x84a5d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5004,7 +5004,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x84f040", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f050", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5026,7 +5026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1567 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x8519c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8519d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5048,7 +5048,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x84b140", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5070,7 +5070,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x84b150", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5092,11 +5092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x8520a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8520b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1596 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x8520bc", Frameless: true}]
+              InjectionPoints: [{PC: "0x8520cc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5123,7 +5123,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1564 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x851990", Frameless: true}]
+              InjectionPoints: [{PC: "0x8519a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5150,7 +5150,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x84cfe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84cff0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5171,11 +5171,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1557 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x85139c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8513ac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1558 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x85142c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85143c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5197,11 +5197,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x851fb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851fc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1592 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x851fc8", Frameless: true}]
+              InjectionPoints: [{PC: "0x851fd8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5222,7 +5222,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x851fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851fb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5249,7 +5249,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1419 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x84d590", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5281,7 +5281,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x851a10", Frameless: true}]
+              InjectionPoints: [{PC: "0x851a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5321,7 +5321,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x851e30", Frameless: true}]
+              InjectionPoints: [{PC: "0x851e40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5354,11 +5354,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1496 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1497 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc54", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5379,11 +5379,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1498 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1499 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc54", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5406,11 +5406,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1500 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1501 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc54", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5439,7 +5439,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x851db0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851dc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5471,11 +5471,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1578 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x851dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851dd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1579 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x851dd8", Frameless: true}]
+              InjectionPoints: [{PC: "0x851de8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5505,11 +5505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1580 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x851dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851dd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1581 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x851dd8", Frameless: true}]
+              InjectionPoints: [{PC: "0x851de8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5541,7 +5541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1582 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x851de0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851df0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x851de0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851df0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x84ab10", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ab20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5625,7 +5625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1356 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0x84a660", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a670", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5647,7 +5647,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1357 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0x84a670", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5669,7 +5669,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1358 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0x84a680", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a690", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5691,7 +5691,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1355 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0x84a650", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5713,7 +5713,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1354 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0x84a640", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a650", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5735,7 +5735,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x84efd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84efe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5757,7 +5757,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1561 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x851960", Frameless: true}]
+              InjectionPoints: [{PC: "0x851970", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5779,7 +5779,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x851e10", Frameless: true}]
+              InjectionPoints: [{PC: "0x851e20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5801,7 +5801,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x84efb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84efc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5823,7 +5823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1364 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0x84a6f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5845,7 +5845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1570 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x8519f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5867,7 +5867,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x8519f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5890,14 +5890,14 @@ Probes:
             - Kind: Entry
               Type: 1668 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x84ce18"
+                - PC: "0x84ce28"
                   Frameless: false
-                - PC: "0x85461c"
+                - PC: "0x85462c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1669 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x84ce50", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ce60", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5919,11 +5919,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1559 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x851468", Frameless: false}]
+              InjectionPoints: [{PC: "0x851478", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1560 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8514d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8514e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5940,481 +5940,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x84a5b0..0x84a5c0]
+      OutOfLinePCRanges: [0x84a5c0..0x84a5d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 ArrayType [2]uint8
           Locations:
-            - Range: 0x84a5b0..0x84a5c0
+            - Range: 0x84a5c0..0x84a5d0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x84a5c0..0x84a5d0]
+      OutOfLinePCRanges: [0x84a5d0..0x84a5e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]int32
           Locations:
-            - Range: 0x84a5c0..0x84a5d0
+            - Range: 0x84a5d0..0x84a5e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x84a5d0..0x84a5e0]
+      OutOfLinePCRanges: [0x84a5e0..0x84a5f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]string
           Locations:
-            - Range: 0x84a5d0..0x84a5e0
+            - Range: 0x84a5e0..0x84a5f0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x84a5e0..0x84a5f0]
+      OutOfLinePCRanges: [0x84a5f0..0x84a600]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]bool
           Locations:
-            - Range: 0x84a5e0..0x84a5f0
+            - Range: 0x84a5f0..0x84a600
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x84a5f0..0x84a600]
+      OutOfLinePCRanges: [0x84a600..0x84a610]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x84a5f0..0x84a600
+            - Range: 0x84a600..0x84a610
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x84a600..0x84a610]
+      OutOfLinePCRanges: [0x84a610..0x84a620]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]int8
           Locations:
-            - Range: 0x84a600..0x84a610
+            - Range: 0x84a610..0x84a620
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x84a610..0x84a620]
+      OutOfLinePCRanges: [0x84a620..0x84a630]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 113 ArrayType [2]int16
           Locations:
-            - Range: 0x84a610..0x84a620
+            - Range: 0x84a620..0x84a630
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x84a620..0x84a630]
+      OutOfLinePCRanges: [0x84a630..0x84a640]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]int32
           Locations:
-            - Range: 0x84a620..0x84a630
+            - Range: 0x84a630..0x84a640
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x84a630..0x84a640]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 114 ArrayType [2]int64
-          Locations:
-            - Range: 0x84a630..0x84a640
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 10
-      Name: main.testUintArray
       OutOfLinePCRanges: [0x84a640..0x84a650]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 115 ArrayType [2]uint
+          Type: 114 ArrayType [2]int64
           Locations:
             - Range: 0x84a640..0x84a650
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 10
+      Name: main.testUintArray
+      OutOfLinePCRanges: [0x84a650..0x84a660]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 115 ArrayType [2]uint
+          Locations:
+            - Range: 0x84a650..0x84a660
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x84a650..0x84a660]
+      OutOfLinePCRanges: [0x84a660..0x84a670]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 ArrayType [2]uint8
           Locations:
-            - Range: 0x84a650..0x84a660
+            - Range: 0x84a660..0x84a670
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x84a660..0x84a670]
+      OutOfLinePCRanges: [0x84a670..0x84a680]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]uint16
           Locations:
-            - Range: 0x84a660..0x84a670
+            - Range: 0x84a670..0x84a680
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x84a670..0x84a680]
+      OutOfLinePCRanges: [0x84a680..0x84a690]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]uint32
           Locations:
-            - Range: 0x84a670..0x84a680
+            - Range: 0x84a680..0x84a690
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x84a680..0x84a690]
+      OutOfLinePCRanges: [0x84a690..0x84a6a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 54 ArrayType [2]uint64
           Locations:
-            - Range: 0x84a680..0x84a690
+            - Range: 0x84a690..0x84a6a0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x84a690..0x84a6a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 118 ArrayType [2][2]int
-          Locations:
-            - Range: 0x84a690..0x84a6a0
-              Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 16
-      Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0x84a6a0..0x84a6b0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 109 ArrayType [2]string
+          Type: 118 ArrayType [2][2]int
           Locations:
             - Range: 0x84a6a0..0x84a6b0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 16
+      Name: main.testArrayOfStrings
+      OutOfLinePCRanges: [0x84a6b0..0x84a6c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 109 ArrayType [2]string
+          Locations:
+            - Range: 0x84a6b0..0x84a6c0
+              Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x84a6b0..0x84a6c0]
+      OutOfLinePCRanges: [0x84a6c0..0x84a6d0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 119 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x84a6b0..0x84a6c0
+            - Range: 0x84a6c0..0x84a6d0
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0x84a6c0..0x84a6d0]
+      OutOfLinePCRanges: [0x84a6d0..0x84a6e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 120 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0x84a6c0..0x84a6d0
+            - Range: 0x84a6d0..0x84a6e0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0x84a6d0..0x84a6e0]
+      OutOfLinePCRanges: [0x84a6e0..0x84a6f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 122 ArrayType [2]struct {}
           Locations:
-            - Range: 0x84a6d0..0x84a6e0
+            - Range: 0x84a6e0..0x84a6f0
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x84a6f0..0x84a700]
+      OutOfLinePCRanges: [0x84a700..0x84a710]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 124 ArrayType [100]uint
           Locations:
-            - Range: 0x84a6f0..0x84a700
+            - Range: 0x84a700..0x84a710
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x84aa20..0x84aa30]
+      OutOfLinePCRanges: [0x84aa30..0x84aa40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84aa20..0x84aa30
+            - Range: 0x84aa30..0x84aa40
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x84aa30..0x84aa40]
+      OutOfLinePCRanges: [0x84aa40..0x84aa50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84aa30..0x84aa40
+            - Range: 0x84aa40..0x84aa50
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x84aa40..0x84aa50]
+      OutOfLinePCRanges: [0x84aa50..0x84aa60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84aa40..0x84aa50
+            - Range: 0x84aa50..0x84aa60
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x84aa50..0x84aa60]
+      OutOfLinePCRanges: [0x84aa60..0x84aa70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84aa50..0x84aa60
+            - Range: 0x84aa60..0x84aa70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x84aa60..0x84aa70]
+      OutOfLinePCRanges: [0x84aa70..0x84aa80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x84aa60..0x84aa70
+            - Range: 0x84aa70..0x84aa80
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x84aa70..0x84aa80]
+      OutOfLinePCRanges: [0x84aa80..0x84aa90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 94 BaseType int16
           Locations:
-            - Range: 0x84aa70..0x84aa80
+            - Range: 0x84aa80..0x84aa90
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x84aa80..0x84aa90]
+      OutOfLinePCRanges: [0x84aa90..0x84aaa0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84aa80..0x84aa90
+            - Range: 0x84aa90..0x84aaa0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x84aa90..0x84aaa0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 13 BaseType int64
-          Locations:
-            - Range: 0x84aa90..0x84aaa0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 29
-      Name: main.testSingleUint
       OutOfLinePCRanges: [0x84aaa0..0x84aab0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 BaseType uint
+          Type: 13 BaseType int64
           Locations:
             - Range: 0x84aaa0..0x84aab0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 29
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0x84aab0..0x84aac0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 BaseType uint
+          Locations:
+            - Range: 0x84aab0..0x84aac0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x84aab0..0x84aac0]
+      OutOfLinePCRanges: [0x84aac0..0x84aad0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84aab0..0x84aac0
+            - Range: 0x84aac0..0x84aad0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x84aac0..0x84aad0]
+      OutOfLinePCRanges: [0x84aad0..0x84aae0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x84aac0..0x84aad0
+            - Range: 0x84aad0..0x84aae0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x84aad0..0x84aae0]
+      OutOfLinePCRanges: [0x84aae0..0x84aaf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x84aad0..0x84aae0
+            - Range: 0x84aae0..0x84aaf0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x84aae0..0x84aaf0]
+      OutOfLinePCRanges: [0x84aaf0..0x84ab00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x84aae0..0x84aaf0
+            - Range: 0x84aaf0..0x84ab00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x84aaf0..0x84ab00]
+      OutOfLinePCRanges: [0x84ab00..0x84ab10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x84aaf0..0x84ab00
+            - Range: 0x84ab00..0x84ab10
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x84ab00..0x84ab10]
+      OutOfLinePCRanges: [0x84ab10..0x84ab20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x84ab00..0x84ab10
+            - Range: 0x84ab10..0x84ab20
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x84ab10..0x84ab20]
+      OutOfLinePCRanges: [0x84ab20..0x84ab30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 125 BaseType main.typeAlias
           Locations:
-            - Range: 0x84ab10..0x84ab20
+            - Range: 0x84ab20..0x84ab30
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x84ac20..0x84ac40]
+      OutOfLinePCRanges: [0x84ac30..0x84ac50]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 126 StructureType main.bigStruct
           Locations:
-            - Range: 0x84ac20..0x84ac40
+            - Range: 0x84ac30..0x84ac50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6433,48 +6433,48 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x84ac60..0x84ad80]
+      OutOfLinePCRanges: [0x84ac70..0x84ad90]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84ac60..0x84ac80
+            - Range: 0x84ac70..0x84ac90
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84ac60..0x84ad80, Pieces: []}]
+          Locations: [{Range: 0x84ac70..0x84ad90, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
-          Locations: [{Range: 0x84ac60..0x84ad80, Pieces: []}]
+          Locations: [{Range: 0x84ac70..0x84ad90, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84ac98..0x84acb8
+            - Range: 0x84aca8..0x84acc8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x84acb8..0x84acd4
+            - Range: 0x84acc8..0x84ace4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84acd4..0x84ace8
+            - Range: 0x84ace4..0x84acf8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: -64}
-            - Range: 0x84ace8..0x84ad80
+            - Range: 0x84acf8..0x84ad90
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
@@ -6485,39 +6485,39 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x84ae10..0x84ae20]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 130 StructureType main.deepPtr1
-          Locations:
-            - Range: 0x84ae10..0x84ae20
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 40
-      Name: main.testDeepPtr7
       OutOfLinePCRanges: [0x84ae20..0x84ae30]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 133 PointerType *main.deepPtr7
+          Type: 130 StructureType main.deepPtr1
           Locations:
             - Range: 0x84ae20..0x84ae30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 40
+      Name: main.testDeepPtr7
+      OutOfLinePCRanges: [0x84ae30..0x84ae40]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 133 PointerType *main.deepPtr7
+          Locations:
+            - Range: 0x84ae30..0x84ae40
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x84afc0..0x84afd0]
+      OutOfLinePCRanges: [0x84afd0..0x84afe0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 135 StructureType main.deepSlice1
           Locations:
-            - Range: 0x84afc0..0x84afd0
+            - Range: 0x84afd0..0x84afe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6530,129 +6530,129 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x84afd0..0x84afe0]
+      OutOfLinePCRanges: [0x84afe0..0x84aff0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 139 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x84afd0..0x84afe0
+            - Range: 0x84afe0..0x84aff0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x84b120..0x84b130]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 141 StructureType main.deepMap1
-          Locations:
-            - Range: 0x84b120..0x84b130
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 44
-      Name: main.testDeepMap7
       OutOfLinePCRanges: [0x84b130..0x84b140]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 147 PointerType *main.deepMap7
+          Type: 141 StructureType main.deepMap1
           Locations:
             - Range: 0x84b130..0x84b140
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 45
-      Name: main.testStringType1
+    - ID: 44
+      Name: main.testDeepMap7
       OutOfLinePCRanges: [0x84b140..0x84b150]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 149 PointerType *main.stringType1
+          Type: 147 PointerType *main.deepMap7
           Locations:
             - Range: 0x84b140..0x84b150
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 46
-      Name: main.testStringType2
+    - ID: 45
+      Name: main.testStringType1
       OutOfLinePCRanges: [0x84b150..0x84b160]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 151 PointerType **main.stringType2
+          Type: 149 PointerType *main.stringType1
           Locations:
             - Range: 0x84b150..0x84b160
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 46
+      Name: main.testStringType2
+      OutOfLinePCRanges: [0x84b160..0x84b170]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 151 PointerType **main.stringType2
+          Locations:
+            - Range: 0x84b160..0x84b170
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x84b160..0x84b360]
+      OutOfLinePCRanges: [0x84b170..0x84b370]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84b224..0x84b234
+            - Range: 0x84b234..0x84b244
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84b2d0..0x84b2e0
+            - Range: 0x84b2e0..0x84b2f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84b20c..0x84b210
+            - Range: 0x84b21c..0x84b220
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84b210..0x84b234
+            - Range: 0x84b220..0x84b244
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84b234..0x84b2c4
+            - Range: 0x84b244..0x84b2d4
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x84b2c4..0x84b2cc
+            - Range: 0x84b2d4..0x84b2dc
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x84b2cc..0x84b360
+            - Range: 0x84b2dc..0x84b370
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84b208..0x84b210
+            - Range: 0x84b218..0x84b220
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84b210..0x84b210
+            - Range: 0x84b220..0x84b220
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84b210..0x84b234
+            - Range: 0x84b220..0x84b244
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84b234..0x84b2c4
+            - Range: 0x84b244..0x84b2d4
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x84b2c4..0x84b2c8
+            - Range: 0x84b2d4..0x84b2d8
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x84b2c8..0x84b2cc
+            - Range: 0x84b2d8..0x84b2dc
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x84b2cc..0x84b2e0
+            - Range: 0x84b2dc..0x84b2f0
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x84b2e0..0x84b360
+            - Range: 0x84b2f0..0x84b370
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x84b6f0..0x84b7c0]
+      OutOfLinePCRanges: [0x84b700..0x84b7d0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 153 StructureType main.esotericStack
           Locations:
-            - Range: 0x84b6f0..0x84b738
+            - Range: 0x84b700..0x84b748
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6672,7 +6672,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x84b738..0x84b73c
+            - Range: 0x84b748..0x84b74c
               Pieces:
                 - Size: 4
                   Op: null
@@ -6692,7 +6692,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x84b73c..0x84b740
+            - Range: 0x84b74c..0x84b750
               Pieces:
                 - Size: 4
                   Op: null
@@ -6717,157 +6717,157 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x84b7c0..0x84b840]
+      OutOfLinePCRanges: [0x84b7d0..0x84b850]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 157 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x84b7c0..0x84b7f8
+            - Range: 0x84b7d0..0x84b808
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 50
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x84c950..0x84c9e0]
+      OutOfLinePCRanges: [0x84c960..0x84c9f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84c950..0x84c988
+            - Range: 0x84c960..0x84c998
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 51
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x84c9e0..0x84caa0]
+      OutOfLinePCRanges: [0x84c9f0..0x84cab0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84c9e0..0x84c9fc
+            - Range: 0x84c9f0..0x84ca0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84c9e0..0x84ca0c
+            - Range: 0x84c9f0..0x84ca1c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84c9fc..0x84ca0c
+            - Range: 0x84ca0c..0x84ca1c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84ca0c..0x84caa0
+            - Range: 0x84ca1c..0x84cab0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x84caa0..0x84cb20]
+      OutOfLinePCRanges: [0x84cab0..0x84cb30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84caa0..0x84cac4
+            - Range: 0x84cab0..0x84cad4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x84cb20..0x84cc40]
+      OutOfLinePCRanges: [0x84cb30..0x84cc50]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84cb88..0x84cb90
+            - Range: 0x84cb98..0x84cba0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84cb90..0x84cba8
+            - Range: 0x84cba0..0x84cbb8
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84cba8..0x84cbbc
+            - Range: 0x84cbb8..0x84cbcc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84cb84..0x84cb8c
+            - Range: 0x84cb94..0x84cb9c
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84cb8c..0x84cba8
+            - Range: 0x84cb9c..0x84cbb8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84cba8..0x84cbb8
+            - Range: 0x84cbb8..0x84cbc8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x84cc40..0x84cc50]
+      OutOfLinePCRanges: [0x84cc50..0x84cc60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84cc40..0x84cc48
+            - Range: 0x84cc50..0x84cc58
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84cc40..0x84cc48
+            - Range: 0x84cc50..0x84cc58
               Pieces: []
-            - Range: 0x84cc48..0x84cc49
+            - Range: 0x84cc58..0x84cc59
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84cc49..0x84cc50
+            - Range: 0x84cc59..0x84cc60
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x84cc50..0x84ccb0]
+      OutOfLinePCRanges: [0x84cc60..0x84ccc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0x84cc50..0x84ccb0
+            - Range: 0x84cc60..0x84ccc0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84cc50..0x84cc98
+            - Range: 0x84cc60..0x84cca8
               Pieces: []
-            - Range: 0x84cc98..0x84cc99
+            - Range: 0x84cca8..0x84cca9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84cc99..0x84ccb0
+            - Range: 0x84cca9..0x84ccc0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0x84cee0..0x84cef0]
+      OutOfLinePCRanges: [0x84cef0..0x84cf00]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84cee0..0x84cef0
+            - Range: 0x84cef0..0x84cf00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6878,19 +6878,19 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0x84cef0..0x84cf60]
+      OutOfLinePCRanges: [0x84cf00..0x84cf70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84cef0..0x84cf20
+            - Range: 0x84cf00..0x84cf30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84cf20..0x84cf24
+            - Range: 0x84cf30..0x84cf34
               Pieces:
                 - Size: 8
                   Op: null
@@ -6901,28 +6901,28 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84cef0..0x84cf34
+            - Range: 0x84cf00..0x84cf44
               Pieces: []
-            - Range: 0x84cf34..0x84cf35
+            - Range: 0x84cf44..0x84cf45
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84cf35..0x84cf60
+            - Range: 0x84cf45..0x84cf70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0x84cf60..0x84cf70]
+      OutOfLinePCRanges: [0x84cf70..0x84cf80]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84cf60..0x84cf70
+            - Range: 0x84cf70..0x84cf80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6933,41 +6933,41 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x84cf70..0x84cfe0]
+      OutOfLinePCRanges: [0x84cf80..0x84cff0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 161 PointerType *interface {}
           Locations:
-            - Range: 0x84cf70..0x84cfa0
+            - Range: 0x84cf80..0x84cfb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84cf70..0x84cfb4
+            - Range: 0x84cf80..0x84cfc4
               Pieces: []
-            - Range: 0x84cfb4..0x84cfb5
+            - Range: 0x84cfc4..0x84cfc5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84cfb5..0x84cfe0
+            - Range: 0x84cfc5..0x84cff0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x84cfe0..0x84cff0]
+      OutOfLinePCRanges: [0x84cff0..0x84d000]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 162 StructureType main.structWithAny
           Locations:
-            - Range: 0x84cfe0..0x84cff0
+            - Range: 0x84cff0..0x84d000
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6978,140 +6978,127 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x84d590..0x84d5a0]
+      OutOfLinePCRanges: [0x84d5a0..0x84d5b0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 163 StructureType main.structWithMap
-          Locations:
-            - Range: 0x84d590..0x84d5a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x84d5a0..0x84d5b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 169 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x84d5a0..0x84d5b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 63
-      Name: main.testMapStringToInt
+    - ID: 62
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x84d5b0..0x84d5c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 174 GoMapType map[string]int
+          Type: 169 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x84d5b0..0x84d5c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToSlice
+    - ID: 63
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x84d5c0..0x84d5d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 179 GoMapType map[string][]string
+          Type: 174 GoMapType map[string]int
           Locations:
             - Range: 0x84d5c0..0x84d5d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 65
-      Name: main.testMapArrayToArray
+    - ID: 64
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x84d5d0..0x84d5e0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 184 GoMapType map[[4]string][2]int
+          Type: 179 GoMapType map[string][]string
           Locations:
             - Range: 0x84d5d0..0x84d5e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testSmallMap
+    - ID: 65
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x84d5e0..0x84d5f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 174 GoMapType map[string]int
+          Type: 184 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x84d5e0..0x84d5f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 66
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x84d5f0..0x84d600]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 174 GoMapType map[string]int
+          Locations:
+            - Range: 0x84d5f0..0x84d600
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 67
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x84d5f0..0x84d600]
+      OutOfLinePCRanges: [0x84d600..0x84d610]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 189 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x84d5f0..0x84d600
+            - Range: 0x84d600..0x84d610
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 68
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x84d600..0x84d610]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 190 PointerType *map[string]int
-          Locations:
-            - Range: 0x84d600..0x84d610
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x84d610..0x84d620]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 164 GoMapType map[int]int
+          Type: 190 PointerType *map[string]int
           Locations:
             - Range: 0x84d610..0x84d620
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 70
-      Name: main.testMapMassive
+    - ID: 69
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x84d620..0x84d630]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 191 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 164 GoMapType map[int]int
           Locations:
             - Range: 0x84d620..0x84d630
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 71
-      Name: main.testMapEmbeddedMaps
+    - ID: 70
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0x84d630..0x84d640]
       InlinePCRanges: []
       Variables:
-        - Name: m
+        - Name: redactMyEntries
           Type: 191 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84d630..0x84d640
@@ -7119,38 +7106,38 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapWithLinkedList
+    - ID: 71
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x84d640..0x84d650]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 196 GoMapType map[bool]main.node
+          Type: 191 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84d640..0x84d650
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapWithSmallValue
+    - ID: 72
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x84d650..0x84d660]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 201 GoMapType map[int]uint8
+          Type: 196 GoMapType map[bool]main.node
           Locations:
             - Range: 0x84d650..0x84d660
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithSmallValueMassive
+    - ID: 73
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x84d660..0x84d670]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
+        - Name: m
           Type: 201 GoMapType map[int]uint8
           Locations:
             - Range: 0x84d660..0x84d670
@@ -7158,21 +7145,21 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 74
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x84d670..0x84d680]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 206 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 201 GoMapType map[int]uint8
           Locations:
             - Range: 0x84d670..0x84d680
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 75
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x84d680..0x84d690]
       InlinePCRanges: []
       Variables:
@@ -7184,8 +7171,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapSmallKeySmallValue
+    - ID: 76
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x84d690..0x84d6a0]
       InlinePCRanges: []
       Variables:
@@ -7197,127 +7184,140 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 77
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x84d6a0..0x84d6b0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 211 GoMapType map[uint8][4]int
+          Type: 206 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84d6a0..0x84d6b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapLargeKeySmallValue
+    - ID: 78
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x84d6b0..0x84d6c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 216 GoMapType map[[4]int]uint8
+          Type: 211 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x84d6b0..0x84d6c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 79
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x84d6c0..0x84d6d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 221 GoMapType map[[4]int][4]int
+          Type: 216 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x84d6c0..0x84d6d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapEmptyKey
+    - ID: 80
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x84d6d0..0x84d6e0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 226 GoMapType map[struct {}]int
+          Type: 221 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x84d6d0..0x84d6e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapEmptyValue
+    - ID: 81
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0x84d6e0..0x84d6f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 231 GoMapType map[int]struct {}
+          Type: 226 GoMapType map[struct {}]int
           Locations:
             - Range: 0x84d6e0..0x84d6f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 82
+      Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0x84d6f0..0x84d700]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 236 GoMapType map[struct {}]struct {}
+          Type: 231 GoMapType map[int]struct {}
           Locations:
             - Range: 0x84d6f0..0x84d700
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x84d700..0x84d710]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 236 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x84d700..0x84d710
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x84eb10..0x84eb20]
+      OutOfLinePCRanges: [0x84eb20..0x84eb30]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84eb10..0x84eb20
+            - Range: 0x84eb20..0x84eb30
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84eb10..0x84eb20
+            - Range: 0x84eb20..0x84eb30
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x84eb10..0x84eb20
+            - Range: 0x84eb20..0x84eb30
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x84eb30..0x84eb40]
+      OutOfLinePCRanges: [0x84eb40..0x84eb50]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84eb30..0x84eb40
+            - Range: 0x84eb40..0x84eb50
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84eb30..0x84eb40
+            - Range: 0x84eb40..0x84eb50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7328,48 +7328,48 @@ Subprograms:
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x84eb30..0x84eb40
+            - Range: 0x84eb40..0x84eb50
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x84ebf0..0x84ec00]
+      OutOfLinePCRanges: [0x84ec00..0x84ec10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84ebf0..0x84ec00
+            - Range: 0x84ec00..0x84ec10
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84ebf0..0x84ec00
+            - Range: 0x84ec00..0x84ec10
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84ebf0..0x84ec00
+            - Range: 0x84ec00..0x84ec10
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84ebf0..0x84ec00
+            - Range: 0x84ec00..0x84ec10
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ebf0..0x84ec00
+            - Range: 0x84ec00..0x84ec10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7380,63 +7380,63 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x84ed90..0x84edd0]
+      OutOfLinePCRanges: [0x84eda0..0x84ede0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x84ed90..0x84edcc
+            - Range: 0x84eda0..0x84eddc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x84ed90..0x84edcc
+            - Range: 0x84eda0..0x84eddc
               Pieces: []
-            - Range: 0x84edcc..0x84edcd
+            - Range: 0x84eddc..0x84eddd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84edcd..0x84edd0
+            - Range: 0x84eddd..0x84ede0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0x84edd0..0x84ede0]
+      OutOfLinePCRanges: [0x84ede0..0x84edf0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 241 GoChannelType chan bool
           Locations:
-            - Range: 0x84edd0..0x84ede0
+            - Range: 0x84ede0..0x84edf0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x84ef80..0x84ef90]
+      OutOfLinePCRanges: [0x84ef90..0x84efa0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x84ef80..0x84ef90
+            - Range: 0x84ef90..0x84efa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x84ef90..0x84efa0]
+      OutOfLinePCRanges: [0x84efa0..0x84efb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 StructureType main.node
           Locations:
-            - Range: 0x84ef90..0x84efa0
+            - Range: 0x84efa0..0x84efb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7447,273 +7447,273 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x84efa0..0x84efb0]
+      OutOfLinePCRanges: [0x84efb0..0x84efc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 245 PointerType *main.node
-          Locations:
-            - Range: 0x84efa0..0x84efb0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 92
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x84efb0..0x84efc0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 15 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x84efb0..0x84efc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 92
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0x84efc0..0x84efd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 15 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0x84efc0..0x84efd0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x84efd0..0x84efe0]
+      OutOfLinePCRanges: [0x84efe0..0x84eff0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 PointerType *uint
           Locations:
-            - Range: 0x84efd0..0x84efe0
+            - Range: 0x84efe0..0x84eff0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x84f040..0x84f050]
+      OutOfLinePCRanges: [0x84f050..0x84f060]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 93 PointerType *string
           Locations:
-            - Range: 0x84f040..0x84f050
+            - Range: 0x84f050..0x84f060
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x84f060..0x84f070]
+      OutOfLinePCRanges: [0x84f070..0x84f080]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x84f060..0x84f070
+            - Range: 0x84f070..0x84f080
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84f060..0x84f070
+            - Range: 0x84f070..0x84f080
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0x84f080..0x84f090]
+      OutOfLinePCRanges: [0x84f090..0x84f0a0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 246 PointerType *main.t
           Locations:
-            - Range: 0x84f080..0x84f090
+            - Range: 0x84f090..0x84f0a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x84f3c0..0x84f440]
+      OutOfLinePCRanges: [0x84f3d0..0x84f450]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f3c0..0x84f3dc
+            - Range: 0x84f3d0..0x84f3ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f3c0..0x84f41c
+            - Range: 0x84f3d0..0x84f42c
               Pieces: []
-            - Range: 0x84f41c..0x84f41d
+            - Range: 0x84f42c..0x84f42d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f41d..0x84f440
+            - Range: 0x84f42d..0x84f450
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f3dc..0x84f3e8
+            - Range: 0x84f3ec..0x84f3f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f3e8..0x84f440
+            - Range: 0x84f3f8..0x84f450
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x84f440..0x84f4e0]
+      OutOfLinePCRanges: [0x84f450..0x84f4f0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f440..0x84f464
+            - Range: 0x84f450..0x84f474
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f464..0x84f4e0
+            - Range: 0x84f474..0x84f4f0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84f440..0x84f4b8
+            - Range: 0x84f450..0x84f4c8
               Pieces: []
-            - Range: 0x84f4b8..0x84f4b9
+            - Range: 0x84f4c8..0x84f4c9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f4b9..0x84f4e0
+            - Range: 0x84f4c9..0x84f4f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84f468..0x84f480
+            - Range: 0x84f478..0x84f490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f480..0x84f4e0
+            - Range: 0x84f490..0x84f4f0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x84f4e0..0x84f5b0]
+      OutOfLinePCRanges: [0x84f4f0..0x84f5c0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f4e0..0x84f538
+            - Range: 0x84f4f0..0x84f548
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f4e0..0x84f590
+            - Range: 0x84f4f0..0x84f5a0
               Pieces: []
-            - Range: 0x84f590..0x84f591
+            - Range: 0x84f5a0..0x84f5a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f591..0x84f5b0
+            - Range: 0x84f5a1..0x84f5c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84f4e0..0x84f5b0, Pieces: []}]
+          Locations: [{Range: 0x84f4f0..0x84f5c0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f4fc..0x84f53c
+            - Range: 0x84f50c..0x84f54c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84f53c..0x84f5b0
+            - Range: 0x84f54c..0x84f5c0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x84f50c..0x84f53c
+            - Range: 0x84f51c..0x84f54c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x84f53c..0x84f5b0
+            - Range: 0x84f54c..0x84f5c0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x84f5b0..0x84f630]
+      OutOfLinePCRanges: [0x84f5c0..0x84f640]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84f5b0..0x84f5d4
+            - Range: 0x84f5c0..0x84f5e4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84f5b0..0x84f5f8
+            - Range: 0x84f5c0..0x84f608
               Pieces: []
-            - Range: 0x84f5f8..0x84f5f9
+            - Range: 0x84f608..0x84f609
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f5f9..0x84f60c
+            - Range: 0x84f609..0x84f61c
               Pieces: []
-            - Range: 0x84f60c..0x84f60d
+            - Range: 0x84f61c..0x84f61d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f60d..0x84f630
+            - Range: 0x84f61d..0x84f640
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x84f630..0x84f7b0]
+      OutOfLinePCRanges: [0x84f640..0x84f7c0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84f630..0x84f680
+            - Range: 0x84f640..0x84f690
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f680..0x84f684
+            - Range: 0x84f690..0x84f694
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x84f6d4..0x84f6d8
+            - Range: 0x84f6e4..0x84f6e8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f714..0x84f718
+            - Range: 0x84f724..0x84f728
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f754..0x84f758
+            - Range: 0x84f764..0x84f768
               Pieces:
                 - Size: 8
                   Op: null
@@ -7724,117 +7724,117 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84f630..0x84f674
+            - Range: 0x84f640..0x84f684
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84f630..0x84f69c
+            - Range: 0x84f640..0x84f6ac
               Pieces: []
-            - Range: 0x84f69c..0x84f69d
+            - Range: 0x84f6ac..0x84f6ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f69d..0x84f700
+            - Range: 0x84f6ad..0x84f710
               Pieces: []
-            - Range: 0x84f700..0x84f701
+            - Range: 0x84f710..0x84f711
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f701..0x84f740
+            - Range: 0x84f711..0x84f750
               Pieces: []
-            - Range: 0x84f740..0x84f741
+            - Range: 0x84f750..0x84f751
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f741..0x84f780
+            - Range: 0x84f751..0x84f790
               Pieces: []
-            - Range: 0x84f780..0x84f781
+            - Range: 0x84f790..0x84f791
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f781..0x84f7b0
+            - Range: 0x84f791..0x84f7c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84f630..0x84f69c
+            - Range: 0x84f640..0x84f6ac
               Pieces: []
-            - Range: 0x84f69c..0x84f69d
+            - Range: 0x84f6ac..0x84f6ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84f69d..0x84f700
+            - Range: 0x84f6ad..0x84f710
               Pieces: []
-            - Range: 0x84f700..0x84f701
+            - Range: 0x84f710..0x84f711
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84f701..0x84f740
+            - Range: 0x84f711..0x84f750
               Pieces: []
-            - Range: 0x84f740..0x84f741
+            - Range: 0x84f750..0x84f751
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84f741..0x84f780
+            - Range: 0x84f751..0x84f790
               Pieces: []
-            - Range: 0x84f780..0x84f781
+            - Range: 0x84f790..0x84f791
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84f781..0x84f7b0
+            - Range: 0x84f791..0x84f7c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f680..0x84f688
+            - Range: 0x84f690..0x84f698
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x84f7b0..0x84f9b0]
+      OutOfLinePCRanges: [0x84f7c0..0x84f9c0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84f7b0..0x84f7f8
+            - Range: 0x84f7c0..0x84f808
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f7f8..0x84f800
+            - Range: 0x84f808..0x84f810
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84f800..0x84f9b0
+            - Range: 0x84f810..0x84f9c0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7845,549 +7845,549 @@ Subprograms:
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84f7b0..0x84f864
+            - Range: 0x84f7c0..0x84f874
               Pieces: []
-            - Range: 0x84f864..0x84f865
+            - Range: 0x84f874..0x84f875
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f865..0x84f8ac
+            - Range: 0x84f875..0x84f8bc
               Pieces: []
-            - Range: 0x84f8ac..0x84f8ad
+            - Range: 0x84f8bc..0x84f8bd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f8ad..0x84f970
+            - Range: 0x84f8bd..0x84f980
               Pieces: []
-            - Range: 0x84f970..0x84f971
+            - Range: 0x84f980..0x84f981
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f971..0x84f984
+            - Range: 0x84f981..0x84f994
               Pieces: []
-            - Range: 0x84f984..0x84f985
+            - Range: 0x84f994..0x84f995
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f985..0x84f9b0
+            - Range: 0x84f995..0x84f9c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f898..0x84f8a0
+            - Range: 0x84f8a8..0x84f8b0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84f848..0x84f864
+            - Range: 0x84f858..0x84f874
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x84f9b0..0x84fb10]
+      OutOfLinePCRanges: [0x84f9c0..0x84fb20]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84f9b0..0x84f9ec
+            - Range: 0x84f9c0..0x84f9fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f9ec..0x84fa34
+            - Range: 0x84f9fc..0x84fa44
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84fa34..0x84fab4
+            - Range: 0x84fa44..0x84fac4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84fab4..0x84fadc
+            - Range: 0x84fac4..0x84faec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84fadc..0x84fae0
+            - Range: 0x84faec..0x84faf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84fae0..0x84fb10
+            - Range: 0x84faf0..0x84fb20
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84f9b0..0x84fa94
+            - Range: 0x84f9c0..0x84faa4
               Pieces: []
-            - Range: 0x84fa94..0x84fa95
+            - Range: 0x84faa4..0x84faa5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84fa95..0x84faa8
+            - Range: 0x84faa5..0x84fab8
               Pieces: []
-            - Range: 0x84faa8..0x84faa9
+            - Range: 0x84fab8..0x84fab9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84faa9..0x84fb10
+            - Range: 0x84fab9..0x84fb20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84f9b0..0x84f9ec
+            - Range: 0x84f9c0..0x84f9fc
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f9ec..0x84fa34
+            - Range: 0x84f9fc..0x84fa44
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84fa34..0x84fa3c
+            - Range: 0x84fa44..0x84fa4c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84fa3c..0x84faa0
+            - Range: 0x84fa4c..0x84fab0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84faa0..0x84faa4
+            - Range: 0x84fab0..0x84fab4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84faa4..0x84faa8
+            - Range: 0x84fab4..0x84fab8
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84faa8..0x84fb10
+            - Range: 0x84fab8..0x84fb20
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x84fb10..0x84fbb0]
+      OutOfLinePCRanges: [0x84fb20..0x84fbc0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fb10..0x84fb2c
+            - Range: 0x84fb20..0x84fb3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fb10..0x84fb88
+            - Range: 0x84fb20..0x84fb98
               Pieces: []
-            - Range: 0x84fb88..0x84fb89
+            - Range: 0x84fb98..0x84fb99
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fb89..0x84fbb0
+            - Range: 0x84fb99..0x84fbc0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x84fbb0..0x84fc80]
+      OutOfLinePCRanges: [0x84fbc0..0x84fc90]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fbb0..0x84fc00
+            - Range: 0x84fbc0..0x84fc10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fbb0..0x84fc54
+            - Range: 0x84fbc0..0x84fc64
               Pieces: []
-            - Range: 0x84fc54..0x84fc55
+            - Range: 0x84fc64..0x84fc65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fc55..0x84fc80
+            - Range: 0x84fc65..0x84fc90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fbb0..0x84fc54
+            - Range: 0x84fbc0..0x84fc64
               Pieces: []
-            - Range: 0x84fc54..0x84fc55
+            - Range: 0x84fc64..0x84fc65
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84fc55..0x84fc80
+            - Range: 0x84fc65..0x84fc90
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x84fc80..0x84fd40]
+      OutOfLinePCRanges: [0x84fc90..0x84fd50]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fc80..0x84fcc0
+            - Range: 0x84fc90..0x84fcd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fcc0..0x84fd40
+            - Range: 0x84fcd0..0x84fd50
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fc80..0x84fd20
+            - Range: 0x84fc90..0x84fd30
               Pieces: []
-            - Range: 0x84fd20..0x84fd21
+            - Range: 0x84fd30..0x84fd31
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fd21..0x84fd40
+            - Range: 0x84fd31..0x84fd50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fc80..0x84fd20
+            - Range: 0x84fc90..0x84fd30
               Pieces: []
-            - Range: 0x84fd20..0x84fd21
+            - Range: 0x84fd30..0x84fd31
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84fd21..0x84fd40
+            - Range: 0x84fd31..0x84fd50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fc80..0x84fd20
+            - Range: 0x84fc90..0x84fd30
               Pieces: []
-            - Range: 0x84fd20..0x84fd21
+            - Range: 0x84fd30..0x84fd31
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84fd21..0x84fd40
+            - Range: 0x84fd31..0x84fd50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x84fd40..0x84fe30]
+      OutOfLinePCRanges: [0x84fd50..0x84fe40]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fd40..0x84fd80
+            - Range: 0x84fd50..0x84fd90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fd80..0x84fe30
+            - Range: 0x84fd90..0x84fe40
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fd40..0x84fe04
+            - Range: 0x84fd50..0x84fe14
               Pieces: []
-            - Range: 0x84fe04..0x84fe05
+            - Range: 0x84fe14..0x84fe15
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fe05..0x84fe30
+            - Range: 0x84fe15..0x84fe40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84fd40..0x84fe04
+            - Range: 0x84fd50..0x84fe14
               Pieces: []
-            - Range: 0x84fe04..0x84fe05
+            - Range: 0x84fe14..0x84fe15
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x84fe05..0x84fe30
+            - Range: 0x84fe15..0x84fe40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x84fe30..0x84fff0]
+      OutOfLinePCRanges: [0x84fe40..0x850000]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fe30..0x84fe94
+            - Range: 0x84fe40..0x84fea4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fe94..0x84fff0
+            - Range: 0x84fea4..0x850000
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84fe5c..0x84fff0
+            - Range: 0x84fe6c..0x850000
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84fe60..0x84fff0
+            - Range: 0x84fe70..0x850000
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x8500d0..0x850160]
+      OutOfLinePCRanges: [0x8500e0..0x850170]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x8500d0..0x850140
+            - Range: 0x8500e0..0x850150
               Pieces: []
-            - Range: 0x850140..0x850141
+            - Range: 0x850150..0x850151
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850141..0x850160
+            - Range: 0x850151..0x850170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 94 BaseType int16
           Locations:
-            - Range: 0x8500d0..0x850140
+            - Range: 0x8500e0..0x850150
               Pieces: []
-            - Range: 0x850140..0x850141
+            - Range: 0x850150..0x850151
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x850141..0x850160
+            - Range: 0x850151..0x850170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x8500d0..0x850140
+            - Range: 0x8500e0..0x850150
               Pieces: []
-            - Range: 0x850140..0x850141
+            - Range: 0x850150..0x850151
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x850141..0x850160
+            - Range: 0x850151..0x850170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x8500d0..0x850140
+            - Range: 0x8500e0..0x850150
               Pieces: []
-            - Range: 0x850140..0x850141
+            - Range: 0x850150..0x850151
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x850141..0x850160
+            - Range: 0x850151..0x850170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8500d0..0x850140
+            - Range: 0x8500e0..0x850150
               Pieces: []
-            - Range: 0x850140..0x850141
+            - Range: 0x850150..0x850151
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x850141..0x850160
+            - Range: 0x850151..0x850170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x8500d0..0x850140
+            - Range: 0x8500e0..0x850150
               Pieces: []
-            - Range: 0x850140..0x850141
+            - Range: 0x850150..0x850151
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x850141..0x850160
+            - Range: 0x850151..0x850170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x8500d0..0x850140
+            - Range: 0x8500e0..0x850150
               Pieces: []
-            - Range: 0x850140..0x850141
+            - Range: 0x850150..0x850151
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x850141..0x850160
+            - Range: 0x850151..0x850170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x8500d0..0x850140
+            - Range: 0x8500e0..0x850150
               Pieces: []
-            - Range: 0x850140..0x850141
+            - Range: 0x850150..0x850151
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x850141..0x850160
+            - Range: 0x850151..0x850170
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x850160..0x850220]
+      OutOfLinePCRanges: [0x850170..0x850230]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x850160..0x8501fc
+            - Range: 0x850170..0x85020c
               Pieces: []
-            - Range: 0x8501fc..0x8501fd
+            - Range: 0x85020c..0x85020d
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x8501fd..0x850220
+            - Range: 0x85020d..0x850230
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x850220..0x8502a0]
+      OutOfLinePCRanges: [0x850230..0x8502b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 95 BaseType complex64
-          Locations: [{Range: 0x850220..0x8502a0, Pieces: []}]
+          Locations: [{Range: 0x850230..0x8502b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 96 BaseType complex128
-          Locations: [{Range: 0x850220..0x8502a0, Pieces: []}]
+          Locations: [{Range: 0x850230..0x8502b0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x8502a0..0x850370]
+      OutOfLinePCRanges: [0x8502b0..0x850380]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x8502a0..0x850354
+            - Range: 0x8502b0..0x850364
               Pieces: []
-            - Range: 0x850354..0x850355
+            - Range: 0x850364..0x850365
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8409,193 +8409,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850355..0x850370
+            - Range: 0x850365..0x850380
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x850370..0x850400]
+      OutOfLinePCRanges: [0x850380..0x850410]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x850370..0x8503e0
+            - Range: 0x850380..0x8503f0
               Pieces: []
-            - Range: 0x8503e0..0x8503e1
+            - Range: 0x8503f0..0x8503f1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8503e1..0x850400
+            - Range: 0x8503f1..0x850410
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x850400..0x850470]
+      OutOfLinePCRanges: [0x850410..0x850480]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 ArrayType [1]int
           Locations:
-            - Range: 0x850400..0x850454
+            - Range: 0x850410..0x850464
               Pieces: []
-            - Range: 0x850454..0x850455
+            - Range: 0x850464..0x850465
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850455..0x850470
+            - Range: 0x850465..0x850480
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x850470..0x8504e0]
+      OutOfLinePCRanges: [0x850480..0x8504f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0x850470..0x8504c0
+            - Range: 0x850480..0x8504d0
               Pieces: []
-            - Range: 0x8504c0..0x8504c1
+            - Range: 0x8504d0..0x8504d1
               Pieces: []
-            - Range: 0x8504c1..0x8504e0
+            - Range: 0x8504d1..0x8504f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x8504e0..0x850560]
+      OutOfLinePCRanges: [0x8504f0..0x850570]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 StructureType main.mixedStruct
-          Locations: [{Range: 0x8504e0..0x850560, Pieces: []}]
+          Locations: [{Range: 0x8504f0..0x850570, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x850560..0x850600]
+      OutOfLinePCRanges: [0x850570..0x850610]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850560..0x8505dc
+            - Range: 0x850570..0x8505ec
               Pieces: []
-            - Range: 0x8505dc..0x8505dd
+            - Range: 0x8505ec..0x8505ed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8505dd..0x850600
+            - Range: 0x8505ed..0x850610
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850560..0x8505dc
+            - Range: 0x850570..0x8505ec
               Pieces: []
-            - Range: 0x8505dc..0x8505dd
+            - Range: 0x8505ec..0x8505ed
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8505dd..0x850600
+            - Range: 0x8505ed..0x850610
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850560..0x8505dc
+            - Range: 0x850570..0x8505ec
               Pieces: []
-            - Range: 0x8505dc..0x8505dd
+            - Range: 0x8505ec..0x8505ed
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8505dd..0x850600
+            - Range: 0x8505ed..0x850610
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850560..0x8505dc
+            - Range: 0x850570..0x8505ec
               Pieces: []
-            - Range: 0x8505dc..0x8505dd
+            - Range: 0x8505ec..0x8505ed
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8505dd..0x850600
+            - Range: 0x8505ed..0x850610
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850560..0x8505dc
+            - Range: 0x850570..0x8505ec
               Pieces: []
-            - Range: 0x8505dc..0x8505dd
+            - Range: 0x8505ec..0x8505ed
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8505dd..0x850600
+            - Range: 0x8505ed..0x850610
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850560..0x8505dc
+            - Range: 0x850570..0x8505ec
               Pieces: []
-            - Range: 0x8505dc..0x8505dd
+            - Range: 0x8505ec..0x8505ed
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8505dd..0x850600
+            - Range: 0x8505ed..0x850610
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850560..0x8505dc
+            - Range: 0x850570..0x8505ec
               Pieces: []
-            - Range: 0x8505dc..0x8505dd
+            - Range: 0x8505ec..0x8505ed
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8505dd..0x850600
+            - Range: 0x8505ed..0x850610
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850560..0x8505dc
+            - Range: 0x850570..0x8505ec
               Pieces: []
-            - Range: 0x8505dc..0x8505dd
+            - Range: 0x8505ec..0x8505ed
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8505dd..0x850600
+            - Range: 0x8505ed..0x850610
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x850560..0x8505dc
+            - Range: 0x850570..0x8505ec
               Pieces: []
-            - Range: 0x8505dc..0x8505dd
+            - Range: 0x8505ec..0x8505ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8505dd..0x850600
+            - Range: 0x8505ed..0x850610
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x850600..0x8506e0]
+      OutOfLinePCRanges: [0x850610..0x8506f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 StructureType main.wideStruct
           Locations:
-            - Range: 0x850600..0x8506c4
+            - Range: 0x850610..0x8506d4
               Pieces: []
-            - Range: 0x8506c4..0x8506c5
+            - Range: 0x8506d4..0x8506d5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8619,145 +8619,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x8506c5..0x8506e0
+            - Range: 0x8506d5..0x8506f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x8506e0..0x850770]
+      OutOfLinePCRanges: [0x8506f0..0x850780]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8506e0..0x850750
+            - Range: 0x8506f0..0x850760
               Pieces: []
-            - Range: 0x850750..0x850751
+            - Range: 0x850760..0x850761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850751..0x850770
+            - Range: 0x850761..0x850780
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8506e0..0x850770, Pieces: []}]
+          Locations: [{Range: 0x8506f0..0x850780, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8506e0..0x850750
+            - Range: 0x8506f0..0x850760
               Pieces: []
-            - Range: 0x850750..0x850751
+            - Range: 0x850760..0x850761
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x850751..0x850770
+            - Range: 0x850761..0x850780
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8506e0..0x850770, Pieces: []}]
+          Locations: [{Range: 0x8506f0..0x850780, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8506e0..0x850750
+            - Range: 0x8506f0..0x850760
               Pieces: []
-            - Range: 0x850750..0x850751
+            - Range: 0x850760..0x850761
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x850751..0x850770
+            - Range: 0x850761..0x850780
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x850770..0x850800]
+      OutOfLinePCRanges: [0x850780..0x850810]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x850770..0x8507e0
+            - Range: 0x850780..0x8507f0
               Pieces: []
-            - Range: 0x8507e0..0x8507e1
+            - Range: 0x8507f0..0x8507f1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8507e1..0x850800
+            - Range: 0x8507f1..0x850810
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x850800..0x850870]
+      OutOfLinePCRanges: [0x850810..0x850880]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850800..0x850870, Pieces: []}]
+          Locations: [{Range: 0x850810..0x850880, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x850870..0x8508f0]
+      OutOfLinePCRanges: [0x850880..0x850900]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0x850870..0x8508f0, Pieces: []}]
+          Locations: [{Range: 0x850880..0x850900, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850870..0x8508f0, Pieces: []}]
+          Locations: [{Range: 0x850880..0x850900, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x8508f0..0x850960]
+      OutOfLinePCRanges: [0x850900..0x850970]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8508f0..0x850948
+            - Range: 0x850900..0x850958
               Pieces: []
-            - Range: 0x850948..0x850949
+            - Range: 0x850958..0x850959
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850949..0x850960
+            - Range: 0x850959..0x850970
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x8508f0..0x850948
+            - Range: 0x850900..0x850958
               Pieces: []
-            - Range: 0x850948..0x850949
+            - Range: 0x850958..0x850959
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x850949..0x850960
+            - Range: 0x850959..0x850970
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x850960..0x850b20]
+      OutOfLinePCRanges: [0x850970..0x850b30]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850960..0x8509cc
+            - Range: 0x850970..0x8509dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8779,7 +8779,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8509cc..0x8509e0
+            - Range: 0x8509dc..0x8509f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8801,7 +8801,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8509e0..0x8509e4
+            - Range: 0x8509f0..0x8509f4
               Pieces:
                 - Size: 8
                   Op: null
@@ -8828,9 +8828,9 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850960..0x850ad8
+            - Range: 0x850970..0x850ae8
               Pieces: []
-            - Range: 0x850ad8..0x850ad9
+            - Range: 0x850ae8..0x850ae9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8852,44 +8852,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850ad9..0x850b20
+            - Range: 0x850ae9..0x850b30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x850b20..0x850bf0]
+      OutOfLinePCRanges: [0x850b30..0x850c00]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x850b20..0x850bf0
+            - Range: 0x850b30..0x850c00
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x850b20..0x850bd4
+            - Range: 0x850b30..0x850be4
               Pieces: []
-            - Range: 0x850bd4..0x850bd5
+            - Range: 0x850be4..0x850be5
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x850bd5..0x850bf0
+            - Range: 0x850be5..0x850c00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x850bf0..0x850e20]
+      OutOfLinePCRanges: [0x850c00..0x850e30]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850bf0..0x850c60
+            - Range: 0x850c00..0x850c70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8911,7 +8911,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850c60..0x850c74
+            - Range: 0x850c70..0x850c84
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8933,7 +8933,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850c74..0x850c78
+            - Range: 0x850c84..0x850c88
               Pieces:
                 - Size: 8
                   Op: null
@@ -8960,16 +8960,16 @@ Subprograms:
         - Name: s2
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850bf0..0x850e20
+            - Range: 0x850c00..0x850e30
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850bf0..0x850de0
+            - Range: 0x850c00..0x850df0
               Pieces: []
-            - Range: 0x850de0..0x850de1
+            - Range: 0x850df0..0x850df1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8991,196 +8991,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850de1..0x850e20
+            - Range: 0x850df1..0x850e30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x850e20..0x850ff0]
+      OutOfLinePCRanges: [0x850e30..0x851000]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e20..0x850e98
+            - Range: 0x850e30..0x850ea8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850e98..0x850ff0
+            - Range: 0x850ea8..0x851000
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e20..0x850e84
+            - Range: 0x850e30..0x850e94
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x850e84..0x850ff0
+            - Range: 0x850e94..0x851000
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e20..0x850e98
+            - Range: 0x850e30..0x850ea8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x850e98..0x850ff0
+            - Range: 0x850ea8..0x851000
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e20..0x850e98
+            - Range: 0x850e30..0x850ea8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x850e98..0x850ff0
+            - Range: 0x850ea8..0x851000
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e20..0x850e98
+            - Range: 0x850e30..0x850ea8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x850e98..0x850ff0
+            - Range: 0x850ea8..0x851000
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e20..0x850e98
+            - Range: 0x850e30..0x850ea8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x850e98..0x850ff0
+            - Range: 0x850ea8..0x851000
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e20..0x850e98
+            - Range: 0x850e30..0x850ea8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x850e98..0x850ff0
+            - Range: 0x850ea8..0x851000
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e20..0x850e98
+            - Range: 0x850e30..0x850ea8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x850e98..0x850ff0
+            - Range: 0x850ea8..0x851000
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e20..0x850e98
+            - Range: 0x850e30..0x850ea8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x850e98..0x850ff0
+            - Range: 0x850ea8..0x851000
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x850e20..0x850fa8
+            - Range: 0x850e30..0x850fb8
               Pieces: []
-            - Range: 0x850fa8..0x850fa9
+            - Range: 0x850fb8..0x850fb9
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x850fa9..0x850ff0
+            - Range: 0x850fb9..0x851000
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x850ff0..0x851200]
+      OutOfLinePCRanges: [0x851000..0x851210]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850ff0..0x851078
+            - Range: 0x851000..0x851088
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851078..0x851200
+            - Range: 0x851088..0x851210
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850ff0..0x851064
+            - Range: 0x851000..0x851074
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x851064..0x851200
+            - Range: 0x851074..0x851210
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850ff0..0x851078
+            - Range: 0x851000..0x851088
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x851078..0x851200
+            - Range: 0x851088..0x851210
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850ff0..0x851078
+            - Range: 0x851000..0x851088
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x851078..0x851200
+            - Range: 0x851088..0x851210
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850ff0..0x851078
+            - Range: 0x851000..0x851088
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x851078..0x851200
+            - Range: 0x851088..0x851210
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850ff0..0x851078
+            - Range: 0x851000..0x851088
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x851078..0x851200
+            - Range: 0x851088..0x851210
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850ff0..0x851078
+            - Range: 0x851000..0x851088
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x851078..0x851200
+            - Range: 0x851088..0x851210
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850ff0..0x851078
+            - Range: 0x851000..0x851088
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x851078..0x851200
+            - Range: 0x851088..0x851210
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x850ff0..0x851078
+            - Range: 0x851000..0x851088
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x851078..0x851200
+            - Range: 0x851088..0x851210
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9191,9 +9191,9 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850ff0..0x8511bc
+            - Range: 0x851000..0x8511cc
               Pieces: []
-            - Range: 0x8511bc..0x8511bd
+            - Range: 0x8511cc..0x8511cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9215,208 +9215,189 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8511bd..0x851200
+            - Range: 0x8511cd..0x851210
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x851200..0x8512a0]
+      OutOfLinePCRanges: [0x851210..0x8512b0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0x851200..0x8512a0
+            - Range: 0x851210..0x8512b0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851200..0x85127c
+            - Range: 0x851210..0x85128c
               Pieces: []
-            - Range: 0x85127c..0x85127d
+            - Range: 0x85128c..0x85128d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85127d..0x8512a0
+            - Range: 0x85128d..0x8512b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851200..0x85127c
+            - Range: 0x851210..0x85128c
               Pieces: []
-            - Range: 0x85127c..0x85127d
+            - Range: 0x85128c..0x85128d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x85127d..0x8512a0
+            - Range: 0x85128d..0x8512b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851200..0x85127c
+            - Range: 0x851210..0x85128c
               Pieces: []
-            - Range: 0x85127c..0x85127d
+            - Range: 0x85128c..0x85128d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x85127d..0x8512a0
+            - Range: 0x85128d..0x8512b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x8512a0..0x851380]
+      OutOfLinePCRanges: [0x8512b0..0x851390]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x8512a0..0x851380
+            - Range: 0x8512b0..0x851390
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x8512a0..0x851380
+            - Range: 0x8512b0..0x851390
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8512a0..0x851364
+            - Range: 0x8512b0..0x851374
               Pieces: []
-            - Range: 0x851364..0x851365
+            - Range: 0x851374..0x851375
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851365..0x851380
+            - Range: 0x851375..0x851390
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x8512a0..0x851364
+            - Range: 0x8512b0..0x851374
               Pieces: []
-            - Range: 0x851364..0x851365
+            - Range: 0x851374..0x851375
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x851365..0x851380
+            - Range: 0x851375..0x851390
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x851380..0x851450]
+      OutOfLinePCRanges: [0x851390..0x851460]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x851380..0x851450
+            - Range: 0x851390..0x851460
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851380..0x85142c
+            - Range: 0x851390..0x85143c
               Pieces: []
-            - Range: 0x85142c..0x85142d
+            - Range: 0x85143c..0x85143d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85142d..0x851450
+            - Range: 0x85143d..0x851460
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x851380..0x85142c
+            - Range: 0x851390..0x85143c
               Pieces: []
-            - Range: 0x85142c..0x85142d
+            - Range: 0x85143c..0x85143d
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x85142d..0x851450
+            - Range: 0x85143d..0x851460
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851400..0x851450
+            - Range: 0x851410..0x851460
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x851450..0x8514f0]
+      OutOfLinePCRanges: [0x851460..0x851500]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 ArrayType [0]int
-          Locations: [{Range: 0x851450..0x8514f0, Pieces: []}]
+          Locations: [{Range: 0x851460..0x851500, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851450..0x851490
+            - Range: 0x851460..0x8514a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851490..0x8514ac
+            - Range: 0x8514a0..0x8514bc
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x8514ac..0x8514b4
+            - Range: 0x8514bc..0x8514c4
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x8514b4..0x8514f0
+            - Range: 0x8514c4..0x851500
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851450..0x8514d0
+            - Range: 0x851460..0x8514e0
               Pieces: []
-            - Range: 0x8514d0..0x8514d1
+            - Range: 0x8514e0..0x8514e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8514d1..0x8514f0
+            - Range: 0x8514e1..0x851500
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0x851450..0x8514d0
+            - Range: 0x851460..0x8514e0
               Pieces: []
-            - Range: 0x8514d0..0x8514d1
+            - Range: 0x8514e0..0x8514e1
               Pieces: []
-            - Range: 0x8514d1..0x8514f0
+            - Range: 0x8514e1..0x851500
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x851960..0x851970]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x851960..0x851970
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 134
-      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x851970..0x851980]
       InlinePCRanges: []
       Variables:
@@ -9434,13 +9415,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 135
-      Name: main.testSliceOfSlices
+    - ID: 134
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x851980..0x851990]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 256 GoSliceHeaderType [][]uint
+          Type: 255 GoSliceHeaderType []uint
           Locations:
             - Range: 0x851980..0x851990
               Pieces:
@@ -9453,13 +9434,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 136
-      Name: main.testStructSlice
+    - ID: 135
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x851990..0x8519a0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 256 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x851990..0x8519a0
               Pieces:
@@ -9471,16 +9452,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x851990..0x8519a0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 137
-      Name: main.testEmptySliceOfStructs
+    - ID: 136
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0x8519a0..0x8519b0]
       InlinePCRanges: []
       Variables:
@@ -9505,8 +9479,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testNilSliceOfStructs
+    - ID: 137
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x8519b0..0x8519c0]
       InlinePCRanges: []
       Variables:
@@ -9531,15 +9505,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x8519c0..0x8519d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x8519c0..0x8519d0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x8519c0..0x8519d0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x8519c0..0x8519d0]
+      OutOfLinePCRanges: [0x8519d0..0x8519e0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 261 GoSliceHeaderType []string
           Locations:
-            - Range: 0x8519c0..0x8519d0
+            - Range: 0x8519d0..0x8519e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9552,20 +9552,20 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x8519d0..0x8519e0]
+      OutOfLinePCRanges: [0x8519e0..0x8519f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x8519d0..0x8519e0
+            - Range: 0x8519e0..0x8519f0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 262 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x8519d0..0x8519e0
+            - Range: 0x8519e0..0x8519f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9578,37 +9578,18 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x8519d0..0x8519e0
+            - Range: 0x8519e0..0x8519f0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x8519e0..0x8519f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0x8519e0..0x8519f0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 142
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x8519f0..0x851a00]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 255 GoSliceHeaderType []uint
+          Type: 263 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x8519f0..0x851a00
               Pieces:
@@ -9621,13 +9602,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 143
-      Name: main.testSliceEmptyStructs
+    - ID: 142
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x851a00..0x851a10]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 264 GoSliceHeaderType []struct {}
+          Type: 255 GoSliceHeaderType []uint
           Locations:
             - Range: 0x851a00..0x851a10
               Pieces:
@@ -9640,15 +9621,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x851a10..0x851a20]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 264 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x851a10..0x851a20
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x851a10..0x851a20]
+      OutOfLinePCRanges: [0x851a20..0x851a30]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x851a10..0x851a20
+            - Range: 0x851a20..0x851a30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9661,7 +9661,7 @@ Subprograms:
         - Name: bs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x851a10..0x851a20
+            - Range: 0x851a20..0x851a30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9674,7 +9674,7 @@ Subprograms:
         - Name: cs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x851a10..0x851a20
+            - Range: 0x851a20..0x851a30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9687,44 +9687,27 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0x851d30..0x851da0]
+      OutOfLinePCRanges: [0x851d40..0x851db0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851d30..0x851d7c
+            - Range: 0x851d40..0x851d8c
               Pieces: []
-            - Range: 0x851d7c..0x851d7d
+            - Range: 0x851d8c..0x851d8d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851d7d..0x851da0
+            - Range: 0x851d8d..0x851db0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x851da0..0x851db0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x851da0..0x851db0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 147
-      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x851db0..0x851dc0]
       InlinePCRanges: []
       Variables:
@@ -9739,10 +9722,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 147
+      Name: main.testThreeStrings
+      OutOfLinePCRanges: [0x851dc0..0x851dd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x851dc0..0x851dd0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851db0..0x851dc0
+            - Range: 0x851dc0..0x851dd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9753,7 +9753,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851db0..0x851dc0
+            - Range: 0x851dc0..0x851dd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9764,13 +9764,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x851dc0..0x851de0]
+      OutOfLinePCRanges: [0x851dd0..0x851df0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 266 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x851dc0..0x851de0
+            - Range: 0x851dd0..0x851df0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9789,49 +9789,32 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x851de0..0x851df0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 267 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x851de0..0x851df0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 150
-      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x851df0..0x851e00]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 268 PointerType *main.oneStringStruct
+          Type: 267 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x851df0..0x851e00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 151
-      Name: main.testMassiveString
+    - ID: 150
+      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x851e00..0x851e10]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 268 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x851e00..0x851e10
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 152
-      Name: main.testUnitializedString
+    - ID: 151
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0x851e10..0x851e20]
       InlinePCRanges: []
       Variables:
@@ -9847,8 +9830,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 153
-      Name: main.testEmptyString
+    - ID: 152
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0x851e20..0x851e30]
       InlinePCRanges: []
       Variables:
@@ -9864,12 +9847,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
-      Name: main.testSubstrings
+    - ID: 153
+      Name: main.testEmptyString
       OutOfLinePCRanges: [0x851e30..0x851e40]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x851e30..0x851e40
@@ -9880,10 +9863,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 154
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0x851e40..0x851e50]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x851e40..0x851e50
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851e30..0x851e40
+            - Range: 0x851e40..0x851e50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9894,7 +9894,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851e30..0x851e40
+            - Range: 0x851e40..0x851e50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9905,26 +9905,26 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x851fa0..0x851fb0]
+      OutOfLinePCRanges: [0x851fb0..0x851fc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x851fa0..0x851fb0
+            - Range: 0x851fb0..0x851fc0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x851fb0..0x851fd0]
+      OutOfLinePCRanges: [0x851fc0..0x851fe0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 283 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x851fb0..0x851fd0
+            - Range: 0x851fc0..0x851fe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9943,13 +9943,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0x8520a0..0x8520c0]
+      OutOfLinePCRanges: [0x8520b0..0x8520d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.aStruct
           Locations:
-            - Range: 0x8520a0..0x8520c0
+            - Range: 0x8520b0..0x8520d0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9970,93 +9970,93 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x852140..0x852150]
+      OutOfLinePCRanges: [0x852150..0x852160]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 315 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x852140..0x852150
+            - Range: 0x852150..0x852160
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x852150..0x852160]
+      OutOfLinePCRanges: [0x852160..0x852170]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 StructureType main.tenStrings
           Locations:
-            - Range: 0x852150..0x852160
+            - Range: 0x852160..0x852170
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x8521a0..0x8521b0]
+      OutOfLinePCRanges: [0x8521b0..0x8521c0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 318 StructureType main.emptyStruct
-          Locations: [{Range: 0x8521a0..0x8521b0, Pieces: []}]
+          Locations: [{Range: 0x8521b0..0x8521c0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x8521b0..0x8521c0]
+      OutOfLinePCRanges: [0x8521c0..0x8521d0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 319 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x8521b0..0x8521c0
+            - Range: 0x8521c0..0x8521d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x853ac0..0x853ad0]
+      OutOfLinePCRanges: [0x853ad0..0x853ae0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x853ac0..0x853ad0
+            - Range: 0x853ad0..0x853ae0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x853ac0..0x853ac4
+            - Range: 0x853ad0..0x853ad4
               Pieces: []
-            - Range: 0x853ac4..0x853ac5
+            - Range: 0x853ad4..0x853ad5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853ac5..0x853ad0
+            - Range: 0x853ad5..0x853ae0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x853ad0..0x853ae0]
+      OutOfLinePCRanges: [0x853ae0..0x853af0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x853ad0..0x853adc
+            - Range: 0x853ae0..0x853aec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x853adc..0x853ae0
+            - Range: 0x853aec..0x853af0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10067,58 +10067,58 @@ Subprograms:
         - Name: ~r0
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x853ad0..0x853adc
+            - Range: 0x853ae0..0x853aec
               Pieces: []
-            - Range: 0x853adc..0x853add
+            - Range: 0x853aec..0x853aed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853add..0x853ae0
+            - Range: 0x853aed..0x853af0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x853ae0..0x853af0]
+      OutOfLinePCRanges: [0x853af0..0x853b00]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x853ae0..0x853af0
+            - Range: 0x853af0..0x853b00
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x853ae0..0x853ae4
+            - Range: 0x853af0..0x853af4
               Pieces: []
-            - Range: 0x853ae4..0x853ae5
+            - Range: 0x853af4..0x853af5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853ae5..0x853af0
+            - Range: 0x853af5..0x853b00
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x853af0..0x853b00]
+      OutOfLinePCRanges: [0x853b00..0x853b10]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x853af0..0x853afc
+            - Range: 0x853b00..0x853b0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x853afc..0x853b00
+            - Range: 0x853b0c..0x853b10
               Pieces:
                 - Size: 8
                   Op: null
@@ -10129,28 +10129,28 @@ Subprograms:
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x853af0..0x853afc
+            - Range: 0x853b00..0x853b0c
               Pieces: []
-            - Range: 0x853afc..0x853afd
+            - Range: 0x853b0c..0x853b0d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853afd..0x853b00
+            - Range: 0x853b0d..0x853b10
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x853b60..0x853c80]
+      OutOfLinePCRanges: [0x853b70..0x853c90]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x853b60..0x853b8c
+            - Range: 0x853b70..0x853b9c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10158,7 +10158,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x853b8c..0x853b9c
+            - Range: 0x853b9c..0x853bac
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10166,7 +10166,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x853b9c..0x853c80
+            - Range: 0x853bac..0x853c90
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10179,18 +10179,18 @@ Subprograms:
         - Name: pred
           Type: 326 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x853b60..0x853b9c
+            - Range: 0x853b70..0x853bac
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x853b9c..0x853c80
+            - Range: 0x853bac..0x853c90
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x853b60..0x853c4c
+            - Range: 0x853b70..0x853c5c
               Pieces: []
-            - Range: 0x853c4c..0x853c4d
+            - Range: 0x853c5c..0x853c5d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10198,14 +10198,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x853c4d..0x853c80
+            - Range: 0x853c5d..0x853c90
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x853b9c..0x853bb8
+            - Range: 0x853bac..0x853bc8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10213,7 +10213,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853bb8..0x853bbc
+            - Range: 0x853bc8..0x853bcc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10221,7 +10221,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853bbc..0x853bc0
+            - Range: 0x853bcc..0x853bd0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10229,7 +10229,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853bc0..0x853bc0
+            - Range: 0x853bd0..0x853bd0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10237,7 +10237,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853bc0..0x853bec
+            - Range: 0x853bd0..0x853bfc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10245,7 +10245,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x853bec..0x853c40
+            - Range: 0x853bfc..0x853c50
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10253,7 +10253,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853c40..0x853c80
+            - Range: 0x853c50..0x853c90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10266,86 +10266,62 @@ Subprograms:
         - Name: item
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x853bdc..0x853bec
+            - Range: 0x853bec..0x853bfc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853bec..0x853c40
+            - Range: 0x853bfc..0x853c50
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x853c80..0x853cd0]
+      OutOfLinePCRanges: [0x853c90..0x853ce0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x853c80..0x853ca8
+            - Range: 0x853c90..0x853cb8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 327 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x853c80..0x853ca8
+            - Range: 0x853c90..0x853cb8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x853c80..0x853ca8
+            - Range: 0x853c90..0x853cb8
               Pieces: []
-            - Range: 0x853ca8..0x853ca9
+            - Range: 0x853cb8..0x853cb9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853ca9..0x853cd0
+            - Range: 0x853cb9..0x853ce0
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 168
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x853f40..0x853f50]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 325 PointerType *go.shape.int
-          Locations:
-            - Range: 0x853f40..0x853f50
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 325 PointerType *go.shape.int
-          Locations:
-            - Range: 0x853f40..0x853f44
-              Pieces: []
-            - Range: 0x853f44..0x853f45
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853f45..0x853f50
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 169
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0x853f50..0x853f60]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 328 PointerType *go.shape.struct { Name string }
+          Type: 325 PointerType *go.shape.int
           Locations:
             - Range: 0x853f50..0x853f60
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 328 PointerType *go.shape.struct { Name string }
+          Type: 325 PointerType *go.shape.int
           Locations:
             - Range: 0x853f50..0x853f54
               Pieces: []
@@ -10356,20 +10332,20 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 170
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+    - ID: 169
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0x853f60..0x853f70]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 330 PointerType *go.shape.struct { X int; Y int }
+          Type: 328 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0x853f60..0x853f70
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 330 PointerType *go.shape.struct { X int; Y int }
+          Type: 328 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0x853f60..0x853f64
               Pieces: []
@@ -10380,101 +10356,125 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 170
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0x853f70..0x853f80]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 330 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x853f70..0x853f80
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 330 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x853f70..0x853f74
+              Pieces: []
+            - Range: 0x853f74..0x853f75
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x853f75..0x853f80
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x853f70..0x853f80]
+      OutOfLinePCRanges: [0x853f80..0x853f90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x853f70..0x853f80
+            - Range: 0x853f80..0x853f90
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x853f70..0x853f78
+            - Range: 0x853f80..0x853f88
               Pieces: []
-            - Range: 0x853f78..0x853f79
+            - Range: 0x853f88..0x853f89
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853f79..0x853f80
+            - Range: 0x853f89..0x853f90
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x854000..0x854010]
+      OutOfLinePCRanges: [0x854010..0x854020]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x854000..0x854010
+            - Range: 0x854010..0x854020
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x854000..0x854004
+            - Range: 0x854010..0x854014
               Pieces: []
-            - Range: 0x854004..0x854005
+            - Range: 0x854014..0x854015
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854005..0x854010
+            - Range: 0x854015..0x854020
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x8540a0..0x8540b0]
+      OutOfLinePCRanges: [0x8540b0..0x8540c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x8540a0..0x8540b0
+            - Range: 0x8540b0..0x8540c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x8540a0..0x8540b0
+            - Range: 0x8540b0..0x8540c0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0x8540a0..0x8540b0
+            - Range: 0x8540b0..0x8540c0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x854130..0x8541b0]
+      OutOfLinePCRanges: [0x854140..0x8541c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 338 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x854130..0x8541b0
+            - Range: 0x854140..0x8541c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854130..0x8541b0
+            - Range: 0x854140..0x8541c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10485,20 +10485,20 @@ Subprograms:
         - Name: v
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x854130..0x8541b0
+            - Range: 0x854140..0x8541c0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x854230..0x854240]
+      OutOfLinePCRanges: [0x854240..0x854250]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854230..0x854240
+            - Range: 0x854240..0x854250
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10509,59 +10509,59 @@ Subprograms:
         - Name: b
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0x854230..0x854240
+            - Range: 0x854240..0x854250
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0x854230..0x854238
+            - Range: 0x854240..0x854248
               Pieces: []
-            - Range: 0x854238..0x854239
+            - Range: 0x854248..0x854249
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854239..0x854240
+            - Range: 0x854249..0x854250
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854230..0x854238
+            - Range: 0x854240..0x854248
               Pieces: []
-            - Range: 0x854238..0x854239
+            - Range: 0x854248..0x854249
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x854239..0x854240
+            - Range: 0x854249..0x854250
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x854240..0x854260]
+      OutOfLinePCRanges: [0x854250..0x854270]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x854240..0x854250
+            - Range: 0x854250..0x854260
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854240..0x85424c
+            - Range: 0x854250..0x85425c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x85424c..0x854260
+            - Range: 0x85425c..0x854270
               Pieces:
                 - Size: 8
                   Op: null
@@ -10572,73 +10572,73 @@ Subprograms:
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854240..0x854250
+            - Range: 0x854250..0x854260
               Pieces: []
-            - Range: 0x854250..0x854251
+            - Range: 0x854260..0x854261
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854251..0x854260
+            - Range: 0x854261..0x854270
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x854240..0x854250
+            - Range: 0x854250..0x854260
               Pieces: []
-            - Range: 0x854250..0x854251
+            - Range: 0x854260..0x854261
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x854251..0x854260
+            - Range: 0x854261..0x854270
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x854260..0x8542b0]
+      OutOfLinePCRanges: [0x854270..0x8542c0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 340 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x854260..0x854288
+            - Range: 0x854270..0x854298
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x854260..0x854288
+            - Range: 0x854270..0x854298
               Pieces: []
-            - Range: 0x854288..0x854289
+            - Range: 0x854298..0x854299
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854289..0x8542b0
+            - Range: 0x854299..0x8542c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x8542b0..0x854310]
+      OutOfLinePCRanges: [0x8542c0..0x854320]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 341 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x8542b0..0x8542dc
+            - Range: 0x8542c0..0x8542ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8542dc..0x8542e0
+            - Range: 0x8542ec..0x8542f0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10649,65 +10649,65 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8542b0..0x8542e0
+            - Range: 0x8542c0..0x8542f0
               Pieces: []
-            - Range: 0x8542e0..0x8542e1
+            - Range: 0x8542f0..0x8542f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8542e1..0x854310
+            - Range: 0x8542f1..0x854320
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x854310..0x854320]
+      OutOfLinePCRanges: [0x854320..0x854330]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 342 PointerType *go.shape.string
           Locations:
-            - Range: 0x854310..0x854318
+            - Range: 0x854320..0x854328
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854310..0x854318
+            - Range: 0x854320..0x854328
               Pieces: []
-            - Range: 0x854318..0x854319
+            - Range: 0x854328..0x854329
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854319..0x854320
+            - Range: 0x854329..0x854330
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x854320..0x854380]
+      OutOfLinePCRanges: [0x854330..0x854390]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 343 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x854320..0x85435c
+            - Range: 0x854330..0x85436c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 344 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x854320..0x85436c
+            - Range: 0x854330..0x85437c
               Pieces: []
-            - Range: 0x85436c..0x85436d
+            - Range: 0x85437c..0x85437d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10721,20 +10721,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x85436d..0x854380
+            - Range: 0x85437d..0x854390
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x854380..0x8543c0]
+      OutOfLinePCRanges: [0x854390..0x8543d0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x854380..0x85438c
+            - Range: 0x854390..0x85439c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10742,7 +10742,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x85438c..0x8543c0
+            - Range: 0x85439c..0x8543d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10755,42 +10755,42 @@ Subprograms:
         - Name: needle
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x854380..0x8543c0
+            - Range: 0x854390..0x8543d0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x854380..0x8543a8
+            - Range: 0x854390..0x8543b8
               Pieces: []
-            - Range: 0x8543a8..0x8543a9
+            - Range: 0x8543b8..0x8543b9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8543a9..0x8543b0
+            - Range: 0x8543b9..0x8543c0
               Pieces: []
-            - Range: 0x8543b0..0x8543b1
+            - Range: 0x8543c0..0x8543c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8543b1..0x8543c0
+            - Range: 0x8543c1..0x8543d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x85439c..0x8543ac
+            - Range: 0x8543ac..0x8543bc
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x8543c0..0x854480]
+      OutOfLinePCRanges: [0x8543d0..0x854490]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 345 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x8543c0..0x8543e4
+            - Range: 0x8543d0..0x8543f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10798,7 +10798,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8543e4..0x8543e8
+            - Range: 0x8543f4..0x8543f8
               Pieces:
                 - Size: 8
                   Op: null
@@ -10811,13 +10811,13 @@ Subprograms:
         - Name: needle
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8543c0..0x85441c
+            - Range: 0x8543d0..0x85442c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x85441c..0x854480
+            - Range: 0x85442c..0x854490
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10828,28 +10828,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8543c0..0x854438
-              Pieces: []
-            - Range: 0x854438..0x854439
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854439..0x854448
+            - Range: 0x8543d0..0x854448
               Pieces: []
             - Range: 0x854448..0x854449
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854449..0x854480
+            - Range: 0x854449..0x854458
+              Pieces: []
+            - Range: 0x854458..0x854459
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x854459..0x854490
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8543fc..0x854410
+            - Range: 0x85440c..0x854420
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x854410..0x85441c
+            - Range: 0x854420..0x85442c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10860,56 +10860,56 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x854480..0x854490]
+      OutOfLinePCRanges: [0x854490..0x8544a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x854480..0x854488
+            - Range: 0x854490..0x854498
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x854480..0x854490
+            - Range: 0x854490..0x8544a0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x854480..0x854488
+            - Range: 0x854490..0x854498
               Pieces: []
-            - Range: 0x854488..0x854489
+            - Range: 0x854498..0x854499
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854489..0x854490
+            - Range: 0x854499..0x8544a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x854500..0x854570]
+      OutOfLinePCRanges: [0x854510..0x854580]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x854500..0x85452c
+            - Range: 0x854510..0x85453c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85452c..0x854538
+            - Range: 0x85453c..0x854548
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854538..0x85453c
+            - Range: 0x854548..0x85454c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10920,7 +10920,7 @@ Subprograms:
         - Name: value
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854500..0x85453c
+            - Range: 0x854510..0x85454c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10931,11 +10931,11 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x854500..0x85453c
+            - Range: 0x854510..0x85454c
               Pieces: []
-            - Range: 0x85453c..0x85453d
+            - Range: 0x85454c..0x85454d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85453d..0x854570
+            - Range: 0x85454d..0x854580
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11073,31 +11073,31 @@ Subprograms:
       DictRegister: 0
     - ID: 186
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x84c7b0..0x84c820]
+      OutOfLinePCRanges: [0x84c7c0..0x84c830]
       InlinePCRanges:
-        - Ranges: [0x84c83c..0x84c874]
-          RootRanges: [0x84c820..0x84c8a0]
-        - Ranges: [0x84c988..0x84c9c0]
-          RootRanges: [0x84c950..0x84c9e0]
-        - Ranges: [0x84ca04..0x84ca3c]
-          RootRanges: [0x84c9e0..0x84caa0]
-        - Ranges: [0x84cabc..0x84caf4]
-          RootRanges: [0x84caa0..0x84cb20]
+        - Ranges: [0x84c84c..0x84c884]
+          RootRanges: [0x84c830..0x84c8b0]
+        - Ranges: [0x84c998..0x84c9d0]
+          RootRanges: [0x84c960..0x84c9f0]
+        - Ranges: [0x84ca14..0x84ca4c]
+          RootRanges: [0x84c9f0..0x84cab0]
+        - Ranges: [0x84cacc..0x84cb04]
+          RootRanges: [0x84cab0..0x84cb30]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84c7b0..0x84c7d0
+            - Range: 0x84c7c0..0x84c7e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84c83c..0x84c844
+            - Range: 0x84c84c..0x84c854
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84c988..0x84c990
+            - Range: 0x84c998..0x84c9a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84c9fc..0x84ca0c
+            - Range: 0x84ca0c..0x84ca1c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84ca0c..0x84caa0
+            - Range: 0x84ca1c..0x84cab0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x84caa0..0x84cac4
+            - Range: 0x84cab0..0x84cad4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11106,37 +11106,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84ca48..0x84ca80]
-          RootRanges: [0x84c9e0..0x84caa0]
+        - Ranges: [0x84ca58..0x84ca90]
+          RootRanges: [0x84c9f0..0x84cab0]
       Variables: []
       DictRegister: null
     - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84cb3c..0x84cb80]
-          RootRanges: [0x84cb20..0x84cc40]
+        - Ranges: [0x84cb4c..0x84cb90]
+          RootRanges: [0x84cb30..0x84cc50]
       Variables: []
       DictRegister: null
     - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84cbf0..0x84cc28]
-          RootRanges: [0x84cb20..0x84cc40]
+        - Ranges: [0x84cc00..0x84cc38]
+          RootRanges: [0x84cb30..0x84cc50]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84cc44..0x84cc48]
-          RootRanges: [0x84cc40..0x84cc50]
+        - Ranges: [0x84cc54..0x84cc58]
+          RootRanges: [0x84cc50..0x84cc60]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84cc40..0x84cc48
+            - Range: 0x84cc50..0x84cc58
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11145,38 +11145,38 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84cc74..0x84cc98]
-          RootRanges: [0x84cc50..0x84ccb0]
-        - Ranges: [0x84cd0c..0x84cd34]
-          RootRanges: [0x84ccb0..0x84ce00]
+        - Ranges: [0x84cc84..0x84cca8]
+          RootRanges: [0x84cc60..0x84ccc0]
+        - Ranges: [0x84cd1c..0x84cd44]
+          RootRanges: [0x84ccc0..0x84ce10]
       Variables:
         - Name: a
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0x84cc60..0x84ccb0
+            - Range: 0x84cc70..0x84ccc0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x84ccf8..0x84ce00
+            - Range: 0x84cd08..0x84ce10
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 192
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x84ce00..0x84ce70]
+      OutOfLinePCRanges: [0x84ce10..0x84ce80]
       InlinePCRanges:
-        - Ranges: [0x85461c..0x854650]
-          RootRanges: [0x8545f0..0x8546a0]
+        - Ranges: [0x85462c..0x854660]
+          RootRanges: [0x854600..0x8546b0]
       Variables:
         - Name: b
           Type: 352 StructureType main.firstBehavior
           Locations:
-            - Range: 0x84ce00..0x84ce2c
+            - Range: 0x84ce10..0x84ce3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ce2c..0x84ce30
+            - Range: 0x84ce3c..0x84ce40
               Pieces:
                 - Size: 8
                   Op: null
@@ -11187,15 +11187,15 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ce00..0x84ce50
+            - Range: 0x84ce10..0x84ce60
               Pieces: []
-            - Range: 0x84ce50..0x84ce51
+            - Range: 0x84ce60..0x84ce61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ce51..0x84ce70
+            - Range: 0x84ce61..0x84ce80
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11204,8 +11204,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84d4c8..0x84d4d4, 0x84d4d8..0x84d4e0]
-          RootRanges: [0x84d3b0..0x84d520]
+        - Ranges: [0x84d4d8..0x84d4e4, 0x84d4e8..0x84d4f0]
+          RootRanges: [0x84d3c0..0x84d530]
         - Ranges: [0x129ba8..0x129bac, 0x129bb0..0x129bb8]
           RootRanges: [0x129ba0..0x129bc0]
       Variables: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1574 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x851d58", Frameless: false}]
+              InjectionPoints: [{PC: "0x851ea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1575 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x851d8c", Frameless: false}]
+              InjectionPoints: [{PC: "0x851edc", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1413 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x84cf18", Frameless: false}]
+              InjectionPoints: [{PC: "0x84d068", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1414 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x84cf44", Frameless: false}]
+              InjectionPoints: [{PC: "0x84d094", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x84cf98", Frameless: false}]
+              InjectionPoints: [{PC: "0x84d0e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x84cfc4", Frameless: false}]
+              InjectionPoints: [{PC: "0x84d114", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1545 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x850b4c", Frameless: false}]
+              InjectionPoints: [{PC: "0x850c9c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1546 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x850be4", Frameless: false}]
+              InjectionPoints: [{PC: "0x850d34", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1363 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0x84a6e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a830", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1359 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0x84a6a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a7f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1361 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0x84a6c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a810", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x84d600", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d750", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1360 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0x84a6b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1362 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0x84a6d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x84eda0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84eef0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1448 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x84eddc", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ef2c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x84ac30", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ad80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1382 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0x84ac48", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ad98", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1348 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0x84a5f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1345 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0x84a5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a710", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x8520b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x852200", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1594 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x8520cc", Frameless: true}]
+              InjectionPoints: [{PC: "0x85221c", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1654 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x84c7d8"
+                - PC: "0x84c928"
                   Frameless: false
-                - PC: "0x84c84c"
+                - PC: "0x84c99c"
                   Frameless: false
-                - PC: "0x84c998"
+                - PC: "0x84cae8"
                   Frameless: false
-                - PC: "0x84ca14"
+                - PC: "0x84cb64"
                   Frameless: false
-                - PC: "0x84cacc"
+                - PC: "0x84cc1c"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1655 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x84c7d8"
+                - PC: "0x84c928"
                   Frameless: false
-                - PC: "0x84c84c"
+                - PC: "0x84c99c"
                   Frameless: false
-                - PC: "0x84c998"
+                - PC: "0x84cae8"
                   Frameless: false
-                - PC: "0x84ca14"
+                - PC: "0x84cb64"
                   Frameless: false
-                - PC: "0x84cacc"
+                - PC: "0x84cc1c"
                   Frameless: false
               Condition:
                 Type: 4 BaseType bool
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 1656 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x84c7d8"
+                - PC: "0x84c928"
                   Frameless: false
-                - PC: "0x84c84c"
+                - PC: "0x84c99c"
                   Frameless: false
-                - PC: "0x84c998"
+                - PC: "0x84cae8"
                   Frameless: false
-                - PC: "0x84ca14"
+                - PC: "0x84cb64"
                   Frameless: false
-                - PC: "0x84cacc"
+                - PC: "0x84cc1c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -474,7 +474,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x84eb40", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ec90", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -493,7 +493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x84eb40", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ec90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -519,7 +519,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1601 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x852160", Frameless: true}]
+              InjectionPoints: [{PC: "0x8522b0", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -554,7 +554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x84ede0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ef30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -584,7 +584,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x84eb20", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ec70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -613,11 +613,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1510 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x84fd68", Frameless: false}]
+              InjectionPoints: [{PC: "0x84feb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1511 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x84fe14", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ff64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -639,7 +639,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x84f090", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f1e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -661,7 +661,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x84b130", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -683,7 +683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x84b140", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b290", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -705,7 +705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x84ae20", Frameless: true}]
+              InjectionPoints: [{PC: "0x84af70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -727,7 +727,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x84ae30", Frameless: true}]
+              InjectionPoints: [{PC: "0x84af80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -749,7 +749,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x84afd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -771,7 +771,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x84afe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b130", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -793,7 +793,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1562 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x851980", Frameless: true}]
+              InjectionPoints: [{PC: "0x851ad0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -820,7 +820,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1565 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x8519b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -848,7 +848,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x851e30", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -870,7 +870,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x8521b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x852300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -891,7 +891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x8521c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x852310", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -913,7 +913,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x84cf70", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d0c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -947,7 +947,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1383 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x84acbc", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ae0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -975,11 +975,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x84b7e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b938", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1398 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x84b824", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b974", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1001,11 +1001,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x84b71c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b86c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1396 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x84b78c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b8dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1027,11 +1027,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1407 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x84cc50", Frameless: true}]
+              InjectionPoints: [{PC: "0x84cda0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1408 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x84cc58", Frameless: true}]
+              InjectionPoints: [{PC: "0x84cda8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1053,11 +1053,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x84cc6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cdbc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1410 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x84cca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cdf8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1082,7 +1082,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1411 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x84cc6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cdbc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1104,11 +1104,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1640 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x854320", Frameless: true}]
+              InjectionPoints: [{PC: "0x854470", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1641 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x854328", Frameless: true}]
+              InjectionPoints: [{PC: "0x854478", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1122,11 +1122,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1642 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x854340", Frameless: false}]
+              InjectionPoints: [{PC: "0x854490", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1643 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x85437c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8544cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1149,11 +1149,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1636 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x854288", Frameless: false}]
+              InjectionPoints: [{PC: "0x8543d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1637 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x854298", Frameless: false}]
+              InjectionPoints: [{PC: "0x8543e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1167,11 +1167,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1638 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x8542d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x854428", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1639 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x8542f0", Frameless: false}]
+              InjectionPoints: [{PC: "0x854440", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1194,14 +1194,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1644 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x854390", Frameless: true}]
+              InjectionPoints: [{PC: "0x8544e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1645 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x8543b8"
+                - PC: "0x854508"
                   Frameless: true
-                - PC: "0x8543c0"
+                - PC: "0x854510"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1216,14 +1216,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1646 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x8543e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x854538", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1647 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x854448"
+                - PC: "0x854598"
                   Frameless: false
-                - PC: "0x854458"
+                - PC: "0x8545a8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1250,7 +1250,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1648 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x854394", Frameless: true}]
+              InjectionPoints: [{PC: "0x8544e4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1262,7 +1262,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1649 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x8543f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x854548", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1283,11 +1283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x853f80", Frameless: true}]
+              InjectionPoints: [{PC: "0x8540d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1625 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x853f88", Frameless: true}]
+              InjectionPoints: [{PC: "0x8540d8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1301,11 +1301,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1626 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x854010", Frameless: true}]
+              InjectionPoints: [{PC: "0x854160", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1627 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x854014", Frameless: true}]
+              InjectionPoints: [{PC: "0x854164", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1329,11 +1329,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x853b88", Frameless: false}]
+              InjectionPoints: [{PC: "0x853cd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1613 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x853c5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x853dac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1375,11 +1375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x853ca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x853df8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1617 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x853cb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x853e08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1402,11 +1402,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1650 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x854490", Frameless: true}]
+              InjectionPoints: [{PC: "0x8545e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1651 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x854498", Frameless: true}]
+              InjectionPoints: [{PC: "0x8545e8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1420,11 +1420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1652 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x854528", Frameless: false}]
+              InjectionPoints: [{PC: "0x854678", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1653 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x85454c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85469c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1447,11 +1447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x853af0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853c40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1609 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x853af4", Frameless: true}]
+              InjectionPoints: [{PC: "0x853c44", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1465,11 +1465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x853b00", Frameless: true}]
+              InjectionPoints: [{PC: "0x853c50", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1611 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x853b0c", Frameless: true}]
+              InjectionPoints: [{PC: "0x853c5c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1492,11 +1492,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1628 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x8540b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x854200", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1629 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x8540b8", Frameless: true}]
+              InjectionPoints: [{PC: "0x854208", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1510,11 +1510,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1630 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x854158", Frameless: false}]
+              InjectionPoints: [{PC: "0x8542a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1631 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x854184", Frameless: false}]
+              InjectionPoints: [{PC: "0x8542d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1537,11 +1537,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1618 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x853f50", Frameless: true}]
+              InjectionPoints: [{PC: "0x8540a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1619 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x853f54", Frameless: true}]
+              InjectionPoints: [{PC: "0x8540a4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1555,11 +1555,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1620 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x853f60", Frameless: true}]
+              InjectionPoints: [{PC: "0x8540b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1621 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x853f64", Frameless: true}]
+              InjectionPoints: [{PC: "0x8540b4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1573,11 +1573,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1622 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x853f70", Frameless: true}]
+              InjectionPoints: [{PC: "0x8540c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1623 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x853f74", Frameless: true}]
+              InjectionPoints: [{PC: "0x8540c4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1600,11 +1600,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1632 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x854240", Frameless: true}]
+              InjectionPoints: [{PC: "0x854390", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1633 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x854248", Frameless: true}]
+              InjectionPoints: [{PC: "0x854398", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1618,11 +1618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1634 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x854250", Frameless: true}]
+              InjectionPoints: [{PC: "0x8543a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1635 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x854260", Frameless: true}]
+              InjectionPoints: [{PC: "0x8543b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1645,11 +1645,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x853ad0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853c20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1605 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x853ad4", Frameless: true}]
+              InjectionPoints: [{PC: "0x853c24", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1663,11 +1663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x853ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853c30", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1607 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x853aec", Frameless: true}]
+              InjectionPoints: [{PC: "0x853c3c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1690,11 +1690,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x84c978", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cac8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1400 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x84c9d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cb20", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1721,11 +1721,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x84ca08", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cb58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1402 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x84ca90", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cbe0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1752,11 +1752,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x84cac8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cc18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1404 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x84cb04", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cc54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1778,7 +1778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1660 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x84ca58", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cba8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1796,11 +1796,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x84cb48", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cc98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1406 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x84cc38", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cd88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1818,7 +1818,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1661 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x84cb4c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cc9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1839,7 +1839,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1662 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x84cb4c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cc9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1857,7 +1857,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1663 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x84cc00", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cd50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1878,7 +1878,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1664 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x84cc00", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cd50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1899,7 +1899,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x129ba8"
                   Frameless: true
-                - PC: "0x84d4d8"
+                - PC: "0x84d62c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1920,20 +1920,20 @@ Probes:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x84c7d8"
+                - PC: "0x84c928"
                   Frameless: false
-                - PC: "0x84c84c"
+                - PC: "0x84c99c"
                   Frameless: false
-                - PC: "0x84c998"
+                - PC: "0x84cae8"
                   Frameless: false
-                - PC: "0x84ca14"
+                - PC: "0x84cb64"
                   Frameless: false
-                - PC: "0x84cacc"
+                - PC: "0x84cc1c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x84c810", Frameless: false}]
+              InjectionPoints: [{PC: "0x84c960", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1959,15 +1959,15 @@ Probes:
             - Kind: Line
               Type: 1659 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x84c7d8"
+                - PC: "0x84c928"
                   Frameless: false
-                - PC: "0x84c84c"
+                - PC: "0x84c99c"
                   Frameless: false
-                - PC: "0x84c998"
+                - PC: "0x84cae8"
                   Frameless: false
-                - PC: "0x84ca14"
+                - PC: "0x84cb64"
                   Frameless: false
-                - PC: "0x84cacc"
+                - PC: "0x84cc1c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1990,7 +1990,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1665 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x84cc54", Frameless: true}]
+              InjectionPoints: [{PC: "0x84cda4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2015,7 +2015,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1666 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x84cc54", Frameless: true}]
+              InjectionPoints: [{PC: "0x84cda4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2039,9 +2039,9 @@ Probes:
             - Kind: Entry
               Type: 1667 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x84cc84"
+                - PC: "0x84cdd4"
                   Frameless: false
-                - PC: "0x84cd1c"
+                - PC: "0x84ce6c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2064,7 +2064,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1351 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0x84a620", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a770", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2086,7 +2086,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1352 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0x84a630", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2108,7 +2108,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1353 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0x84a640", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a790", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2130,7 +2130,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1350 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0x84a610", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2152,7 +2152,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1349 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0x84a600", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a750", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2174,7 +2174,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x84cef0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2195,11 +2195,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1543 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x850990", Frameless: false}]
+              InjectionPoints: [{PC: "0x850ae0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1544 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x850ae8", Frameless: false}]
+              InjectionPoints: [{PC: "0x850c38", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2221,7 +2221,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x84efa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f0f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2246,7 +2246,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1392 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x84b18c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b2dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2268,7 +2268,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1393 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x84b21c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b36c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2290,7 +2290,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1394 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x84b2c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b414", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2333,11 +2333,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1549 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x850e4c", Frameless: false}]
+              InjectionPoints: [{PC: "0x850f9c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1550 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x850fb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851108", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2399,7 +2399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x84d5e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d730", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2421,7 +2421,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1430 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x84d640", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d790", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2443,7 +2443,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x84d6e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d830", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2465,7 +2465,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x84d700", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d850", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2487,7 +2487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x84d6f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2509,7 +2509,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x84d620", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d770", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2531,7 +2531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x84d6d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2553,7 +2553,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x84d6c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d810", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2577,7 +2577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x84d630", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2601,7 +2601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x84d630", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2623,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x84d6b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2645,7 +2645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1436 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x84d6a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d7f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2667,7 +2667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1421 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x84d5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d710", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2689,7 +2689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2711,7 +2711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x84d5b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2733,7 +2733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x84d650", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d7a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2755,7 +2755,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x84d680", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d7d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2777,7 +2777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x84d690", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d7e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2799,7 +2799,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x84d660", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d7b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2823,7 +2823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x84d670", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d7c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2845,7 +2845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x851e10", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2868,7 +2868,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1586 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x851e10", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2915,11 +2915,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1551 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x851020", Frameless: false}]
+              InjectionPoints: [{PC: "0x851170", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1552 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x8511cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x85131c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2985,11 +2985,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1555 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x8512cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x85141c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1556 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x851374", Frameless: false}]
+              InjectionPoints: [{PC: "0x8514c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3020,11 +3020,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1547 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x850c20", Frameless: false}]
+              InjectionPoints: [{PC: "0x850d70", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1548 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x850df0", Frameless: false}]
+              InjectionPoints: [{PC: "0x850f40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3050,11 +3050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fd28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1489 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fdb4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3090,7 +3090,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x84ec00", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ed50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3131,11 +3131,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x84fb38", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fc88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1483 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fb98", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fce8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3159,11 +3159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x84fb38", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fc88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fb98", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fce8", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3182,11 +3182,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fd28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1491 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fdb4", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3206,11 +3206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fd28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1493 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fdb4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3243,11 +3243,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x84fb38", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fc88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1487 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fb98", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fce8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3275,7 +3275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x852150", Frameless: true}]
+              InjectionPoints: [{PC: "0x8522a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3300,7 +3300,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x852150", Frameless: true}]
+              InjectionPoints: [{PC: "0x8522a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3331,7 +3331,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x852150", Frameless: true}]
+              InjectionPoints: [{PC: "0x8522a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3356,7 +3356,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x852150", Frameless: true}]
+              InjectionPoints: [{PC: "0x8522a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3383,7 +3383,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x84f070", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f1c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3410,7 +3410,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x8519f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851b40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3437,7 +3437,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1566 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x8519c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851b10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3472,7 +3472,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1568 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x8519e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851b30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3504,7 +3504,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1584 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x851e00", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3526,7 +3526,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x84efb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3548,7 +3548,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x84d610", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3570,7 +3570,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x84ef90", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f0e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3594,11 +3594,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x84f3e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f538", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1459 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f57c", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3618,11 +3618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1502 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x84fca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fdf8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1503 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fd30", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fe80", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3663,11 +3663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x84f508", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f658", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1469 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x84f5a0", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f6f0", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3705,11 +3705,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x84f3e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f538", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1461 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f57c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3750,11 +3750,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x84f508", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f658", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1471 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x84f5a0", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f6f0", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3794,11 +3794,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1504 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x84fca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fdf8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1505 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fd30", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fe80", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3815,11 +3815,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1506 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x84fca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fdf8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1507 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fd30", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fe80", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3841,11 +3841,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x84f3e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f538", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1463 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f57c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3868,18 +3868,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x84f7d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f928", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1479 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x84f874"
+                - PC: "0x84f9c4"
                   Frameless: false
-                - PC: "0x84f8bc"
+                - PC: "0x84fa0c"
                   Frameless: false
-                - PC: "0x84f980"
+                - PC: "0x84fad0"
                   Frameless: false
-                - PC: "0x84f994"
+                - PC: "0x84fae4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3907,18 +3907,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x84f658", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f7a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1477 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x84f6ac"
+                - PC: "0x84f7fc"
                   Frameless: false
-                - PC: "0x84f710"
+                - PC: "0x84f860"
                   Frameless: false
-                - PC: "0x84f750"
+                - PC: "0x84f8a0"
                   Frameless: false
-                - PC: "0x84f790"
+                - PC: "0x84f8e0"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3945,11 +3945,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1521 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x85039c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8504ec", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1522 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x8503f0", Frameless: false}]
+              InjectionPoints: [{PC: "0x850540", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3966,11 +3966,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1523 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x850428", Frameless: false}]
+              InjectionPoints: [{PC: "0x850578", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1524 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x850464", Frameless: false}]
+              InjectionPoints: [{PC: "0x8505b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3987,11 +3987,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1525 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x850498", Frameless: false}]
+              InjectionPoints: [{PC: "0x8505e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1526 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x8504d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x850620", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4008,11 +4008,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1529 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x850588", Frameless: false}]
+              InjectionPoints: [{PC: "0x8506d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1530 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x8505ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x85073c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4029,11 +4029,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1541 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x850918", Frameless: false}]
+              InjectionPoints: [{PC: "0x850a68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1542 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x850958", Frameless: false}]
+              InjectionPoints: [{PC: "0x850aa8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4050,11 +4050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1517 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x850248", Frameless: false}]
+              InjectionPoints: [{PC: "0x850398", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1518 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x850294", Frameless: false}]
+              InjectionPoints: [{PC: "0x8503e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4072,14 +4072,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1474 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x84f5d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f728", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1475 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x84f608"
+                - PC: "0x84f758"
                   Frameless: false
-                - PC: "0x84f61c"
+                - PC: "0x84f76c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4101,11 +4101,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x84f3e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f538", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1465 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f57c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4126,11 +4126,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x84f508", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f658", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1473 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x84f5a0", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f6f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4151,11 +4151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x84f468", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f5b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1467 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x84f4c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84f618", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4177,14 +4177,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1480 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x84f9d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fb28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1481 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x84faa4"
+                - PC: "0x84fbf4"
                   Frameless: false
-                - PC: "0x84fab8"
+                - PC: "0x84fc08"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4206,11 +4206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1519 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x8502d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x850420", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1520 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x850364", Frameless: false}]
+              InjectionPoints: [{PC: "0x8504b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4227,11 +4227,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1515 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x850188", Frameless: false}]
+              InjectionPoints: [{PC: "0x8502d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1516 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x85020c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85035c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4248,11 +4248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1533 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x850708", Frameless: false}]
+              InjectionPoints: [{PC: "0x850858", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1534 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x850760", Frameless: false}]
+              InjectionPoints: [{PC: "0x8508b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4269,11 +4269,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1527 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x850508", Frameless: false}]
+              InjectionPoints: [{PC: "0x850658", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1528 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x850550", Frameless: false}]
+              InjectionPoints: [{PC: "0x8506a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4290,11 +4290,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1539 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x850898", Frameless: false}]
+              InjectionPoints: [{PC: "0x8509e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1540 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x8508dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x850a2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4314,7 +4314,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1512 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x84ff18", Frameless: false}]
+              InjectionPoints: [{PC: "0x850068", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4335,11 +4335,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1537 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x850828", Frameless: false}]
+              InjectionPoints: [{PC: "0x850978", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1538 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x850868", Frameless: false}]
+              InjectionPoints: [{PC: "0x8509b8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4356,11 +4356,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1513 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x8500f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x850248", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1514 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x850150", Frameless: false}]
+              InjectionPoints: [{PC: "0x8502a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4377,11 +4377,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1535 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x85079c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8508ec", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1536 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x8507f0", Frameless: false}]
+              InjectionPoints: [{PC: "0x850940", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4398,11 +4398,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1531 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x850630", Frameless: false}]
+              InjectionPoints: [{PC: "0x850780", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1532 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x8506d4", Frameless: false}]
+              InjectionPoints: [{PC: "0x850824", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4420,7 +4420,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1346 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0x84a5d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1494 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fd28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1495 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fdb4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4505,7 +4505,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x84aa50", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4527,7 +4527,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x84aa30", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ab80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4549,7 +4549,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x84ab00", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ac50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4567,7 +4567,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x84ab10", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ac60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x84aa60", Frameless: true}]
+              InjectionPoints: [{PC: "0x84abb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x84aa80", Frameless: true}]
+              InjectionPoints: [{PC: "0x84abd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4630,7 +4630,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x84aa90", Frameless: true}]
+              InjectionPoints: [{PC: "0x84abe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4652,7 +4652,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x84aaa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84abf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4681,7 +4681,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x84aa70", Frameless: true}]
+              InjectionPoints: [{PC: "0x84abc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4712,7 +4712,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x84aa40", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ab90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4734,7 +4734,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1576 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x851db0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4756,7 +4756,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x84aab0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ac00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4778,7 +4778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x84aad0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ac20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4800,7 +4800,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x84aae0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ac30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4822,7 +4822,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x84aaf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ac40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4844,7 +4844,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x84aac0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ac10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4866,7 +4866,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1572 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x851a10", Frameless: true}]
+              InjectionPoints: [{PC: "0x851b60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4888,7 +4888,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1563 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x851990", Frameless: true}]
+              InjectionPoints: [{PC: "0x851ae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4910,7 +4910,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1424 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x84d5f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4931,11 +4931,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1508 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x84fca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fdf8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1509 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fd30", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fe80", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4956,11 +4956,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1553 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x851228", Frameless: false}]
+              InjectionPoints: [{PC: "0x851378", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1554 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x85128c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8513dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4982,7 +4982,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1347 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0x84a5e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a730", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5004,7 +5004,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x84f050", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f1a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5026,7 +5026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1567 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x8519d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851b20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5048,7 +5048,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x84b150", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5070,7 +5070,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x84b160", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b2b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5092,11 +5092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x8520b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x852200", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1596 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x8520cc", Frameless: true}]
+              InjectionPoints: [{PC: "0x85221c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5123,7 +5123,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1564 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x8519a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851af0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5150,7 +5150,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x84cff0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5171,11 +5171,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1557 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x8513ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x8514fc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1558 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x85143c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85158c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5197,11 +5197,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x851fc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x852110", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1592 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x851fd8", Frameless: true}]
+              InjectionPoints: [{PC: "0x852128", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5222,7 +5222,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x851fb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x852100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5249,7 +5249,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1419 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x84d5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d6f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5281,7 +5281,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x851a20", Frameless: true}]
+              InjectionPoints: [{PC: "0x851b70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5321,7 +5321,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x851e40", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5354,11 +5354,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1496 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fd28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1497 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fdb4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5379,11 +5379,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1498 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fd28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1499 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fdb4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5406,11 +5406,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1500 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x84fbd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fd28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1501 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x84fc64", Frameless: false}]
+              InjectionPoints: [{PC: "0x84fdb4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5439,7 +5439,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x851dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5471,11 +5471,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1578 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x851dd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1579 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x851de8", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f38", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5505,11 +5505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1580 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x851dd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1581 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x851de8", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f38", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5541,7 +5541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1582 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x851df0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x851df0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x84ab20", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ac70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5625,7 +5625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1356 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0x84a670", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a7c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5647,7 +5647,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1357 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0x84a680", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a7d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5669,7 +5669,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1358 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0x84a690", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a7e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5691,7 +5691,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1355 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0x84a660", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a7b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5713,7 +5713,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1354 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0x84a650", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a7a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5735,7 +5735,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x84efe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f130", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5757,7 +5757,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1561 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x851970", Frameless: true}]
+              InjectionPoints: [{PC: "0x851ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5779,7 +5779,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x851e20", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5801,7 +5801,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x84efc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f110", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5823,7 +5823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1364 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0x84a700", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a850", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5845,7 +5845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1570 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x851a00", Frameless: true}]
+              InjectionPoints: [{PC: "0x851b50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5867,7 +5867,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x851a00", Frameless: true}]
+              InjectionPoints: [{PC: "0x851b50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5890,14 +5890,14 @@ Probes:
             - Kind: Entry
               Type: 1668 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x84ce28"
+                - PC: "0x84cf78"
                   Frameless: false
-                - PC: "0x85462c"
+                - PC: "0x85477c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1669 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x84ce60", Frameless: false}]
+              InjectionPoints: [{PC: "0x84cfb0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5919,11 +5919,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1559 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x851478", Frameless: false}]
+              InjectionPoints: [{PC: "0x8515c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1560 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8514e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x851630", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5940,481 +5940,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x84a5c0..0x84a5d0]
+      OutOfLinePCRanges: [0x84a710..0x84a720]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 ArrayType [2]uint8
           Locations:
-            - Range: 0x84a5c0..0x84a5d0
+            - Range: 0x84a710..0x84a720
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x84a5d0..0x84a5e0]
+      OutOfLinePCRanges: [0x84a720..0x84a730]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]int32
           Locations:
-            - Range: 0x84a5d0..0x84a5e0
+            - Range: 0x84a720..0x84a730
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x84a5e0..0x84a5f0]
+      OutOfLinePCRanges: [0x84a730..0x84a740]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]string
           Locations:
-            - Range: 0x84a5e0..0x84a5f0
+            - Range: 0x84a730..0x84a740
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x84a5f0..0x84a600]
+      OutOfLinePCRanges: [0x84a740..0x84a750]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]bool
           Locations:
-            - Range: 0x84a5f0..0x84a600
+            - Range: 0x84a740..0x84a750
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x84a600..0x84a610]
+      OutOfLinePCRanges: [0x84a750..0x84a760]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x84a600..0x84a610
+            - Range: 0x84a750..0x84a760
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x84a610..0x84a620]
+      OutOfLinePCRanges: [0x84a760..0x84a770]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]int8
           Locations:
-            - Range: 0x84a610..0x84a620
+            - Range: 0x84a760..0x84a770
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x84a620..0x84a630]
+      OutOfLinePCRanges: [0x84a770..0x84a780]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 113 ArrayType [2]int16
           Locations:
-            - Range: 0x84a620..0x84a630
+            - Range: 0x84a770..0x84a780
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x84a630..0x84a640]
+      OutOfLinePCRanges: [0x84a780..0x84a790]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]int32
           Locations:
-            - Range: 0x84a630..0x84a640
+            - Range: 0x84a780..0x84a790
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x84a640..0x84a650]
+      OutOfLinePCRanges: [0x84a790..0x84a7a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 114 ArrayType [2]int64
           Locations:
-            - Range: 0x84a640..0x84a650
+            - Range: 0x84a790..0x84a7a0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x84a650..0x84a660]
+      OutOfLinePCRanges: [0x84a7a0..0x84a7b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 ArrayType [2]uint
           Locations:
-            - Range: 0x84a650..0x84a660
+            - Range: 0x84a7a0..0x84a7b0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x84a660..0x84a670]
+      OutOfLinePCRanges: [0x84a7b0..0x84a7c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 ArrayType [2]uint8
           Locations:
-            - Range: 0x84a660..0x84a670
+            - Range: 0x84a7b0..0x84a7c0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x84a670..0x84a680]
+      OutOfLinePCRanges: [0x84a7c0..0x84a7d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]uint16
           Locations:
-            - Range: 0x84a670..0x84a680
+            - Range: 0x84a7c0..0x84a7d0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x84a680..0x84a690]
+      OutOfLinePCRanges: [0x84a7d0..0x84a7e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]uint32
           Locations:
-            - Range: 0x84a680..0x84a690
+            - Range: 0x84a7d0..0x84a7e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x84a690..0x84a6a0]
+      OutOfLinePCRanges: [0x84a7e0..0x84a7f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 54 ArrayType [2]uint64
           Locations:
-            - Range: 0x84a690..0x84a6a0
+            - Range: 0x84a7e0..0x84a7f0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x84a6a0..0x84a6b0]
+      OutOfLinePCRanges: [0x84a7f0..0x84a800]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 118 ArrayType [2][2]int
           Locations:
-            - Range: 0x84a6a0..0x84a6b0
+            - Range: 0x84a7f0..0x84a800
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x84a6b0..0x84a6c0]
+      OutOfLinePCRanges: [0x84a800..0x84a810]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 109 ArrayType [2]string
           Locations:
-            - Range: 0x84a6b0..0x84a6c0
+            - Range: 0x84a800..0x84a810
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x84a6c0..0x84a6d0]
+      OutOfLinePCRanges: [0x84a810..0x84a820]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 119 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x84a6c0..0x84a6d0
+            - Range: 0x84a810..0x84a820
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0x84a6d0..0x84a6e0]
+      OutOfLinePCRanges: [0x84a820..0x84a830]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 120 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0x84a6d0..0x84a6e0
+            - Range: 0x84a820..0x84a830
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0x84a6e0..0x84a6f0]
+      OutOfLinePCRanges: [0x84a830..0x84a840]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 122 ArrayType [2]struct {}
           Locations:
-            - Range: 0x84a6e0..0x84a6f0
+            - Range: 0x84a830..0x84a840
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x84a700..0x84a710]
+      OutOfLinePCRanges: [0x84a850..0x84a860]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 124 ArrayType [100]uint
           Locations:
-            - Range: 0x84a700..0x84a710
+            - Range: 0x84a850..0x84a860
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x84aa30..0x84aa40]
+      OutOfLinePCRanges: [0x84ab80..0x84ab90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84aa30..0x84aa40
+            - Range: 0x84ab80..0x84ab90
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x84aa40..0x84aa50]
+      OutOfLinePCRanges: [0x84ab90..0x84aba0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84aa40..0x84aa50
+            - Range: 0x84ab90..0x84aba0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x84aa50..0x84aa60]
+      OutOfLinePCRanges: [0x84aba0..0x84abb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84aa50..0x84aa60
+            - Range: 0x84aba0..0x84abb0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x84aa60..0x84aa70]
+      OutOfLinePCRanges: [0x84abb0..0x84abc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84aa60..0x84aa70
+            - Range: 0x84abb0..0x84abc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x84aa70..0x84aa80]
+      OutOfLinePCRanges: [0x84abc0..0x84abd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x84aa70..0x84aa80
+            - Range: 0x84abc0..0x84abd0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x84aa80..0x84aa90]
+      OutOfLinePCRanges: [0x84abd0..0x84abe0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 94 BaseType int16
           Locations:
-            - Range: 0x84aa80..0x84aa90
+            - Range: 0x84abd0..0x84abe0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x84aa90..0x84aaa0]
+      OutOfLinePCRanges: [0x84abe0..0x84abf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84aa90..0x84aaa0
+            - Range: 0x84abe0..0x84abf0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x84aaa0..0x84aab0]
+      OutOfLinePCRanges: [0x84abf0..0x84ac00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x84aaa0..0x84aab0
+            - Range: 0x84abf0..0x84ac00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x84aab0..0x84aac0]
+      OutOfLinePCRanges: [0x84ac00..0x84ac10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84aab0..0x84aac0
+            - Range: 0x84ac00..0x84ac10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x84aac0..0x84aad0]
+      OutOfLinePCRanges: [0x84ac10..0x84ac20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84aac0..0x84aad0
+            - Range: 0x84ac10..0x84ac20
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x84aad0..0x84aae0]
+      OutOfLinePCRanges: [0x84ac20..0x84ac30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x84aad0..0x84aae0
+            - Range: 0x84ac20..0x84ac30
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x84aae0..0x84aaf0]
+      OutOfLinePCRanges: [0x84ac30..0x84ac40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x84aae0..0x84aaf0
+            - Range: 0x84ac30..0x84ac40
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x84aaf0..0x84ab00]
+      OutOfLinePCRanges: [0x84ac40..0x84ac50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x84aaf0..0x84ab00
+            - Range: 0x84ac40..0x84ac50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x84ab00..0x84ab10]
+      OutOfLinePCRanges: [0x84ac50..0x84ac60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x84ab00..0x84ab10
+            - Range: 0x84ac50..0x84ac60
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x84ab10..0x84ab20]
+      OutOfLinePCRanges: [0x84ac60..0x84ac70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x84ab10..0x84ab20
+            - Range: 0x84ac60..0x84ac70
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x84ab20..0x84ab30]
+      OutOfLinePCRanges: [0x84ac70..0x84ac80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 125 BaseType main.typeAlias
           Locations:
-            - Range: 0x84ab20..0x84ab30
+            - Range: 0x84ac70..0x84ac80
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x84ac30..0x84ac50]
+      OutOfLinePCRanges: [0x84ad80..0x84ada0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 126 StructureType main.bigStruct
           Locations:
-            - Range: 0x84ac30..0x84ac50
+            - Range: 0x84ad80..0x84ada0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6433,48 +6433,48 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x84ac70..0x84ad90]
+      OutOfLinePCRanges: [0x84adc0..0x84aee0]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84ac70..0x84ac90
+            - Range: 0x84adc0..0x84ade0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84ac70..0x84ad90, Pieces: []}]
+          Locations: [{Range: 0x84adc0..0x84aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
-          Locations: [{Range: 0x84ac70..0x84ad90, Pieces: []}]
+          Locations: [{Range: 0x84adc0..0x84aee0, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84aca8..0x84acc8
+            - Range: 0x84adf8..0x84ae18
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x84acc8..0x84ace4
+            - Range: 0x84ae18..0x84ae34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ace4..0x84acf8
+            - Range: 0x84ae34..0x84ae48
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: -64}
-            - Range: 0x84acf8..0x84ad90
+            - Range: 0x84ae48..0x84aee0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
@@ -6485,39 +6485,39 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x84ae20..0x84ae30]
+      OutOfLinePCRanges: [0x84af70..0x84af80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 130 StructureType main.deepPtr1
           Locations:
-            - Range: 0x84ae20..0x84ae30
+            - Range: 0x84af70..0x84af80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x84ae30..0x84ae40]
+      OutOfLinePCRanges: [0x84af80..0x84af90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 133 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x84ae30..0x84ae40
+            - Range: 0x84af80..0x84af90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x84afd0..0x84afe0]
+      OutOfLinePCRanges: [0x84b120..0x84b130]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 135 StructureType main.deepSlice1
           Locations:
-            - Range: 0x84afd0..0x84afe0
+            - Range: 0x84b120..0x84b130
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6530,129 +6530,129 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x84afe0..0x84aff0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 139 PointerType *main.deepSlice7
-          Locations:
-            - Range: 0x84afe0..0x84aff0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 43
-      Name: main.testDeepMap1
       OutOfLinePCRanges: [0x84b130..0x84b140]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 141 StructureType main.deepMap1
+          Type: 139 PointerType *main.deepSlice7
           Locations:
             - Range: 0x84b130..0x84b140
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 43
+      Name: main.testDeepMap1
+      OutOfLinePCRanges: [0x84b280..0x84b290]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 141 StructureType main.deepMap1
+          Locations:
+            - Range: 0x84b280..0x84b290
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x84b140..0x84b150]
+      OutOfLinePCRanges: [0x84b290..0x84b2a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 147 PointerType *main.deepMap7
           Locations:
-            - Range: 0x84b140..0x84b150
+            - Range: 0x84b290..0x84b2a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x84b150..0x84b160]
+      OutOfLinePCRanges: [0x84b2a0..0x84b2b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 PointerType *main.stringType1
           Locations:
-            - Range: 0x84b150..0x84b160
+            - Range: 0x84b2a0..0x84b2b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x84b160..0x84b170]
+      OutOfLinePCRanges: [0x84b2b0..0x84b2c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 151 PointerType **main.stringType2
           Locations:
-            - Range: 0x84b160..0x84b170
+            - Range: 0x84b2b0..0x84b2c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x84b170..0x84b370]
+      OutOfLinePCRanges: [0x84b2c0..0x84b4c0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84b234..0x84b244
+            - Range: 0x84b384..0x84b394
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84b2e0..0x84b2f0
+            - Range: 0x84b430..0x84b440
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84b21c..0x84b220
+            - Range: 0x84b36c..0x84b370
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84b220..0x84b244
+            - Range: 0x84b370..0x84b394
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84b244..0x84b2d4
+            - Range: 0x84b394..0x84b424
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x84b2d4..0x84b2dc
+            - Range: 0x84b424..0x84b42c
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x84b2dc..0x84b370
+            - Range: 0x84b42c..0x84b4c0
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84b218..0x84b220
+            - Range: 0x84b368..0x84b370
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84b220..0x84b220
+            - Range: 0x84b370..0x84b370
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84b220..0x84b244
+            - Range: 0x84b370..0x84b394
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84b244..0x84b2d4
+            - Range: 0x84b394..0x84b424
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x84b2d4..0x84b2d8
+            - Range: 0x84b424..0x84b428
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x84b2d8..0x84b2dc
+            - Range: 0x84b428..0x84b42c
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x84b2dc..0x84b2f0
+            - Range: 0x84b42c..0x84b440
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x84b2f0..0x84b370
+            - Range: 0x84b440..0x84b4c0
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x84b700..0x84b7d0]
+      OutOfLinePCRanges: [0x84b850..0x84b920]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 153 StructureType main.esotericStack
           Locations:
-            - Range: 0x84b700..0x84b748
+            - Range: 0x84b850..0x84b898
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6672,7 +6672,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x84b748..0x84b74c
+            - Range: 0x84b898..0x84b89c
               Pieces:
                 - Size: 4
                   Op: null
@@ -6692,7 +6692,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x84b74c..0x84b750
+            - Range: 0x84b89c..0x84b8a0
               Pieces:
                 - Size: 4
                   Op: null
@@ -6717,157 +6717,157 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x84b7d0..0x84b850]
+      OutOfLinePCRanges: [0x84b920..0x84b9a0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 157 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x84b7d0..0x84b808
+            - Range: 0x84b920..0x84b958
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 50
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x84c960..0x84c9f0]
+      OutOfLinePCRanges: [0x84cab0..0x84cb40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84c960..0x84c998
+            - Range: 0x84cab0..0x84cae8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 51
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x84c9f0..0x84cab0]
+      OutOfLinePCRanges: [0x84cb40..0x84cc00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84c9f0..0x84ca0c
+            - Range: 0x84cb40..0x84cb5c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84c9f0..0x84ca1c
+            - Range: 0x84cb40..0x84cb6c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ca0c..0x84ca1c
+            - Range: 0x84cb5c..0x84cb6c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84ca1c..0x84cab0
+            - Range: 0x84cb6c..0x84cc00
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x84cab0..0x84cb30]
+      OutOfLinePCRanges: [0x84cc00..0x84cc80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84cab0..0x84cad4
+            - Range: 0x84cc00..0x84cc24
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x84cb30..0x84cc50]
+      OutOfLinePCRanges: [0x84cc80..0x84cda0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84cb98..0x84cba0
+            - Range: 0x84cce8..0x84ccf0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84cba0..0x84cbb8
+            - Range: 0x84ccf0..0x84cd08
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84cbb8..0x84cbcc
+            - Range: 0x84cd08..0x84cd1c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84cb94..0x84cb9c
+            - Range: 0x84cce4..0x84ccec
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84cb9c..0x84cbb8
+            - Range: 0x84ccec..0x84cd08
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84cbb8..0x84cbc8
+            - Range: 0x84cd08..0x84cd18
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x84cc50..0x84cc60]
+      OutOfLinePCRanges: [0x84cda0..0x84cdb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84cc50..0x84cc58
+            - Range: 0x84cda0..0x84cda8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84cc50..0x84cc58
+            - Range: 0x84cda0..0x84cda8
               Pieces: []
-            - Range: 0x84cc58..0x84cc59
+            - Range: 0x84cda8..0x84cda9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84cc59..0x84cc60
+            - Range: 0x84cda9..0x84cdb0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x84cc60..0x84ccc0]
+      OutOfLinePCRanges: [0x84cdb0..0x84ce10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0x84cc60..0x84ccc0
+            - Range: 0x84cdb0..0x84ce10
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84cc60..0x84cca8
+            - Range: 0x84cdb0..0x84cdf8
               Pieces: []
-            - Range: 0x84cca8..0x84cca9
+            - Range: 0x84cdf8..0x84cdf9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84cca9..0x84ccc0
+            - Range: 0x84cdf9..0x84ce10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0x84cef0..0x84cf00]
+      OutOfLinePCRanges: [0x84d040..0x84d050]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84cef0..0x84cf00
+            - Range: 0x84d040..0x84d050
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6878,19 +6878,19 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0x84cf00..0x84cf70]
+      OutOfLinePCRanges: [0x84d050..0x84d0c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84cf00..0x84cf30
+            - Range: 0x84d050..0x84d080
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84cf30..0x84cf34
+            - Range: 0x84d080..0x84d084
               Pieces:
                 - Size: 8
                   Op: null
@@ -6901,28 +6901,28 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84cf00..0x84cf44
+            - Range: 0x84d050..0x84d094
               Pieces: []
-            - Range: 0x84cf44..0x84cf45
+            - Range: 0x84d094..0x84d095
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84cf45..0x84cf70
+            - Range: 0x84d095..0x84d0c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0x84cf70..0x84cf80]
+      OutOfLinePCRanges: [0x84d0c0..0x84d0d0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84cf70..0x84cf80
+            - Range: 0x84d0c0..0x84d0d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6933,41 +6933,41 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x84cf80..0x84cff0]
+      OutOfLinePCRanges: [0x84d0d0..0x84d140]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 161 PointerType *interface {}
           Locations:
-            - Range: 0x84cf80..0x84cfb0
+            - Range: 0x84d0d0..0x84d100
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84cf80..0x84cfc4
+            - Range: 0x84d0d0..0x84d114
               Pieces: []
-            - Range: 0x84cfc4..0x84cfc5
+            - Range: 0x84d114..0x84d115
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84cfc5..0x84cff0
+            - Range: 0x84d115..0x84d140
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x84cff0..0x84d000]
+      OutOfLinePCRanges: [0x84d140..0x84d150]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 162 StructureType main.structWithAny
           Locations:
-            - Range: 0x84cff0..0x84d000
+            - Range: 0x84d140..0x84d150
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6978,346 +6978,346 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x84d5a0..0x84d5b0]
+      OutOfLinePCRanges: [0x84d6f0..0x84d700]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 163 StructureType main.structWithMap
-          Locations:
-            - Range: 0x84d5a0..0x84d5b0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x84d5b0..0x84d5c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 169 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x84d5b0..0x84d5c0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 63
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x84d5c0..0x84d5d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 174 GoMapType map[string]int
-          Locations:
-            - Range: 0x84d5c0..0x84d5d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x84d5d0..0x84d5e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 179 GoMapType map[string][]string
-          Locations:
-            - Range: 0x84d5d0..0x84d5e0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x84d5e0..0x84d5f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 184 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0x84d5e0..0x84d5f0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 66
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0x84d5f0..0x84d600]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 174 GoMapType map[string]int
-          Locations:
-            - Range: 0x84d5f0..0x84d600
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x84d600..0x84d610]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 189 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0x84d600..0x84d610
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x84d610..0x84d620]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 190 PointerType *map[string]int
-          Locations:
-            - Range: 0x84d610..0x84d620
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x84d620..0x84d630]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 164 GoMapType map[int]int
-          Locations:
-            - Range: 0x84d620..0x84d630
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0x84d630..0x84d640]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 191 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x84d630..0x84d640
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 71
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x84d640..0x84d650]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 191 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x84d640..0x84d650
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 72
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x84d650..0x84d660]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 196 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0x84d650..0x84d660
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 73
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x84d660..0x84d670]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 201 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x84d660..0x84d670
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 74
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x84d670..0x84d680]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 201 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x84d670..0x84d680
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x84d680..0x84d690]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 206 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x84d680..0x84d690
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x84d690..0x84d6a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 206 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x84d690..0x84d6a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 77
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x84d6a0..0x84d6b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 206 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x84d6a0..0x84d6b0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 78
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x84d6b0..0x84d6c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 211 GoMapType map[uint8][4]int
-          Locations:
-            - Range: 0x84d6b0..0x84d6c0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 79
-      Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x84d6c0..0x84d6d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 216 GoMapType map[[4]int]uint8
-          Locations:
-            - Range: 0x84d6c0..0x84d6d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 80
-      Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x84d6d0..0x84d6e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 221 GoMapType map[[4]int][4]int
-          Locations:
-            - Range: 0x84d6d0..0x84d6e0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 81
-      Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x84d6e0..0x84d6f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 226 GoMapType map[struct {}]int
-          Locations:
-            - Range: 0x84d6e0..0x84d6f0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 82
-      Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x84d6f0..0x84d700]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 231 GoMapType map[int]struct {}
           Locations:
             - Range: 0x84d6f0..0x84d700
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 62
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x84d700..0x84d710]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 236 GoMapType map[struct {}]struct {}
+          Type: 169 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x84d700..0x84d710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 63
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0x84d710..0x84d720]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 174 GoMapType map[string]int
+          Locations:
+            - Range: 0x84d710..0x84d720
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 64
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0x84d720..0x84d730]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 179 GoMapType map[string][]string
+          Locations:
+            - Range: 0x84d720..0x84d730
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 65
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0x84d730..0x84d740]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 184 GoMapType map[[4]string][2]int
+          Locations:
+            - Range: 0x84d730..0x84d740
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 66
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x84d740..0x84d750]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 174 GoMapType map[string]int
+          Locations:
+            - Range: 0x84d740..0x84d750
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 67
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x84d750..0x84d760]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 189 ArrayType [2]map[string]int
+          Locations:
+            - Range: 0x84d750..0x84d760
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 68
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x84d760..0x84d770]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 190 PointerType *map[string]int
+          Locations:
+            - Range: 0x84d760..0x84d770
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 69
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x84d770..0x84d780]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 164 GoMapType map[int]int
+          Locations:
+            - Range: 0x84d770..0x84d780
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 70
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x84d780..0x84d790]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 191 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x84d780..0x84d790
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 71
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x84d790..0x84d7a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 191 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x84d790..0x84d7a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 72
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x84d7a0..0x84d7b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 196 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0x84d7a0..0x84d7b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x84d7b0..0x84d7c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 201 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x84d7b0..0x84d7c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x84d7c0..0x84d7d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 201 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x84d7c0..0x84d7d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 75
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x84d7d0..0x84d7e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 206 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84d7d0..0x84d7e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 76
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x84d7e0..0x84d7f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 206 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84d7e0..0x84d7f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x84d7f0..0x84d800]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 206 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84d7f0..0x84d800
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 78
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x84d800..0x84d810]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 211 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x84d800..0x84d810
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 79
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x84d810..0x84d820]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 216 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x84d810..0x84d820
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 80
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x84d820..0x84d830]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 221 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x84d820..0x84d830
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 81
+      Name: main.testMapEmptyKey
+      OutOfLinePCRanges: [0x84d830..0x84d840]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 226 GoMapType map[struct {}]int
+          Locations:
+            - Range: 0x84d830..0x84d840
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 82
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0x84d840..0x84d850]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 231 GoMapType map[int]struct {}
+          Locations:
+            - Range: 0x84d840..0x84d850
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x84d850..0x84d860]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 236 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x84d850..0x84d860
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x84eb20..0x84eb30]
+      OutOfLinePCRanges: [0x84ec70..0x84ec80]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84eb20..0x84eb30
+            - Range: 0x84ec70..0x84ec80
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84eb20..0x84eb30
+            - Range: 0x84ec70..0x84ec80
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x84eb20..0x84eb30
+            - Range: 0x84ec70..0x84ec80
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x84eb40..0x84eb50]
+      OutOfLinePCRanges: [0x84ec90..0x84eca0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84eb40..0x84eb50
+            - Range: 0x84ec90..0x84eca0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84eb40..0x84eb50
+            - Range: 0x84ec90..0x84eca0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7328,48 +7328,48 @@ Subprograms:
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x84eb40..0x84eb50
+            - Range: 0x84ec90..0x84eca0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x84ec00..0x84ec10]
+      OutOfLinePCRanges: [0x84ed50..0x84ed60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84ec00..0x84ec10
+            - Range: 0x84ed50..0x84ed60
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84ec00..0x84ec10
+            - Range: 0x84ed50..0x84ed60
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84ec00..0x84ec10
+            - Range: 0x84ed50..0x84ed60
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84ec00..0x84ec10
+            - Range: 0x84ed50..0x84ed60
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ec00..0x84ec10
+            - Range: 0x84ed50..0x84ed60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7380,63 +7380,63 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x84eda0..0x84ede0]
+      OutOfLinePCRanges: [0x84eef0..0x84ef30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x84eda0..0x84eddc
+            - Range: 0x84eef0..0x84ef2c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x84eda0..0x84eddc
+            - Range: 0x84eef0..0x84ef2c
               Pieces: []
-            - Range: 0x84eddc..0x84eddd
+            - Range: 0x84ef2c..0x84ef2d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84eddd..0x84ede0
+            - Range: 0x84ef2d..0x84ef30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0x84ede0..0x84edf0]
+      OutOfLinePCRanges: [0x84ef30..0x84ef40]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 241 GoChannelType chan bool
           Locations:
-            - Range: 0x84ede0..0x84edf0
+            - Range: 0x84ef30..0x84ef40
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x84ef90..0x84efa0]
+      OutOfLinePCRanges: [0x84f0e0..0x84f0f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x84ef90..0x84efa0
+            - Range: 0x84f0e0..0x84f0f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x84efa0..0x84efb0]
+      OutOfLinePCRanges: [0x84f0f0..0x84f100]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 StructureType main.node
           Locations:
-            - Range: 0x84efa0..0x84efb0
+            - Range: 0x84f0f0..0x84f100
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7447,273 +7447,273 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x84efb0..0x84efc0]
+      OutOfLinePCRanges: [0x84f100..0x84f110]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 245 PointerType *main.node
           Locations:
-            - Range: 0x84efb0..0x84efc0
+            - Range: 0x84f100..0x84f110
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x84efc0..0x84efd0]
+      OutOfLinePCRanges: [0x84f110..0x84f120]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x84efc0..0x84efd0
+            - Range: 0x84f110..0x84f120
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x84efe0..0x84eff0]
+      OutOfLinePCRanges: [0x84f130..0x84f140]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 PointerType *uint
           Locations:
-            - Range: 0x84efe0..0x84eff0
+            - Range: 0x84f130..0x84f140
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x84f050..0x84f060]
+      OutOfLinePCRanges: [0x84f1a0..0x84f1b0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 93 PointerType *string
           Locations:
-            - Range: 0x84f050..0x84f060
+            - Range: 0x84f1a0..0x84f1b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x84f070..0x84f080]
+      OutOfLinePCRanges: [0x84f1c0..0x84f1d0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x84f070..0x84f080
+            - Range: 0x84f1c0..0x84f1d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84f070..0x84f080
+            - Range: 0x84f1c0..0x84f1d0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0x84f090..0x84f0a0]
+      OutOfLinePCRanges: [0x84f1e0..0x84f1f0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 246 PointerType *main.t
           Locations:
-            - Range: 0x84f090..0x84f0a0
+            - Range: 0x84f1e0..0x84f1f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x84f3d0..0x84f450]
+      OutOfLinePCRanges: [0x84f520..0x84f5a0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f3d0..0x84f3ec
+            - Range: 0x84f520..0x84f53c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f3d0..0x84f42c
+            - Range: 0x84f520..0x84f57c
               Pieces: []
-            - Range: 0x84f42c..0x84f42d
+            - Range: 0x84f57c..0x84f57d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f42d..0x84f450
+            - Range: 0x84f57d..0x84f5a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f3ec..0x84f3f8
+            - Range: 0x84f53c..0x84f548
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f3f8..0x84f450
+            - Range: 0x84f548..0x84f5a0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x84f450..0x84f4f0]
+      OutOfLinePCRanges: [0x84f5a0..0x84f640]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f450..0x84f474
+            - Range: 0x84f5a0..0x84f5c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f474..0x84f4f0
+            - Range: 0x84f5c4..0x84f640
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84f450..0x84f4c8
+            - Range: 0x84f5a0..0x84f618
               Pieces: []
-            - Range: 0x84f4c8..0x84f4c9
+            - Range: 0x84f618..0x84f619
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f4c9..0x84f4f0
+            - Range: 0x84f619..0x84f640
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84f478..0x84f490
+            - Range: 0x84f5c8..0x84f5e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f490..0x84f4f0
+            - Range: 0x84f5e0..0x84f640
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x84f4f0..0x84f5c0]
+      OutOfLinePCRanges: [0x84f640..0x84f710]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f4f0..0x84f548
+            - Range: 0x84f640..0x84f698
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f4f0..0x84f5a0
+            - Range: 0x84f640..0x84f6f0
               Pieces: []
-            - Range: 0x84f5a0..0x84f5a1
+            - Range: 0x84f6f0..0x84f6f1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f5a1..0x84f5c0
+            - Range: 0x84f6f1..0x84f710
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84f4f0..0x84f5c0, Pieces: []}]
+          Locations: [{Range: 0x84f640..0x84f710, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f50c..0x84f54c
+            - Range: 0x84f65c..0x84f69c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84f54c..0x84f5c0
+            - Range: 0x84f69c..0x84f710
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x84f51c..0x84f54c
+            - Range: 0x84f66c..0x84f69c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x84f54c..0x84f5c0
+            - Range: 0x84f69c..0x84f710
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x84f5c0..0x84f640]
+      OutOfLinePCRanges: [0x84f710..0x84f790]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84f5c0..0x84f5e4
+            - Range: 0x84f710..0x84f734
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84f5c0..0x84f608
+            - Range: 0x84f710..0x84f758
               Pieces: []
-            - Range: 0x84f608..0x84f609
+            - Range: 0x84f758..0x84f759
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f609..0x84f61c
+            - Range: 0x84f759..0x84f76c
               Pieces: []
-            - Range: 0x84f61c..0x84f61d
+            - Range: 0x84f76c..0x84f76d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f61d..0x84f640
+            - Range: 0x84f76d..0x84f790
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x84f640..0x84f7c0]
+      OutOfLinePCRanges: [0x84f790..0x84f910]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84f640..0x84f690
+            - Range: 0x84f790..0x84f7e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f690..0x84f694
+            - Range: 0x84f7e0..0x84f7e4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x84f6e4..0x84f6e8
+            - Range: 0x84f834..0x84f838
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f724..0x84f728
+            - Range: 0x84f874..0x84f878
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f764..0x84f768
+            - Range: 0x84f8b4..0x84f8b8
               Pieces:
                 - Size: 8
                   Op: null
@@ -7724,117 +7724,117 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84f640..0x84f684
+            - Range: 0x84f790..0x84f7d4
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84f640..0x84f6ac
+            - Range: 0x84f790..0x84f7fc
               Pieces: []
-            - Range: 0x84f6ac..0x84f6ad
+            - Range: 0x84f7fc..0x84f7fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f6ad..0x84f710
+            - Range: 0x84f7fd..0x84f860
               Pieces: []
-            - Range: 0x84f710..0x84f711
+            - Range: 0x84f860..0x84f861
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f711..0x84f750
+            - Range: 0x84f861..0x84f8a0
               Pieces: []
-            - Range: 0x84f750..0x84f751
+            - Range: 0x84f8a0..0x84f8a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f751..0x84f790
+            - Range: 0x84f8a1..0x84f8e0
               Pieces: []
-            - Range: 0x84f790..0x84f791
+            - Range: 0x84f8e0..0x84f8e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f791..0x84f7c0
+            - Range: 0x84f8e1..0x84f910
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84f640..0x84f6ac
+            - Range: 0x84f790..0x84f7fc
               Pieces: []
-            - Range: 0x84f6ac..0x84f6ad
+            - Range: 0x84f7fc..0x84f7fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84f6ad..0x84f710
+            - Range: 0x84f7fd..0x84f860
               Pieces: []
-            - Range: 0x84f710..0x84f711
+            - Range: 0x84f860..0x84f861
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84f711..0x84f750
+            - Range: 0x84f861..0x84f8a0
               Pieces: []
-            - Range: 0x84f750..0x84f751
+            - Range: 0x84f8a0..0x84f8a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84f751..0x84f790
+            - Range: 0x84f8a1..0x84f8e0
               Pieces: []
-            - Range: 0x84f790..0x84f791
+            - Range: 0x84f8e0..0x84f8e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84f791..0x84f7c0
+            - Range: 0x84f8e1..0x84f910
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f690..0x84f698
+            - Range: 0x84f7e0..0x84f7e8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x84f7c0..0x84f9c0]
+      OutOfLinePCRanges: [0x84f910..0x84fb10]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84f7c0..0x84f808
+            - Range: 0x84f910..0x84f958
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f808..0x84f810
+            - Range: 0x84f958..0x84f960
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84f810..0x84f9c0
+            - Range: 0x84f960..0x84fb10
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7845,549 +7845,549 @@ Subprograms:
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84f7c0..0x84f874
+            - Range: 0x84f910..0x84f9c4
               Pieces: []
-            - Range: 0x84f874..0x84f875
+            - Range: 0x84f9c4..0x84f9c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f875..0x84f8bc
+            - Range: 0x84f9c5..0x84fa0c
               Pieces: []
-            - Range: 0x84f8bc..0x84f8bd
+            - Range: 0x84fa0c..0x84fa0d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f8bd..0x84f980
+            - Range: 0x84fa0d..0x84fad0
               Pieces: []
-            - Range: 0x84f980..0x84f981
+            - Range: 0x84fad0..0x84fad1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f981..0x84f994
+            - Range: 0x84fad1..0x84fae4
               Pieces: []
-            - Range: 0x84f994..0x84f995
+            - Range: 0x84fae4..0x84fae5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f995..0x84f9c0
+            - Range: 0x84fae5..0x84fb10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f8a8..0x84f8b0
+            - Range: 0x84f9f8..0x84fa00
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84f858..0x84f874
+            - Range: 0x84f9a8..0x84f9c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x84f9c0..0x84fb20]
+      OutOfLinePCRanges: [0x84fb10..0x84fc70]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84f9c0..0x84f9fc
+            - Range: 0x84fb10..0x84fb4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f9fc..0x84fa44
+            - Range: 0x84fb4c..0x84fb94
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84fa44..0x84fac4
+            - Range: 0x84fb94..0x84fc14
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84fac4..0x84faec
+            - Range: 0x84fc14..0x84fc3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84faec..0x84faf0
+            - Range: 0x84fc3c..0x84fc40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84faf0..0x84fb20
+            - Range: 0x84fc40..0x84fc70
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84f9c0..0x84faa4
+            - Range: 0x84fb10..0x84fbf4
               Pieces: []
-            - Range: 0x84faa4..0x84faa5
+            - Range: 0x84fbf4..0x84fbf5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84faa5..0x84fab8
+            - Range: 0x84fbf5..0x84fc08
               Pieces: []
-            - Range: 0x84fab8..0x84fab9
+            - Range: 0x84fc08..0x84fc09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84fab9..0x84fb20
+            - Range: 0x84fc09..0x84fc70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84f9c0..0x84f9fc
+            - Range: 0x84fb10..0x84fb4c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84f9fc..0x84fa44
+            - Range: 0x84fb4c..0x84fb94
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84fa44..0x84fa4c
+            - Range: 0x84fb94..0x84fb9c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84fa4c..0x84fab0
+            - Range: 0x84fb9c..0x84fc00
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84fab0..0x84fab4
+            - Range: 0x84fc00..0x84fc04
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84fab4..0x84fab8
+            - Range: 0x84fc04..0x84fc08
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84fab8..0x84fb20
+            - Range: 0x84fc08..0x84fc70
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x84fb20..0x84fbc0]
+      OutOfLinePCRanges: [0x84fc70..0x84fd10]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fb20..0x84fb3c
+            - Range: 0x84fc70..0x84fc8c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fb20..0x84fb98
+            - Range: 0x84fc70..0x84fce8
               Pieces: []
-            - Range: 0x84fb98..0x84fb99
+            - Range: 0x84fce8..0x84fce9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fb99..0x84fbc0
+            - Range: 0x84fce9..0x84fd10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x84fbc0..0x84fc90]
+      OutOfLinePCRanges: [0x84fd10..0x84fde0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fbc0..0x84fc10
+            - Range: 0x84fd10..0x84fd60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fbc0..0x84fc64
+            - Range: 0x84fd10..0x84fdb4
               Pieces: []
-            - Range: 0x84fc64..0x84fc65
+            - Range: 0x84fdb4..0x84fdb5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fc65..0x84fc90
+            - Range: 0x84fdb5..0x84fde0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fbc0..0x84fc64
+            - Range: 0x84fd10..0x84fdb4
               Pieces: []
-            - Range: 0x84fc64..0x84fc65
+            - Range: 0x84fdb4..0x84fdb5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84fc65..0x84fc90
+            - Range: 0x84fdb5..0x84fde0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x84fc90..0x84fd50]
+      OutOfLinePCRanges: [0x84fde0..0x84fea0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fc90..0x84fcd0
+            - Range: 0x84fde0..0x84fe20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fcd0..0x84fd50
+            - Range: 0x84fe20..0x84fea0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fc90..0x84fd30
+            - Range: 0x84fde0..0x84fe80
               Pieces: []
-            - Range: 0x84fd30..0x84fd31
+            - Range: 0x84fe80..0x84fe81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fd31..0x84fd50
+            - Range: 0x84fe81..0x84fea0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fc90..0x84fd30
+            - Range: 0x84fde0..0x84fe80
               Pieces: []
-            - Range: 0x84fd30..0x84fd31
+            - Range: 0x84fe80..0x84fe81
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84fd31..0x84fd50
+            - Range: 0x84fe81..0x84fea0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fc90..0x84fd30
+            - Range: 0x84fde0..0x84fe80
               Pieces: []
-            - Range: 0x84fd30..0x84fd31
+            - Range: 0x84fe80..0x84fe81
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84fd31..0x84fd50
+            - Range: 0x84fe81..0x84fea0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x84fd50..0x84fe40]
+      OutOfLinePCRanges: [0x84fea0..0x84ff90]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fd50..0x84fd90
+            - Range: 0x84fea0..0x84fee0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fd90..0x84fe40
+            - Range: 0x84fee0..0x84ff90
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fd50..0x84fe14
+            - Range: 0x84fea0..0x84ff64
               Pieces: []
-            - Range: 0x84fe14..0x84fe15
+            - Range: 0x84ff64..0x84ff65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fe15..0x84fe40
+            - Range: 0x84ff65..0x84ff90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84fd50..0x84fe14
+            - Range: 0x84fea0..0x84ff64
               Pieces: []
-            - Range: 0x84fe14..0x84fe15
+            - Range: 0x84ff64..0x84ff65
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x84fe15..0x84fe40
+            - Range: 0x84ff65..0x84ff90
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x84fe40..0x850000]
+      OutOfLinePCRanges: [0x84ff90..0x850150]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84fe40..0x84fea4
+            - Range: 0x84ff90..0x84fff4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fea4..0x850000
+            - Range: 0x84fff4..0x850150
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84fe6c..0x850000
+            - Range: 0x84ffbc..0x850150
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84fe70..0x850000
+            - Range: 0x84ffc0..0x850150
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x8500e0..0x850170]
+      OutOfLinePCRanges: [0x850230..0x8502c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x8500e0..0x850150
+            - Range: 0x850230..0x8502a0
               Pieces: []
-            - Range: 0x850150..0x850151
+            - Range: 0x8502a0..0x8502a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850151..0x850170
+            - Range: 0x8502a1..0x8502c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 94 BaseType int16
           Locations:
-            - Range: 0x8500e0..0x850150
+            - Range: 0x850230..0x8502a0
               Pieces: []
-            - Range: 0x850150..0x850151
+            - Range: 0x8502a0..0x8502a1
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x850151..0x850170
+            - Range: 0x8502a1..0x8502c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x8500e0..0x850150
+            - Range: 0x850230..0x8502a0
               Pieces: []
-            - Range: 0x850150..0x850151
+            - Range: 0x8502a0..0x8502a1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x850151..0x850170
+            - Range: 0x8502a1..0x8502c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x8500e0..0x850150
+            - Range: 0x850230..0x8502a0
               Pieces: []
-            - Range: 0x850150..0x850151
+            - Range: 0x8502a0..0x8502a1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x850151..0x850170
+            - Range: 0x8502a1..0x8502c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8500e0..0x850150
+            - Range: 0x850230..0x8502a0
               Pieces: []
-            - Range: 0x850150..0x850151
+            - Range: 0x8502a0..0x8502a1
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x850151..0x850170
+            - Range: 0x8502a1..0x8502c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x8500e0..0x850150
+            - Range: 0x850230..0x8502a0
               Pieces: []
-            - Range: 0x850150..0x850151
+            - Range: 0x8502a0..0x8502a1
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x850151..0x850170
+            - Range: 0x8502a1..0x8502c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x8500e0..0x850150
+            - Range: 0x850230..0x8502a0
               Pieces: []
-            - Range: 0x850150..0x850151
+            - Range: 0x8502a0..0x8502a1
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x850151..0x850170
+            - Range: 0x8502a1..0x8502c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x8500e0..0x850150
+            - Range: 0x850230..0x8502a0
               Pieces: []
-            - Range: 0x850150..0x850151
+            - Range: 0x8502a0..0x8502a1
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x850151..0x850170
+            - Range: 0x8502a1..0x8502c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x850170..0x850230]
+      OutOfLinePCRanges: [0x8502c0..0x850380]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850170..0x850230, Pieces: []}]
+          Locations: [{Range: 0x8502c0..0x850380, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x850170..0x85020c
+            - Range: 0x8502c0..0x85035c
               Pieces: []
-            - Range: 0x85020c..0x85020d
+            - Range: 0x85035c..0x85035d
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x85020d..0x850230
+            - Range: 0x85035d..0x850380
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x850230..0x8502b0]
+      OutOfLinePCRanges: [0x850380..0x850400]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 95 BaseType complex64
-          Locations: [{Range: 0x850230..0x8502b0, Pieces: []}]
+          Locations: [{Range: 0x850380..0x850400, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 96 BaseType complex128
-          Locations: [{Range: 0x850230..0x8502b0, Pieces: []}]
+          Locations: [{Range: 0x850380..0x850400, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x8502b0..0x850380]
+      OutOfLinePCRanges: [0x850400..0x8504d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x8502b0..0x850364
+            - Range: 0x850400..0x8504b4
               Pieces: []
-            - Range: 0x850364..0x850365
+            - Range: 0x8504b4..0x8504b5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8409,193 +8409,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850365..0x850380
+            - Range: 0x8504b5..0x8504d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x850380..0x850410]
+      OutOfLinePCRanges: [0x8504d0..0x850560]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x850380..0x8503f0
+            - Range: 0x8504d0..0x850540
               Pieces: []
-            - Range: 0x8503f0..0x8503f1
+            - Range: 0x850540..0x850541
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8503f1..0x850410
+            - Range: 0x850541..0x850560
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x850410..0x850480]
+      OutOfLinePCRanges: [0x850560..0x8505d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 ArrayType [1]int
           Locations:
-            - Range: 0x850410..0x850464
+            - Range: 0x850560..0x8505b4
               Pieces: []
-            - Range: 0x850464..0x850465
+            - Range: 0x8505b4..0x8505b5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850465..0x850480
+            - Range: 0x8505b5..0x8505d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x850480..0x8504f0]
+      OutOfLinePCRanges: [0x8505d0..0x850640]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0x850480..0x8504d0
+            - Range: 0x8505d0..0x850620
               Pieces: []
-            - Range: 0x8504d0..0x8504d1
+            - Range: 0x850620..0x850621
               Pieces: []
-            - Range: 0x8504d1..0x8504f0
+            - Range: 0x850621..0x850640
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x8504f0..0x850570]
+      OutOfLinePCRanges: [0x850640..0x8506c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 StructureType main.mixedStruct
-          Locations: [{Range: 0x8504f0..0x850570, Pieces: []}]
+          Locations: [{Range: 0x850640..0x8506c0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x850570..0x850610]
+      OutOfLinePCRanges: [0x8506c0..0x850760]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850570..0x8505ec
+            - Range: 0x8506c0..0x85073c
               Pieces: []
-            - Range: 0x8505ec..0x8505ed
+            - Range: 0x85073c..0x85073d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8505ed..0x850610
+            - Range: 0x85073d..0x850760
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850570..0x8505ec
+            - Range: 0x8506c0..0x85073c
               Pieces: []
-            - Range: 0x8505ec..0x8505ed
+            - Range: 0x85073c..0x85073d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8505ed..0x850610
+            - Range: 0x85073d..0x850760
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850570..0x8505ec
+            - Range: 0x8506c0..0x85073c
               Pieces: []
-            - Range: 0x8505ec..0x8505ed
+            - Range: 0x85073c..0x85073d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8505ed..0x850610
+            - Range: 0x85073d..0x850760
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850570..0x8505ec
+            - Range: 0x8506c0..0x85073c
               Pieces: []
-            - Range: 0x8505ec..0x8505ed
+            - Range: 0x85073c..0x85073d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8505ed..0x850610
+            - Range: 0x85073d..0x850760
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850570..0x8505ec
+            - Range: 0x8506c0..0x85073c
               Pieces: []
-            - Range: 0x8505ec..0x8505ed
+            - Range: 0x85073c..0x85073d
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8505ed..0x850610
+            - Range: 0x85073d..0x850760
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850570..0x8505ec
+            - Range: 0x8506c0..0x85073c
               Pieces: []
-            - Range: 0x8505ec..0x8505ed
+            - Range: 0x85073c..0x85073d
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8505ed..0x850610
+            - Range: 0x85073d..0x850760
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850570..0x8505ec
+            - Range: 0x8506c0..0x85073c
               Pieces: []
-            - Range: 0x8505ec..0x8505ed
+            - Range: 0x85073c..0x85073d
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8505ed..0x850610
+            - Range: 0x85073d..0x850760
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850570..0x8505ec
+            - Range: 0x8506c0..0x85073c
               Pieces: []
-            - Range: 0x8505ec..0x8505ed
+            - Range: 0x85073c..0x85073d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8505ed..0x850610
+            - Range: 0x85073d..0x850760
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x850570..0x8505ec
+            - Range: 0x8506c0..0x85073c
               Pieces: []
-            - Range: 0x8505ec..0x8505ed
+            - Range: 0x85073c..0x85073d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8505ed..0x850610
+            - Range: 0x85073d..0x850760
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x850610..0x8506f0]
+      OutOfLinePCRanges: [0x850760..0x850840]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 StructureType main.wideStruct
           Locations:
-            - Range: 0x850610..0x8506d4
+            - Range: 0x850760..0x850824
               Pieces: []
-            - Range: 0x8506d4..0x8506d5
+            - Range: 0x850824..0x850825
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8619,145 +8619,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x8506d5..0x8506f0
+            - Range: 0x850825..0x850840
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x8506f0..0x850780]
+      OutOfLinePCRanges: [0x850840..0x8508d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8506f0..0x850760
+            - Range: 0x850840..0x8508b0
               Pieces: []
-            - Range: 0x850760..0x850761
+            - Range: 0x8508b0..0x8508b1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850761..0x850780
+            - Range: 0x8508b1..0x8508d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8506f0..0x850780, Pieces: []}]
+          Locations: [{Range: 0x850840..0x8508d0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8506f0..0x850760
+            - Range: 0x850840..0x8508b0
               Pieces: []
-            - Range: 0x850760..0x850761
+            - Range: 0x8508b0..0x8508b1
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x850761..0x850780
+            - Range: 0x8508b1..0x8508d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8506f0..0x850780, Pieces: []}]
+          Locations: [{Range: 0x850840..0x8508d0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8506f0..0x850760
+            - Range: 0x850840..0x8508b0
               Pieces: []
-            - Range: 0x850760..0x850761
+            - Range: 0x8508b0..0x8508b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x850761..0x850780
+            - Range: 0x8508b1..0x8508d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x850780..0x850810]
+      OutOfLinePCRanges: [0x8508d0..0x850960]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x850780..0x8507f0
+            - Range: 0x8508d0..0x850940
               Pieces: []
-            - Range: 0x8507f0..0x8507f1
+            - Range: 0x850940..0x850941
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8507f1..0x850810
+            - Range: 0x850941..0x850960
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x850810..0x850880]
+      OutOfLinePCRanges: [0x850960..0x8509d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850810..0x850880, Pieces: []}]
+          Locations: [{Range: 0x850960..0x8509d0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x850880..0x850900]
+      OutOfLinePCRanges: [0x8509d0..0x850a50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0x850880..0x850900, Pieces: []}]
+          Locations: [{Range: 0x8509d0..0x850a50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x850880..0x850900, Pieces: []}]
+          Locations: [{Range: 0x8509d0..0x850a50, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x850900..0x850970]
+      OutOfLinePCRanges: [0x850a50..0x850ac0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x850900..0x850958
+            - Range: 0x850a50..0x850aa8
               Pieces: []
-            - Range: 0x850958..0x850959
+            - Range: 0x850aa8..0x850aa9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850959..0x850970
+            - Range: 0x850aa9..0x850ac0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x850900..0x850958
+            - Range: 0x850a50..0x850aa8
               Pieces: []
-            - Range: 0x850958..0x850959
+            - Range: 0x850aa8..0x850aa9
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x850959..0x850970
+            - Range: 0x850aa9..0x850ac0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x850970..0x850b30]
+      OutOfLinePCRanges: [0x850ac0..0x850c80]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850970..0x8509dc
+            - Range: 0x850ac0..0x850b2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8779,7 +8779,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8509dc..0x8509f0
+            - Range: 0x850b2c..0x850b40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8801,7 +8801,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8509f0..0x8509f4
+            - Range: 0x850b40..0x850b44
               Pieces:
                 - Size: 8
                   Op: null
@@ -8828,9 +8828,9 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850970..0x850ae8
+            - Range: 0x850ac0..0x850c38
               Pieces: []
-            - Range: 0x850ae8..0x850ae9
+            - Range: 0x850c38..0x850c39
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8852,44 +8852,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850ae9..0x850b30
+            - Range: 0x850c39..0x850c80
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x850b30..0x850c00]
+      OutOfLinePCRanges: [0x850c80..0x850d50]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x850b30..0x850c00
+            - Range: 0x850c80..0x850d50
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x850b30..0x850be4
+            - Range: 0x850c80..0x850d34
               Pieces: []
-            - Range: 0x850be4..0x850be5
+            - Range: 0x850d34..0x850d35
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x850be5..0x850c00
+            - Range: 0x850d35..0x850d50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x850c00..0x850e30]
+      OutOfLinePCRanges: [0x850d50..0x850f80]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850c00..0x850c70
+            - Range: 0x850d50..0x850dc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8911,7 +8911,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850c70..0x850c84
+            - Range: 0x850dc0..0x850dd4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8933,7 +8933,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850c84..0x850c88
+            - Range: 0x850dd4..0x850dd8
               Pieces:
                 - Size: 8
                   Op: null
@@ -8960,16 +8960,16 @@ Subprograms:
         - Name: s2
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850c00..0x850e30
+            - Range: 0x850d50..0x850f80
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850c00..0x850df0
+            - Range: 0x850d50..0x850f40
               Pieces: []
-            - Range: 0x850df0..0x850df1
+            - Range: 0x850f40..0x850f41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8991,196 +8991,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850df1..0x850e30
+            - Range: 0x850f41..0x850f80
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x850e30..0x851000]
+      OutOfLinePCRanges: [0x850f80..0x851150]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e30..0x850ea8
+            - Range: 0x850f80..0x850ff8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850ea8..0x851000
+            - Range: 0x850ff8..0x851150
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e30..0x850e94
+            - Range: 0x850f80..0x850fe4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x850e94..0x851000
+            - Range: 0x850fe4..0x851150
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e30..0x850ea8
+            - Range: 0x850f80..0x850ff8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x850ea8..0x851000
+            - Range: 0x850ff8..0x851150
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e30..0x850ea8
+            - Range: 0x850f80..0x850ff8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x850ea8..0x851000
+            - Range: 0x850ff8..0x851150
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e30..0x850ea8
+            - Range: 0x850f80..0x850ff8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x850ea8..0x851000
+            - Range: 0x850ff8..0x851150
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e30..0x850ea8
+            - Range: 0x850f80..0x850ff8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x850ea8..0x851000
+            - Range: 0x850ff8..0x851150
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e30..0x850ea8
+            - Range: 0x850f80..0x850ff8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x850ea8..0x851000
+            - Range: 0x850ff8..0x851150
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e30..0x850ea8
+            - Range: 0x850f80..0x850ff8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x850ea8..0x851000
+            - Range: 0x850ff8..0x851150
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850e30..0x850ea8
+            - Range: 0x850f80..0x850ff8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x850ea8..0x851000
+            - Range: 0x850ff8..0x851150
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x850e30..0x850fb8
+            - Range: 0x850f80..0x851108
               Pieces: []
-            - Range: 0x850fb8..0x850fb9
+            - Range: 0x851108..0x851109
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x850fb9..0x851000
+            - Range: 0x851109..0x851150
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x851000..0x851210]
+      OutOfLinePCRanges: [0x851150..0x851360]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851000..0x851088
+            - Range: 0x851150..0x8511d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851088..0x851210
+            - Range: 0x8511d8..0x851360
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851000..0x851074
+            - Range: 0x851150..0x8511c4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x851074..0x851210
+            - Range: 0x8511c4..0x851360
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851000..0x851088
+            - Range: 0x851150..0x8511d8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x851088..0x851210
+            - Range: 0x8511d8..0x851360
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851000..0x851088
+            - Range: 0x851150..0x8511d8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x851088..0x851210
+            - Range: 0x8511d8..0x851360
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851000..0x851088
+            - Range: 0x851150..0x8511d8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x851088..0x851210
+            - Range: 0x8511d8..0x851360
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851000..0x851088
+            - Range: 0x851150..0x8511d8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x851088..0x851210
+            - Range: 0x8511d8..0x851360
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851000..0x851088
+            - Range: 0x851150..0x8511d8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x851088..0x851210
+            - Range: 0x8511d8..0x851360
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851000..0x851088
+            - Range: 0x851150..0x8511d8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x851088..0x851210
+            - Range: 0x8511d8..0x851360
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851000..0x851088
+            - Range: 0x851150..0x8511d8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x851088..0x851210
+            - Range: 0x8511d8..0x851360
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9191,9 +9191,9 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x851000..0x8511cc
+            - Range: 0x851150..0x85131c
               Pieces: []
-            - Range: 0x8511cc..0x8511cd
+            - Range: 0x85131c..0x85131d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9215,196 +9215,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8511cd..0x851210
+            - Range: 0x85131d..0x851360
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x851210..0x8512b0]
+      OutOfLinePCRanges: [0x851360..0x851400]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0x851210..0x8512b0
+            - Range: 0x851360..0x851400
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851210..0x85128c
+            - Range: 0x851360..0x8513dc
               Pieces: []
-            - Range: 0x85128c..0x85128d
+            - Range: 0x8513dc..0x8513dd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85128d..0x8512b0
+            - Range: 0x8513dd..0x851400
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851210..0x85128c
+            - Range: 0x851360..0x8513dc
               Pieces: []
-            - Range: 0x85128c..0x85128d
+            - Range: 0x8513dc..0x8513dd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x85128d..0x8512b0
+            - Range: 0x8513dd..0x851400
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851210..0x85128c
+            - Range: 0x851360..0x8513dc
               Pieces: []
-            - Range: 0x85128c..0x85128d
+            - Range: 0x8513dc..0x8513dd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x85128d..0x8512b0
+            - Range: 0x8513dd..0x851400
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x8512b0..0x851390]
+      OutOfLinePCRanges: [0x851400..0x8514e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x8512b0..0x851390
+            - Range: 0x851400..0x8514e0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x8512b0..0x851390
+            - Range: 0x851400..0x8514e0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8512b0..0x851374
+            - Range: 0x851400..0x8514c4
               Pieces: []
-            - Range: 0x851374..0x851375
+            - Range: 0x8514c4..0x8514c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851375..0x851390
+            - Range: 0x8514c5..0x8514e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x8512b0..0x851374
+            - Range: 0x851400..0x8514c4
               Pieces: []
-            - Range: 0x851374..0x851375
+            - Range: 0x8514c4..0x8514c5
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x851375..0x851390
+            - Range: 0x8514c5..0x8514e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x851390..0x851460]
+      OutOfLinePCRanges: [0x8514e0..0x8515b0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x851390..0x851460
+            - Range: 0x8514e0..0x8515b0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851390..0x85143c
+            - Range: 0x8514e0..0x85158c
               Pieces: []
-            - Range: 0x85143c..0x85143d
+            - Range: 0x85158c..0x85158d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85143d..0x851460
+            - Range: 0x85158d..0x8515b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x851390..0x85143c
+            - Range: 0x8514e0..0x85158c
               Pieces: []
-            - Range: 0x85143c..0x85143d
+            - Range: 0x85158c..0x85158d
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x85143d..0x851460
+            - Range: 0x85158d..0x8515b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851410..0x851460
+            - Range: 0x851560..0x8515b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x851460..0x851500]
+      OutOfLinePCRanges: [0x8515b0..0x851650]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 ArrayType [0]int
-          Locations: [{Range: 0x851460..0x851500, Pieces: []}]
+          Locations: [{Range: 0x8515b0..0x851650, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851460..0x8514a0
+            - Range: 0x8515b0..0x8515f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8514a0..0x8514bc
+            - Range: 0x8515f0..0x85160c
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x8514bc..0x8514c4
+            - Range: 0x85160c..0x851614
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x8514c4..0x851500
+            - Range: 0x851614..0x851650
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851460..0x8514e0
+            - Range: 0x8515b0..0x851630
               Pieces: []
-            - Range: 0x8514e0..0x8514e1
+            - Range: 0x851630..0x851631
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8514e1..0x851500
+            - Range: 0x851631..0x851650
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0x851460..0x8514e0
+            - Range: 0x8515b0..0x851630
               Pieces: []
-            - Range: 0x8514e0..0x8514e1
+            - Range: 0x851630..0x851631
               Pieces: []
-            - Range: 0x8514e1..0x851500
+            - Range: 0x851631..0x851650
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x851970..0x851980]
+      OutOfLinePCRanges: [0x851ac0..0x851ad0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x851970..0x851980
+            - Range: 0x851ac0..0x851ad0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9417,13 +9417,13 @@ Subprograms:
       DictRegister: null
     - ID: 134
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x851980..0x851990]
+      OutOfLinePCRanges: [0x851ad0..0x851ae0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x851980..0x851990
+            - Range: 0x851ad0..0x851ae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9436,13 +9436,13 @@ Subprograms:
       DictRegister: null
     - ID: 135
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x851990..0x8519a0]
+      OutOfLinePCRanges: [0x851ae0..0x851af0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 256 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x851990..0x8519a0
+            - Range: 0x851ae0..0x851af0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9455,13 +9455,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x8519a0..0x8519b0]
+      OutOfLinePCRanges: [0x851af0..0x851b00]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x8519a0..0x8519b0
+            - Range: 0x851af0..0x851b00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9474,20 +9474,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8519a0..0x8519b0
+            - Range: 0x851af0..0x851b00
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 137
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x8519b0..0x8519c0]
+      OutOfLinePCRanges: [0x851b00..0x851b10]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x8519b0..0x8519c0
+            - Range: 0x851b00..0x851b10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9500,20 +9500,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8519b0..0x8519c0
+            - Range: 0x851b00..0x851b10
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 138
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x8519c0..0x8519d0]
+      OutOfLinePCRanges: [0x851b10..0x851b20]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x8519c0..0x8519d0
+            - Range: 0x851b10..0x851b20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9526,20 +9526,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8519c0..0x8519d0
+            - Range: 0x851b10..0x851b20
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x8519d0..0x8519e0]
+      OutOfLinePCRanges: [0x851b20..0x851b30]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 261 GoSliceHeaderType []string
           Locations:
-            - Range: 0x8519d0..0x8519e0
+            - Range: 0x851b20..0x851b30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9552,20 +9552,20 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x8519e0..0x8519f0]
+      OutOfLinePCRanges: [0x851b30..0x851b40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x8519e0..0x8519f0
+            - Range: 0x851b30..0x851b40
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 262 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x8519e0..0x8519f0
+            - Range: 0x851b30..0x851b40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9578,20 +9578,20 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x8519e0..0x8519f0
+            - Range: 0x851b30..0x851b40
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x8519f0..0x851a00]
+      OutOfLinePCRanges: [0x851b40..0x851b50]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 263 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x8519f0..0x851a00
+            - Range: 0x851b40..0x851b50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9604,13 +9604,13 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x851a00..0x851a10]
+      OutOfLinePCRanges: [0x851b50..0x851b60]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x851a00..0x851a10
+            - Range: 0x851b50..0x851b60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9623,13 +9623,13 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x851a10..0x851a20]
+      OutOfLinePCRanges: [0x851b60..0x851b70]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 264 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x851a10..0x851a20
+            - Range: 0x851b60..0x851b70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9642,13 +9642,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x851a20..0x851a30]
+      OutOfLinePCRanges: [0x851b70..0x851b80]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x851a20..0x851a30
+            - Range: 0x851b70..0x851b80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9661,7 +9661,7 @@ Subprograms:
         - Name: bs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x851a20..0x851a30
+            - Range: 0x851b70..0x851b80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9674,7 +9674,7 @@ Subprograms:
         - Name: cs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x851a20..0x851a30
+            - Range: 0x851b70..0x851b80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9687,34 +9687,34 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0x851d40..0x851db0]
+      OutOfLinePCRanges: [0x851e90..0x851f00]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851d40..0x851d8c
+            - Range: 0x851e90..0x851edc
               Pieces: []
-            - Range: 0x851d8c..0x851d8d
+            - Range: 0x851edc..0x851edd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851d8d..0x851db0
+            - Range: 0x851edd..0x851f00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x851db0..0x851dc0]
+      OutOfLinePCRanges: [0x851f00..0x851f10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851db0..0x851dc0
+            - Range: 0x851f00..0x851f10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9725,13 +9725,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x851dc0..0x851dd0]
+      OutOfLinePCRanges: [0x851f10..0x851f20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851dc0..0x851dd0
+            - Range: 0x851f10..0x851f20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9742,7 +9742,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851dc0..0x851dd0
+            - Range: 0x851f10..0x851f20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9753,7 +9753,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851dc0..0x851dd0
+            - Range: 0x851f10..0x851f20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9764,13 +9764,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x851dd0..0x851df0]
+      OutOfLinePCRanges: [0x851f20..0x851f40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 266 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x851dd0..0x851df0
+            - Range: 0x851f20..0x851f40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9789,39 +9789,39 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x851df0..0x851e00]
+      OutOfLinePCRanges: [0x851f40..0x851f50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x851df0..0x851e00
+            - Range: 0x851f40..0x851f50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x851e00..0x851e10]
+      OutOfLinePCRanges: [0x851f50..0x851f60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x851e00..0x851e10
+            - Range: 0x851f50..0x851f60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x851e10..0x851e20]
+      OutOfLinePCRanges: [0x851f60..0x851f70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851e10..0x851e20
+            - Range: 0x851f60..0x851f70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9832,13 +9832,13 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x851e20..0x851e30]
+      OutOfLinePCRanges: [0x851f70..0x851f80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851e20..0x851e30
+            - Range: 0x851f70..0x851f80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9849,13 +9849,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x851e30..0x851e40]
+      OutOfLinePCRanges: [0x851f80..0x851f90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851e30..0x851e40
+            - Range: 0x851f80..0x851f90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9866,13 +9866,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x851e40..0x851e50]
+      OutOfLinePCRanges: [0x851f90..0x851fa0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851e40..0x851e50
+            - Range: 0x851f90..0x851fa0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9883,7 +9883,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851e40..0x851e50
+            - Range: 0x851f90..0x851fa0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9894,7 +9894,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851e40..0x851e50
+            - Range: 0x851f90..0x851fa0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9905,26 +9905,26 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x851fb0..0x851fc0]
+      OutOfLinePCRanges: [0x852100..0x852110]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x851fb0..0x851fc0
+            - Range: 0x852100..0x852110
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x851fc0..0x851fe0]
+      OutOfLinePCRanges: [0x852110..0x852130]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 283 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x851fc0..0x851fe0
+            - Range: 0x852110..0x852130
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9943,13 +9943,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0x8520b0..0x8520d0]
+      OutOfLinePCRanges: [0x852200..0x852220]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.aStruct
           Locations:
-            - Range: 0x8520b0..0x8520d0
+            - Range: 0x852200..0x852220
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9970,93 +9970,93 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x852150..0x852160]
+      OutOfLinePCRanges: [0x8522a0..0x8522b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 315 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x852150..0x852160
+            - Range: 0x8522a0..0x8522b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x852160..0x852170]
+      OutOfLinePCRanges: [0x8522b0..0x8522c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 StructureType main.tenStrings
           Locations:
-            - Range: 0x852160..0x852170
+            - Range: 0x8522b0..0x8522c0
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x8521b0..0x8521c0]
+      OutOfLinePCRanges: [0x852300..0x852310]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 318 StructureType main.emptyStruct
-          Locations: [{Range: 0x8521b0..0x8521c0, Pieces: []}]
+          Locations: [{Range: 0x852300..0x852310, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x8521c0..0x8521d0]
+      OutOfLinePCRanges: [0x852310..0x852320]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 319 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x8521c0..0x8521d0
+            - Range: 0x852310..0x852320
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x853ad0..0x853ae0]
+      OutOfLinePCRanges: [0x853c20..0x853c30]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x853ad0..0x853ae0
+            - Range: 0x853c20..0x853c30
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x853ad0..0x853ad4
+            - Range: 0x853c20..0x853c24
               Pieces: []
-            - Range: 0x853ad4..0x853ad5
+            - Range: 0x853c24..0x853c25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853ad5..0x853ae0
+            - Range: 0x853c25..0x853c30
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x853ae0..0x853af0]
+      OutOfLinePCRanges: [0x853c30..0x853c40]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x853ae0..0x853aec
+            - Range: 0x853c30..0x853c3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x853aec..0x853af0
+            - Range: 0x853c3c..0x853c40
               Pieces:
                 - Size: 8
                   Op: null
@@ -10067,58 +10067,58 @@ Subprograms:
         - Name: ~r0
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x853ae0..0x853aec
+            - Range: 0x853c30..0x853c3c
               Pieces: []
-            - Range: 0x853aec..0x853aed
+            - Range: 0x853c3c..0x853c3d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853aed..0x853af0
+            - Range: 0x853c3d..0x853c40
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x853af0..0x853b00]
+      OutOfLinePCRanges: [0x853c40..0x853c50]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x853af0..0x853b00
+            - Range: 0x853c40..0x853c50
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x853af0..0x853af4
+            - Range: 0x853c40..0x853c44
               Pieces: []
-            - Range: 0x853af4..0x853af5
+            - Range: 0x853c44..0x853c45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853af5..0x853b00
+            - Range: 0x853c45..0x853c50
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x853b00..0x853b10]
+      OutOfLinePCRanges: [0x853c50..0x853c60]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x853b00..0x853b0c
+            - Range: 0x853c50..0x853c5c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x853b0c..0x853b10
+            - Range: 0x853c5c..0x853c60
               Pieces:
                 - Size: 8
                   Op: null
@@ -10129,28 +10129,28 @@ Subprograms:
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x853b00..0x853b0c
+            - Range: 0x853c50..0x853c5c
               Pieces: []
-            - Range: 0x853b0c..0x853b0d
+            - Range: 0x853c5c..0x853c5d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853b0d..0x853b10
+            - Range: 0x853c5d..0x853c60
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x853b70..0x853c90]
+      OutOfLinePCRanges: [0x853cc0..0x853de0]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x853b70..0x853b9c
+            - Range: 0x853cc0..0x853cec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10158,7 +10158,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x853b9c..0x853bac
+            - Range: 0x853cec..0x853cfc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10166,7 +10166,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x853bac..0x853c90
+            - Range: 0x853cfc..0x853de0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10179,18 +10179,18 @@ Subprograms:
         - Name: pred
           Type: 326 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x853b70..0x853bac
+            - Range: 0x853cc0..0x853cfc
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x853bac..0x853c90
+            - Range: 0x853cfc..0x853de0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x853b70..0x853c5c
+            - Range: 0x853cc0..0x853dac
               Pieces: []
-            - Range: 0x853c5c..0x853c5d
+            - Range: 0x853dac..0x853dad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10198,14 +10198,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x853c5d..0x853c90
+            - Range: 0x853dad..0x853de0
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x853bac..0x853bc8
+            - Range: 0x853cfc..0x853d18
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10213,7 +10213,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853bc8..0x853bcc
+            - Range: 0x853d18..0x853d1c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10221,7 +10221,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853bcc..0x853bd0
+            - Range: 0x853d1c..0x853d20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10229,7 +10229,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853bd0..0x853bd0
+            - Range: 0x853d20..0x853d20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10237,7 +10237,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853bd0..0x853bfc
+            - Range: 0x853d20..0x853d4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10245,7 +10245,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x853bfc..0x853c50
+            - Range: 0x853d4c..0x853da0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10253,7 +10253,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853c50..0x853c90
+            - Range: 0x853da0..0x853de0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10266,215 +10266,215 @@ Subprograms:
         - Name: item
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x853bec..0x853bfc
+            - Range: 0x853d3c..0x853d4c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853bfc..0x853c50
+            - Range: 0x853d4c..0x853da0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x853c90..0x853ce0]
+      OutOfLinePCRanges: [0x853de0..0x853e30]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x853c90..0x853cb8
+            - Range: 0x853de0..0x853e08
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 327 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x853c90..0x853cb8
+            - Range: 0x853de0..0x853e08
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x853c90..0x853cb8
+            - Range: 0x853de0..0x853e08
               Pieces: []
-            - Range: 0x853cb8..0x853cb9
+            - Range: 0x853e08..0x853e09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853cb9..0x853ce0
+            - Range: 0x853e09..0x853e30
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 168
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x853f50..0x853f60]
+      OutOfLinePCRanges: [0x8540a0..0x8540b0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 325 PointerType *go.shape.int
           Locations:
-            - Range: 0x853f50..0x853f60
+            - Range: 0x8540a0..0x8540b0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 325 PointerType *go.shape.int
           Locations:
-            - Range: 0x853f50..0x853f54
+            - Range: 0x8540a0..0x8540a4
               Pieces: []
-            - Range: 0x853f54..0x853f55
+            - Range: 0x8540a4..0x8540a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853f55..0x853f60
+            - Range: 0x8540a5..0x8540b0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x853f60..0x853f70]
+      OutOfLinePCRanges: [0x8540b0..0x8540c0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 328 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x853f60..0x853f70
+            - Range: 0x8540b0..0x8540c0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x853f60..0x853f64
+            - Range: 0x8540b0..0x8540b4
               Pieces: []
-            - Range: 0x853f64..0x853f65
+            - Range: 0x8540b4..0x8540b5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853f65..0x853f70
+            - Range: 0x8540b5..0x8540c0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x853f70..0x853f80]
+      OutOfLinePCRanges: [0x8540c0..0x8540d0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 330 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x853f70..0x853f80
+            - Range: 0x8540c0..0x8540d0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x853f70..0x853f74
+            - Range: 0x8540c0..0x8540c4
               Pieces: []
-            - Range: 0x853f74..0x853f75
+            - Range: 0x8540c4..0x8540c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853f75..0x853f80
+            - Range: 0x8540c5..0x8540d0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x853f80..0x853f90]
+      OutOfLinePCRanges: [0x8540d0..0x8540e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x853f80..0x853f90
+            - Range: 0x8540d0..0x8540e0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x853f80..0x853f88
+            - Range: 0x8540d0..0x8540d8
               Pieces: []
-            - Range: 0x853f88..0x853f89
+            - Range: 0x8540d8..0x8540d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853f89..0x853f90
+            - Range: 0x8540d9..0x8540e0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x854010..0x854020]
+      OutOfLinePCRanges: [0x854160..0x854170]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x854010..0x854020
+            - Range: 0x854160..0x854170
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x854010..0x854014
+            - Range: 0x854160..0x854164
               Pieces: []
-            - Range: 0x854014..0x854015
+            - Range: 0x854164..0x854165
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854015..0x854020
+            - Range: 0x854165..0x854170
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x8540b0..0x8540c0]
+      OutOfLinePCRanges: [0x854200..0x854210]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x8540b0..0x8540c0
+            - Range: 0x854200..0x854210
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x8540b0..0x8540c0
+            - Range: 0x854200..0x854210
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0x8540b0..0x8540c0
+            - Range: 0x854200..0x854210
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x854140..0x8541c0]
+      OutOfLinePCRanges: [0x854290..0x854310]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 338 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x854140..0x8541c0
+            - Range: 0x854290..0x854310
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854140..0x8541c0
+            - Range: 0x854290..0x854310
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10485,20 +10485,20 @@ Subprograms:
         - Name: v
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x854140..0x8541c0
+            - Range: 0x854290..0x854310
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x854240..0x854250]
+      OutOfLinePCRanges: [0x854390..0x8543a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854240..0x854250
+            - Range: 0x854390..0x8543a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10509,59 +10509,59 @@ Subprograms:
         - Name: b
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0x854240..0x854250
+            - Range: 0x854390..0x8543a0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0x854240..0x854248
+            - Range: 0x854390..0x854398
               Pieces: []
-            - Range: 0x854248..0x854249
+            - Range: 0x854398..0x854399
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854249..0x854250
+            - Range: 0x854399..0x8543a0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854240..0x854248
+            - Range: 0x854390..0x854398
               Pieces: []
-            - Range: 0x854248..0x854249
+            - Range: 0x854398..0x854399
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x854249..0x854250
+            - Range: 0x854399..0x8543a0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x854250..0x854270]
+      OutOfLinePCRanges: [0x8543a0..0x8543c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x854250..0x854260
+            - Range: 0x8543a0..0x8543b0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854250..0x85425c
+            - Range: 0x8543a0..0x8543ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x85425c..0x854270
+            - Range: 0x8543ac..0x8543c0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10572,73 +10572,73 @@ Subprograms:
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854250..0x854260
+            - Range: 0x8543a0..0x8543b0
               Pieces: []
-            - Range: 0x854260..0x854261
+            - Range: 0x8543b0..0x8543b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854261..0x854270
+            - Range: 0x8543b1..0x8543c0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x854250..0x854260
+            - Range: 0x8543a0..0x8543b0
               Pieces: []
-            - Range: 0x854260..0x854261
+            - Range: 0x8543b0..0x8543b1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x854261..0x854270
+            - Range: 0x8543b1..0x8543c0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x854270..0x8542c0]
+      OutOfLinePCRanges: [0x8543c0..0x854410]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 340 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x854270..0x854298
+            - Range: 0x8543c0..0x8543e8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x854270..0x854298
+            - Range: 0x8543c0..0x8543e8
               Pieces: []
-            - Range: 0x854298..0x854299
+            - Range: 0x8543e8..0x8543e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854299..0x8542c0
+            - Range: 0x8543e9..0x854410
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x8542c0..0x854320]
+      OutOfLinePCRanges: [0x854410..0x854470]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 341 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x8542c0..0x8542ec
+            - Range: 0x854410..0x85443c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8542ec..0x8542f0
+            - Range: 0x85443c..0x854440
               Pieces:
                 - Size: 8
                   Op: null
@@ -10649,65 +10649,65 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8542c0..0x8542f0
+            - Range: 0x854410..0x854440
               Pieces: []
-            - Range: 0x8542f0..0x8542f1
+            - Range: 0x854440..0x854441
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8542f1..0x854320
+            - Range: 0x854441..0x854470
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x854320..0x854330]
+      OutOfLinePCRanges: [0x854470..0x854480]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 342 PointerType *go.shape.string
           Locations:
-            - Range: 0x854320..0x854328
+            - Range: 0x854470..0x854478
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854320..0x854328
+            - Range: 0x854470..0x854478
               Pieces: []
-            - Range: 0x854328..0x854329
+            - Range: 0x854478..0x854479
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854329..0x854330
+            - Range: 0x854479..0x854480
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x854330..0x854390]
+      OutOfLinePCRanges: [0x854480..0x8544e0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 343 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x854330..0x85436c
+            - Range: 0x854480..0x8544bc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 344 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x854330..0x85437c
+            - Range: 0x854480..0x8544cc
               Pieces: []
-            - Range: 0x85437c..0x85437d
+            - Range: 0x8544cc..0x8544cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10721,20 +10721,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x85437d..0x854390
+            - Range: 0x8544cd..0x8544e0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x854390..0x8543d0]
+      OutOfLinePCRanges: [0x8544e0..0x854520]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x854390..0x85439c
+            - Range: 0x8544e0..0x8544ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10742,7 +10742,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x85439c..0x8543d0
+            - Range: 0x8544ec..0x854520
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10755,42 +10755,42 @@ Subprograms:
         - Name: needle
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x854390..0x8543d0
+            - Range: 0x8544e0..0x854520
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x854390..0x8543b8
+            - Range: 0x8544e0..0x854508
               Pieces: []
-            - Range: 0x8543b8..0x8543b9
+            - Range: 0x854508..0x854509
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8543b9..0x8543c0
+            - Range: 0x854509..0x854510
               Pieces: []
-            - Range: 0x8543c0..0x8543c1
+            - Range: 0x854510..0x854511
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8543c1..0x8543d0
+            - Range: 0x854511..0x854520
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x8543ac..0x8543bc
+            - Range: 0x8544fc..0x85450c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x8543d0..0x854490]
+      OutOfLinePCRanges: [0x854520..0x8545e0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 345 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x8543d0..0x8543f4
+            - Range: 0x854520..0x854544
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10798,7 +10798,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8543f4..0x8543f8
+            - Range: 0x854544..0x854548
               Pieces:
                 - Size: 8
                   Op: null
@@ -10811,13 +10811,13 @@ Subprograms:
         - Name: needle
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8543d0..0x85442c
+            - Range: 0x854520..0x85457c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x85442c..0x854490
+            - Range: 0x85457c..0x8545e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10828,28 +10828,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8543d0..0x854448
+            - Range: 0x854520..0x854598
               Pieces: []
-            - Range: 0x854448..0x854449
+            - Range: 0x854598..0x854599
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854449..0x854458
+            - Range: 0x854599..0x8545a8
               Pieces: []
-            - Range: 0x854458..0x854459
+            - Range: 0x8545a8..0x8545a9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854459..0x854490
+            - Range: 0x8545a9..0x8545e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x85440c..0x854420
+            - Range: 0x85455c..0x854570
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x854420..0x85442c
+            - Range: 0x854570..0x85457c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10860,56 +10860,56 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x854490..0x8544a0]
+      OutOfLinePCRanges: [0x8545e0..0x8545f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x854490..0x854498
+            - Range: 0x8545e0..0x8545e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x854490..0x8544a0
+            - Range: 0x8545e0..0x8545f0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x854490..0x854498
+            - Range: 0x8545e0..0x8545e8
               Pieces: []
-            - Range: 0x854498..0x854499
+            - Range: 0x8545e8..0x8545e9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854499..0x8544a0
+            - Range: 0x8545e9..0x8545f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x854510..0x854580]
+      OutOfLinePCRanges: [0x854660..0x8546d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x854510..0x85453c
+            - Range: 0x854660..0x85468c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85453c..0x854548
+            - Range: 0x85468c..0x854698
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854548..0x85454c
+            - Range: 0x854698..0x85469c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10920,7 +10920,7 @@ Subprograms:
         - Name: value
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854510..0x85454c
+            - Range: 0x854660..0x85469c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10931,11 +10931,11 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x854510..0x85454c
+            - Range: 0x854660..0x85469c
               Pieces: []
-            - Range: 0x85454c..0x85454d
+            - Range: 0x85469c..0x85469d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85454d..0x854580
+            - Range: 0x85469d..0x8546d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11073,31 +11073,31 @@ Subprograms:
       DictRegister: 0
     - ID: 186
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x84c7c0..0x84c830]
+      OutOfLinePCRanges: [0x84c910..0x84c980]
       InlinePCRanges:
-        - Ranges: [0x84c84c..0x84c884]
-          RootRanges: [0x84c830..0x84c8b0]
-        - Ranges: [0x84c998..0x84c9d0]
-          RootRanges: [0x84c960..0x84c9f0]
-        - Ranges: [0x84ca14..0x84ca4c]
-          RootRanges: [0x84c9f0..0x84cab0]
-        - Ranges: [0x84cacc..0x84cb04]
-          RootRanges: [0x84cab0..0x84cb30]
+        - Ranges: [0x84c99c..0x84c9d4]
+          RootRanges: [0x84c980..0x84ca00]
+        - Ranges: [0x84cae8..0x84cb20]
+          RootRanges: [0x84cab0..0x84cb40]
+        - Ranges: [0x84cb64..0x84cb9c]
+          RootRanges: [0x84cb40..0x84cc00]
+        - Ranges: [0x84cc1c..0x84cc54]
+          RootRanges: [0x84cc00..0x84cc80]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84c7c0..0x84c7e0
+            - Range: 0x84c910..0x84c930
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84c84c..0x84c854
+            - Range: 0x84c99c..0x84c9a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84c998..0x84c9a0
+            - Range: 0x84cae8..0x84caf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84ca0c..0x84ca1c
+            - Range: 0x84cb5c..0x84cb6c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84ca1c..0x84cab0
+            - Range: 0x84cb6c..0x84cc00
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x84cab0..0x84cad4
+            - Range: 0x84cc00..0x84cc24
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11106,37 +11106,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84ca58..0x84ca90]
-          RootRanges: [0x84c9f0..0x84cab0]
+        - Ranges: [0x84cba8..0x84cbe0]
+          RootRanges: [0x84cb40..0x84cc00]
       Variables: []
       DictRegister: null
     - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84cb4c..0x84cb90]
-          RootRanges: [0x84cb30..0x84cc50]
+        - Ranges: [0x84cc9c..0x84cce0]
+          RootRanges: [0x84cc80..0x84cda0]
       Variables: []
       DictRegister: null
     - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84cc00..0x84cc38]
-          RootRanges: [0x84cb30..0x84cc50]
+        - Ranges: [0x84cd50..0x84cd88]
+          RootRanges: [0x84cc80..0x84cda0]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84cc54..0x84cc58]
-          RootRanges: [0x84cc50..0x84cc60]
+        - Ranges: [0x84cda4..0x84cda8]
+          RootRanges: [0x84cda0..0x84cdb0]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84cc50..0x84cc58
+            - Range: 0x84cda0..0x84cda8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11145,38 +11145,38 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84cc84..0x84cca8]
-          RootRanges: [0x84cc60..0x84ccc0]
-        - Ranges: [0x84cd1c..0x84cd44]
-          RootRanges: [0x84ccc0..0x84ce10]
+        - Ranges: [0x84cdd4..0x84cdf8]
+          RootRanges: [0x84cdb0..0x84ce10]
+        - Ranges: [0x84ce6c..0x84ce94]
+          RootRanges: [0x84ce10..0x84cf60]
       Variables:
         - Name: a
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0x84cc70..0x84ccc0
+            - Range: 0x84cdc0..0x84ce10
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x84cd08..0x84ce10
+            - Range: 0x84ce58..0x84cf60
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 192
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x84ce10..0x84ce80]
+      OutOfLinePCRanges: [0x84cf60..0x84cfd0]
       InlinePCRanges:
-        - Ranges: [0x85462c..0x854660]
-          RootRanges: [0x854600..0x8546b0]
+        - Ranges: [0x85477c..0x8547b0]
+          RootRanges: [0x854750..0x854800]
       Variables:
         - Name: b
           Type: 352 StructureType main.firstBehavior
           Locations:
-            - Range: 0x84ce10..0x84ce3c
+            - Range: 0x84cf60..0x84cf8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ce3c..0x84ce40
+            - Range: 0x84cf8c..0x84cf90
               Pieces:
                 - Size: 8
                   Op: null
@@ -11187,15 +11187,15 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ce10..0x84ce60
+            - Range: 0x84cf60..0x84cfb0
               Pieces: []
-            - Range: 0x84ce60..0x84ce61
+            - Range: 0x84cfb0..0x84cfb1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ce61..0x84ce80
+            - Range: 0x84cfb1..0x84cfd0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11204,8 +11204,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84d4d8..0x84d4e4, 0x84d4e8..0x84d4f0]
-          RootRanges: [0x84d3c0..0x84d530]
+        - Ranges: [0x84d62c..0x84d638, 0x84d63c..0x84d644]
+          RootRanges: [0x84d510..0x84d680]
         - Ranges: [0x129ba8..0x129bac, 0x129bb0..0x129bb8]
           RootRanges: [0x129ba0..0x129bc0]
       Variables: []
@@ -11246,7 +11246,7 @@ Types:
       ID: 128
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 529152
+      GoRuntimeType: 529184
       GoKind: 22
       Pointee: 93 PointerType *string
     - __kind: PointerType
@@ -11513,7 +11513,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 488672
+      GoRuntimeType: 488704
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11555,14 +11555,14 @@ Types:
       ID: 1170
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.98656e+06
+      GoRuntimeType: 1.986848e+06
       GoKind: 22
       Pointee: 1171 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
       ID: 811
       Name: '*archive/tar.headerError'
       ByteSize: 8
-      GoRuntimeType: 930240
+      GoRuntimeType: 930272
       GoKind: 22
       Pointee: 812 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
@@ -11574,84 +11574,84 @@ Types:
       ID: 1105
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.438016e+06
+      GoRuntimeType: 1.438144e+06
       GoKind: 22
       Pointee: 1106 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
       ID: 1053
       Name: '*archive/zip.countWriter'
       ByteSize: 8
-      GoRuntimeType: 930432
+      GoRuntimeType: 930464
       GoKind: 22
       Pointee: 1054 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
       ID: 1055
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
-      GoRuntimeType: 930528
+      GoRuntimeType: 930560
       GoKind: 22
       Pointee: 1056 StructureType archive/zip.dirWriter
     - __kind: PointerType
       ID: 1153
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.90624e+06
+      GoRuntimeType: 1.906528e+06
       GoKind: 22
       Pointee: 1154 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 1081
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.057728e+06
+      GoRuntimeType: 1.057856e+06
       GoKind: 22
       Pointee: 1082 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 1083
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.057984e+06
+      GoRuntimeType: 1.058112e+06
       GoKind: 22
       Pointee: 1084 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 392736
+      GoRuntimeType: 392768
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 1128
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.175392e+06
+      GoRuntimeType: 2.17568e+06
       GoKind: 22
       Pointee: 1129 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1159
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.951264e+06
+      GoRuntimeType: 1.951552e+06
       GoKind: 22
       Pointee: 1160 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1208
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.272672e+06
+      GoRuntimeType: 2.27296e+06
       GoKind: 22
       Pointee: 1209 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
       ID: 723
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 912864
+      GoRuntimeType: 912896
       GoKind: 22
       Pointee: 615 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
       ID: 724
       Name: '*compress/flate.InternalError'
       ByteSize: 8
-      GoRuntimeType: 912960
+      GoRuntimeType: 912992
       GoKind: 22
       Pointee: 616 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
@@ -11663,357 +11663,357 @@ Types:
       ID: 1103
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.427456e+06
+      GoRuntimeType: 1.427584e+06
       GoKind: 22
       Pointee: 1104 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
       ID: 1049
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
-      GoRuntimeType: 913056
+      GoRuntimeType: 913088
       GoKind: 22
       Pointee: 1050 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
       ID: 1125
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.728224e+06
+      GoRuntimeType: 1.728512e+06
       GoKind: 22
       Pointee: 1126 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 955
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.205472e+06
+      GoRuntimeType: 1.2056e+06
       GoKind: 22
       Pointee: 956 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 803
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 924864
+      GoRuntimeType: 924896
       GoKind: 22
       Pointee: 629 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
       ID: 804
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 925056
+      GoRuntimeType: 925088
       GoKind: 22
       Pointee: 630 BaseType crypto/des.KeySizeError
     - __kind: PointerType
       ID: 805
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 925344
+      GoRuntimeType: 925376
       GoKind: 22
       Pointee: 631 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
       ID: 1115
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
-      GoRuntimeType: 1.569056e+06
+      GoRuntimeType: 1.569344e+06
       GoKind: 22
       Pointee: 1116 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
       ID: 1149
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.864896e+06
+      GoRuntimeType: 1.865184e+06
       GoKind: 22
       Pointee: 1150 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
       ID: 1181
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
-      GoRuntimeType: 2.12272e+06
+      GoRuntimeType: 2.123008e+06
       GoKind: 22
       Pointee: 1182 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
       ID: 1155
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.906752e+06
+      GoRuntimeType: 1.90704e+06
       GoKind: 22
       Pointee: 1156 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
       ID: 1151
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.865344e+06
+      GoRuntimeType: 1.865632e+06
       GoKind: 22
       Pointee: 1152 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
       ID: 1147
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.857728e+06
+      GoRuntimeType: 1.858016e+06
       GoKind: 22
       Pointee: 1148 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
       ID: 806
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 925632
+      GoRuntimeType: 925664
       GoKind: 22
       Pointee: 632 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
       ID: 1165
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 1.956128e+06
+      GoRuntimeType: 1.956416e+06
       GoKind: 22
       Pointee: 1166 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1137
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
-      GoRuntimeType: 1.811712e+06
+      GoRuntimeType: 1.812e+06
       GoKind: 22
       Pointee: 1138 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
       ID: 729
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
-      GoRuntimeType: 914496
+      GoRuntimeType: 914528
       GoKind: 22
       Pointee: 619 BaseType crypto/tls.AlertError
     - __kind: PointerType
       ID: 895
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.046336e+06
+      GoRuntimeType: 1.046464e+06
       GoKind: 22
       Pointee: 896 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1234
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.384544e+06
+      GoRuntimeType: 2.384832e+06
       GoKind: 22
       Pointee: 1235 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
       ID: 727
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
-      GoRuntimeType: 914304
+      GoRuntimeType: 914336
       GoKind: 22
       Pointee: 728 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
       ID: 725
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
-      GoRuntimeType: 914208
+      GoRuntimeType: 914240
       GoKind: 22
       Pointee: 726 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
       ID: 894
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.044672e+06
+      GoRuntimeType: 1.0448e+06
       GoKind: 22
       Pointee: 851 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 1113
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.562016e+06
+      GoRuntimeType: 1.562304e+06
       GoKind: 22
       Pointee: 1114 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
       ID: 1120
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.64592e+06
+      GoRuntimeType: 1.646208e+06
       GoKind: 22
       Pointee: 1121 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 990
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.427776e+06
+      GoRuntimeType: 1.427904e+06
       GoKind: 22
       Pointee: 991 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 1005
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.044608e+06
+      GoRuntimeType: 2.044896e+06
       GoKind: 22
       Pointee: 1006 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
       ID: 799
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
-      GoRuntimeType: 923904
+      GoRuntimeType: 923936
       GoKind: 22
       Pointee: 800 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
       ID: 793
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
-      GoRuntimeType: 923424
+      GoRuntimeType: 923456
       GoKind: 22
       Pointee: 794 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
       ID: 795
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
-      GoRuntimeType: 923520
+      GoRuntimeType: 923552
       GoKind: 22
       Pointee: 796 StructureType crypto/x509.HostnameError
     - __kind: PointerType
       ID: 792
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
-      GoRuntimeType: 923328
+      GoRuntimeType: 923360
       GoKind: 22
       Pointee: 628 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
       ID: 900
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.052096e+06
+      GoRuntimeType: 1.052224e+06
       GoKind: 22
       Pointee: 901 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
       ID: 801
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
-      GoRuntimeType: 924000
+      GoRuntimeType: 924032
       GoKind: 22
       Pointee: 802 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
       ID: 797
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
-      GoRuntimeType: 923808
+      GoRuntimeType: 923840
       GoKind: 22
       Pointee: 798 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
       ID: 815
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
-      GoRuntimeType: 930720
+      GoRuntimeType: 930752
       GoKind: 22
       Pointee: 816 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
       ID: 819
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 930912
+      GoRuntimeType: 930944
       GoKind: 22
       Pointee: 820 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
       ID: 817
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 930816
+      GoRuntimeType: 930848
       GoKind: 22
       Pointee: 818 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
       ID: 713
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 911232
+      GoRuntimeType: 911264
       GoKind: 22
       Pointee: 613 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 1071
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.04224e+06
+      GoRuntimeType: 1.042368e+06
       GoKind: 22
       Pointee: 1072 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
       ID: 716
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
-      GoRuntimeType: 912096
+      GoRuntimeType: 912128
       GoKind: 22
       Pointee: 614 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
       ID: 684
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 905952
+      GoRuntimeType: 905984
       GoKind: 22
       Pointee: 685 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 886
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.038528e+06
+      GoRuntimeType: 1.038656e+06
       GoKind: 22
       Pointee: 887 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 676
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 905568
+      GoRuntimeType: 905600
       GoKind: 22
       Pointee: 677 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 682
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 905856
+      GoRuntimeType: 905888
       GoKind: 22
       Pointee: 683 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 680
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
-      GoRuntimeType: 905760
+      GoRuntimeType: 905792
       GoKind: 22
       Pointee: 681 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
       ID: 678
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 905664
+      GoRuntimeType: 905696
       GoKind: 22
       Pointee: 679 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1214
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.297696e+06
+      GoRuntimeType: 2.297984e+06
       GoKind: 22
       Pointee: 1215 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
       ID: 686
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 906336
+      GoRuntimeType: 906368
       GoKind: 22
       Pointee: 687 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 1079
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.054656e+06
+      GoRuntimeType: 1.054784e+06
       GoKind: 22
       Pointee: 1080 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
       ID: 787
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 922368
+      GoRuntimeType: 922400
       GoKind: 22
       Pointee: 788 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 785
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
-      GoRuntimeType: 922272
+      GoRuntimeType: 922304
       GoKind: 22
       Pointee: 786 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
       ID: 789
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 922464
+      GoRuntimeType: 922496
       GoKind: 22
       Pointee: 625 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
@@ -12025,119 +12025,119 @@ Types:
       ID: 790
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
-      GoRuntimeType: 922560
+      GoRuntimeType: 922592
       GoKind: 22
       Pointee: 791 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 1192
       Name: '*encoding/xml.printer'
       ByteSize: 8
-      GoRuntimeType: 2.161152e+06
+      GoRuntimeType: 2.16144e+06
       GoKind: 22
       Pointee: 1193 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 104
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 391648
+      GoRuntimeType: 391680
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 654
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 895968
+      GoRuntimeType: 896000
       GoKind: 22
       Pointee: 655 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 853
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1.02304e+06
+      GoRuntimeType: 1.023168e+06
       GoKind: 22
       Pointee: 854 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 106
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 392608
+      GoRuntimeType: 392640
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 97
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 392672
+      GoRuntimeType: 392704
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 1202
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.264992e+06
+      GoRuntimeType: 2.26528e+06
       GoKind: 22
       Pointee: 1203 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 855
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.023168e+06
+      GoRuntimeType: 1.023296e+06
       GoKind: 22
       Pointee: 856 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 857
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.023296e+06
+      GoRuntimeType: 1.023424e+06
       GoKind: 22
       Pointee: 858 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
       ID: 714
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 911616
+      GoRuntimeType: 911648
       GoKind: 22
       Pointee: 715 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 695
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 908736
+      GoRuntimeType: 908768
       GoKind: 22
       Pointee: 696 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
       ID: 697
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 908832
+      GoRuntimeType: 908864
       GoKind: 22
       Pointee: 698 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 1017
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 908544
+      GoRuntimeType: 908576
       GoKind: 22
       Pointee: 1018 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
       ID: 701
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 909120
+      GoRuntimeType: 909152
       GoKind: 22
       Pointee: 702 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 1019
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 908640
+      GoRuntimeType: 908672
       GoKind: 22
       Pointee: 1020 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
       ID: 699
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 908928
+      GoRuntimeType: 908960
       GoKind: 22
       Pointee: 607 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -12149,7 +12149,7 @@ Types:
       ID: 694
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 908448
+      GoRuntimeType: 908480
       GoKind: 22
       Pointee: 604 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -12161,7 +12161,7 @@ Types:
       ID: 700
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 909024
+      GoRuntimeType: 909056
       GoKind: 22
       Pointee: 610 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -12173,98 +12173,98 @@ Types:
       ID: 1093
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.210976e+06
+      GoRuntimeType: 1.211104e+06
       GoKind: 22
       Pointee: 1094 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1178
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 2.059936e+06
+      GoRuntimeType: 2.060224e+06
       GoKind: 22
       Pointee: 1179 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
       ID: 809
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
-      GoRuntimeType: 929184
+      GoRuntimeType: 929216
       GoKind: 22
       Pointee: 810 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 964
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.21456e+06
+      GoRuntimeType: 1.214688e+06
       GoKind: 22
       Pointee: 965 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1210
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.27472e+06
+      GoRuntimeType: 2.275008e+06
       GoKind: 22
       Pointee: 1211 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
       ID: 736
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
-      GoRuntimeType: 917856
+      GoRuntimeType: 917888
       GoKind: 22
       Pointee: 737 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
       ID: 743
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
-      GoRuntimeType: 918912
+      GoRuntimeType: 918944
       GoKind: 22
       Pointee: 744 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
       ID: 738
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
-      GoRuntimeType: 918624
+      GoRuntimeType: 918656
       GoKind: 22
       Pointee: 624 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
       ID: 741
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
-      GoRuntimeType: 918816
+      GoRuntimeType: 918848
       GoKind: 22
       Pointee: 742 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
       ID: 739
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
-      GoRuntimeType: 918720
+      GoRuntimeType: 918752
       GoKind: 22
       Pointee: 740 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
       ID: 759
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
-      GoRuntimeType: 920832
+      GoRuntimeType: 920864
       GoKind: 22
       Pointee: 760 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
       ID: 763
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
-      GoRuntimeType: 921024
+      GoRuntimeType: 921056
       GoKind: 22
       Pointee: 764 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
       ID: 761
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
-      GoRuntimeType: 920928
+      GoRuntimeType: 920960
       GoKind: 22
       Pointee: 762 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
       ID: 757
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
-      GoRuntimeType: 920736
+      GoRuntimeType: 920768
       GoKind: 22
       Pointee: 758 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
@@ -12276,357 +12276,357 @@ Types:
       ID: 771
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
-      GoRuntimeType: 921408
+      GoRuntimeType: 921440
       GoKind: 22
       Pointee: 772 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
       ID: 765
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
-      GoRuntimeType: 921120
+      GoRuntimeType: 921152
       GoKind: 22
       Pointee: 766 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
       ID: 769
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
-      GoRuntimeType: 921312
+      GoRuntimeType: 921344
       GoKind: 22
       Pointee: 770 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
       ID: 767
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
-      GoRuntimeType: 921216
+      GoRuntimeType: 921248
       GoKind: 22
       Pointee: 768 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
       ID: 773
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
-      GoRuntimeType: 921504
+      GoRuntimeType: 921536
       GoKind: 22
       Pointee: 774 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
       ID: 779
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
-      GoRuntimeType: 921792
+      GoRuntimeType: 921824
       GoKind: 22
       Pointee: 780 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
       ID: 781
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
-      GoRuntimeType: 921888
+      GoRuntimeType: 921920
       GoKind: 22
       Pointee: 782 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
       ID: 777
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
-      GoRuntimeType: 921696
+      GoRuntimeType: 921728
       GoKind: 22
       Pointee: 778 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
       ID: 775
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
-      GoRuntimeType: 921600
+      GoRuntimeType: 921632
       GoKind: 22
       Pointee: 776 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
       ID: 783
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
-      GoRuntimeType: 922080
+      GoRuntimeType: 922112
       GoKind: 22
       Pointee: 784 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 703
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 910272
+      GoRuntimeType: 910304
       GoKind: 22
       Pointee: 704 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 1131
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.80432e+06
+      GoRuntimeType: 1.804608e+06
       GoKind: 22
       Pointee: 1132 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
       ID: 705
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 910368
+      GoRuntimeType: 910400
       GoKind: 22
       Pointee: 706 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 1111
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.560896e+06
+      GoRuntimeType: 1.561184e+06
       GoKind: 22
       Pointee: 1112 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 1067
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.041216e+06
+      GoRuntimeType: 1.041344e+06
       GoKind: 22
       Pointee: 1068 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1101
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.425536e+06
+      GoRuntimeType: 1.425664e+06
       GoKind: 22
       Pointee: 1102 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 709
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 910560
+      GoRuntimeType: 910592
       GoKind: 22
       Pointee: 710 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1168
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.976768e+06
+      GoRuntimeType: 1.977056e+06
       GoKind: 22
       Pointee: 1169 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1185
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.134688e+06
+      GoRuntimeType: 2.134976e+06
       GoKind: 22
       Pointee: 1180 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1184
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.134304e+06
+      GoRuntimeType: 2.134592e+06
       GoKind: 22
       Pointee: 1183 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 1069
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.041344e+06
+      GoRuntimeType: 1.041472e+06
       GoKind: 22
       Pointee: 1070 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 707
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 910464
+      GoRuntimeType: 910496
       GoKind: 22
       Pointee: 708 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
       ID: 711
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 910656
+      GoRuntimeType: 910688
       GoKind: 22
       Pointee: 712 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 1133
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.806112e+06
+      GoRuntimeType: 1.8064e+06
       GoKind: 22
       Pointee: 1134 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1174
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.013216e+06
+      GoRuntimeType: 2.013504e+06
       GoKind: 22
       Pointee: 1175 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1176
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.044288e+06
+      GoRuntimeType: 2.044576e+06
       GoKind: 22
       Pointee: 1177 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 995
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.440416e+06
+      GoRuntimeType: 1.440544e+06
       GoKind: 22
       Pointee: 996 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 908
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.066176e+06
+      GoRuntimeType: 1.066304e+06
       GoKind: 22
       Pointee: 909 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 906
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.066048e+06
+      GoRuntimeType: 1.066176e+06
       GoKind: 22
       Pointee: 907 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 910
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.070144e+06
+      GoRuntimeType: 1.070272e+06
       GoKind: 22
       Pointee: 911 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 912
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.070272e+06
+      GoRuntimeType: 1.0704e+06
       GoKind: 22
       Pointee: 913 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 1122
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.672992e+06
+      GoRuntimeType: 1.67328e+06
       GoKind: 22
       Pointee: 1123 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 902
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.052736e+06
+      GoRuntimeType: 1.052864e+06
       GoKind: 22
       Pointee: 903 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 717
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
-      GoRuntimeType: 912288
+      GoRuntimeType: 912320
       GoKind: 22
       Pointee: 718 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
       ID: 1226
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.360768e+06
+      GoRuntimeType: 2.361056e+06
       GoKind: 22
       Pointee: 1227 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 966
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.223008e+06
+      GoRuntimeType: 1.223136e+06
       GoKind: 22
       Pointee: 967 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 939
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.20176e+06
+      GoRuntimeType: 1.201888e+06
       GoKind: 22
       Pointee: 940 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 933
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.201376e+06
+      GoRuntimeType: 1.201504e+06
       GoKind: 22
       Pointee: 934 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 872
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.032512e+06
+      GoRuntimeType: 1.03264e+06
       GoKind: 22
       Pointee: 873 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 945
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.202144e+06
+      GoRuntimeType: 1.202272e+06
       GoKind: 22
       Pointee: 946 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 871
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1.032384e+06
+      GoRuntimeType: 1.032512e+06
       GoKind: 22
       Pointee: 850 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 937
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.201632e+06
+      GoRuntimeType: 1.20176e+06
       GoKind: 22
       Pointee: 938 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 935
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.201504e+06
+      GoRuntimeType: 1.201632e+06
       GoKind: 22
       Pointee: 936 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 943
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.202016e+06
+      GoRuntimeType: 1.202144e+06
       GoKind: 22
       Pointee: 944 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 941
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.201888e+06
+      GoRuntimeType: 1.202016e+06
       GoKind: 22
       Pointee: 942 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1230
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.372576e+06
+      GoRuntimeType: 2.372864e+06
       GoKind: 22
       Pointee: 1231 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 949
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.202528e+06
+      GoRuntimeType: 1.202656e+06
       GoKind: 22
       Pointee: 950 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 876
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1.032768e+06
+      GoRuntimeType: 1.032896e+06
       GoKind: 22
       Pointee: 877 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 874
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1.03264e+06
+      GoRuntimeType: 1.032768e+06
       GoKind: 22
       Pointee: 875 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 947
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.2024e+06
+      GoRuntimeType: 1.202528e+06
       GoKind: 22
       Pointee: 948 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
       ID: 831
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
-      GoRuntimeType: 943680
+      GoRuntimeType: 943712
       GoKind: 22
       Pointee: 637 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
@@ -12638,21 +12638,21 @@ Types:
       ID: 349
       Name: '*go.shape.float64'
       ByteSize: 8
-      GoRuntimeType: 479136
+      GoRuntimeType: 479168
       GoKind: 22
       Pointee: 350 BaseType go.shape.float64
     - __kind: PointerType
       ID: 325
       Name: '*go.shape.int'
       ByteSize: 8
-      GoRuntimeType: 478688
+      GoRuntimeType: 478720
       GoKind: 22
       Pointee: 320 BaseType go.shape.int
     - __kind: PointerType
       ID: 342
       Name: '*go.shape.string'
       ByteSize: 8
-      GoRuntimeType: 478752
+      GoRuntimeType: 478784
       GoKind: 22
       Pointee: 322 GoStringHeaderType go.shape.string
     - __kind: PointerType
@@ -12682,63 +12682,63 @@ Types:
       ID: 1008
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.671456e+06
+      GoRuntimeType: 1.671744e+06
       GoKind: 22
       Pointee: 1009 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 916
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.084992e+06
+      GoRuntimeType: 1.08512e+06
       GoKind: 22
       Pointee: 917 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 1099
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.26256e+06
+      GoRuntimeType: 1.262688e+06
       GoKind: 22
       Pointee: 1100 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1190
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.14928e+06
+      GoRuntimeType: 2.149568e+06
       GoKind: 22
       Pointee: 1191 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 1085
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.087296e+06
+      GoRuntimeType: 1.087424e+06
       GoKind: 22
       Pointee: 1086 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
       ID: 832
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 944928
+      GoRuntimeType: 944960
       GoKind: 22
       Pointee: 640 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
       ID: 974
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.264224e+06
+      GoRuntimeType: 1.264352e+06
       GoKind: 22
       Pointee: 975 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
       ID: 835
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
-      GoRuntimeType: 945216
+      GoRuntimeType: 945248
       GoKind: 22
       Pointee: 836 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
       ID: 834
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 945120
+      GoRuntimeType: 945152
       GoKind: 22
       Pointee: 644 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
@@ -12750,7 +12750,7 @@ Types:
       ID: 838
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 945408
+      GoRuntimeType: 945440
       GoKind: 22
       Pointee: 650 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
@@ -12762,7 +12762,7 @@ Types:
       ID: 837
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 945312
+      GoRuntimeType: 945344
       GoKind: 22
       Pointee: 647 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
@@ -12774,7 +12774,7 @@ Types:
       ID: 833
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 945024
+      GoRuntimeType: 945056
       GoKind: 22
       Pointee: 641 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
@@ -12786,266 +12786,266 @@ Types:
       ID: 1188
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.14736e+06
+      GoRuntimeType: 2.147648e+06
       GoKind: 22
       Pointee: 1189 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
       ID: 839
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
-      GoRuntimeType: 945504
+      GoRuntimeType: 945536
       GoKind: 22
       Pointee: 840 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
       ID: 841
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
-      GoRuntimeType: 945600
+      GoRuntimeType: 945632
       GoKind: 22
       Pointee: 653 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
       ID: 827
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
-      GoRuntimeType: 938880
+      GoRuntimeType: 938912
       GoKind: 22
       Pointee: 828 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
       ID: 972
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.26128e+06
+      GoRuntimeType: 1.261408e+06
       GoKind: 22
       Pointee: 973 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 997
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.447776e+06
+      GoRuntimeType: 1.447904e+06
       GoKind: 22
       Pointee: 998 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
       ID: 829
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
-      GoRuntimeType: 941952
+      GoRuntimeType: 941984
       GoKind: 22
       Pointee: 830 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 1139
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.81216e+06
+      GoRuntimeType: 1.812448e+06
       GoKind: 22
       Pointee: 1140 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 1097
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.257824e+06
+      GoRuntimeType: 1.257952e+06
       GoKind: 22
       Pointee: 1098 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 914
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.079232e+06
+      GoRuntimeType: 1.07936e+06
       GoKind: 22
       Pointee: 915 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 1057
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
-      GoRuntimeType: 942048
+      GoRuntimeType: 942080
       GoKind: 22
       Pointee: 1058 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
       ID: 807
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
-      GoRuntimeType: 927072
+      GoRuntimeType: 927104
       GoKind: 22
       Pointee: 808 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
       ID: 904
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.056064e+06
+      GoRuntimeType: 1.056192e+06
       GoKind: 22
       Pointee: 905 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 970
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.22928e+06
+      GoRuntimeType: 1.229408e+06
       GoKind: 22
       Pointee: 971 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 968
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.229024e+06
+      GoRuntimeType: 1.229152e+06
       GoKind: 22
       Pointee: 969 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
       ID: 821
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
-      GoRuntimeType: 931776
+      GoRuntimeType: 931808
       GoKind: 22
       Pointee: 822 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
       ID: 823
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
-      GoRuntimeType: 931872
+      GoRuntimeType: 931904
       GoKind: 22
       Pointee: 824 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
       ID: 751
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
-      GoRuntimeType: 919296
+      GoRuntimeType: 919328
       GoKind: 22
       Pointee: 752 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
       ID: 1145
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.8528e+06
+      GoRuntimeType: 1.853088e+06
       GoKind: 22
       Pointee: 1146 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 842
       Name: '*html/template.Error'
       ByteSize: 8
-      GoRuntimeType: 946368
+      GoRuntimeType: 946400
       GoKind: 22
       Pointee: 843 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 99
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 392288
+      GoRuntimeType: 392320
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 102
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 391904
+      GoRuntimeType: 391936
       GoKind: 22
       Pointee: 94 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 392032
+      GoRuntimeType: 392064
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 98
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 392160
+      GoRuntimeType: 392192
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 103
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 391776
+      GoRuntimeType: 391808
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
       ID: 161
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 392864
+      GoRuntimeType: 392896
       GoKind: 22
       Pointee: 155 GoEmptyInterfaceType interface {}
     - __kind: PointerType
       ID: 721
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 912576
+      GoRuntimeType: 912608
       GoKind: 22
       Pointee: 722 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 719
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
-      GoRuntimeType: 912480
+      GoRuntimeType: 912512
       GoKind: 22
       Pointee: 720 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
       ID: 1043
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 900768
+      GoRuntimeType: 900800
       GoKind: 22
       Pointee: 1044 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
       ID: 931
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.200608e+06
+      GoRuntimeType: 1.200736e+06
       GoKind: 22
       Pointee: 932 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1232
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.378208e+06
+      GoRuntimeType: 2.378496e+06
       GoKind: 22
       Pointee: 1233 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 929
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.20048e+06
+      GoRuntimeType: 1.200608e+06
       GoKind: 22
       Pointee: 930 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 656
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 899712
+      GoRuntimeType: 899744
       GoKind: 22
       Pointee: 657 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 1089
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.192288e+06
+      GoRuntimeType: 1.192416e+06
       GoKind: 22
       Pointee: 1090 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1087
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.191904e+06
+      GoRuntimeType: 1.192032e+06
       GoKind: 22
       Pointee: 1088 StructureType io.discard
     - __kind: PointerType
       ID: 1061
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.024064e+06
+      GoRuntimeType: 1.024192e+06
       GoKind: 22
       Pointee: 1062 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 927
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.200224e+06
+      GoRuntimeType: 1.200352e+06
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 1135
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.806336e+06
+      GoRuntimeType: 1.806624e+06
       GoKind: 22
       Pointee: 1136 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13070,105 +13070,105 @@ Types:
       ID: 370
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 385184
+      GoRuntimeType: 385216
       GoKind: 22
       Pointee: 371 StructureType main.deepMap2
     - __kind: PointerType
       ID: 1276
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 385120
+      GoRuntimeType: 385152
       GoKind: 22
       Pointee: 1277 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 147
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 384864
+      GoRuntimeType: 384896
       GoKind: 22
       Pointee: 148 StructureType main.deepMap7
     - __kind: PointerType
       ID: 1310
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 384800
+      GoRuntimeType: 384832
       GoKind: 22
       Pointee: 1311 StructureType main.deepMap8
     - __kind: PointerType
       ID: 1325
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 384736
+      GoRuntimeType: 384768
       GoKind: 22
       Pointee: 1326 StructureType main.deepMap9
     - __kind: PointerType
       ID: 131
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 385760
+      GoRuntimeType: 385792
       GoKind: 22
       Pointee: 132 StructureType main.deepPtr2
     - __kind: PointerType
       ID: 1236
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 385696
+      GoRuntimeType: 385728
       GoKind: 22
       Pointee: 1237 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 133
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 385440
+      GoRuntimeType: 385472
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr7
     - __kind: PointerType
       ID: 1280
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 385376
+      GoRuntimeType: 385408
       GoKind: 22
       Pointee: 1281 StructureType main.deepPtr8
     - __kind: PointerType
       ID: 1282
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 385312
+      GoRuntimeType: 385344
       GoKind: 22
       Pointee: 1283 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 138
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 386336
+      GoRuntimeType: 386368
       GoKind: 22
       Pointee: 361 StructureType main.deepSlice2
     - __kind: PointerType
       ID: 1261
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 386272
+      GoRuntimeType: 386304
       GoKind: 22
       Pointee: 1262 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 139
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 386016
+      GoRuntimeType: 386048
       GoKind: 22
       Pointee: 140 StructureType main.deepSlice7
     - __kind: PointerType
       ID: 1286
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 385952
+      GoRuntimeType: 385984
       GoKind: 22
       Pointee: 1287 StructureType main.deepSlice8
     - __kind: PointerType
       ID: 1292
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 385888
+      GoRuntimeType: 385920
       GoKind: 22
       Pointee: 1293 StructureType main.deepSlice9
     - __kind: PointerType
@@ -13181,28 +13181,28 @@ Types:
       ID: 157
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 386464
+      GoRuntimeType: 386496
       GoKind: 22
       Pointee: 158 StructureType main.esotericHeap
     - __kind: PointerType
       ID: 1253
       Name: '*main.firstBehavior'
       ByteSize: 8
-      GoRuntimeType: 895680
+      GoRuntimeType: 895712
       GoKind: 22
       Pointee: 352 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 1342
       Name: '*main.nestedStruct'
       ByteSize: 8
-      GoRuntimeType: 386720
+      GoRuntimeType: 386752
       GoKind: 22
       Pointee: 121 StructureType main.nestedStruct
     - __kind: PointerType
       ID: 245
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 386528
+      GoRuntimeType: 386560
       GoKind: 22
       Pointee: 244 StructureType main.node
     - __kind: PointerType
@@ -13215,14 +13215,14 @@ Types:
       ID: 1254
       Name: '*main.secondBehavior'
       ByteSize: 8
-      GoRuntimeType: 895776
+      GoRuntimeType: 895808
       GoKind: 22
       Pointee: 1255 StructureType main.secondBehavior
     - __kind: PointerType
       ID: 1241
       Name: '*main.somethingImpl'
       ByteSize: 8
-      GoRuntimeType: 895872
+      GoRuntimeType: 895904
       GoKind: 22
       Pointee: 1242 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
@@ -13256,7 +13256,7 @@ Types:
       ID: 422
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 384672
+      GoRuntimeType: 384704
       GoKind: 22
       Pointee: 163 StructureType main.structWithMap
     - __kind: PointerType
@@ -13432,77 +13432,77 @@ Types:
       ID: 755
       Name: '*math/big.ErrNaN'
       ByteSize: 8
-      GoRuntimeType: 920160
+      GoRuntimeType: 920192
       GoKind: 22
       Pointee: 756 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 1051
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
-      GoRuntimeType: 914976
+      GoRuntimeType: 915008
       GoKind: 22
       Pointee: 1052 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
       ID: 958
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.2088e+06
+      GoRuntimeType: 1.208928e+06
       GoKind: 22
       Pointee: 959 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 984
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.423776e+06
+      GoRuntimeType: 1.423904e+06
       GoKind: 22
       Pointee: 985 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1196
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.235808e+06
+      GoRuntimeType: 2.236096e+06
       GoKind: 22
       Pointee: 1197 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 982
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.423456e+06
+      GoRuntimeType: 1.423584e+06
       GoKind: 22
       Pointee: 983 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 960
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.208928e+06
+      GoRuntimeType: 1.209056e+06
       GoKind: 22
       Pointee: 961 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1206
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.266016e+06
+      GoRuntimeType: 2.266304e+06
       GoKind: 22
       Pointee: 1207 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1216
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.311008e+06
+      GoRuntimeType: 2.311296e+06
       GoKind: 22
       Pointee: 1217 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1204
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.265504e+06
+      GoRuntimeType: 2.265792e+06
       GoKind: 22
       Pointee: 1205 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 957
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.208032e+06
+      GoRuntimeType: 1.20816e+06
       GoKind: 22
       Pointee: 920 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13514,126 +13514,126 @@ Types:
       ID: 888
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.039424e+06
+      GoRuntimeType: 1.039552e+06
       GoKind: 22
       Pointee: 889 StructureType net.canceledError
     - __kind: PointerType
       ID: 1172
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2.010336e+06
+      GoRuntimeType: 2.010624e+06
       GoKind: 22
       Pointee: 1173 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1026
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.848544e+06
+      GoRuntimeType: 1.848832e+06
       GoKind: 22
       Pointee: 1027 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1218
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.315264e+06
+      GoRuntimeType: 2.315552e+06
       GoKind: 22
       Pointee: 1219 UnresolvedPointeeType net.netFD
     - __kind: PointerType
       ID: 688
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 907296
+      GoRuntimeType: 907328
       GoKind: 22
       Pointee: 689 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 690
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 907968
+      GoRuntimeType: 908000
       GoKind: 22
       Pointee: 691 StructureType net.result·2
     - __kind: PointerType
       ID: 1200
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.251552e+06
+      GoRuntimeType: 2.25184e+06
       GoKind: 22
       Pointee: 1201 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1198
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.251072e+06
+      GoRuntimeType: 2.25136e+06
       GoKind: 22
       Pointee: 1199 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 962
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.209568e+06
+      GoRuntimeType: 1.209696e+06
       GoKind: 22
       Pointee: 963 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 986
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.423936e+06
+      GoRuntimeType: 1.424064e+06
       GoKind: 22
       Pointee: 987 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 878
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1.0352e+06
+      GoRuntimeType: 1.035328e+06
       GoKind: 22
       Pointee: 879 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 1045
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 903072
+      GoRuntimeType: 903104
       GoKind: 22
       Pointee: 1046 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 665
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 903744
+      GoRuntimeType: 903776
       GoKind: 22
       Pointee: 585 BaseType net/http.http2ConnectionError
     - __kind: PointerType
       ID: 666
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 903840
+      GoRuntimeType: 903872
       GoKind: 22
       Pointee: 667 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 978
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.419616e+06
+      GoRuntimeType: 1.419744e+06
       GoKind: 22
       Pointee: 979 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 670
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 904416
+      GoRuntimeType: 904448
       GoKind: 22
       Pointee: 671 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 1107
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.557376e+06
+      GoRuntimeType: 1.557664e+06
       GoKind: 22
       Pointee: 1108 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
       ID: 669
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 904320
+      GoRuntimeType: 904352
       GoKind: 22
       Pointee: 589 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -13645,7 +13645,7 @@ Types:
       ID: 673
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 904608
+      GoRuntimeType: 904640
       GoKind: 22
       Pointee: 595 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -13657,7 +13657,7 @@ Types:
       ID: 672
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 904512
+      GoRuntimeType: 904544
       GoKind: 22
       Pointee: 592 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -13669,28 +13669,28 @@ Types:
       ID: 953
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.204576e+06
+      GoRuntimeType: 1.204704e+06
       GoKind: 22
       Pointee: 954 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 884
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1.03584e+06
+      GoRuntimeType: 1.035968e+06
       GoKind: 22
       Pointee: 885 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1161
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.9528e+06
+      GoRuntimeType: 1.953088e+06
       GoKind: 22
       Pointee: 1162 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
       ID: 668
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 904224
+      GoRuntimeType: 904256
       GoKind: 22
       Pointee: 586 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -13702,133 +13702,133 @@ Types:
       ID: 1047
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 904704
+      GoRuntimeType: 904736
       GoKind: 22
       Pointee: 1048 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 880
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1.035456e+06
+      GoRuntimeType: 1.035584e+06
       GoKind: 22
       Pointee: 881 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1109
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.177056e+06
+      GoRuntimeType: 2.177344e+06
       GoKind: 22
       Pointee: 1110 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1065
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1.035328e+06
+      GoRuntimeType: 1.035456e+06
       GoKind: 22
       Pointee: 1066 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 1091
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.20368e+06
+      GoRuntimeType: 1.203808e+06
       GoKind: 22
       Pointee: 1092 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
       ID: 674
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 904800
+      GoRuntimeType: 904832
       GoKind: 22
       Pointee: 675 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 980
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.420736e+06
+      GoRuntimeType: 1.420864e+06
       GoKind: 22
       Pointee: 981 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 951
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.204448e+06
+      GoRuntimeType: 1.204576e+06
       GoKind: 22
       Pointee: 952 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 882
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1.035584e+06
+      GoRuntimeType: 1.035712e+06
       GoKind: 22
       Pointee: 883 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1143
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1.845184e+06
+      GoRuntimeType: 1.845472e+06
       GoKind: 22
       Pointee: 1144 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
       ID: 663
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 902976
+      GoRuntimeType: 903008
       GoKind: 22
       Pointee: 664 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 1163
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.954336e+06
+      GoRuntimeType: 1.954624e+06
       GoKind: 22
       Pointee: 1164 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 1075
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.047488e+06
+      GoRuntimeType: 1.047616e+06
       GoKind: 22
       Pointee: 1076 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
       ID: 747
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
-      GoRuntimeType: 919104
+      GoRuntimeType: 919136
       GoKind: 22
       Pointee: 748 StructureType net/netip.parseAddrError
     - __kind: PointerType
       ID: 745
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
-      GoRuntimeType: 919008
+      GoRuntimeType: 919040
       GoKind: 22
       Pointee: 746 StructureType net/netip.parsePrefixError
     - __kind: PointerType
       ID: 1117
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 2.121312e+06
+      GoRuntimeType: 2.1216e+06
       GoKind: 22
       Pointee: 1118 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 1077
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.052352e+06
+      GoRuntimeType: 1.05248e+06
       GoKind: 22
       Pointee: 1078 StructureType net/smtp.dataCloser
     - __kind: PointerType
       ID: 731
       Name: '*net/textproto.Error'
       ByteSize: 8
-      GoRuntimeType: 915168
+      GoRuntimeType: 915200
       GoKind: 22
       Pointee: 732 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
       ID: 730
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 915072
+      GoRuntimeType: 915104
       GoKind: 22
       Pointee: 620 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
@@ -13840,21 +13840,21 @@ Types:
       ID: 1073
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.04672e+06
+      GoRuntimeType: 1.046848e+06
       GoKind: 22
       Pointee: 1074 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 988
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.424256e+06
+      GoRuntimeType: 1.424384e+06
       GoKind: 22
       Pointee: 989 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
       ID: 692
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 908064
+      GoRuntimeType: 908096
       GoKind: 22
       Pointee: 598 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -13866,7 +13866,7 @@ Types:
       ID: 693
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 908160
+      GoRuntimeType: 908192
       GoKind: 22
       Pointee: 601 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -14013,70 +14013,70 @@ Types:
       ID: 1224
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.35392e+06
+      GoRuntimeType: 2.354208e+06
       GoKind: 22
       Pointee: 1225 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 861
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 1.026752e+06
+      GoRuntimeType: 1.02688e+06
       GoKind: 22
       Pointee: 862 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 923
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.193696e+06
+      GoRuntimeType: 1.193824e+06
       GoKind: 22
       Pointee: 924 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1222
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.35024e+06
+      GoRuntimeType: 2.350528e+06
       GoKind: 22
       Pointee: 1223 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1220
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.349504e+06
+      GoRuntimeType: 2.349792e+06
       GoKind: 22
       Pointee: 1221 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 890
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.043392e+06
+      GoRuntimeType: 1.04352e+06
       GoKind: 22
       Pointee: 891 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 1029
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 2.090464e+06
+      GoRuntimeType: 2.090752e+06
       GoKind: 22
       Pointee: 1030 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 1095
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.21584e+06
+      GoRuntimeType: 1.215968e+06
       GoKind: 22
       Pointee: 1096 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 892
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.04352e+06
+      GoRuntimeType: 1.043648e+06
       GoKind: 22
       Pointee: 893 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 826
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
-      GoRuntimeType: 936960
+      GoRuntimeType: 936992
       GoKind: 22
       Pointee: 634 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
@@ -14088,84 +14088,84 @@ Types:
       ID: 825
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
-      GoRuntimeType: 936864
+      GoRuntimeType: 936896
       GoKind: 22
       Pointee: 633 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
       ID: 658
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 900384
+      GoRuntimeType: 900416
       GoKind: 22
       Pointee: 659 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 753
       Name: '*regexp/syntax.Error'
       ByteSize: 8
-      GoRuntimeType: 919776
+      GoRuntimeType: 919808
       GoKind: 22
       Pointee: 754 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
       ID: 865
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1.028288e+06
+      GoRuntimeType: 1.028416e+06
       GoKind: 22
       Pointee: 866 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 869
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1.03008e+06
+      GoRuntimeType: 1.030208e+06
       GoKind: 22
       Pointee: 870 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 392928
+      GoRuntimeType: 392960
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.417696e+06
+      GoRuntimeType: 1.417824e+06
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 867
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1.028416e+06
+      GoRuntimeType: 1.028544e+06
       GoKind: 22
       Pointee: 868 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 393568
+      GoRuntimeType: 393600
       GoKind: 22
       Pointee: 63 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 393632
+      GoRuntimeType: 393664
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 925
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.199072e+06
+      GoRuntimeType: 1.1992e+06
       GoKind: 22
       Pointee: 926 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 863
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1.027904e+06
+      GoRuntimeType: 1.028032e+06
       GoKind: 22
       Pointee: 844 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14177,21 +14177,21 @@ Types:
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 898944
+      GoRuntimeType: 898976
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.029568e+06
+      GoRuntimeType: 1.029696e+06
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 864
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1.028032e+06
+      GoRuntimeType: 1.02816e+06
       GoKind: 22
       Pointee: 847 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14203,42 +14203,42 @@ Types:
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 394336
+      GoRuntimeType: 394368
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 1.555136e+06
+      GoRuntimeType: 1.555424e+06
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.056736e+06
+      GoRuntimeType: 2.057024e+06
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.623264e+06
+      GoRuntimeType: 1.623552e+06
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 859
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 1.026112e+06
+      GoRuntimeType: 1.02624e+06
       GoKind: 22
       Pointee: 860 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 93
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 391712
+      GoRuntimeType: 391744
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -14250,21 +14250,21 @@ Types:
       ID: 1157
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.950752e+06
+      GoRuntimeType: 1.95104e+06
       GoKind: 22
       Pointee: 1158 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 1063
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 1.02624e+06
+      GoRuntimeType: 1.026368e+06
       GoKind: 22
       Pointee: 1064 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
       ID: 1059
       Name: '*struct { io.Writer }'
       ByteSize: 8
-      GoRuntimeType: 970624
+      GoRuntimeType: 970752
       GoKind: 22
       Pointee: 1060 StructureType struct { io.Writer }
     - __kind: PointerType
@@ -14276,7 +14276,7 @@ Types:
       ID: 977
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.418976e+06
+      GoRuntimeType: 1.419104e+06
       GoKind: 22
       Pointee: 976 BaseType syscall.Errno
     - __kind: PointerType
@@ -14418,35 +14418,35 @@ Types:
       ID: 1194
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.161536e+06
+      GoRuntimeType: 2.161824e+06
       GoKind: 22
       Pointee: 1195 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 918
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.088832e+06
+      GoRuntimeType: 1.08896e+06
       GoKind: 22
       Pointee: 919 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 993
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.628256e+06
+      GoRuntimeType: 1.628544e+06
       GoKind: 22
       Pointee: 994 UnresolvedPointeeType time.Location
     - __kind: PointerType
       ID: 661
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 901536
+      GoRuntimeType: 901568
       GoKind: 22
       Pointee: 662 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 660
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 901440
+      GoRuntimeType: 901472
       GoKind: 22
       Pointee: 582 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -14458,84 +14458,84 @@ Types:
       ID: 105
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 392352
+      GoRuntimeType: 392384
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 101
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 391968
+      GoRuntimeType: 392000
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 392096
+      GoRuntimeType: 392128
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 100
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 392224
+      GoRuntimeType: 392256
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 391840
+      GoRuntimeType: 391872
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 392416
+      GoRuntimeType: 392448
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
       ID: 749
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
-      GoRuntimeType: 919200
+      GoRuntimeType: 919232
       GoKind: 22
       Pointee: 750 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
       ID: 1186
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.136992e+06
+      GoRuntimeType: 2.13728e+06
       GoKind: 22
       Pointee: 1187 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
       ID: 733
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
-      GoRuntimeType: 915360
+      GoRuntimeType: 915392
       GoKind: 22
       Pointee: 734 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
       ID: 735
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
-      GoRuntimeType: 915456
+      GoRuntimeType: 915488
       GoKind: 22
       Pointee: 623 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
       ID: 897
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.047232e+06
+      GoRuntimeType: 1.04736e+06
       GoKind: 22
       Pointee: 898 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 899
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.04736e+06
+      GoRuntimeType: 1.047488e+06
       GoKind: 22
       Pointee: 852 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -23536,7 +23536,7 @@ Types:
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 686432
+      GoRuntimeType: 686464
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -23552,7 +23552,7 @@ Types:
       ID: 89
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 701376
+      GoRuntimeType: 701408
       GoKind: 17
       Count: 10
       HasCount: true
@@ -23561,7 +23561,7 @@ Types:
       ID: 333
       Name: '[16]uint8'
       ByteSize: 16
-      GoRuntimeType: 680096
+      GoRuntimeType: 680128
       GoKind: 17
       Count: 16
       HasCount: true
@@ -23570,7 +23570,7 @@ Types:
       ID: 250
       Name: '[1]int'
       ByteSize: 8
-      GoRuntimeType: 686528
+      GoRuntimeType: 686560
       GoKind: 17
       Count: 1
       HasCount: true
@@ -23579,7 +23579,7 @@ Types:
       ID: 75
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 700992
+      GoRuntimeType: 701024
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23588,7 +23588,7 @@ Types:
       ID: 74
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 701088
+      GoRuntimeType: 701120
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23613,7 +23613,7 @@ Types:
       ID: 81
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 701280
+      GoRuntimeType: 701312
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23630,7 +23630,7 @@ Types:
       ID: 111
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 683168
+      GoRuntimeType: 683200
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23647,7 +23647,7 @@ Types:
       ID: 108
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 684800
+      GoRuntimeType: 684832
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23688,7 +23688,7 @@ Types:
       ID: 109
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 684896
+      GoRuntimeType: 684928
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23728,7 +23728,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 684992
+      GoRuntimeType: 685024
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23737,7 +23737,7 @@ Types:
       ID: 107
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 684704
+      GoRuntimeType: 684736
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23746,7 +23746,7 @@ Types:
       ID: 87
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 734656
+      GoRuntimeType: 734688
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23755,7 +23755,7 @@ Types:
       ID: 65
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 700800
+      GoRuntimeType: 700832
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23764,7 +23764,7 @@ Types:
       ID: 249
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 685088
+      GoRuntimeType: 685120
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23773,7 +23773,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 700512
+      GoRuntimeType: 700544
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23782,7 +23782,7 @@ Types:
       ID: 455
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 682784
+      GoRuntimeType: 682816
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23791,7 +23791,7 @@ Types:
       ID: 412
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 683072
+      GoRuntimeType: 683104
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23800,7 +23800,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 692480
+      GoRuntimeType: 692512
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23817,7 +23817,7 @@ Types:
       ID: 1021
       Name: '[5]uint8'
       ByteSize: 5
-      GoRuntimeType: 684608
+      GoRuntimeType: 684640
       GoKind: 17
       Count: 5
       HasCount: true
@@ -23826,7 +23826,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 686048
+      GoRuntimeType: 686080
       GoKind: 17
       Count: 6
       HasCount: true
@@ -23835,7 +23835,7 @@ Types:
       ID: 82
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 701184
+      GoRuntimeType: 701216
       GoKind: 17
       Count: 8
       HasCount: true
@@ -23844,7 +23844,7 @@ Types:
       ID: 136
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 477152
+      GoRuntimeType: 477184
       GoKind: 23
       RawFields:
         - Name: array
@@ -23867,7 +23867,7 @@ Types:
       ID: 1259
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 477088
+      GoRuntimeType: 477120
       GoKind: 23
       RawFields:
         - Name: array
@@ -23890,7 +23890,7 @@ Types:
       ID: 1284
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 476768
+      GoRuntimeType: 476800
       GoKind: 23
       RawFields:
         - Name: array
@@ -23913,7 +23913,7 @@ Types:
       ID: 1290
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 476704
+      GoRuntimeType: 476736
       GoKind: 23
       RawFields:
         - Name: array
@@ -23936,7 +23936,7 @@ Types:
       ID: 127
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 475488
+      GoRuntimeType: 475520
       GoKind: 23
       RawFields:
         - Name: array
@@ -24253,7 +24253,7 @@ Types:
       ID: 262
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 486880
+      GoRuntimeType: 486912
       GoKind: 23
       RawFields:
         - Name: array
@@ -24276,7 +24276,7 @@ Types:
       ID: 1016
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 486752
+      GoRuntimeType: 486784
       GoKind: 23
       RawFields:
         - Name: array
@@ -24299,7 +24299,7 @@ Types:
       ID: 348
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 482016
+      GoRuntimeType: 482048
       GoKind: 23
       RawFields:
         - Name: array
@@ -24366,7 +24366,7 @@ Types:
       ID: 1296
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 487200
+      GoRuntimeType: 487232
       GoKind: 23
       RawFields:
         - Name: array
@@ -24411,7 +24411,7 @@ Types:
       ID: 421
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 477728
+      GoRuntimeType: 477760
       GoKind: 23
       RawFields:
         - Name: array
@@ -24622,7 +24622,7 @@ Types:
       ID: 261
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 487008
+      GoRuntimeType: 487040
       GoKind: 23
       RawFields:
         - Name: array
@@ -24666,7 +24666,7 @@ Types:
       ID: 255
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 486496
+      GoRuntimeType: 486528
       GoKind: 23
       RawFields:
         - Name: array
@@ -24689,7 +24689,7 @@ Types:
       ID: 263
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 485856
+      GoRuntimeType: 485888
       GoKind: 23
       RawFields:
         - Name: array
@@ -24712,7 +24712,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 485728
+      GoRuntimeType: 485760
       GoKind: 23
       RawFields:
         - Name: array
@@ -24735,7 +24735,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 486560
+      GoRuntimeType: 486592
       GoKind: 23
       RawFields:
         - Name: array
@@ -24762,7 +24762,7 @@ Types:
       ID: 812
       Name: archive/tar.headerError
       ByteSize: 24
-      GoRuntimeType: 930336
+      GoRuntimeType: 930368
       GoKind: 23
       RawFields:
         - Name: array
@@ -24792,7 +24792,7 @@ Types:
     - __kind: StructureType
       ID: 1056
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.120864e+06
+      GoRuntimeType: 1.120992e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24803,7 +24803,7 @@ Types:
       ID: 1082
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.567936e+06
+      GoRuntimeType: 1.568224e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -24817,7 +24817,7 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 584256
+      GoRuntimeType: 584288
       GoKind: 1
     - __kind: UnresolvedPointeeType
       ID: 1129
@@ -24834,36 +24834,36 @@ Types:
     - __kind: GoChannelType
       ID: 241
       Name: chan bool
-      GoRuntimeType: 595904
+      GoRuntimeType: 595936
       GoKind: 18
     - __kind: GoChannelType
       ID: 154
       Name: chan struct {}
-      GoRuntimeType: 594944
+      GoRuntimeType: 594976
       GoKind: 18
     - __kind: BaseType
       ID: 96
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 584064
+      GoRuntimeType: 584096
       GoKind: 16
     - __kind: BaseType
       ID: 95
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 584000
+      GoRuntimeType: 584032
       GoKind: 15
     - __kind: BaseType
       ID: 615
       Name: compress/flate.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 834560
+      GoRuntimeType: 834592
       GoKind: 6
     - __kind: GoStringHeaderType
       ID: 616
       Name: compress/flate.InternalError
       ByteSize: 16
-      GoRuntimeType: 834656
+      GoRuntimeType: 834688
       GoKind: 24
       RawFields:
         - Name: str
@@ -24893,26 +24893,26 @@ Types:
     - __kind: StructureType
       ID: 956
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.482336e+06
+      GoRuntimeType: 1.482624e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 629
       Name: crypto/aes.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 837152
+      GoRuntimeType: 837184
       GoKind: 2
     - __kind: BaseType
       ID: 630
       Name: crypto/des.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 837248
+      GoRuntimeType: 837280
       GoKind: 2
     - __kind: BaseType
       ID: 631
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 837344
+      GoRuntimeType: 837376
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1116
@@ -24942,7 +24942,7 @@ Types:
       ID: 632
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 837440
+      GoRuntimeType: 837472
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1166
@@ -24956,7 +24956,7 @@ Types:
       ID: 619
       Name: crypto/tls.AlertError
       ByteSize: 1
-      GoRuntimeType: 835136
+      GoRuntimeType: 835168
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 896
@@ -24974,7 +24974,7 @@ Types:
       ID: 726
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.732832e+06
+      GoRuntimeType: 1.73312e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24990,7 +24990,7 @@ Types:
       ID: 851
       Name: crypto/tls.alert
       ByteSize: 1
-      GoRuntimeType: 993440
+      GoRuntimeType: 993568
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1114
@@ -25012,7 +25012,7 @@ Types:
       ID: 800
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.735712e+06
+      GoRuntimeType: 1.736e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25027,14 +25027,14 @@ Types:
     - __kind: StructureType
       ID: 794
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.118432e+06
+      GoRuntimeType: 1.11856e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 796
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.602656e+06
+      GoRuntimeType: 1.602944e+06
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -25047,19 +25047,19 @@ Types:
       ID: 628
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
-      GoRuntimeType: 836768
+      GoRuntimeType: 836800
       GoKind: 2
     - __kind: BaseType
       ID: 1024
       Name: crypto/x509.InvalidReason
       ByteSize: 8
-      GoRuntimeType: 589440
+      GoRuntimeType: 589472
       GoKind: 2
     - __kind: StructureType
       ID: 901
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.563936e+06
+      GoRuntimeType: 1.564224e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -25068,14 +25068,14 @@ Types:
     - __kind: StructureType
       ID: 802
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.118688e+06
+      GoRuntimeType: 1.118816e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 798
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.73552e+06
+      GoRuntimeType: 1.735808e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25091,7 +25091,7 @@ Types:
       ID: 816
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.438656e+06
+      GoRuntimeType: 1.438784e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25101,7 +25101,7 @@ Types:
       ID: 820
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.438816e+06
+      GoRuntimeType: 1.438944e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25115,7 +25115,7 @@ Types:
       ID: 613
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 834272
+      GoRuntimeType: 834304
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1072
@@ -25125,7 +25125,7 @@ Types:
       ID: 614
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
-      GoRuntimeType: 834464
+      GoRuntimeType: 834496
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 685
@@ -25159,7 +25159,7 @@ Types:
       ID: 687
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.422496e+06
+      GoRuntimeType: 1.422624e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -25181,7 +25181,7 @@ Types:
       ID: 625
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
-      GoRuntimeType: 836672
+      GoRuntimeType: 836704
       GoKind: 24
       RawFields:
         - Name: str
@@ -25208,7 +25208,7 @@ Types:
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.027776e+06
+      GoRuntimeType: 1.027904e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25229,13 +25229,13 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 584128
+      GoRuntimeType: 584160
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 584192
+      GoRuntimeType: 584224
       GoKind: 14
     - __kind: UnresolvedPointeeType
       ID: 1203
@@ -25253,13 +25253,13 @@ Types:
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 475232
+      GoRuntimeType: 475264
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 70
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 848864
+      GoRuntimeType: 848896
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 351
@@ -25302,7 +25302,7 @@ Types:
       ID: 696
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.73168e+06
+      GoRuntimeType: 1.731968e+06
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25325,7 +25325,7 @@ Types:
     - __kind: StructureType
       ID: 702
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.11472e+06
+      GoRuntimeType: 1.114848e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25336,7 +25336,7 @@ Types:
       ID: 607
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 833696
+      GoRuntimeType: 833728
       GoKind: 24
       RawFields:
         - Name: str
@@ -25355,7 +25355,7 @@ Types:
       ID: 1014
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.221344e+06
+      GoRuntimeType: 2.221632e+06
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25404,13 +25404,13 @@ Types:
       ID: 1015
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 586496
+      GoRuntimeType: 586528
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 604
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 833600
+      GoRuntimeType: 833632
       GoKind: 24
       RawFields:
         - Name: str
@@ -25429,7 +25429,7 @@ Types:
       ID: 610
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 833792
+      GoRuntimeType: 833824
       GoKind: 24
       RawFields:
         - Name: str
@@ -25471,26 +25471,26 @@ Types:
     - __kind: StructureType
       ID: 744
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.117664e+06
+      GoRuntimeType: 1.117792e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 624
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
-      GoRuntimeType: 835808
+      GoRuntimeType: 835840
       GoKind: 2
     - __kind: StructureType
       ID: 742
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.117536e+06
+      GoRuntimeType: 1.117664e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 740
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.600736e+06
+      GoRuntimeType: 1.601024e+06
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25503,7 +25503,7 @@ Types:
       ID: 760
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.601536e+06
+      GoRuntimeType: 1.601824e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25516,7 +25516,7 @@ Types:
       ID: 764
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.734944e+06
+      GoRuntimeType: 1.735232e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25532,7 +25532,7 @@ Types:
       ID: 762
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.432256e+06
+      GoRuntimeType: 1.432384e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25542,7 +25542,7 @@ Types:
       ID: 758
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.431936e+06
+      GoRuntimeType: 1.432064e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25552,14 +25552,14 @@ Types:
       ID: 1000
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.502976e+06
+      GoRuntimeType: 1.503264e+06
       GoKind: 21
       HeaderType: 1002 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 1023
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.050816e+06
+      GoRuntimeType: 1.050944e+06
       GoKind: 23
       RawFields:
         - Name: array
@@ -25582,7 +25582,7 @@ Types:
       ID: 772
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.601856e+06
+      GoRuntimeType: 1.602144e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25595,7 +25595,7 @@ Types:
       ID: 766
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.432416e+06
+      GoRuntimeType: 1.432544e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25605,7 +25605,7 @@ Types:
       ID: 770
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.735136e+06
+      GoRuntimeType: 1.735424e+06
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25621,7 +25621,7 @@ Types:
       ID: 768
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.601696e+06
+      GoRuntimeType: 1.601984e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25634,7 +25634,7 @@ Types:
       ID: 774
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.432576e+06
+      GoRuntimeType: 1.432704e+06
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25644,7 +25644,7 @@ Types:
       ID: 780
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.602176e+06
+      GoRuntimeType: 1.602464e+06
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25657,7 +25657,7 @@ Types:
       ID: 782
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.432896e+06
+      GoRuntimeType: 1.433024e+06
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25667,7 +25667,7 @@ Types:
       ID: 778
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.602016e+06
+      GoRuntimeType: 1.602304e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25680,7 +25680,7 @@ Types:
       ID: 776
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.432736e+06
+      GoRuntimeType: 1.432864e+06
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25690,7 +25690,7 @@ Types:
       ID: 784
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.602336e+06
+      GoRuntimeType: 1.602624e+06
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25703,7 +25703,7 @@ Types:
       ID: 704
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.424736e+06
+      GoRuntimeType: 1.424864e+06
       GoKind: 25
       RawFields:
         - Name: message
@@ -25717,7 +25717,7 @@ Types:
       ID: 706
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.424896e+06
+      GoRuntimeType: 1.425024e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25739,7 +25739,7 @@ Types:
       ID: 710
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.425216e+06
+      GoRuntimeType: 1.425344e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25753,7 +25753,7 @@ Types:
       ID: 1180
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 2.109728e+06
+      GoRuntimeType: 2.110016e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25766,7 +25766,7 @@ Types:
       ID: 1183
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.13392e+06
+      GoRuntimeType: 2.134208e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25786,7 +25786,7 @@ Types:
       ID: 708
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.425056e+06
+      GoRuntimeType: 1.425184e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25796,7 +25796,7 @@ Types:
       ID: 712
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.425376e+06
+      GoRuntimeType: 1.425504e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25846,7 +25846,7 @@ Types:
       ID: 718
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.426336e+06
+      GoRuntimeType: 1.426464e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -25861,7 +25861,7 @@ Types:
       ID: 940
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.843392e+06
+      GoRuntimeType: 1.84368e+06
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -25881,7 +25881,7 @@ Types:
       ID: 873
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.705728e+06
+      GoRuntimeType: 1.706016e+06
       GoKind: 25
       RawFields:
         - Name: Got
@@ -25894,7 +25894,7 @@ Types:
       ID: 946
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.84384e+06
+      GoRuntimeType: 1.844128e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25910,13 +25910,13 @@ Types:
       ID: 850
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 990752
+      GoRuntimeType: 990880
       GoKind: 8
     - __kind: StructureType
       ID: 938
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.843168e+06
+      GoRuntimeType: 1.843456e+06
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -25932,13 +25932,13 @@ Types:
       ID: 1025
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 831872
+      GoRuntimeType: 831904
       GoKind: 8
     - __kind: StructureType
       ID: 936
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.842944e+06
+      GoRuntimeType: 1.843232e+06
       GoKind: 25
       RawFields:
         - Name: Method
@@ -25954,7 +25954,7 @@ Types:
       ID: 944
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.757952e+06
+      GoRuntimeType: 1.75824e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25967,7 +25967,7 @@ Types:
       ID: 942
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.843616e+06
+      GoRuntimeType: 1.843904e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25987,7 +25987,7 @@ Types:
       ID: 950
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.629216e+06
+      GoRuntimeType: 1.629504e+06
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -25996,20 +25996,20 @@ Types:
     - __kind: StructureType
       ID: 877
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.285024e+06
+      GoRuntimeType: 1.285152e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 875
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.284896e+06
+      GoRuntimeType: 1.285024e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 948
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.758144e+06
+      GoRuntimeType: 1.758432e+06
       GoKind: 25
       RawFields:
         - Name: cause
@@ -26022,7 +26022,7 @@ Types:
       ID: 637
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
-      GoRuntimeType: 839264
+      GoRuntimeType: 839296
       GoKind: 24
       RawFields:
         - Name: str
@@ -26041,25 +26041,25 @@ Types:
       ID: 337
       Name: go.shape.bool
       ByteSize: 1
-      GoRuntimeType: 596096
+      GoRuntimeType: 596128
       GoKind: 1
     - __kind: BaseType
       ID: 350
       Name: go.shape.float64
       ByteSize: 8
-      GoRuntimeType: 596160
+      GoRuntimeType: 596192
       GoKind: 14
     - __kind: BaseType
       ID: 320
       Name: go.shape.int
       ByteSize: 8
-      GoRuntimeType: 595968
+      GoRuntimeType: 596000
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 322
       Name: go.shape.string
       ByteSize: 16
-      GoRuntimeType: 596032
+      GoRuntimeType: 596064
       GoKind: 24
       RawFields:
         - Name: str
@@ -26133,7 +26133,7 @@ Types:
       ID: 917
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.450496e+06
+      GoRuntimeType: 1.450624e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26143,7 +26143,7 @@ Types:
       ID: 1100
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.681824e+06
+      GoRuntimeType: 1.682112e+06
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -26157,7 +26157,7 @@ Types:
       ID: 1124
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.128416e+06
+      GoRuntimeType: 1.128544e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26170,7 +26170,7 @@ Types:
       ID: 1086
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.572896e+06
+      GoRuntimeType: 1.573184e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -26180,19 +26180,19 @@ Types:
       ID: 640
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
-      GoRuntimeType: 839840
+      GoRuntimeType: 839872
       GoKind: 10
     - __kind: BaseType
       ID: 1007
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.003904e+06
+      GoRuntimeType: 1.004032e+06
       GoKind: 10
     - __kind: StructureType
       ID: 975
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.88192e+06
+      GoRuntimeType: 1.882208e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26208,7 +26208,7 @@ Types:
       ID: 836
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.609376e+06
+      GoRuntimeType: 1.609664e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26221,7 +26221,7 @@ Types:
       ID: 644
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 840032
+      GoRuntimeType: 840064
       GoKind: 24
       RawFields:
         - Name: str
@@ -26240,7 +26240,7 @@ Types:
       ID: 650
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 840224
+      GoRuntimeType: 840256
       GoKind: 24
       RawFields:
         - Name: str
@@ -26259,7 +26259,7 @@ Types:
       ID: 647
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 840128
+      GoRuntimeType: 840160
       GoKind: 24
       RawFields:
         - Name: str
@@ -26278,7 +26278,7 @@ Types:
       ID: 641
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 839936
+      GoRuntimeType: 839968
       GoKind: 24
       RawFields:
         - Name: str
@@ -26301,7 +26301,7 @@ Types:
       ID: 840
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.451136e+06
+      GoRuntimeType: 1.451264e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26311,13 +26311,13 @@ Types:
       ID: 653
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
-      GoRuntimeType: 840320
+      GoRuntimeType: 840352
       GoKind: 2
     - __kind: StructureType
       ID: 828
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.446176e+06
+      GoRuntimeType: 1.446304e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26331,7 +26331,7 @@ Types:
       ID: 998
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.909824e+06
+      GoRuntimeType: 1.910112e+06
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26347,7 +26347,7 @@ Types:
       ID: 830
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.608896e+06
+      GoRuntimeType: 1.609184e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26360,7 +26360,7 @@ Types:
       ID: 1140
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.967392e+06
+      GoRuntimeType: 1.96768e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26377,7 +26377,7 @@ Types:
       ID: 915
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.570496e+06
+      GoRuntimeType: 1.570784e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26402,14 +26402,14 @@ Types:
     - __kind: StructureType
       ID: 969
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.513536e+06
+      GoRuntimeType: 1.513824e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 822
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.439456e+06
+      GoRuntimeType: 1.439584e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26419,7 +26419,7 @@ Types:
       ID: 824
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.439616e+06
+      GoRuntimeType: 1.439744e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26819,37 +26819,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 583808
+      GoRuntimeType: 583840
       GoKind: 2
     - __kind: BaseType
       ID: 94
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 583424
+      GoRuntimeType: 583456
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 583552
+      GoRuntimeType: 583584
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 583680
+      GoRuntimeType: 583712
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 583296
+      GoRuntimeType: 583328
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 155
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 848576
+      GoRuntimeType: 848608
       GoKind: 20
       RawFields:
         - Name: _type
@@ -26866,7 +26866,7 @@ Types:
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.85168e+06
+      GoRuntimeType: 1.851968e+06
       GoKind: 25
       RawFields:
         - Name: buf
@@ -26903,7 +26903,7 @@ Types:
     - __kind: StructureType
       ID: 930
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.479136e+06
+      GoRuntimeType: 1.479424e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -26914,7 +26914,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.215328e+06
+      GoRuntimeType: 1.215456e+06
       GoKind: 25
       RawFields:
         - Name: u
@@ -26924,7 +26924,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.643808e+06
+      GoRuntimeType: 1.644096e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26940,7 +26940,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.492896e+06
+      GoRuntimeType: 1.493184e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26953,7 +26953,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.492736e+06
+      GoRuntimeType: 1.493024e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26966,7 +26966,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.493056e+06
+      GoRuntimeType: 1.493344e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26978,20 +26978,20 @@ Types:
     - __kind: StructureType
       ID: 69
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 993152
+      GoRuntimeType: 993280
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 993056
+      GoRuntimeType: 993184
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1245
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.476096e+06
+      GoRuntimeType: 1.476384e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -27008,7 +27008,7 @@ Types:
       ID: 1130
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.192032e+06
+      GoRuntimeType: 1.19216e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27021,7 +27021,7 @@ Types:
       ID: 1167
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.024192e+06
+      GoRuntimeType: 1.02432e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27034,7 +27034,7 @@ Types:
       ID: 1119
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.111008e+06
+      GoRuntimeType: 1.111136e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27047,7 +27047,7 @@ Types:
       ID: 129
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.023936e+06
+      GoRuntimeType: 1.024064e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27059,7 +27059,7 @@ Types:
     - __kind: StructureType
       ID: 1088
       Name: io.discard
-      GoRuntimeType: 1.466496e+06
+      GoRuntimeType: 1.466784e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27129,7 +27129,7 @@ Types:
       ID: 160
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.022784e+06
+      GoRuntimeType: 1.022912e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27142,7 +27142,7 @@ Types:
       ID: 126
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.616352e+06
+      GoRuntimeType: 1.61664e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -27158,7 +27158,7 @@ Types:
       ID: 141
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.18832e+06
+      GoRuntimeType: 1.188448e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27168,7 +27168,7 @@ Types:
       ID: 371
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.188192e+06
+      GoRuntimeType: 1.18832e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27182,7 +27182,7 @@ Types:
       ID: 148
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.187552e+06
+      GoRuntimeType: 1.18768e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27192,7 +27192,7 @@ Types:
       ID: 1311
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.187424e+06
+      GoRuntimeType: 1.187552e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27202,7 +27202,7 @@ Types:
       ID: 1326
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.187296e+06
+      GoRuntimeType: 1.187424e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27212,7 +27212,7 @@ Types:
       ID: 130
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.189472e+06
+      GoRuntimeType: 1.1896e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27222,7 +27222,7 @@ Types:
       ID: 132
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.189344e+06
+      GoRuntimeType: 1.189472e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27236,7 +27236,7 @@ Types:
       ID: 134
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.188704e+06
+      GoRuntimeType: 1.188832e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27246,7 +27246,7 @@ Types:
       ID: 1281
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.188576e+06
+      GoRuntimeType: 1.188704e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27256,7 +27256,7 @@ Types:
       ID: 1283
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.188448e+06
+      GoRuntimeType: 1.188576e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27266,7 +27266,7 @@ Types:
       ID: 135
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.190624e+06
+      GoRuntimeType: 1.190752e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27276,7 +27276,7 @@ Types:
       ID: 361
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.190496e+06
+      GoRuntimeType: 1.190624e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27290,7 +27290,7 @@ Types:
       ID: 140
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.189856e+06
+      GoRuntimeType: 1.189984e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27300,7 +27300,7 @@ Types:
       ID: 1287
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.189728e+06
+      GoRuntimeType: 1.189856e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27310,7 +27310,7 @@ Types:
       ID: 1293
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.1896e+06
+      GoRuntimeType: 1.189728e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27325,7 +27325,7 @@ Types:
       ID: 158
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.835104e+06
+      GoRuntimeType: 1.835392e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27347,7 +27347,7 @@ Types:
       ID: 153
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.968704e+06
+      GoRuntimeType: 1.968992e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -27375,7 +27375,7 @@ Types:
       ID: 352
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.415616e+06
+      GoRuntimeType: 1.415744e+06
       GoKind: 25
       RawFields:
         - Name: s
@@ -27502,7 +27502,7 @@ Types:
       ID: 121
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.465536e+06
+      GoRuntimeType: 1.465824e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -27515,7 +27515,7 @@ Types:
       ID: 244
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.465216e+06
+      GoRuntimeType: 1.465504e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -27537,14 +27537,14 @@ Types:
       ID: 1255
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.415776e+06
+      GoRuntimeType: 1.415904e+06
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 156
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.022912e+06
+      GoRuntimeType: 1.02304e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27597,7 +27597,7 @@ Types:
       ID: 162
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.18704e+06
+      GoRuntimeType: 1.187168e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27667,7 +27667,7 @@ Types:
       ID: 163
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.187168e+06
+      GoRuntimeType: 1.187296e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -28700,119 +28700,119 @@ Types:
       ID: 221
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.130464e+06
+      GoRuntimeType: 1.130592e+06
       GoKind: 21
       HeaderType: 223 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 216
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.130592e+06
+      GoRuntimeType: 1.13072e+06
       GoKind: 21
       HeaderType: 218 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 184
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.13072e+06
+      GoRuntimeType: 1.130848e+06
       GoKind: 21
       HeaderType: 186 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 196
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.130848e+06
+      GoRuntimeType: 1.130976e+06
       GoKind: 21
       HeaderType: 198 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 142
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.130336e+06
+      GoRuntimeType: 1.130464e+06
       GoKind: 21
       HeaderType: 144 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1265
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.130208e+06
+      GoRuntimeType: 1.130336e+06
       GoKind: 21
       HeaderType: 1267 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1299
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.129568e+06
+      GoRuntimeType: 1.129696e+06
       GoKind: 21
       HeaderType: 1301 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1314
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.12944e+06
+      GoRuntimeType: 1.129568e+06
       GoKind: 21
       HeaderType: 1316 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 164
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.1288e+06
+      GoRuntimeType: 1.128928e+06
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 1329
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.129312e+06
+      GoRuntimeType: 1.12944e+06
       GoKind: 21
       HeaderType: 1331 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 231
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.130976e+06
+      GoRuntimeType: 1.131104e+06
       GoKind: 21
       HeaderType: 233 GoSwissMapHeaderType map<int,struct {}>
     - __kind: GoMapType
       ID: 201
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.131104e+06
+      GoRuntimeType: 1.131232e+06
       GoKind: 21
       HeaderType: 203 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 191
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.131232e+06
+      GoRuntimeType: 1.13136e+06
       GoKind: 21
       HeaderType: 193 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 179
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.13136e+06
+      GoRuntimeType: 1.131488e+06
       GoKind: 21
       HeaderType: 181 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 174
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.131488e+06
+      GoRuntimeType: 1.131616e+06
       GoKind: 21
       HeaderType: 176 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 169
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.131616e+06
+      GoRuntimeType: 1.131744e+06
       GoKind: 21
       HeaderType: 171 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 226
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 1.131744e+06
+      GoRuntimeType: 1.131872e+06
       GoKind: 21
       HeaderType: 228 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
@@ -28855,28 +28855,28 @@ Types:
       ID: 236
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.131872e+06
+      GoRuntimeType: 1.132e+06
       GoKind: 21
       HeaderType: 238 GoSwissMapHeaderType map<struct {},struct {}>
     - __kind: GoMapType
       ID: 211
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.132e+06
+      GoRuntimeType: 1.132128e+06
       GoKind: 21
       HeaderType: 213 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 206
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.132128e+06
+      GoRuntimeType: 1.132256e+06
       GoKind: 21
       HeaderType: 208 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
       ID: 756
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.431616e+06
+      GoRuntimeType: 1.431744e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -28886,7 +28886,7 @@ Types:
       ID: 1052
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.428416e+06
+      GoRuntimeType: 1.428544e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -28900,7 +28900,7 @@ Types:
       ID: 1022
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.599456e+06
+      GoRuntimeType: 1.599744e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -28941,7 +28941,7 @@ Types:
       ID: 920
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.114336e+06
+      GoRuntimeType: 1.114464e+06
       GoKind: 24
       RawFields:
         - Name: str
@@ -28959,7 +28959,7 @@ Types:
     - __kind: StructureType
       ID: 889
       Name: net.canceledError
-      GoRuntimeType: 1.286048e+06
+      GoRuntimeType: 1.286176e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28970,7 +28970,7 @@ Types:
       ID: 1027
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 2.109024e+06
+      GoRuntimeType: 2.109312e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -28992,13 +28992,13 @@ Types:
     - __kind: StructureType
       ID: 1213
       Name: net.noReadFrom
-      GoRuntimeType: 1.114592e+06
+      GoRuntimeType: 1.11472e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1212
       Name: net.noWriteTo
-      GoRuntimeType: 1.114464e+06
+      GoRuntimeType: 1.114592e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29009,7 +29009,7 @@ Types:
       ID: 691
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.731488e+06
+      GoRuntimeType: 1.731776e+06
       GoKind: 25
       RawFields:
         - Name: p
@@ -29025,7 +29025,7 @@ Types:
       ID: 1201
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.29376e+06
+      GoRuntimeType: 2.294048e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29038,7 +29038,7 @@ Types:
       ID: 1199
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.293216e+06
+      GoRuntimeType: 2.293504e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29063,7 +29063,7 @@ Types:
       ID: 1046
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.419936e+06
+      GoRuntimeType: 1.420064e+06
       GoKind: 25
       RawFields:
         - Name: w
@@ -29073,19 +29073,19 @@ Types:
       ID: 585
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 832352
+      GoRuntimeType: 832384
       GoKind: 10
     - __kind: BaseType
       ID: 999
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 990848
+      GoRuntimeType: 990976
       GoKind: 10
     - __kind: StructureType
       ID: 667
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.72976e+06
+      GoRuntimeType: 1.730048e+06
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -29101,7 +29101,7 @@ Types:
       ID: 979
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.90112e+06
+      GoRuntimeType: 1.901408e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -29117,7 +29117,7 @@ Types:
       ID: 671
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.598976e+06
+      GoRuntimeType: 1.599264e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29134,7 +29134,7 @@ Types:
       ID: 589
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 832544
+      GoRuntimeType: 832576
       GoKind: 24
       RawFields:
         - Name: str
@@ -29153,7 +29153,7 @@ Types:
       ID: 595
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 832736
+      GoRuntimeType: 832768
       GoKind: 24
       RawFields:
         - Name: str
@@ -29172,7 +29172,7 @@ Types:
       ID: 592
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 832640
+      GoRuntimeType: 832672
       GoKind: 24
       RawFields:
         - Name: str
@@ -29194,7 +29194,7 @@ Types:
     - __kind: StructureType
       ID: 885
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.28528e+06
+      GoRuntimeType: 1.285408e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29205,7 +29205,7 @@ Types:
       ID: 586
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 832448
+      GoRuntimeType: 832480
       GoKind: 24
       RawFields:
         - Name: str
@@ -29224,7 +29224,7 @@ Types:
       ID: 1048
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
-      GoRuntimeType: 1.825632e+06
+      GoRuntimeType: 1.82592e+06
       GoKind: 25
       RawFields:
         - Name: group
@@ -29243,7 +29243,7 @@ Types:
       ID: 1141
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
-      GoRuntimeType: 1.419296e+06
+      GoRuntimeType: 1.419424e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29255,7 +29255,7 @@ Types:
     - __kind: ArrayType
       ID: 1127
       Name: net/http.incomparable
-      GoRuntimeType: 902784
+      GoRuntimeType: 902816
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
@@ -29263,7 +29263,7 @@ Types:
       ID: 881
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.558016e+06
+      GoRuntimeType: 1.558304e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -29277,7 +29277,7 @@ Types:
       ID: 1066
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.557856e+06
+      GoRuntimeType: 1.558144e+06
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29287,7 +29287,7 @@ Types:
       ID: 1092
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.801632e+06
+      GoRuntimeType: 1.80192e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -29303,7 +29303,7 @@ Types:
       ID: 675
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.420896e+06
+      GoRuntimeType: 1.421024e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -29316,14 +29316,14 @@ Types:
     - __kind: StructureType
       ID: 952
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.482016e+06
+      GoRuntimeType: 1.482304e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 883
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.558176e+06
+      GoRuntimeType: 1.558464e+06
       GoKind: 25
       RawFields:
         - Name: err
@@ -29333,7 +29333,7 @@ Types:
       ID: 1144
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2.027296e+06
+      GoRuntimeType: 2.027584e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29350,7 +29350,7 @@ Types:
       ID: 1164
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 2.043328e+06
+      GoRuntimeType: 2.043616e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29364,7 +29364,7 @@ Types:
       ID: 748
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.73456e+06
+      GoRuntimeType: 1.734848e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29380,7 +29380,7 @@ Types:
       ID: 746
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.600896e+06
+      GoRuntimeType: 1.601184e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29397,7 +29397,7 @@ Types:
       ID: 1078
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.602816e+06
+      GoRuntimeType: 1.603104e+06
       GoKind: 25
       RawFields:
         - Name: c
@@ -29414,7 +29414,7 @@ Types:
       ID: 620
       Name: net/textproto.ProtocolError
       ByteSize: 16
-      GoRuntimeType: 835232
+      GoRuntimeType: 835264
       GoKind: 24
       RawFields:
         - Name: str
@@ -29441,7 +29441,7 @@ Types:
       ID: 598
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 833312
+      GoRuntimeType: 833344
       GoKind: 24
       RawFields:
         - Name: str
@@ -29460,7 +29460,7 @@ Types:
       ID: 601
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 833408
+      GoRuntimeType: 833440
       GoKind: 24
       RawFields:
         - Name: str
@@ -29479,7 +29479,7 @@ Types:
       ID: 470
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 682880
+      GoRuntimeType: 682912
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29488,7 +29488,7 @@ Types:
       ID: 462
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 682976
+      GoRuntimeType: 683008
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29497,7 +29497,7 @@ Types:
       ID: 410
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 683264
+      GoRuntimeType: 683296
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29506,7 +29506,7 @@ Types:
       ID: 429
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 683360
+      GoRuntimeType: 683392
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29515,7 +29515,7 @@ Types:
       ID: 368
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
-      GoRuntimeType: 682112
+      GoRuntimeType: 682144
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29524,7 +29524,7 @@ Types:
       ID: 1274
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
-      GoRuntimeType: 682016
+      GoRuntimeType: 682048
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29533,7 +29533,7 @@ Types:
       ID: 1308
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
-      GoRuntimeType: 681536
+      GoRuntimeType: 681568
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29542,7 +29542,7 @@ Types:
       ID: 1323
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
-      GoRuntimeType: 681440
+      GoRuntimeType: 681472
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29551,7 +29551,7 @@ Types:
       ID: 378
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 680192
+      GoRuntimeType: 680224
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29560,7 +29560,7 @@ Types:
       ID: 1338
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
-      GoRuntimeType: 681344
+      GoRuntimeType: 681376
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29569,7 +29569,7 @@ Types:
       ID: 486
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
-      GoRuntimeType: 683456
+      GoRuntimeType: 683488
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29578,7 +29578,7 @@ Types:
       ID: 437
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 683552
+      GoRuntimeType: 683584
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29587,7 +29587,7 @@ Types:
       ID: 419
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 683648
+      GoRuntimeType: 683680
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29596,7 +29596,7 @@ Types:
       ID: 402
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 683744
+      GoRuntimeType: 683776
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29605,7 +29605,7 @@ Types:
       ID: 1035
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
-      GoRuntimeType: 758560
+      GoRuntimeType: 758592
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29614,7 +29614,7 @@ Types:
       ID: 394
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 683840
+      GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29623,7 +29623,7 @@ Types:
       ID: 386
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 683936
+      GoRuntimeType: 683968
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29632,7 +29632,7 @@ Types:
       ID: 478
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
-      GoRuntimeType: 684032
+      GoRuntimeType: 684064
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29688,7 +29688,7 @@ Types:
     - __kind: ArrayType
       ID: 494
       Name: noalg.[8]struct { key struct {}; elem struct {} }
-      GoRuntimeType: 684128
+      GoRuntimeType: 684160
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29697,7 +29697,7 @@ Types:
       ID: 453
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 684224
+      GoRuntimeType: 684256
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29706,7 +29706,7 @@ Types:
       ID: 445
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 684320
+      GoRuntimeType: 684352
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29715,7 +29715,7 @@ Types:
       ID: 469
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.297312e+06
+      GoRuntimeType: 1.29744e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29728,7 +29728,7 @@ Types:
       ID: 461
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.297568e+06
+      GoRuntimeType: 1.297696e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29741,7 +29741,7 @@ Types:
       ID: 409
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.297824e+06
+      GoRuntimeType: 1.297952e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29754,7 +29754,7 @@ Types:
       ID: 428
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.29808e+06
+      GoRuntimeType: 1.298208e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29767,7 +29767,7 @@ Types:
       ID: 367
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.297056e+06
+      GoRuntimeType: 1.297184e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29780,7 +29780,7 @@ Types:
       ID: 1273
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.2968e+06
+      GoRuntimeType: 1.296928e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29793,7 +29793,7 @@ Types:
       ID: 1307
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.29552e+06
+      GoRuntimeType: 1.295648e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29806,7 +29806,7 @@ Types:
       ID: 1322
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.295264e+06
+      GoRuntimeType: 1.295392e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29819,7 +29819,7 @@ Types:
       ID: 377
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.293984e+06
+      GoRuntimeType: 1.294112e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29832,7 +29832,7 @@ Types:
       ID: 1337
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.295008e+06
+      GoRuntimeType: 1.295136e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29845,7 +29845,7 @@ Types:
       ID: 485
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
-      GoRuntimeType: 1.298336e+06
+      GoRuntimeType: 1.298464e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29858,7 +29858,7 @@ Types:
       ID: 436
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.298592e+06
+      GoRuntimeType: 1.29872e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29871,7 +29871,7 @@ Types:
       ID: 418
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.298848e+06
+      GoRuntimeType: 1.298976e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29884,7 +29884,7 @@ Types:
       ID: 401
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.299104e+06
+      GoRuntimeType: 1.299232e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29897,7 +29897,7 @@ Types:
       ID: 1034
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
-      GoRuntimeType: 1.3608e+06
+      GoRuntimeType: 1.360928e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29910,7 +29910,7 @@ Types:
       ID: 393
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.29936e+06
+      GoRuntimeType: 1.299488e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29923,7 +29923,7 @@ Types:
       ID: 385
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.299616e+06
+      GoRuntimeType: 1.299744e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29936,7 +29936,7 @@ Types:
       ID: 477
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
-      GoRuntimeType: 1.299872e+06
+      GoRuntimeType: 1.3e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30021,7 +30021,7 @@ Types:
       ID: 493
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
-      GoRuntimeType: 1.300128e+06
+      GoRuntimeType: 1.300256e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30034,7 +30034,7 @@ Types:
       ID: 452
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.300384e+06
+      GoRuntimeType: 1.300512e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30047,7 +30047,7 @@ Types:
       ID: 444
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.30064e+06
+      GoRuntimeType: 1.300768e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30060,7 +30060,7 @@ Types:
       ID: 471
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.297184e+06
+      GoRuntimeType: 1.297312e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30073,7 +30073,7 @@ Types:
       ID: 463
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.29744e+06
+      GoRuntimeType: 1.297568e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30086,7 +30086,7 @@ Types:
       ID: 411
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.297696e+06
+      GoRuntimeType: 1.297824e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30099,7 +30099,7 @@ Types:
       ID: 430
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.297952e+06
+      GoRuntimeType: 1.29808e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30112,7 +30112,7 @@ Types:
       ID: 369
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.296928e+06
+      GoRuntimeType: 1.297056e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30125,7 +30125,7 @@ Types:
       ID: 1275
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.296672e+06
+      GoRuntimeType: 1.2968e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30138,7 +30138,7 @@ Types:
       ID: 1309
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.295392e+06
+      GoRuntimeType: 1.29552e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30151,7 +30151,7 @@ Types:
       ID: 1324
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.295136e+06
+      GoRuntimeType: 1.295264e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30164,7 +30164,7 @@ Types:
       ID: 379
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.293856e+06
+      GoRuntimeType: 1.293984e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30177,7 +30177,7 @@ Types:
       ID: 1339
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.29488e+06
+      GoRuntimeType: 1.295008e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30190,7 +30190,7 @@ Types:
       ID: 487
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
-      GoRuntimeType: 1.298208e+06
+      GoRuntimeType: 1.298336e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30203,7 +30203,7 @@ Types:
       ID: 438
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.298464e+06
+      GoRuntimeType: 1.298592e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30216,7 +30216,7 @@ Types:
       ID: 420
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.29872e+06
+      GoRuntimeType: 1.298848e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30229,7 +30229,7 @@ Types:
       ID: 403
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.298976e+06
+      GoRuntimeType: 1.299104e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30242,7 +30242,7 @@ Types:
       ID: 1036
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
-      GoRuntimeType: 1.360672e+06
+      GoRuntimeType: 1.3608e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30255,7 +30255,7 @@ Types:
       ID: 395
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.299232e+06
+      GoRuntimeType: 1.29936e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30268,7 +30268,7 @@ Types:
       ID: 387
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.299488e+06
+      GoRuntimeType: 1.299616e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30281,7 +30281,7 @@ Types:
       ID: 479
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
-      GoRuntimeType: 1.299744e+06
+      GoRuntimeType: 1.299872e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30365,7 +30365,7 @@ Types:
     - __kind: StructureType
       ID: 495
       Name: noalg.struct { key struct {}; elem struct {} }
-      GoRuntimeType: 1.3e+06
+      GoRuntimeType: 1.300128e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30378,7 +30378,7 @@ Types:
       ID: 454
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.300256e+06
+      GoRuntimeType: 1.300384e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30391,7 +30391,7 @@ Types:
       ID: 446
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.300512e+06
+      GoRuntimeType: 1.30064e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30416,7 +30416,7 @@ Types:
       ID: 1223
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.362368e+06
+      GoRuntimeType: 2.362656e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -30429,7 +30429,7 @@ Types:
       ID: 1221
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.361568e+06
+      GoRuntimeType: 2.361856e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -30441,13 +30441,13 @@ Types:
     - __kind: StructureType
       ID: 1229
       Name: os.noReadFrom
-      GoRuntimeType: 1.112032e+06
+      GoRuntimeType: 1.11216e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1228
       Name: os.noWriteTo
-      GoRuntimeType: 1.111904e+06
+      GoRuntimeType: 1.112032e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -30466,7 +30466,7 @@ Types:
       ID: 893
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.706304e+06
+      GoRuntimeType: 1.706592e+06
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -30479,7 +30479,7 @@ Types:
       ID: 634
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
-      GoRuntimeType: 838496
+      GoRuntimeType: 838528
       GoKind: 24
       RawFields:
         - Name: str
@@ -30498,7 +30498,7 @@ Types:
       ID: 633
       Name: os/user.UnknownUserIdError
       ByteSize: 8
-      GoRuntimeType: 838400
+      GoRuntimeType: 838432
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 659
@@ -30528,7 +30528,7 @@ Types:
       ID: 868
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.889536e+06
+      GoRuntimeType: 1.889824e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -30547,7 +30547,7 @@ Types:
       ID: 1028
       Name: runtime.boundsErrorCode
       ByteSize: 1
-      GoRuntimeType: 584384
+      GoRuntimeType: 584416
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 63
@@ -30560,14 +30560,14 @@ Types:
     - __kind: StructureType
       ID: 84
       Name: runtime.dlogPerM
-      GoRuntimeType: 989984
+      GoRuntimeType: 990112
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 926
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.754112e+06
+      GoRuntimeType: 1.7544e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30580,7 +30580,7 @@ Types:
       ID: 844
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 989504
+      GoRuntimeType: 989632
       GoKind: 24
       RawFields:
         - Name: str
@@ -30599,7 +30599,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.410656e+06
+      GoRuntimeType: 2.410944e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30780,7 +30780,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.198816e+06
+      GoRuntimeType: 1.198944e+06
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -30790,7 +30790,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.971008e+06
+      GoRuntimeType: 1.971296e+06
       GoKind: 25
       RawFields:
         - Name: sp
@@ -30818,7 +30818,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.474016e+06
+      GoRuntimeType: 1.474304e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -30831,7 +30831,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.753152e+06
+      GoRuntimeType: 1.75344e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30850,13 +30850,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 831104
+      GoRuntimeType: 831136
       GoKind: 12
     - __kind: StructureType
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.473856e+06
+      GoRuntimeType: 1.474144e+06
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -30869,7 +30869,7 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.914912e+06
+      GoRuntimeType: 1.9152e+06
       GoKind: 25
       RawFields:
         - Name: fn
@@ -30894,13 +30894,13 @@ Types:
       ID: 91
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 831008
+      GoRuntimeType: 831040
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 2.415712e+06
+      GoRuntimeType: 2.416e+06
       GoKind: 25
       RawFields:
         - Name: g0
@@ -31123,7 +31123,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.971296e+06
+      GoRuntimeType: 1.971584e+06
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31151,7 +31151,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.84048e+06
+      GoRuntimeType: 1.840768e+06
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31173,7 +31173,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.840256e+06
+      GoRuntimeType: 1.840544e+06
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -31195,7 +31195,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 1.19856e+06
+      GoRuntimeType: 1.198688e+06
       GoKind: 25
       RawFields:
         - Name: next
@@ -31205,20 +31205,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 830720
+      GoRuntimeType: 830752
       GoKind: 12
     - __kind: StructureType
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.198432e+06
+      GoRuntimeType: 1.19856e+06
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.473696e+06
+      GoRuntimeType: 1.473984e+06
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31231,7 +31231,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.75392e+06
+      GoRuntimeType: 1.754208e+06
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -31250,7 +31250,7 @@ Types:
       ID: 847
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 989600
+      GoRuntimeType: 989728
       GoKind: 24
       RawFields:
         - Name: str
@@ -31269,13 +31269,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 830912
+      GoRuntimeType: 830944
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 898560
+      GoRuntimeType: 898592
       GoKind: 17
       Count: 2
       HasCount: true
@@ -31284,7 +31284,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.472096e+06
+      GoRuntimeType: 1.472384e+06
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31305,7 +31305,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 584512
+      GoRuntimeType: 584544
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -31315,7 +31315,7 @@ Types:
       ID: 71
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 584576
+      GoRuntimeType: 584608
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 77
@@ -31325,7 +31325,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.473056e+06
+      GoRuntimeType: 1.473344e+06
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -31338,12 +31338,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.284256e+06
+      GoRuntimeType: 1.284384e+06
       GoKind: 8
     - __kind: StructureType
       ID: 79
       Name: runtime.winlibcall
-      GoRuntimeType: 989888
+      GoRuntimeType: 990016
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -31354,7 +31354,7 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 583232
+      GoRuntimeType: 583264
       GoKind: 24
       RawFields:
         - Name: str
@@ -31381,7 +31381,7 @@ Types:
       ID: 1060
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.458176e+06
+      GoRuntimeType: 1.458464e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -31390,14 +31390,14 @@ Types:
     - __kind: StructureType
       ID: 123
       Name: struct {}
-      GoRuntimeType: 842144
+      GoRuntimeType: 842176
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1243
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.466816e+06
+      GoRuntimeType: 1.467104e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31410,7 +31410,7 @@ Types:
       ID: 1246
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.61712e+06
+      GoRuntimeType: 1.617408e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31426,7 +31426,7 @@ Types:
       ID: 1249
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.617312e+06
+      GoRuntimeType: 1.6176e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31441,14 +31441,14 @@ Types:
     - __kind: StructureType
       ID: 1244
       Name: sync.noCopy
-      GoRuntimeType: 988448
+      GoRuntimeType: 988576
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1252
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.468096e+06
+      GoRuntimeType: 1.468384e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31461,7 +31461,7 @@ Types:
       ID: 1247
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.468256e+06
+      GoRuntimeType: 1.468544e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31474,7 +31474,7 @@ Types:
       ID: 1250
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.617696e+06
+      GoRuntimeType: 1.617984e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31489,20 +31489,20 @@ Types:
     - __kind: StructureType
       ID: 1251
       Name: sync/atomic.align64
-      GoRuntimeType: 988640
+      GoRuntimeType: 988768
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1248
       Name: sync/atomic.noCopy
-      GoRuntimeType: 988544
+      GoRuntimeType: 988672
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 976
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.28464e+06
+      GoRuntimeType: 1.284768e+06
       GoKind: 12
     - __kind: StructureType
       ID: 466
@@ -32160,7 +32160,7 @@ Types:
       ID: 919
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.71072e+06
+      GoRuntimeType: 1.711008e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -32173,7 +32173,7 @@ Types:
       ID: 1142
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.91568e+06
+      GoRuntimeType: 1.915968e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 994
@@ -32187,7 +32187,7 @@ Types:
       ID: 992
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.377248e+06
+      GoRuntimeType: 2.377536e+06
       GoKind: 25
       RawFields:
         - Name: wall
@@ -32203,7 +32203,7 @@ Types:
       ID: 582
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 831488
+      GoRuntimeType: 831520
       GoKind: 24
       RawFields:
         - Name: str
@@ -32222,49 +32222,49 @@ Types:
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 583872
+      GoRuntimeType: 583904
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 583488
+      GoRuntimeType: 583520
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 583616
+      GoRuntimeType: 583648
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 583744
+      GoRuntimeType: 583776
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 583360
+      GoRuntimeType: 583392
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 583936
+      GoRuntimeType: 583968
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 584320
+      GoRuntimeType: 584352
       GoKind: 26
     - __kind: StructureType
       ID: 1010
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 2.064736e+06
+      GoRuntimeType: 2.065024e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -32298,13 +32298,13 @@ Types:
       ID: 1013
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
-      GoRuntimeType: 995072
+      GoRuntimeType: 995200
       GoKind: 9
     - __kind: StructureType
       ID: 1011
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.926432e+06
+      GoRuntimeType: 1.92672e+06
       GoKind: 25
       RawFields:
         - Name: id
@@ -32333,7 +32333,7 @@ Types:
       ID: 1012
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
-      GoRuntimeType: 587968
+      GoRuntimeType: 588000
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1187
@@ -32343,7 +32343,7 @@ Types:
       ID: 734
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.428736e+06
+      GoRuntimeType: 1.428864e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -32353,13 +32353,13 @@ Types:
       ID: 623
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
-      GoRuntimeType: 835328
+      GoRuntimeType: 835360
       GoKind: 2
     - __kind: StructureType
       ID: 898
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.706496e+06
+      GoRuntimeType: 1.706784e+06
       GoKind: 25
       RawFields:
         - Name: label
@@ -32372,7 +32372,7 @@ Types:
       ID: 852
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
-      GoRuntimeType: 993920
+      GoRuntimeType: 994048
       GoKind: 5
 MaxTypeID: 1670
 Issues:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x80e0b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e0c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1594 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x80e0e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e0f8", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x8095e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8095f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1433 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x809610", Frameless: false}]
+              InjectionPoints: [{PC: "0x809620", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x809658", Frameless: false}]
+              InjectionPoints: [{PC: "0x809668", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1436 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x809680", Frameless: false}]
+              InjectionPoints: [{PC: "0x809690", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x80cfbc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cfcc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1565 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80d048", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d058", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0x806fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806ff0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0x806fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806fb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0x806fc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806fd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x809c50", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0x806fb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806fc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0x806fd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806fe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x80b3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b3b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1467 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x80b3dc", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b3ec", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x807520", Frameless: true}]
+              InjectionPoints: [{PC: "0x807530", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1401 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0x80752c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80753c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0x806ef0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1364 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0x806ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806ed0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80e3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e3b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1613 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x80e3b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e3c0", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1673 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x808f08"
+                - PC: "0x808f18"
                   Frameless: false
-                - PC: "0x808f7c"
+                - PC: "0x808f8c"
                   Frameless: false
-                - PC: "0x8090b8"
+                - PC: "0x8090c8"
                   Frameless: false
-                - PC: "0x809134"
+                - PC: "0x809144"
                   Frameless: false
-                - PC: "0x8091ec"
+                - PC: "0x8091fc"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1674 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x808f08"
+                - PC: "0x808f18"
                   Frameless: false
-                - PC: "0x808f7c"
+                - PC: "0x808f8c"
                   Frameless: false
-                - PC: "0x8090b8"
+                - PC: "0x8090c8"
                   Frameless: false
-                - PC: "0x809134"
+                - PC: "0x809144"
                   Frameless: false
-                - PC: "0x8091ec"
+                - PC: "0x8091fc"
                   Frameless: false
               Condition:
                 Type: 4 BaseType bool
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 1675 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x808f08"
+                - PC: "0x808f18"
                   Frameless: false
-                - PC: "0x808f7c"
+                - PC: "0x808f8c"
                   Frameless: false
-                - PC: "0x8090b8"
+                - PC: "0x8090c8"
                   Frameless: false
-                - PC: "0x809134"
+                - PC: "0x809144"
                   Frameless: false
-                - PC: "0x8091ec"
+                - PC: "0x8091fc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -474,7 +474,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80b140", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b150", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -493,7 +493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80b140", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -519,7 +519,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1620 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x80e440", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e450", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -554,7 +554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x80b3e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b3f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -584,7 +584,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x80b120", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b130", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -613,11 +613,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1529 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x80c2b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c2c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1530 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x80c358", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c368", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -639,7 +639,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x80b670", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -661,7 +661,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1407 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x8079c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8079d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -683,7 +683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x8079d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8079e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -705,7 +705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x8076e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8076f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -727,7 +727,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x8076f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -749,7 +749,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x807860", Frameless: true}]
+              InjectionPoints: [{PC: "0x807870", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -771,7 +771,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x807870", Frameless: true}]
+              InjectionPoints: [{PC: "0x807880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -793,7 +793,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x80dd10", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dd20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -820,7 +820,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1584 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x80dd40", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dd50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -848,7 +848,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x80e170", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -870,7 +870,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1621 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x80e470", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -891,7 +891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1622 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x80e480", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e490", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -913,7 +913,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x809630", Frameless: true}]
+              InjectionPoints: [{PC: "0x809640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -947,7 +947,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1402 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x80756c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80757c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -975,11 +975,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x807fe8", Frameless: false}]
+              InjectionPoints: [{PC: "0x807ff8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x808020", Frameless: false}]
+              InjectionPoints: [{PC: "0x808030", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1001,11 +1001,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x807f2c", Frameless: false}]
+              InjectionPoints: [{PC: "0x807f3c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1415 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x807f88", Frameless: false}]
+              InjectionPoints: [{PC: "0x807f98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1027,11 +1027,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x809350", Frameless: true}]
+              InjectionPoints: [{PC: "0x809360", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1427 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x809358", Frameless: true}]
+              InjectionPoints: [{PC: "0x809368", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1053,11 +1053,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x80936c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80937c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1429 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x8093a0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8093b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1082,7 +1082,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1430 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x80936c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80937c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1104,11 +1104,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1659 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x810490", Frameless: true}]
+              InjectionPoints: [{PC: "0x8104a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1660 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x810494", Frameless: true}]
+              InjectionPoints: [{PC: "0x8104a4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1122,11 +1122,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1661 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x8104b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8104c0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1662 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x8104e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8104f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1149,11 +1149,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1655 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x8103f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x810408", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1656 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x810408", Frameless: false}]
+              InjectionPoints: [{PC: "0x810418", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1167,11 +1167,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x810448", Frameless: false}]
+              InjectionPoints: [{PC: "0x810458", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x810460", Frameless: false}]
+              InjectionPoints: [{PC: "0x810470", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1194,14 +1194,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1663 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x8104f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810500", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1664 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x810518"
+                - PC: "0x810528"
                   Frameless: true
-                - PC: "0x810520"
+                - PC: "0x810530"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1216,14 +1216,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1665 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x810548", Frameless: false}]
+              InjectionPoints: [{PC: "0x810558", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1666 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x8105a4"
-                  Frameless: false
                 - PC: "0x8105b4"
+                  Frameless: false
+                - PC: "0x8105c4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1250,7 +1250,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1667 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x8104f4", Frameless: true}]
+              InjectionPoints: [{PC: "0x810504", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1262,7 +1262,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1668 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x810558", Frameless: false}]
+              InjectionPoints: [{PC: "0x810568", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1283,11 +1283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1643 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x810100", Frameless: true}]
+              InjectionPoints: [{PC: "0x810110", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1644 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x810104", Frameless: true}]
+              InjectionPoints: [{PC: "0x810114", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1301,11 +1301,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1645 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x810190", Frameless: true}]
+              InjectionPoints: [{PC: "0x8101a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1646 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x810194", Frameless: true}]
+              InjectionPoints: [{PC: "0x8101a4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1329,11 +1329,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1631 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x80fd08", Frameless: false}]
+              InjectionPoints: [{PC: "0x80fd18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1632 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80fddc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80fdec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1375,11 +1375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1635 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80fe28", Frameless: false}]
+              InjectionPoints: [{PC: "0x80fe38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1636 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80fe38", Frameless: false}]
+              InjectionPoints: [{PC: "0x80fe48", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1402,11 +1402,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1669 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x8105f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810600", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1670 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x8105f8", Frameless: true}]
+              InjectionPoints: [{PC: "0x810608", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1420,11 +1420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1671 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x810688", Frameless: false}]
+              InjectionPoints: [{PC: "0x810698", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1672 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x8106ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x8106bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1447,11 +1447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x80fc70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1628 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80fc74", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc84", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1465,11 +1465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x80fc80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc90", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1630 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80fc8c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc9c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1492,11 +1492,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1647 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x810230", Frameless: true}]
+              InjectionPoints: [{PC: "0x810240", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1648 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x810238", Frameless: true}]
+              InjectionPoints: [{PC: "0x810248", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1510,11 +1510,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1649 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x8102d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8102e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1650 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x810300", Frameless: false}]
+              InjectionPoints: [{PC: "0x810310", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1537,11 +1537,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1637 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x8100d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8100e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1638 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8100d4", Frameless: true}]
+              InjectionPoints: [{PC: "0x8100e4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1555,11 +1555,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1639 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x8100e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8100f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1640 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x8100e4", Frameless: true}]
+              InjectionPoints: [{PC: "0x8100f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1573,11 +1573,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1641 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x8100f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810100", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1642 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x8100f4", Frameless: true}]
+              InjectionPoints: [{PC: "0x810104", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1600,11 +1600,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1651 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x8103b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8103c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1652 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x8103b8", Frameless: true}]
+              InjectionPoints: [{PC: "0x8103c8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1618,11 +1618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1653 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x8103c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8103d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1654 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8103d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8103e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1645,11 +1645,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x80fc50", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1624 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80fc54", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc64", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1663,11 +1663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x80fc60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc70", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1626 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80fc6c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc7c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1690,11 +1690,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x809098", Frameless: false}]
+              InjectionPoints: [{PC: "0x8090a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1419 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x8090ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x8090fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1721,11 +1721,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x809128", Frameless: false}]
+              InjectionPoints: [{PC: "0x809138", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1421 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x8091a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8091b8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1752,11 +1752,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x8091e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8091f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1423 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x809220", Frameless: false}]
+              InjectionPoints: [{PC: "0x809230", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1778,7 +1778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1679 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x809174", Frameless: false}]
+              InjectionPoints: [{PC: "0x809184", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1796,11 +1796,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1424 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x809258", Frameless: false}]
+              InjectionPoints: [{PC: "0x809268", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1425 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x809334", Frameless: false}]
+              InjectionPoints: [{PC: "0x809344", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1818,7 +1818,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1680 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x80925c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80926c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1839,7 +1839,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1681 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x80925c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80926c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1857,7 +1857,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1682 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x809300", Frameless: false}]
+              InjectionPoints: [{PC: "0x809310", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1878,7 +1878,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1683 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x809300", Frameless: false}]
+              InjectionPoints: [{PC: "0x809310", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1899,7 +1899,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x12c238"
                   Frameless: true
-                - PC: "0x809b28"
+                - PC: "0x809b38"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1920,20 +1920,20 @@ Probes:
             - Kind: Entry
               Type: 1676 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x808f08"
+                - PC: "0x808f18"
                   Frameless: false
-                - PC: "0x808f7c"
+                - PC: "0x808f8c"
                   Frameless: false
-                - PC: "0x8090b8"
+                - PC: "0x8090c8"
                   Frameless: false
-                - PC: "0x809134"
+                - PC: "0x809144"
                   Frameless: false
-                - PC: "0x8091ec"
+                - PC: "0x8091fc"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1677 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x808f3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x808f4c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1959,15 +1959,15 @@ Probes:
             - Kind: Line
               Type: 1678 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x808f08"
+                - PC: "0x808f18"
                   Frameless: false
-                - PC: "0x808f7c"
+                - PC: "0x808f8c"
                   Frameless: false
-                - PC: "0x8090b8"
+                - PC: "0x8090c8"
                   Frameless: false
-                - PC: "0x809134"
+                - PC: "0x809144"
                   Frameless: false
-                - PC: "0x8091ec"
+                - PC: "0x8091fc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1990,7 +1990,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1684 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x809354", Frameless: true}]
+              InjectionPoints: [{PC: "0x809364", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2015,7 +2015,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1685 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x809354", Frameless: true}]
+              InjectionPoints: [{PC: "0x809364", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2039,9 +2039,9 @@ Probes:
             - Kind: Entry
               Type: 1686 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x809384"
+                - PC: "0x809394"
                   Frameless: false
-                - PC: "0x80940c"
+                - PC: "0x80941c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2064,7 +2064,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0x806f20", Frameless: true}]
+              InjectionPoints: [{PC: "0x806f30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2086,7 +2086,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0x806f30", Frameless: true}]
+              InjectionPoints: [{PC: "0x806f40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2108,7 +2108,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0x806f40", Frameless: true}]
+              InjectionPoints: [{PC: "0x806f50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2130,7 +2130,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0x806f10", Frameless: true}]
+              InjectionPoints: [{PC: "0x806f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2152,7 +2152,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0x806f00", Frameless: true}]
+              InjectionPoints: [{PC: "0x806f10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2174,7 +2174,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x8095c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8095d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2195,11 +2195,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x80ce30", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ce40", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1563 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80cf58", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cf68", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2221,7 +2221,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x80b580", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2246,7 +2246,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1411 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x807a1c", Frameless: false}]
+              InjectionPoints: [{PC: "0x807a2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2268,7 +2268,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1412 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x807aa0", Frameless: false}]
+              InjectionPoints: [{PC: "0x807ab0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2290,7 +2290,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1413 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x807b3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x807b4c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2333,11 +2333,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x80d28c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d29c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1569 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x80d3cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d3dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2399,7 +2399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x809c30", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2421,7 +2421,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x809c90", Frameless: true}]
+              InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2443,7 +2443,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x809d30", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2465,7 +2465,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x809d50", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2487,7 +2487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x809d40", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2509,7 +2509,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x809c70", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2531,7 +2531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x809d20", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2553,7 +2553,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x809d10", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2577,7 +2577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x809c80", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2601,7 +2601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x809c80", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2623,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x809d00", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2645,7 +2645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x809cf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2667,7 +2667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x809c10", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2689,7 +2689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x809c20", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2711,7 +2711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x809c00", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2733,7 +2733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809cb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2755,7 +2755,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x809cd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809ce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2777,7 +2777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x809ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809cf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2799,7 +2799,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x809cb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809cc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2823,7 +2823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x809cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809cd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2845,7 +2845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80e150", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2868,7 +2868,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80e150", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2915,11 +2915,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x80d430", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d440", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1571 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x80d5b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d5c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2985,11 +2985,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x80d6ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d6bc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1575 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x80d744", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d754", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3020,11 +3020,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x80d080", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d090", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1567 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x80d224", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d234", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3050,11 +3050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1507 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c138", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1508 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3090,7 +3090,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x80b200", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b210", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3131,11 +3131,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1501 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80c0a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c0b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1502 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c100", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c110", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3159,11 +3159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1503 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80c0a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c0b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1504 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c100", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c110", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3182,11 +3182,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1509 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c138", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1510 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3206,11 +3206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1511 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c138", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1512 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3243,11 +3243,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1505 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80c0a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c0b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1506 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c100", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c110", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3275,7 +3275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80e430", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3300,7 +3300,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80e430", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3331,7 +3331,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1618 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80e430", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3356,7 +3356,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80e430", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3383,7 +3383,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x80b650", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3410,7 +3410,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x80dd80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dd90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3437,7 +3437,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x80dd50", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dd60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3472,7 +3472,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x80dd70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dd80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3504,7 +3504,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x80e140", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3526,7 +3526,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x80b590", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3548,7 +3548,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x809c60", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3570,7 +3570,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x80b570", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3594,11 +3594,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80b998", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b9a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1478 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80b9d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b9e8", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3618,11 +3618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1521 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80c1f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c208", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1522 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c27c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c28c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3663,11 +3663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1487 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80bab8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bac8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1488 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80bb44", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bb54", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3705,11 +3705,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80b998", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b9a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1480 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80b9d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b9e8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3750,11 +3750,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1489 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80bab8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bac8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1490 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80bb44", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bb54", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3794,11 +3794,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1523 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80c1f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c208", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1524 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c27c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c28c", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3815,11 +3815,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1525 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80c1f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c208", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1526 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c27c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c28c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3841,11 +3841,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80b998", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b9a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1482 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80b9d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b9e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3868,18 +3868,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1497 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x80bd78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bd88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1498 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x80be00"
+                - PC: "0x80be10"
                   Frameless: false
-                - PC: "0x80be54"
+                - PC: "0x80be64"
                   Frameless: false
-                - PC: "0x80bf04"
+                - PC: "0x80bf14"
                   Frameless: false
-                - PC: "0x80bf18"
+                - PC: "0x80bf28"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3907,18 +3907,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1495 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x80bc08", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bc18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1496 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x80bc5c"
+                - PC: "0x80bc6c"
                   Frameless: false
-                - PC: "0x80bcb8"
+                - PC: "0x80bcc8"
                   Frameless: false
-                - PC: "0x80bcf8"
+                - PC: "0x80bd08"
                   Frameless: false
-                - PC: "0x80bd34"
+                - PC: "0x80bd44"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3945,11 +3945,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1540 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x80c88c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c89c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1541 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x80c8d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c8e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3966,11 +3966,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1542 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x80c908", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c918", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1543 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x80c940", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c950", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3987,11 +3987,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1544 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x80c978", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c988", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1545 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x80c9ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c9bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4008,11 +4008,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x80ca68", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ca78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1549 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x80cac8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cad8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4029,11 +4029,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x80cdb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cdc8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1561 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x80cdf4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ce04", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4050,11 +4050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x80c748", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c758", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x80c790", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c7a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4072,14 +4072,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x80bb88", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bb98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1494 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x80bbb4"
+                - PC: "0x80bbc4"
                   Frameless: false
-                - PC: "0x80bbc8"
+                - PC: "0x80bbd8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4101,11 +4101,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80b998", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b9a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1484 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80b9d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b9e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4126,11 +4126,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1491 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80bab8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bac8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1492 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80bb44", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bb54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4151,11 +4151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1485 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x80ba18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ba28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1486 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x80ba74", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ba84", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4177,14 +4177,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1499 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x80bf58", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bf68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1500 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x80c010"
+                - PC: "0x80c020"
                   Frameless: false
-                - PC: "0x80c024"
+                - PC: "0x80c034"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4206,11 +4206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x80c7d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c7e0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1539 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x80c84c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c85c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4227,11 +4227,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x80c698", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c6a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x80c718", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c728", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4248,11 +4248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1552 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x80cbc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cbd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1553 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x80cc1c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cc2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4269,11 +4269,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x80c9e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c9f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1547 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x80ca2c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ca3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4290,11 +4290,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x80cd48", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cd58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1559 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x80cd88", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cd98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4314,7 +4314,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1531 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x80c460", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c470", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4335,11 +4335,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x80ccd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cce8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1557 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x80cd14", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cd24", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4356,11 +4356,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x80c608", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c618", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x80c65c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c66c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4377,11 +4377,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x80cc5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cc6c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1555 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x80cca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ccb8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4398,11 +4398,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1550 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x80cb00", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cb10", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1551 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x80cb8c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cb9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4420,7 +4420,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0x806ed0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1513 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c138", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4505,7 +4505,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x807350", Frameless: true}]
+              InjectionPoints: [{PC: "0x807360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4527,7 +4527,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x807330", Frameless: true}]
+              InjectionPoints: [{PC: "0x807340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4549,7 +4549,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x807400", Frameless: true}]
+              InjectionPoints: [{PC: "0x807410", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4567,7 +4567,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x807410", Frameless: true}]
+              InjectionPoints: [{PC: "0x807420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x807360", Frameless: true}]
+              InjectionPoints: [{PC: "0x807370", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x807380", Frameless: true}]
+              InjectionPoints: [{PC: "0x807390", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4630,7 +4630,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x807390", Frameless: true}]
+              InjectionPoints: [{PC: "0x8073a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4652,7 +4652,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x8073a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8073b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4681,7 +4681,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x807370", Frameless: true}]
+              InjectionPoints: [{PC: "0x807380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4712,7 +4712,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x807340", Frameless: true}]
+              InjectionPoints: [{PC: "0x807350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4734,7 +4734,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x80e100", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e110", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4756,7 +4756,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x8073b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8073c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4778,7 +4778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x8073d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8073e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4800,7 +4800,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x8073e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8073f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4822,7 +4822,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x8073f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4844,7 +4844,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x8073c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8073d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4866,7 +4866,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x80dda0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ddb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4888,7 +4888,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1582 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x80dd20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dd30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4910,7 +4910,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x809c40", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4931,11 +4931,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1527 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80c1f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c208", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c27c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c28c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4956,11 +4956,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1572 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x80d618", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d628", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1573 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x80d670", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d680", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4982,7 +4982,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0x806ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806ef0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5004,7 +5004,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1474 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x80b630", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5026,7 +5026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1586 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x80dd60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dd70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5048,7 +5048,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x8079e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8079f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5070,7 +5070,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x8079f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5092,11 +5092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80e3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e3b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1615 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x80e3b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e3c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5123,7 +5123,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x80dd30", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dd40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5150,7 +5150,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x8096a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8096b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5171,11 +5171,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1576 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x80d77c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d78c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1577 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x80d800", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d810", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5197,11 +5197,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x80e2f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e300", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1611 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x80e2fc", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e30c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5222,7 +5222,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x80e2e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e2f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5249,7 +5249,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x809bf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5281,7 +5281,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x80ddb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ddc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5321,7 +5321,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x80e180", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e190", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5354,11 +5354,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c138", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5379,11 +5379,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c138", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5406,11 +5406,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c138", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5439,7 +5439,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x80e110", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5471,11 +5471,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80e120", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e130", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1598 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x80e12c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e13c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5505,11 +5505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80e120", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e130", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1600 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x80e12c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e13c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5541,7 +5541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1601 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80e130", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80e130", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x807420", Frameless: true}]
+              InjectionPoints: [{PC: "0x807430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5625,7 +5625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0x806f70", Frameless: true}]
+              InjectionPoints: [{PC: "0x806f80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5647,7 +5647,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0x806f80", Frameless: true}]
+              InjectionPoints: [{PC: "0x806f90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5669,7 +5669,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0x806f90", Frameless: true}]
+              InjectionPoints: [{PC: "0x806fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5691,7 +5691,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0x806f60", Frameless: true}]
+              InjectionPoints: [{PC: "0x806f70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5713,7 +5713,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0x806f50", Frameless: true}]
+              InjectionPoints: [{PC: "0x806f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5735,7 +5735,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x80b5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b5d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5757,7 +5757,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1580 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x80dd00", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dd10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5779,7 +5779,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x80e160", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e170", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5801,7 +5801,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x80b5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b5b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5823,7 +5823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0x807000", Frameless: true}]
+              InjectionPoints: [{PC: "0x807010", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5845,7 +5845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80dd90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dda0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5867,7 +5867,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80dd90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dda0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5890,14 +5890,14 @@ Probes:
             - Kind: Entry
               Type: 1687 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x809508"
+                - PC: "0x809518"
                   Frameless: false
-                - PC: "0x810788"
+                - PC: "0x810798"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1688 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x809530", Frameless: false}]
+              InjectionPoints: [{PC: "0x809540", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5919,11 +5919,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x80d838", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d848", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1579 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80d898", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d8a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5940,481 +5940,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x806ec0..0x806ed0]
+      OutOfLinePCRanges: [0x806ed0..0x806ee0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]uint8
           Locations:
-            - Range: 0x806ec0..0x806ed0
+            - Range: 0x806ed0..0x806ee0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x806ed0..0x806ee0]
+      OutOfLinePCRanges: [0x806ee0..0x806ef0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]int32
           Locations:
-            - Range: 0x806ed0..0x806ee0
+            - Range: 0x806ee0..0x806ef0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x806ee0..0x806ef0]
+      OutOfLinePCRanges: [0x806ef0..0x806f00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]string
           Locations:
-            - Range: 0x806ee0..0x806ef0
+            - Range: 0x806ef0..0x806f00
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x806ef0..0x806f00]
+      OutOfLinePCRanges: [0x806f00..0x806f10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]bool
           Locations:
-            - Range: 0x806ef0..0x806f00
+            - Range: 0x806f00..0x806f10
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x806f00..0x806f10]
+      OutOfLinePCRanges: [0x806f10..0x806f20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x806f00..0x806f10
+            - Range: 0x806f10..0x806f20
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x806f10..0x806f20]
+      OutOfLinePCRanges: [0x806f20..0x806f30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 114 ArrayType [2]int8
           Locations:
-            - Range: 0x806f10..0x806f20
+            - Range: 0x806f20..0x806f30
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x806f20..0x806f30]
+      OutOfLinePCRanges: [0x806f30..0x806f40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 ArrayType [2]int16
           Locations:
-            - Range: 0x806f20..0x806f30
+            - Range: 0x806f30..0x806f40
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x806f30..0x806f40]
+      OutOfLinePCRanges: [0x806f40..0x806f50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]int32
           Locations:
-            - Range: 0x806f30..0x806f40
+            - Range: 0x806f40..0x806f50
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x806f40..0x806f50]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 116 ArrayType [2]int64
-          Locations:
-            - Range: 0x806f40..0x806f50
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 10
-      Name: main.testUintArray
       OutOfLinePCRanges: [0x806f50..0x806f60]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 117 ArrayType [2]uint
+          Type: 116 ArrayType [2]int64
           Locations:
             - Range: 0x806f50..0x806f60
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 10
+      Name: main.testUintArray
+      OutOfLinePCRanges: [0x806f60..0x806f70]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 117 ArrayType [2]uint
+          Locations:
+            - Range: 0x806f60..0x806f70
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x806f60..0x806f70]
+      OutOfLinePCRanges: [0x806f70..0x806f80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]uint8
           Locations:
-            - Range: 0x806f60..0x806f70
+            - Range: 0x806f70..0x806f80
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x806f70..0x806f80]
+      OutOfLinePCRanges: [0x806f80..0x806f90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 ArrayType [2]uint16
           Locations:
-            - Range: 0x806f70..0x806f80
+            - Range: 0x806f80..0x806f90
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x806f80..0x806f90]
+      OutOfLinePCRanges: [0x806f90..0x806fa0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 ArrayType [2]uint32
           Locations:
-            - Range: 0x806f80..0x806f90
+            - Range: 0x806f90..0x806fa0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x806f90..0x806fa0]
+      OutOfLinePCRanges: [0x806fa0..0x806fb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 54 ArrayType [2]uint64
           Locations:
-            - Range: 0x806f90..0x806fa0
+            - Range: 0x806fa0..0x806fb0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x806fa0..0x806fb0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 120 ArrayType [2][2]int
-          Locations:
-            - Range: 0x806fa0..0x806fb0
-              Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 16
-      Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0x806fb0..0x806fc0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 111 ArrayType [2]string
+          Type: 120 ArrayType [2][2]int
           Locations:
             - Range: 0x806fb0..0x806fc0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 16
+      Name: main.testArrayOfStrings
+      OutOfLinePCRanges: [0x806fc0..0x806fd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 111 ArrayType [2]string
+          Locations:
+            - Range: 0x806fc0..0x806fd0
+              Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x806fc0..0x806fd0]
+      OutOfLinePCRanges: [0x806fd0..0x806fe0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 121 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x806fc0..0x806fd0
+            - Range: 0x806fd0..0x806fe0
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0x806fd0..0x806fe0]
+      OutOfLinePCRanges: [0x806fe0..0x806ff0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 122 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0x806fd0..0x806fe0
+            - Range: 0x806fe0..0x806ff0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0x806fe0..0x806ff0]
+      OutOfLinePCRanges: [0x806ff0..0x807000]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 124 ArrayType [2]struct {}
           Locations:
-            - Range: 0x806fe0..0x806ff0
+            - Range: 0x806ff0..0x807000
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x807000..0x807010]
+      OutOfLinePCRanges: [0x807010..0x807020]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 126 ArrayType [100]uint
           Locations:
-            - Range: 0x807000..0x807010
+            - Range: 0x807010..0x807020
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x807330..0x807340]
+      OutOfLinePCRanges: [0x807340..0x807350]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x807330..0x807340
+            - Range: 0x807340..0x807350
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x807340..0x807350]
+      OutOfLinePCRanges: [0x807350..0x807360]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x807340..0x807350
+            - Range: 0x807350..0x807360
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x807350..0x807360]
+      OutOfLinePCRanges: [0x807360..0x807370]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x807350..0x807360
+            - Range: 0x807360..0x807370
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x807360..0x807370]
+      OutOfLinePCRanges: [0x807370..0x807380]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807360..0x807370
+            - Range: 0x807370..0x807380
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x807370..0x807380]
+      OutOfLinePCRanges: [0x807380..0x807390]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x807370..0x807380
+            - Range: 0x807380..0x807390
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x807380..0x807390]
+      OutOfLinePCRanges: [0x807390..0x8073a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 96 BaseType int16
           Locations:
-            - Range: 0x807380..0x807390
+            - Range: 0x807390..0x8073a0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x807390..0x8073a0]
+      OutOfLinePCRanges: [0x8073a0..0x8073b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x807390..0x8073a0
+            - Range: 0x8073a0..0x8073b0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x8073a0..0x8073b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 13 BaseType int64
-          Locations:
-            - Range: 0x8073a0..0x8073b0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 29
-      Name: main.testSingleUint
       OutOfLinePCRanges: [0x8073b0..0x8073c0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 BaseType uint
+          Type: 13 BaseType int64
           Locations:
             - Range: 0x8073b0..0x8073c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 29
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0x8073c0..0x8073d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 BaseType uint
+          Locations:
+            - Range: 0x8073c0..0x8073d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x8073c0..0x8073d0]
+      OutOfLinePCRanges: [0x8073d0..0x8073e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8073c0..0x8073d0
+            - Range: 0x8073d0..0x8073e0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x8073d0..0x8073e0]
+      OutOfLinePCRanges: [0x8073e0..0x8073f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x8073d0..0x8073e0
+            - Range: 0x8073e0..0x8073f0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x8073e0..0x8073f0]
+      OutOfLinePCRanges: [0x8073f0..0x807400]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x8073e0..0x8073f0
+            - Range: 0x8073f0..0x807400
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x8073f0..0x807400]
+      OutOfLinePCRanges: [0x807400..0x807410]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x8073f0..0x807400
+            - Range: 0x807400..0x807410
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x807400..0x807410]
+      OutOfLinePCRanges: [0x807410..0x807420]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x807400..0x807410
+            - Range: 0x807410..0x807420
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x807410..0x807420]
+      OutOfLinePCRanges: [0x807420..0x807430]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x807410..0x807420
+            - Range: 0x807420..0x807430
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x807420..0x807430]
+      OutOfLinePCRanges: [0x807430..0x807440]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 127 BaseType main.typeAlias
           Locations:
-            - Range: 0x807420..0x807430
+            - Range: 0x807430..0x807440
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x807520..0x807530]
+      OutOfLinePCRanges: [0x807530..0x807540]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 128 StructureType main.bigStruct
           Locations:
-            - Range: 0x807520..0x807530
+            - Range: 0x807530..0x807540
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6433,89 +6433,89 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x807550..0x807650]
+      OutOfLinePCRanges: [0x807560..0x807660]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x807550..0x807570
+            - Range: 0x807560..0x807580
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x807550..0x807650, Pieces: []}]
+          Locations: [{Range: 0x807560..0x807660, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
-          Locations: [{Range: 0x807550..0x807650, Pieces: []}]
+          Locations: [{Range: 0x807560..0x807660, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x807568..0x8075a4
+            - Range: 0x807578..0x8075b4
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x8075a4..0x8075ac
+            - Range: 0x8075b4..0x8075bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x8075ac..0x8075f8
+            - Range: 0x8075bc..0x807608
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8075f8..0x807600
+            - Range: 0x807608..0x807610
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}, {Size: 8, Op: null}]
-            - Range: 0x807600..0x807650
+            - Range: 0x807610..0x807660
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}, {Size: 8, Op: null}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x8076e0..0x8076f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 132 StructureType main.deepPtr1
-          Locations:
-            - Range: 0x8076e0..0x8076f0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 40
-      Name: main.testDeepPtr7
       OutOfLinePCRanges: [0x8076f0..0x807700]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 135 PointerType *main.deepPtr7
+          Type: 132 StructureType main.deepPtr1
           Locations:
             - Range: 0x8076f0..0x807700
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 40
+      Name: main.testDeepPtr7
+      OutOfLinePCRanges: [0x807700..0x807710]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 135 PointerType *main.deepPtr7
+          Locations:
+            - Range: 0x807700..0x807710
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x807860..0x807870]
+      OutOfLinePCRanges: [0x807870..0x807880]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 137 StructureType main.deepSlice1
           Locations:
-            - Range: 0x807860..0x807870
+            - Range: 0x807870..0x807880
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6528,129 +6528,129 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x807870..0x807880]
+      OutOfLinePCRanges: [0x807880..0x807890]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 141 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x807870..0x807880
+            - Range: 0x807880..0x807890
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x8079c0..0x8079d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 143 StructureType main.deepMap1
-          Locations:
-            - Range: 0x8079c0..0x8079d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 44
-      Name: main.testDeepMap7
       OutOfLinePCRanges: [0x8079d0..0x8079e0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 149 PointerType *main.deepMap7
+          Type: 143 StructureType main.deepMap1
           Locations:
             - Range: 0x8079d0..0x8079e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 45
-      Name: main.testStringType1
+    - ID: 44
+      Name: main.testDeepMap7
       OutOfLinePCRanges: [0x8079e0..0x8079f0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 151 PointerType *main.stringType1
+          Type: 149 PointerType *main.deepMap7
           Locations:
             - Range: 0x8079e0..0x8079f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 46
-      Name: main.testStringType2
+    - ID: 45
+      Name: main.testStringType1
       OutOfLinePCRanges: [0x8079f0..0x807a00]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 153 PointerType **main.stringType2
+          Type: 151 PointerType *main.stringType1
           Locations:
             - Range: 0x8079f0..0x807a00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 46
+      Name: main.testStringType2
+      OutOfLinePCRanges: [0x807a00..0x807a10]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 153 PointerType **main.stringType2
+          Locations:
+            - Range: 0x807a00..0x807a10
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x807a00..0x807be0]
+      OutOfLinePCRanges: [0x807a10..0x807bf0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ab8..0x807ac8
+            - Range: 0x807ac8..0x807ad8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807b58..0x807b68
+            - Range: 0x807b68..0x807b78
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807aa0..0x807aa4
+            - Range: 0x807ab0..0x807ab4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807aa4..0x807ac8
+            - Range: 0x807ab4..0x807ad8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807ac8..0x807b4c
+            - Range: 0x807ad8..0x807b5c
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x807b4c..0x807b54
+            - Range: 0x807b5c..0x807b64
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x807b54..0x807be0
+            - Range: 0x807b64..0x807bf0
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807a98..0x807aa4
+            - Range: 0x807aa8..0x807ab4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807aa4..0x807aa4
+            - Range: 0x807ab4..0x807ab4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x807aa4..0x807ac8
+            - Range: 0x807ab4..0x807ad8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807ac8..0x807b4c
+            - Range: 0x807ad8..0x807b5c
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x807b4c..0x807b50
+            - Range: 0x807b5c..0x807b60
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x807b50..0x807b54
+            - Range: 0x807b60..0x807b64
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x807b54..0x807b68
+            - Range: 0x807b64..0x807b78
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x807b68..0x807be0
+            - Range: 0x807b78..0x807bf0
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x807f10..0x807fd0]
+      OutOfLinePCRanges: [0x807f20..0x807fe0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 155 StructureType main.esotericStack
           Locations:
-            - Range: 0x807f10..0x807f48
+            - Range: 0x807f20..0x807f58
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6670,7 +6670,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x807f48..0x807f4c
+            - Range: 0x807f58..0x807f5c
               Pieces:
                 - Size: 4
                   Op: null
@@ -6690,7 +6690,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x807f4c..0x807f50
+            - Range: 0x807f5c..0x807f60
               Pieces:
                 - Size: 4
                   Op: null
@@ -6715,153 +6715,153 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x807fd0..0x808040]
+      OutOfLinePCRanges: [0x807fe0..0x808050]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 159 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x807fd0..0x808004
+            - Range: 0x807fe0..0x808014
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 50
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x809080..0x809110]
+      OutOfLinePCRanges: [0x809090..0x809120]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809080..0x8090b8
+            - Range: 0x809090..0x8090c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 51
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x809110..0x8091d0]
+      OutOfLinePCRanges: [0x809120..0x8091e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809110..0x80912c
+            - Range: 0x809120..0x80913c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809110..0x80913c
+            - Range: 0x809120..0x80914c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80912c..0x80913c
+            - Range: 0x80913c..0x80914c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80913c..0x8091d0
+            - Range: 0x80914c..0x8091e0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x8091d0..0x809240]
+      OutOfLinePCRanges: [0x8091e0..0x809250]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8091d0..0x8091f4
+            - Range: 0x8091e0..0x809204
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x809240..0x809350]
+      OutOfLinePCRanges: [0x809250..0x809360]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80925c..0x8092c8
+            - Range: 0x80926c..0x8092d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8092c8..0x8092d0
+            - Range: 0x8092d8..0x8092e0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80925c..0x8092c8
+            - Range: 0x80926c..0x8092d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8092c8..0x8092cc
+            - Range: 0x8092d8..0x8092dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x809350..0x809360]
+      OutOfLinePCRanges: [0x809360..0x809370]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809350..0x809358
+            - Range: 0x809360..0x809368
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809350..0x809358
+            - Range: 0x809360..0x809368
               Pieces: []
-            - Range: 0x809358..0x809359
+            - Range: 0x809368..0x809369
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809359..0x809360
+            - Range: 0x809369..0x809370
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x809360..0x8093b0]
+      OutOfLinePCRanges: [0x809370..0x8093c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x809360..0x8093b0
+            - Range: 0x809370..0x8093c0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809360..0x8093a0
+            - Range: 0x809370..0x8093b0
               Pieces: []
-            - Range: 0x8093a0..0x8093a1
+            - Range: 0x8093b0..0x8093b1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8093a1..0x8093b0
+            - Range: 0x8093b1..0x8093c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0x8095c0..0x8095d0]
+      OutOfLinePCRanges: [0x8095d0..0x8095e0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8095c0..0x8095d0
+            - Range: 0x8095d0..0x8095e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6872,19 +6872,19 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0x8095d0..0x809630]
+      OutOfLinePCRanges: [0x8095e0..0x809640]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8095d0..0x8095fc
+            - Range: 0x8095e0..0x80960c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8095fc..0x809600
+            - Range: 0x80960c..0x809610
               Pieces:
                 - Size: 8
                   Op: null
@@ -6895,28 +6895,28 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8095d0..0x809610
+            - Range: 0x8095e0..0x809620
               Pieces: []
-            - Range: 0x809610..0x809611
+            - Range: 0x809620..0x809621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x809611..0x809630
+            - Range: 0x809621..0x809640
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0x809630..0x809640]
+      OutOfLinePCRanges: [0x809640..0x809650]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x809630..0x809640
+            - Range: 0x809640..0x809650
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6927,41 +6927,41 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x809640..0x8096a0]
+      OutOfLinePCRanges: [0x809650..0x8096b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 163 PointerType *interface {}
           Locations:
-            - Range: 0x809640..0x80966c
+            - Range: 0x809650..0x80967c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809640..0x809680
+            - Range: 0x809650..0x809690
               Pieces: []
-            - Range: 0x809680..0x809681
+            - Range: 0x809690..0x809691
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x809681..0x8096a0
+            - Range: 0x809691..0x8096b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x8096a0..0x8096b0]
+      OutOfLinePCRanges: [0x8096b0..0x8096c0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 164 StructureType main.structWithAny
           Locations:
-            - Range: 0x8096a0..0x8096b0
+            - Range: 0x8096b0..0x8096c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6972,140 +6972,127 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x809bf0..0x809c00]
+      OutOfLinePCRanges: [0x809c00..0x809c10]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 165 StructureType main.structWithMap
-          Locations:
-            - Range: 0x809bf0..0x809c00
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x809c00..0x809c10]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 171 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x809c00..0x809c10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 63
-      Name: main.testMapStringToInt
+    - ID: 62
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x809c10..0x809c20]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 176 GoMapType map[string]int
+          Type: 171 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x809c10..0x809c20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToSlice
+    - ID: 63
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x809c20..0x809c30]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 181 GoMapType map[string][]string
+          Type: 176 GoMapType map[string]int
           Locations:
             - Range: 0x809c20..0x809c30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 65
-      Name: main.testMapArrayToArray
+    - ID: 64
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x809c30..0x809c40]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 186 GoMapType map[[4]string][2]int
+          Type: 181 GoMapType map[string][]string
           Locations:
             - Range: 0x809c30..0x809c40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testSmallMap
+    - ID: 65
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x809c40..0x809c50]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 176 GoMapType map[string]int
+          Type: 186 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x809c40..0x809c50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 66
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x809c50..0x809c60]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 176 GoMapType map[string]int
+          Locations:
+            - Range: 0x809c50..0x809c60
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 67
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x809c50..0x809c60]
+      OutOfLinePCRanges: [0x809c60..0x809c70]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 191 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x809c50..0x809c60
+            - Range: 0x809c60..0x809c70
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 68
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x809c60..0x809c70]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 192 PointerType *map[string]int
-          Locations:
-            - Range: 0x809c60..0x809c70
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x809c70..0x809c80]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 166 GoMapType map[int]int
+          Type: 192 PointerType *map[string]int
           Locations:
             - Range: 0x809c70..0x809c80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 70
-      Name: main.testMapMassive
+    - ID: 69
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x809c80..0x809c90]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 193 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 166 GoMapType map[int]int
           Locations:
             - Range: 0x809c80..0x809c90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 71
-      Name: main.testMapEmbeddedMaps
+    - ID: 70
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0x809c90..0x809ca0]
       InlinePCRanges: []
       Variables:
-        - Name: m
+        - Name: redactMyEntries
           Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x809c90..0x809ca0
@@ -7113,38 +7100,38 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapWithLinkedList
+    - ID: 71
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x809ca0..0x809cb0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 198 GoMapType map[bool]main.node
+          Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x809ca0..0x809cb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapWithSmallValue
+    - ID: 72
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x809cb0..0x809cc0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 203 GoMapType map[int]uint8
+          Type: 198 GoMapType map[bool]main.node
           Locations:
             - Range: 0x809cb0..0x809cc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithSmallValueMassive
+    - ID: 73
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x809cc0..0x809cd0]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
+        - Name: m
           Type: 203 GoMapType map[int]uint8
           Locations:
             - Range: 0x809cc0..0x809cd0
@@ -7152,21 +7139,21 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 74
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x809cd0..0x809ce0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 208 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 203 GoMapType map[int]uint8
           Locations:
             - Range: 0x809cd0..0x809ce0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 75
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x809ce0..0x809cf0]
       InlinePCRanges: []
       Variables:
@@ -7178,8 +7165,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapSmallKeySmallValue
+    - ID: 76
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x809cf0..0x809d00]
       InlinePCRanges: []
       Variables:
@@ -7191,127 +7178,140 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 77
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x809d00..0x809d10]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 213 GoMapType map[uint8][4]int
+          Type: 208 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x809d00..0x809d10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapLargeKeySmallValue
+    - ID: 78
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x809d10..0x809d20]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 218 GoMapType map[[4]int]uint8
+          Type: 213 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x809d10..0x809d20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 79
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x809d20..0x809d30]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 223 GoMapType map[[4]int][4]int
+          Type: 218 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x809d20..0x809d30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapEmptyKey
+    - ID: 80
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x809d30..0x809d40]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 228 GoMapType map[struct {}]int
+          Type: 223 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x809d30..0x809d40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapEmptyValue
+    - ID: 81
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0x809d40..0x809d50]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 233 GoMapType map[int]struct {}
+          Type: 228 GoMapType map[struct {}]int
           Locations:
             - Range: 0x809d40..0x809d50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 82
+      Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0x809d50..0x809d60]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 238 GoMapType map[struct {}]struct {}
+          Type: 233 GoMapType map[int]struct {}
           Locations:
             - Range: 0x809d50..0x809d60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x809d60..0x809d70]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 238 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x809d60..0x809d70
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x80b120..0x80b130]
+      OutOfLinePCRanges: [0x80b130..0x80b140]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x80b120..0x80b130
+            - Range: 0x80b130..0x80b140
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x80b120..0x80b130
+            - Range: 0x80b130..0x80b140
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x80b120..0x80b130
+            - Range: 0x80b130..0x80b140
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x80b140..0x80b150]
+      OutOfLinePCRanges: [0x80b150..0x80b160]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x80b140..0x80b150
+            - Range: 0x80b150..0x80b160
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80b140..0x80b150
+            - Range: 0x80b150..0x80b160
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7322,48 +7322,48 @@ Subprograms:
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x80b140..0x80b150
+            - Range: 0x80b150..0x80b160
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x80b200..0x80b210]
+      OutOfLinePCRanges: [0x80b210..0x80b220]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80b200..0x80b210
+            - Range: 0x80b210..0x80b220
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x80b200..0x80b210
+            - Range: 0x80b210..0x80b220
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x80b200..0x80b210
+            - Range: 0x80b210..0x80b220
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x80b200..0x80b210
+            - Range: 0x80b210..0x80b220
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80b200..0x80b210
+            - Range: 0x80b210..0x80b220
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7374,63 +7374,63 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x80b3a0..0x80b3e0]
+      OutOfLinePCRanges: [0x80b3b0..0x80b3f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x80b3a0..0x80b3dc
+            - Range: 0x80b3b0..0x80b3ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x80b3a0..0x80b3dc
+            - Range: 0x80b3b0..0x80b3ec
               Pieces: []
-            - Range: 0x80b3dc..0x80b3dd
+            - Range: 0x80b3ec..0x80b3ed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b3dd..0x80b3e0
+            - Range: 0x80b3ed..0x80b3f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0x80b3e0..0x80b3f0]
+      OutOfLinePCRanges: [0x80b3f0..0x80b400]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 243 GoChannelType chan bool
           Locations:
-            - Range: 0x80b3e0..0x80b3f0
+            - Range: 0x80b3f0..0x80b400
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x80b570..0x80b580]
+      OutOfLinePCRanges: [0x80b580..0x80b590]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x80b570..0x80b580
+            - Range: 0x80b580..0x80b590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x80b580..0x80b590]
+      OutOfLinePCRanges: [0x80b590..0x80b5a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 246 StructureType main.node
           Locations:
-            - Range: 0x80b580..0x80b590
+            - Range: 0x80b590..0x80b5a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7441,267 +7441,267 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x80b590..0x80b5a0]
+      OutOfLinePCRanges: [0x80b5a0..0x80b5b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.node
-          Locations:
-            - Range: 0x80b590..0x80b5a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 92
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x80b5a0..0x80b5b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 15 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x80b5a0..0x80b5b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 92
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0x80b5b0..0x80b5c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 15 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0x80b5b0..0x80b5c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x80b5c0..0x80b5d0]
+      OutOfLinePCRanges: [0x80b5d0..0x80b5e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 PointerType *uint
           Locations:
-            - Range: 0x80b5c0..0x80b5d0
+            - Range: 0x80b5d0..0x80b5e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x80b630..0x80b640]
+      OutOfLinePCRanges: [0x80b640..0x80b650]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 95 PointerType *string
           Locations:
-            - Range: 0x80b630..0x80b640
+            - Range: 0x80b640..0x80b650
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x80b650..0x80b660]
+      OutOfLinePCRanges: [0x80b660..0x80b670]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x80b650..0x80b660
+            - Range: 0x80b660..0x80b670
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x80b650..0x80b660
+            - Range: 0x80b660..0x80b670
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0x80b670..0x80b680]
+      OutOfLinePCRanges: [0x80b680..0x80b690]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 248 PointerType *main.t
           Locations:
-            - Range: 0x80b670..0x80b680
+            - Range: 0x80b680..0x80b690
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x80b980..0x80ba00]
+      OutOfLinePCRanges: [0x80b990..0x80ba10]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b980..0x80b99c
+            - Range: 0x80b990..0x80b9ac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b980..0x80b9d8
+            - Range: 0x80b990..0x80b9e8
               Pieces: []
-            - Range: 0x80b9d8..0x80b9d9
+            - Range: 0x80b9e8..0x80b9e9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b9d9..0x80ba00
+            - Range: 0x80b9e9..0x80ba10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b99c..0x80b9a8
+            - Range: 0x80b9ac..0x80b9b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b9a8..0x80ba00
+            - Range: 0x80b9b8..0x80ba10
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x80ba00..0x80baa0]
+      OutOfLinePCRanges: [0x80ba10..0x80bab0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ba00..0x80ba24
+            - Range: 0x80ba10..0x80ba34
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ba24..0x80baa0
+            - Range: 0x80ba34..0x80bab0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x80ba00..0x80ba74
+            - Range: 0x80ba10..0x80ba84
               Pieces: []
-            - Range: 0x80ba74..0x80ba75
+            - Range: 0x80ba84..0x80ba85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ba75..0x80baa0
+            - Range: 0x80ba85..0x80bab0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x80ba28..0x80ba40
+            - Range: 0x80ba38..0x80ba50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ba40..0x80baa0
+            - Range: 0x80ba50..0x80bab0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x80baa0..0x80bb70]
+      OutOfLinePCRanges: [0x80bab0..0x80bb80]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80baa0..0x80baf4
+            - Range: 0x80bab0..0x80bb04
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80baa0..0x80bb44
+            - Range: 0x80bab0..0x80bb54
               Pieces: []
-            - Range: 0x80bb44..0x80bb45
+            - Range: 0x80bb54..0x80bb55
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bb45..0x80bb70
+            - Range: 0x80bb55..0x80bb80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80baa0..0x80bb70, Pieces: []}]
+          Locations: [{Range: 0x80bab0..0x80bb80, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80babc..0x80baf8
+            - Range: 0x80bacc..0x80bb08
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80baf8..0x80bb70
+            - Range: 0x80bb08..0x80bb80
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x80bacc..0x80baf8
+            - Range: 0x80badc..0x80bb08
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80baf8..0x80bb70
+            - Range: 0x80bb08..0x80bb80
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x80bb70..0x80bbf0]
+      OutOfLinePCRanges: [0x80bb80..0x80bc00]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80bb70..0x80bb94
+            - Range: 0x80bb80..0x80bba4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x80bb70..0x80bbb4
+            - Range: 0x80bb80..0x80bbc4
               Pieces: []
-            - Range: 0x80bbb4..0x80bbb5
+            - Range: 0x80bbc4..0x80bbc5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bbb5..0x80bbc8
+            - Range: 0x80bbc5..0x80bbd8
               Pieces: []
-            - Range: 0x80bbc8..0x80bbc9
+            - Range: 0x80bbd8..0x80bbd9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bbc9..0x80bbf0
+            - Range: 0x80bbd9..0x80bc00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x80bbf0..0x80bd60]
+      OutOfLinePCRanges: [0x80bc00..0x80bd70]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80bbf0..0x80bc40
+            - Range: 0x80bc00..0x80bc50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bc40..0x80bc44
+            - Range: 0x80bc50..0x80bc54
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x80bccc..0x80bcd0
+            - Range: 0x80bcdc..0x80bce0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bd0c..0x80bd10
+            - Range: 0x80bd1c..0x80bd20
               Pieces:
                 - Size: 8
                   Op: null
@@ -7712,117 +7712,117 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80bbf0..0x80bc34
+            - Range: 0x80bc00..0x80bc44
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80bbf0..0x80bc5c
+            - Range: 0x80bc00..0x80bc6c
               Pieces: []
-            - Range: 0x80bc5c..0x80bc5d
+            - Range: 0x80bc6c..0x80bc6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bc5d..0x80bcb8
+            - Range: 0x80bc6d..0x80bcc8
               Pieces: []
-            - Range: 0x80bcb8..0x80bcb9
+            - Range: 0x80bcc8..0x80bcc9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bcb9..0x80bcf8
+            - Range: 0x80bcc9..0x80bd08
               Pieces: []
-            - Range: 0x80bcf8..0x80bcf9
+            - Range: 0x80bd08..0x80bd09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bcf9..0x80bd34
+            - Range: 0x80bd09..0x80bd44
               Pieces: []
-            - Range: 0x80bd34..0x80bd35
+            - Range: 0x80bd44..0x80bd45
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bd35..0x80bd60
+            - Range: 0x80bd45..0x80bd70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x80bbf0..0x80bc5c
+            - Range: 0x80bc00..0x80bc6c
               Pieces: []
-            - Range: 0x80bc5c..0x80bc5d
+            - Range: 0x80bc6c..0x80bc6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80bc5d..0x80bcb8
+            - Range: 0x80bc6d..0x80bcc8
               Pieces: []
-            - Range: 0x80bcb8..0x80bcb9
+            - Range: 0x80bcc8..0x80bcc9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80bcb9..0x80bcf8
+            - Range: 0x80bcc9..0x80bd08
               Pieces: []
-            - Range: 0x80bcf8..0x80bcf9
+            - Range: 0x80bd08..0x80bd09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80bcf9..0x80bd34
+            - Range: 0x80bd09..0x80bd44
               Pieces: []
-            - Range: 0x80bd34..0x80bd35
+            - Range: 0x80bd44..0x80bd45
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80bd35..0x80bd60
+            - Range: 0x80bd45..0x80bd70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80bc40..0x80bc48
+            - Range: 0x80bc50..0x80bc58
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x80bd60..0x80bf40]
+      OutOfLinePCRanges: [0x80bd70..0x80bf50]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80bd60..0x80bda0
+            - Range: 0x80bd70..0x80bdb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bda0..0x80bda8
+            - Range: 0x80bdb0..0x80bdb8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80bda8..0x80bf40
+            - Range: 0x80bdb8..0x80bf50
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7833,549 +7833,549 @@ Subprograms:
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80bd60..0x80be00
+            - Range: 0x80bd70..0x80be10
               Pieces: []
-            - Range: 0x80be00..0x80be01
+            - Range: 0x80be10..0x80be11
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80be01..0x80be54
+            - Range: 0x80be11..0x80be64
               Pieces: []
-            - Range: 0x80be54..0x80be55
+            - Range: 0x80be64..0x80be65
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80be55..0x80bf04
+            - Range: 0x80be65..0x80bf14
               Pieces: []
-            - Range: 0x80bf04..0x80bf05
+            - Range: 0x80bf14..0x80bf15
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bf05..0x80bf18
+            - Range: 0x80bf15..0x80bf28
               Pieces: []
-            - Range: 0x80bf18..0x80bf19
+            - Range: 0x80bf28..0x80bf29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bf19..0x80bf40
+            - Range: 0x80bf29..0x80bf50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80bdec..0x80bdf4
+            - Range: 0x80bdfc..0x80be04
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x80be38..0x80be54
+            - Range: 0x80be48..0x80be64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x80bf40..0x80c090]
+      OutOfLinePCRanges: [0x80bf50..0x80c0a0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80bf40..0x80bf7c
+            - Range: 0x80bf50..0x80bf8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bf7c..0x80bfbc
+            - Range: 0x80bf8c..0x80bfcc
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80bfbc..0x80c030
+            - Range: 0x80bfcc..0x80c040
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80c030..0x80c058
+            - Range: 0x80c040..0x80c068
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80c058..0x80c05c
+            - Range: 0x80c068..0x80c06c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80c05c..0x80c090
+            - Range: 0x80c06c..0x80c0a0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80bf40..0x80c010
+            - Range: 0x80bf50..0x80c020
               Pieces: []
-            - Range: 0x80c010..0x80c011
+            - Range: 0x80c020..0x80c021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c011..0x80c024
+            - Range: 0x80c021..0x80c034
               Pieces: []
-            - Range: 0x80c024..0x80c025
+            - Range: 0x80c034..0x80c035
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c025..0x80c090
+            - Range: 0x80c035..0x80c0a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80bf40..0x80bf7c
+            - Range: 0x80bf50..0x80bf8c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bf7c..0x80bfbc
+            - Range: 0x80bf8c..0x80bfcc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80bfbc..0x80bfc4
+            - Range: 0x80bfcc..0x80bfd4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80bfc4..0x80c01c
+            - Range: 0x80bfd4..0x80c02c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80c01c..0x80c020
+            - Range: 0x80c02c..0x80c030
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80c020..0x80c024
+            - Range: 0x80c030..0x80c034
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80c024..0x80c090
+            - Range: 0x80c034..0x80c0a0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x80c090..0x80c120]
+      OutOfLinePCRanges: [0x80c0a0..0x80c130]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c090..0x80c0ac
+            - Range: 0x80c0a0..0x80c0bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c090..0x80c100
+            - Range: 0x80c0a0..0x80c110
               Pieces: []
-            - Range: 0x80c100..0x80c101
+            - Range: 0x80c110..0x80c111
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c101..0x80c120
+            - Range: 0x80c111..0x80c130
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x80c120..0x80c1e0]
+      OutOfLinePCRanges: [0x80c130..0x80c1f0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c120..0x80c16c
+            - Range: 0x80c130..0x80c17c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c120..0x80c1b8
+            - Range: 0x80c130..0x80c1c8
               Pieces: []
-            - Range: 0x80c1b8..0x80c1b9
+            - Range: 0x80c1c8..0x80c1c9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c1b9..0x80c1e0
+            - Range: 0x80c1c9..0x80c1f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c120..0x80c1b8
+            - Range: 0x80c130..0x80c1c8
               Pieces: []
-            - Range: 0x80c1b8..0x80c1b9
+            - Range: 0x80c1c8..0x80c1c9
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c1b9..0x80c1e0
+            - Range: 0x80c1c9..0x80c1f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x80c1e0..0x80c2a0]
+      OutOfLinePCRanges: [0x80c1f0..0x80c2b0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c1e0..0x80c21c
+            - Range: 0x80c1f0..0x80c22c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c21c..0x80c2a0
+            - Range: 0x80c22c..0x80c2b0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c1e0..0x80c27c
+            - Range: 0x80c1f0..0x80c28c
               Pieces: []
-            - Range: 0x80c27c..0x80c27d
+            - Range: 0x80c28c..0x80c28d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c27d..0x80c2a0
+            - Range: 0x80c28d..0x80c2b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c1e0..0x80c27c
+            - Range: 0x80c1f0..0x80c28c
               Pieces: []
-            - Range: 0x80c27c..0x80c27d
+            - Range: 0x80c28c..0x80c28d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c27d..0x80c2a0
+            - Range: 0x80c28d..0x80c2b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c1e0..0x80c27c
+            - Range: 0x80c1f0..0x80c28c
               Pieces: []
-            - Range: 0x80c27c..0x80c27d
+            - Range: 0x80c28c..0x80c28d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80c27d..0x80c2a0
+            - Range: 0x80c28d..0x80c2b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x80c2a0..0x80c380]
+      OutOfLinePCRanges: [0x80c2b0..0x80c390]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c2a0..0x80c2dc
+            - Range: 0x80c2b0..0x80c2ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c2dc..0x80c380
+            - Range: 0x80c2ec..0x80c390
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c2a0..0x80c358
+            - Range: 0x80c2b0..0x80c368
               Pieces: []
-            - Range: 0x80c358..0x80c359
+            - Range: 0x80c368..0x80c369
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c359..0x80c380
+            - Range: 0x80c369..0x80c390
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c2a0..0x80c358
+            - Range: 0x80c2b0..0x80c368
               Pieces: []
-            - Range: 0x80c358..0x80c359
+            - Range: 0x80c368..0x80c369
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c359..0x80c380
+            - Range: 0x80c369..0x80c390
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x80c380..0x80c530]
+      OutOfLinePCRanges: [0x80c390..0x80c540]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c380..0x80c3e8
+            - Range: 0x80c390..0x80c3f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c3e8..0x80c530
+            - Range: 0x80c3f8..0x80c540
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c3ac..0x80c530
+            - Range: 0x80c3bc..0x80c540
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c3b0..0x80c530
+            - Range: 0x80c3c0..0x80c540
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x80c5f0..0x80c680]
+      OutOfLinePCRanges: [0x80c600..0x80c690]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x80c5f0..0x80c65c
+            - Range: 0x80c600..0x80c66c
               Pieces: []
-            - Range: 0x80c65c..0x80c65d
+            - Range: 0x80c66c..0x80c66d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c65d..0x80c680
+            - Range: 0x80c66d..0x80c690
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 96 BaseType int16
           Locations:
-            - Range: 0x80c5f0..0x80c65c
+            - Range: 0x80c600..0x80c66c
               Pieces: []
-            - Range: 0x80c65c..0x80c65d
+            - Range: 0x80c66c..0x80c66d
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c65d..0x80c680
+            - Range: 0x80c66d..0x80c690
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x80c5f0..0x80c65c
+            - Range: 0x80c600..0x80c66c
               Pieces: []
-            - Range: 0x80c65c..0x80c65d
+            - Range: 0x80c66c..0x80c66d
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80c65d..0x80c680
+            - Range: 0x80c66d..0x80c690
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x80c5f0..0x80c65c
+            - Range: 0x80c600..0x80c66c
               Pieces: []
-            - Range: 0x80c65c..0x80c65d
+            - Range: 0x80c66c..0x80c66d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80c65d..0x80c680
+            - Range: 0x80c66d..0x80c690
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x80c5f0..0x80c65c
+            - Range: 0x80c600..0x80c66c
               Pieces: []
-            - Range: 0x80c65c..0x80c65d
+            - Range: 0x80c66c..0x80c66d
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80c65d..0x80c680
+            - Range: 0x80c66d..0x80c690
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x80c5f0..0x80c65c
+            - Range: 0x80c600..0x80c66c
               Pieces: []
-            - Range: 0x80c65c..0x80c65d
+            - Range: 0x80c66c..0x80c66d
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80c65d..0x80c680
+            - Range: 0x80c66d..0x80c690
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x80c5f0..0x80c65c
+            - Range: 0x80c600..0x80c66c
               Pieces: []
-            - Range: 0x80c65c..0x80c65d
+            - Range: 0x80c66c..0x80c66d
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80c65d..0x80c680
+            - Range: 0x80c66d..0x80c690
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x80c5f0..0x80c65c
+            - Range: 0x80c600..0x80c66c
               Pieces: []
-            - Range: 0x80c65c..0x80c65d
+            - Range: 0x80c66c..0x80c66d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80c65d..0x80c680
+            - Range: 0x80c66d..0x80c690
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x80c680..0x80c730]
+      OutOfLinePCRanges: [0x80c690..0x80c740]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x80c680..0x80c718
+            - Range: 0x80c690..0x80c728
               Pieces: []
-            - Range: 0x80c718..0x80c719
+            - Range: 0x80c728..0x80c729
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80c719..0x80c730
+            - Range: 0x80c729..0x80c740
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x80c730..0x80c7b0]
+      OutOfLinePCRanges: [0x80c740..0x80c7c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 97 BaseType complex64
-          Locations: [{Range: 0x80c730..0x80c7b0, Pieces: []}]
+          Locations: [{Range: 0x80c740..0x80c7c0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 98 BaseType complex128
-          Locations: [{Range: 0x80c730..0x80c7b0, Pieces: []}]
+          Locations: [{Range: 0x80c740..0x80c7c0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x80c7b0..0x80c870]
+      OutOfLinePCRanges: [0x80c7c0..0x80c880]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80c7b0..0x80c84c
+            - Range: 0x80c7c0..0x80c85c
               Pieces: []
-            - Range: 0x80c84c..0x80c84d
+            - Range: 0x80c85c..0x80c85d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8397,193 +8397,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80c84d..0x80c870
+            - Range: 0x80c85d..0x80c880
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x80c870..0x80c8f0]
+      OutOfLinePCRanges: [0x80c880..0x80c900]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80c870..0x80c8d8
+            - Range: 0x80c880..0x80c8e8
               Pieces: []
-            - Range: 0x80c8d8..0x80c8d9
+            - Range: 0x80c8e8..0x80c8e9
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80c8d9..0x80c8f0
+            - Range: 0x80c8e9..0x80c900
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x80c8f0..0x80c960]
+      OutOfLinePCRanges: [0x80c900..0x80c970]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 ArrayType [1]int
           Locations:
-            - Range: 0x80c8f0..0x80c940
+            - Range: 0x80c900..0x80c950
               Pieces: []
-            - Range: 0x80c940..0x80c941
+            - Range: 0x80c950..0x80c951
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c941..0x80c960
+            - Range: 0x80c951..0x80c970
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x80c960..0x80c9d0]
+      OutOfLinePCRanges: [0x80c970..0x80c9e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0x80c960..0x80c9ac
+            - Range: 0x80c970..0x80c9bc
               Pieces: []
-            - Range: 0x80c9ac..0x80c9ad
+            - Range: 0x80c9bc..0x80c9bd
               Pieces: []
-            - Range: 0x80c9ad..0x80c9d0
+            - Range: 0x80c9bd..0x80c9e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x80c9d0..0x80ca50]
+      OutOfLinePCRanges: [0x80c9e0..0x80ca60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
-          Locations: [{Range: 0x80c9d0..0x80ca50, Pieces: []}]
+          Locations: [{Range: 0x80c9e0..0x80ca60, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x80ca50..0x80cae0]
+      OutOfLinePCRanges: [0x80ca60..0x80caf0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca50..0x80cac8
+            - Range: 0x80ca60..0x80cad8
               Pieces: []
-            - Range: 0x80cac8..0x80cac9
+            - Range: 0x80cad8..0x80cad9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cac9..0x80cae0
+            - Range: 0x80cad9..0x80caf0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca50..0x80cac8
+            - Range: 0x80ca60..0x80cad8
               Pieces: []
-            - Range: 0x80cac8..0x80cac9
+            - Range: 0x80cad8..0x80cad9
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80cac9..0x80cae0
+            - Range: 0x80cad9..0x80caf0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca50..0x80cac8
+            - Range: 0x80ca60..0x80cad8
               Pieces: []
-            - Range: 0x80cac8..0x80cac9
+            - Range: 0x80cad8..0x80cad9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80cac9..0x80cae0
+            - Range: 0x80cad9..0x80caf0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca50..0x80cac8
+            - Range: 0x80ca60..0x80cad8
               Pieces: []
-            - Range: 0x80cac8..0x80cac9
+            - Range: 0x80cad8..0x80cad9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80cac9..0x80cae0
+            - Range: 0x80cad9..0x80caf0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca50..0x80cac8
+            - Range: 0x80ca60..0x80cad8
               Pieces: []
-            - Range: 0x80cac8..0x80cac9
+            - Range: 0x80cad8..0x80cad9
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80cac9..0x80cae0
+            - Range: 0x80cad9..0x80caf0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca50..0x80cac8
+            - Range: 0x80ca60..0x80cad8
               Pieces: []
-            - Range: 0x80cac8..0x80cac9
+            - Range: 0x80cad8..0x80cad9
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80cac9..0x80cae0
+            - Range: 0x80cad9..0x80caf0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca50..0x80cac8
+            - Range: 0x80ca60..0x80cad8
               Pieces: []
-            - Range: 0x80cac8..0x80cac9
+            - Range: 0x80cad8..0x80cad9
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80cac9..0x80cae0
+            - Range: 0x80cad9..0x80caf0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca50..0x80cac8
+            - Range: 0x80ca60..0x80cad8
               Pieces: []
-            - Range: 0x80cac8..0x80cac9
+            - Range: 0x80cad8..0x80cad9
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80cac9..0x80cae0
+            - Range: 0x80cad9..0x80caf0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80ca50..0x80cac8
+            - Range: 0x80ca60..0x80cad8
               Pieces: []
-            - Range: 0x80cac8..0x80cac9
+            - Range: 0x80cad8..0x80cad9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80cac9..0x80cae0
+            - Range: 0x80cad9..0x80caf0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x80cae0..0x80cbb0]
+      OutOfLinePCRanges: [0x80caf0..0x80cbc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.wideStruct
           Locations:
-            - Range: 0x80cae0..0x80cb8c
+            - Range: 0x80caf0..0x80cb9c
               Pieces: []
-            - Range: 0x80cb8c..0x80cb8d
+            - Range: 0x80cb9c..0x80cb9d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8607,145 +8607,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x80cb8d..0x80cbb0
+            - Range: 0x80cb9d..0x80cbc0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x80cbb0..0x80cc40]
+      OutOfLinePCRanges: [0x80cbc0..0x80cc50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80cbb0..0x80cc1c
+            - Range: 0x80cbc0..0x80cc2c
               Pieces: []
-            - Range: 0x80cc1c..0x80cc1d
+            - Range: 0x80cc2c..0x80cc2d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cc1d..0x80cc40
+            - Range: 0x80cc2d..0x80cc50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80cbb0..0x80cc40, Pieces: []}]
+          Locations: [{Range: 0x80cbc0..0x80cc50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80cbb0..0x80cc1c
+            - Range: 0x80cbc0..0x80cc2c
               Pieces: []
-            - Range: 0x80cc1c..0x80cc1d
+            - Range: 0x80cc2c..0x80cc2d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80cc1d..0x80cc40
+            - Range: 0x80cc2d..0x80cc50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80cbb0..0x80cc40, Pieces: []}]
+          Locations: [{Range: 0x80cbc0..0x80cc50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80cbb0..0x80cc1c
+            - Range: 0x80cbc0..0x80cc2c
               Pieces: []
-            - Range: 0x80cc1c..0x80cc1d
+            - Range: 0x80cc2c..0x80cc2d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80cc1d..0x80cc40
+            - Range: 0x80cc2d..0x80cc50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x80cc40..0x80ccc0]
+      OutOfLinePCRanges: [0x80cc50..0x80ccd0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80cc40..0x80cca8
+            - Range: 0x80cc50..0x80ccb8
               Pieces: []
-            - Range: 0x80cca8..0x80cca9
+            - Range: 0x80ccb8..0x80ccb9
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80cca9..0x80ccc0
+            - Range: 0x80ccb9..0x80ccd0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x80ccc0..0x80cd30]
+      OutOfLinePCRanges: [0x80ccd0..0x80cd40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80ccc0..0x80cd30, Pieces: []}]
+          Locations: [{Range: 0x80ccd0..0x80cd40, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x80cd30..0x80cda0]
+      OutOfLinePCRanges: [0x80cd40..0x80cdb0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0x80cd30..0x80cda0, Pieces: []}]
+          Locations: [{Range: 0x80cd40..0x80cdb0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80cd30..0x80cda0, Pieces: []}]
+          Locations: [{Range: 0x80cd40..0x80cdb0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x80cda0..0x80ce10]
+      OutOfLinePCRanges: [0x80cdb0..0x80ce20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80cda0..0x80cdf4
+            - Range: 0x80cdb0..0x80ce04
               Pieces: []
-            - Range: 0x80cdf4..0x80cdf5
+            - Range: 0x80ce04..0x80ce05
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cdf5..0x80ce10
+            - Range: 0x80ce05..0x80ce20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x80cda0..0x80cdf4
+            - Range: 0x80cdb0..0x80ce04
               Pieces: []
-            - Range: 0x80cdf4..0x80cdf5
+            - Range: 0x80ce04..0x80ce05
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80cdf5..0x80ce10
+            - Range: 0x80ce05..0x80ce20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x80ce10..0x80cfa0]
+      OutOfLinePCRanges: [0x80ce20..0x80cfb0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80ce10..0x80ce68
+            - Range: 0x80ce20..0x80ce78
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8767,7 +8767,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ce68..0x80ce70
+            - Range: 0x80ce78..0x80ce80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8789,7 +8789,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ce70..0x80ce78
+            - Range: 0x80ce80..0x80ce88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8811,7 +8811,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ce78..0x80ce7c
+            - Range: 0x80ce88..0x80ce8c
               Pieces:
                 - Size: 8
                   Op: null
@@ -8838,9 +8838,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80ce10..0x80cf58
+            - Range: 0x80ce20..0x80cf68
               Pieces: []
-            - Range: 0x80cf58..0x80cf59
+            - Range: 0x80cf68..0x80cf69
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8862,44 +8862,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80cf59..0x80cfa0
+            - Range: 0x80cf69..0x80cfb0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x80cfa0..0x80d060]
+      OutOfLinePCRanges: [0x80cfb0..0x80d070]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80cfa0..0x80d060
+            - Range: 0x80cfb0..0x80d070
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80cfa0..0x80d048
+            - Range: 0x80cfb0..0x80d058
               Pieces: []
-            - Range: 0x80d048..0x80d049
+            - Range: 0x80d058..0x80d059
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80d049..0x80d060
+            - Range: 0x80d059..0x80d070
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x80d060..0x80d270]
+      OutOfLinePCRanges: [0x80d070..0x80d280]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80d060..0x80d0bc
+            - Range: 0x80d070..0x80d0cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8921,7 +8921,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d0bc..0x80d0c4
+            - Range: 0x80d0cc..0x80d0d4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8943,7 +8943,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d0c4..0x80d0cc
+            - Range: 0x80d0d4..0x80d0dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8965,7 +8965,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d0cc..0x80d0d0
+            - Range: 0x80d0dc..0x80d0e0
               Pieces:
                 - Size: 8
                   Op: null
@@ -8992,16 +8992,16 @@ Subprograms:
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80d060..0x80d270
+            - Range: 0x80d070..0x80d280
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80d060..0x80d224
+            - Range: 0x80d070..0x80d234
               Pieces: []
-            - Range: 0x80d224..0x80d225
+            - Range: 0x80d234..0x80d235
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9023,196 +9023,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d225..0x80d270
+            - Range: 0x80d235..0x80d280
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x80d270..0x80d410]
+      OutOfLinePCRanges: [0x80d280..0x80d420]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d270..0x80d2e4
+            - Range: 0x80d280..0x80d2f4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d2e4..0x80d410
+            - Range: 0x80d2f4..0x80d420
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d270..0x80d2d4
+            - Range: 0x80d280..0x80d2e4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80d2d4..0x80d410
+            - Range: 0x80d2e4..0x80d420
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d270..0x80d2dc
+            - Range: 0x80d280..0x80d2ec
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80d2dc..0x80d410
+            - Range: 0x80d2ec..0x80d420
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d270..0x80d2e4
+            - Range: 0x80d280..0x80d2f4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80d2e4..0x80d410
+            - Range: 0x80d2f4..0x80d420
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d270..0x80d2e4
+            - Range: 0x80d280..0x80d2f4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80d2e4..0x80d410
+            - Range: 0x80d2f4..0x80d420
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d270..0x80d2e4
+            - Range: 0x80d280..0x80d2f4
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80d2e4..0x80d410
+            - Range: 0x80d2f4..0x80d420
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d270..0x80d2e4
+            - Range: 0x80d280..0x80d2f4
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80d2e4..0x80d410
+            - Range: 0x80d2f4..0x80d420
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d270..0x80d2e4
+            - Range: 0x80d280..0x80d2f4
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80d2e4..0x80d410
+            - Range: 0x80d2f4..0x80d420
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d270..0x80d2e4
+            - Range: 0x80d280..0x80d2f4
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x80d2e4..0x80d410
+            - Range: 0x80d2f4..0x80d420
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80d270..0x80d3cc
+            - Range: 0x80d280..0x80d3dc
               Pieces: []
-            - Range: 0x80d3cc..0x80d3cd
+            - Range: 0x80d3dc..0x80d3dd
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x80d3cd..0x80d410
+            - Range: 0x80d3dd..0x80d420
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x80d410..0x80d600]
+      OutOfLinePCRanges: [0x80d420..0x80d610]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d410..0x80d494
+            - Range: 0x80d420..0x80d4a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d494..0x80d600
+            - Range: 0x80d4a4..0x80d610
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d410..0x80d484
+            - Range: 0x80d420..0x80d494
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80d484..0x80d600
+            - Range: 0x80d494..0x80d610
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d410..0x80d48c
+            - Range: 0x80d420..0x80d49c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80d48c..0x80d600
+            - Range: 0x80d49c..0x80d610
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d410..0x80d494
+            - Range: 0x80d420..0x80d4a4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80d494..0x80d600
+            - Range: 0x80d4a4..0x80d610
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d410..0x80d494
+            - Range: 0x80d420..0x80d4a4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80d494..0x80d600
+            - Range: 0x80d4a4..0x80d610
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d410..0x80d494
+            - Range: 0x80d420..0x80d4a4
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80d494..0x80d600
+            - Range: 0x80d4a4..0x80d610
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d410..0x80d494
+            - Range: 0x80d420..0x80d4a4
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80d494..0x80d600
+            - Range: 0x80d4a4..0x80d610
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d410..0x80d494
+            - Range: 0x80d420..0x80d4a4
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80d494..0x80d600
+            - Range: 0x80d4a4..0x80d610
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80d410..0x80d494
+            - Range: 0x80d420..0x80d4a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d494..0x80d600
+            - Range: 0x80d4a4..0x80d610
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9223,9 +9223,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80d410..0x80d5b8
+            - Range: 0x80d420..0x80d5c8
               Pieces: []
-            - Range: 0x80d5b8..0x80d5b9
+            - Range: 0x80d5c8..0x80d5c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9247,208 +9247,189 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d5b9..0x80d600
+            - Range: 0x80d5c9..0x80d610
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x80d600..0x80d690]
+      OutOfLinePCRanges: [0x80d610..0x80d6a0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x80d600..0x80d690
+            - Range: 0x80d610..0x80d6a0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d600..0x80d670
+            - Range: 0x80d610..0x80d680
               Pieces: []
-            - Range: 0x80d670..0x80d671
+            - Range: 0x80d680..0x80d681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d671..0x80d690
+            - Range: 0x80d681..0x80d6a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d600..0x80d670
+            - Range: 0x80d610..0x80d680
               Pieces: []
-            - Range: 0x80d670..0x80d671
+            - Range: 0x80d680..0x80d681
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80d671..0x80d690
+            - Range: 0x80d681..0x80d6a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d600..0x80d670
+            - Range: 0x80d610..0x80d680
               Pieces: []
-            - Range: 0x80d670..0x80d671
+            - Range: 0x80d680..0x80d681
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80d671..0x80d690
+            - Range: 0x80d681..0x80d6a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x80d690..0x80d760]
+      OutOfLinePCRanges: [0x80d6a0..0x80d770]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80d690..0x80d760
+            - Range: 0x80d6a0..0x80d770
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80d690..0x80d760
+            - Range: 0x80d6a0..0x80d770
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d690..0x80d744
+            - Range: 0x80d6a0..0x80d754
               Pieces: []
-            - Range: 0x80d744..0x80d745
+            - Range: 0x80d754..0x80d755
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d745..0x80d760
+            - Range: 0x80d755..0x80d770
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80d690..0x80d744
+            - Range: 0x80d6a0..0x80d754
               Pieces: []
-            - Range: 0x80d744..0x80d745
+            - Range: 0x80d754..0x80d755
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x80d745..0x80d760
+            - Range: 0x80d755..0x80d770
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x80d760..0x80d820]
+      OutOfLinePCRanges: [0x80d770..0x80d830]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80d760..0x80d820
+            - Range: 0x80d770..0x80d830
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d760..0x80d800
+            - Range: 0x80d770..0x80d810
               Pieces: []
-            - Range: 0x80d800..0x80d801
+            - Range: 0x80d810..0x80d811
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d801..0x80d820
+            - Range: 0x80d811..0x80d830
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80d760..0x80d800
+            - Range: 0x80d770..0x80d810
               Pieces: []
-            - Range: 0x80d800..0x80d801
+            - Range: 0x80d810..0x80d811
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80d801..0x80d820
+            - Range: 0x80d811..0x80d830
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d7d8..0x80d820
+            - Range: 0x80d7e8..0x80d830
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x80d820..0x80d8c0]
+      OutOfLinePCRanges: [0x80d830..0x80d8d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 ArrayType [0]int
-          Locations: [{Range: 0x80d820..0x80d8c0, Pieces: []}]
+          Locations: [{Range: 0x80d830..0x80d8d0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d820..0x80d85c
+            - Range: 0x80d830..0x80d86c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d85c..0x80d874
+            - Range: 0x80d86c..0x80d884
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80d874..0x80d87c
+            - Range: 0x80d884..0x80d88c
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80d87c..0x80d8c0
+            - Range: 0x80d88c..0x80d8d0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d820..0x80d898
+            - Range: 0x80d830..0x80d8a8
               Pieces: []
-            - Range: 0x80d898..0x80d899
+            - Range: 0x80d8a8..0x80d8a9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d899..0x80d8c0
+            - Range: 0x80d8a9..0x80d8d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0x80d820..0x80d898
+            - Range: 0x80d830..0x80d8a8
               Pieces: []
-            - Range: 0x80d898..0x80d899
+            - Range: 0x80d8a8..0x80d8a9
               Pieces: []
-            - Range: 0x80d899..0x80d8c0
+            - Range: 0x80d8a9..0x80d8d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80dd00..0x80dd10]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80dd00..0x80dd10
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 134
-      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x80dd10..0x80dd20]
       InlinePCRanges: []
       Variables:
@@ -9466,13 +9447,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 135
-      Name: main.testSliceOfSlices
+    - ID: 134
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x80dd20..0x80dd30]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 258 GoSliceHeaderType [][]uint
+          Type: 257 GoSliceHeaderType []uint
           Locations:
             - Range: 0x80dd20..0x80dd30
               Pieces:
@@ -9485,13 +9466,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 136
-      Name: main.testStructSlice
+    - ID: 135
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x80dd30..0x80dd40]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 258 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x80dd30..0x80dd40
               Pieces:
@@ -9503,16 +9484,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80dd30..0x80dd40
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 137
-      Name: main.testEmptySliceOfStructs
+    - ID: 136
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0x80dd40..0x80dd50]
       InlinePCRanges: []
       Variables:
@@ -9537,8 +9511,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testNilSliceOfStructs
+    - ID: 137
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x80dd50..0x80dd60]
       InlinePCRanges: []
       Variables:
@@ -9563,15 +9537,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x80dd60..0x80dd70]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x80dd60..0x80dd70
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80dd60..0x80dd70
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x80dd60..0x80dd70]
+      OutOfLinePCRanges: [0x80dd70..0x80dd80]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 263 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80dd60..0x80dd70
+            - Range: 0x80dd70..0x80dd80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9584,20 +9584,20 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x80dd70..0x80dd80]
+      OutOfLinePCRanges: [0x80dd80..0x80dd90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x80dd70..0x80dd80
+            - Range: 0x80dd80..0x80dd90
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 264 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80dd70..0x80dd80
+            - Range: 0x80dd80..0x80dd90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9610,37 +9610,18 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x80dd70..0x80dd80
+            - Range: 0x80dd80..0x80dd90
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80dd80..0x80dd90]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 265 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0x80dd80..0x80dd90
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 142
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x80dd90..0x80dda0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 257 GoSliceHeaderType []uint
+          Type: 265 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x80dd90..0x80dda0
               Pieces:
@@ -9653,13 +9634,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 143
-      Name: main.testSliceEmptyStructs
+    - ID: 142
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x80dda0..0x80ddb0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 266 GoSliceHeaderType []struct {}
+          Type: 257 GoSliceHeaderType []uint
           Locations:
             - Range: 0x80dda0..0x80ddb0
               Pieces:
@@ -9672,15 +9653,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x80ddb0..0x80ddc0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x80ddb0..0x80ddc0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80ddb0..0x80ddc0]
+      OutOfLinePCRanges: [0x80ddc0..0x80ddd0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80ddb0..0x80ddc0
+            - Range: 0x80ddc0..0x80ddd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9693,7 +9693,7 @@ Subprograms:
         - Name: bs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80ddb0..0x80ddc0
+            - Range: 0x80ddc0..0x80ddd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9706,7 +9706,7 @@ Subprograms:
         - Name: cs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80ddb0..0x80ddc0
+            - Range: 0x80ddc0..0x80ddd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9719,44 +9719,27 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0x80e0a0..0x80e100]
+      OutOfLinePCRanges: [0x80e0b0..0x80e110]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e0a0..0x80e0e8
+            - Range: 0x80e0b0..0x80e0f8
               Pieces: []
-            - Range: 0x80e0e8..0x80e0e9
+            - Range: 0x80e0f8..0x80e0f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e0e9..0x80e100
+            - Range: 0x80e0f9..0x80e110
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80e100..0x80e110]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x80e100..0x80e110
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 147
-      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x80e110..0x80e120]
       InlinePCRanges: []
       Variables:
@@ -9771,10 +9754,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 147
+      Name: main.testThreeStrings
+      OutOfLinePCRanges: [0x80e120..0x80e130]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80e120..0x80e130
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e110..0x80e120
+            - Range: 0x80e120..0x80e130
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9785,7 +9785,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e110..0x80e120
+            - Range: 0x80e120..0x80e130
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9796,13 +9796,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80e120..0x80e130]
+      OutOfLinePCRanges: [0x80e130..0x80e140]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80e120..0x80e130
+            - Range: 0x80e130..0x80e140
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9821,49 +9821,32 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80e130..0x80e140]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 269 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x80e130..0x80e140
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 150
-      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x80e140..0x80e150]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 270 PointerType *main.oneStringStruct
+          Type: 269 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x80e140..0x80e150
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 151
-      Name: main.testMassiveString
+    - ID: 150
+      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x80e150..0x80e160]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 270 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x80e150..0x80e160
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 152
-      Name: main.testUnitializedString
+    - ID: 151
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0x80e160..0x80e170]
       InlinePCRanges: []
       Variables:
@@ -9879,8 +9862,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 153
-      Name: main.testEmptyString
+    - ID: 152
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0x80e170..0x80e180]
       InlinePCRanges: []
       Variables:
@@ -9896,12 +9879,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
-      Name: main.testSubstrings
+    - ID: 153
+      Name: main.testEmptyString
       OutOfLinePCRanges: [0x80e180..0x80e190]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x80e180..0x80e190
@@ -9912,10 +9895,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 154
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0x80e190..0x80e1a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80e190..0x80e1a0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e180..0x80e190
+            - Range: 0x80e190..0x80e1a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9926,7 +9926,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e180..0x80e190
+            - Range: 0x80e190..0x80e1a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9937,26 +9937,26 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80e2e0..0x80e2f0]
+      OutOfLinePCRanges: [0x80e2f0..0x80e300]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80e2e0..0x80e2f0
+            - Range: 0x80e2f0..0x80e300
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80e2f0..0x80e300]
+      OutOfLinePCRanges: [0x80e300..0x80e310]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 285 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80e2f0..0x80e300
+            - Range: 0x80e300..0x80e310
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9975,13 +9975,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80e3a0..0x80e3c0]
+      OutOfLinePCRanges: [0x80e3b0..0x80e3d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 316 StructureType main.aStruct
           Locations:
-            - Range: 0x80e3a0..0x80e3c0
+            - Range: 0x80e3b0..0x80e3d0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10002,93 +10002,93 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x80e430..0x80e440]
+      OutOfLinePCRanges: [0x80e440..0x80e450]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x80e430..0x80e440
+            - Range: 0x80e440..0x80e450
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x80e440..0x80e450]
+      OutOfLinePCRanges: [0x80e450..0x80e460]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 319 StructureType main.tenStrings
           Locations:
-            - Range: 0x80e440..0x80e450
+            - Range: 0x80e450..0x80e460
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80e470..0x80e480]
+      OutOfLinePCRanges: [0x80e480..0x80e490]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 320 StructureType main.emptyStruct
-          Locations: [{Range: 0x80e470..0x80e480, Pieces: []}]
+          Locations: [{Range: 0x80e480..0x80e490, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80e480..0x80e490]
+      OutOfLinePCRanges: [0x80e490..0x80e4a0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 321 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80e480..0x80e490
+            - Range: 0x80e490..0x80e4a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x80fc50..0x80fc60]
+      OutOfLinePCRanges: [0x80fc60..0x80fc70]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x80fc50..0x80fc60
+            - Range: 0x80fc60..0x80fc70
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80fc50..0x80fc54
+            - Range: 0x80fc60..0x80fc64
               Pieces: []
-            - Range: 0x80fc54..0x80fc55
+            - Range: 0x80fc64..0x80fc65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fc55..0x80fc60
+            - Range: 0x80fc65..0x80fc70
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x80fc60..0x80fc70]
+      OutOfLinePCRanges: [0x80fc70..0x80fc80]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80fc60..0x80fc6c
+            - Range: 0x80fc70..0x80fc7c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80fc6c..0x80fc70
+            - Range: 0x80fc7c..0x80fc80
               Pieces:
                 - Size: 8
                   Op: null
@@ -10099,58 +10099,58 @@ Subprograms:
         - Name: ~r0
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80fc60..0x80fc6c
+            - Range: 0x80fc70..0x80fc7c
               Pieces: []
-            - Range: 0x80fc6c..0x80fc6d
+            - Range: 0x80fc7c..0x80fc7d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fc6d..0x80fc70
+            - Range: 0x80fc7d..0x80fc80
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x80fc70..0x80fc80]
+      OutOfLinePCRanges: [0x80fc80..0x80fc90]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80fc70..0x80fc80
+            - Range: 0x80fc80..0x80fc90
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x80fc70..0x80fc74
+            - Range: 0x80fc80..0x80fc84
               Pieces: []
-            - Range: 0x80fc74..0x80fc75
+            - Range: 0x80fc84..0x80fc85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fc75..0x80fc80
+            - Range: 0x80fc85..0x80fc90
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x80fc80..0x80fc90]
+      OutOfLinePCRanges: [0x80fc90..0x80fca0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80fc80..0x80fc8c
+            - Range: 0x80fc90..0x80fc9c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80fc8c..0x80fc90
+            - Range: 0x80fc9c..0x80fca0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10161,28 +10161,28 @@ Subprograms:
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80fc80..0x80fc8c
+            - Range: 0x80fc90..0x80fc9c
               Pieces: []
-            - Range: 0x80fc8c..0x80fc8d
+            - Range: 0x80fc9c..0x80fc9d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fc8d..0x80fc90
+            - Range: 0x80fc9d..0x80fca0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x80fcf0..0x80fe10]
+      OutOfLinePCRanges: [0x80fd00..0x80fe20]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80fcf0..0x80fd1c
+            - Range: 0x80fd00..0x80fd2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10190,7 +10190,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80fd1c..0x80fd2c
+            - Range: 0x80fd2c..0x80fd3c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10198,7 +10198,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x80fd2c..0x80fe10
+            - Range: 0x80fd3c..0x80fe20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10211,18 +10211,18 @@ Subprograms:
         - Name: pred
           Type: 328 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x80fcf0..0x80fd2c
+            - Range: 0x80fd00..0x80fd3c
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80fd2c..0x80fe10
+            - Range: 0x80fd3c..0x80fe20
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80fcf0..0x80fddc
+            - Range: 0x80fd00..0x80fdec
               Pieces: []
-            - Range: 0x80fddc..0x80fddd
+            - Range: 0x80fdec..0x80fded
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10230,14 +10230,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80fddd..0x80fe10
+            - Range: 0x80fded..0x80fe20
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80fd1c..0x80fd2c
+            - Range: 0x80fd2c..0x80fd3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10245,7 +10245,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80fd2c..0x80fd48
+            - Range: 0x80fd3c..0x80fd58
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10253,7 +10253,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fd48..0x80fd4c
+            - Range: 0x80fd58..0x80fd5c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10261,7 +10261,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fd4c..0x80fd50
+            - Range: 0x80fd5c..0x80fd60
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10269,7 +10269,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fd50..0x80fd50
+            - Range: 0x80fd60..0x80fd60
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10277,7 +10277,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fd50..0x80fd7c
+            - Range: 0x80fd60..0x80fd8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10285,7 +10285,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80fd7c..0x80fdd0
+            - Range: 0x80fd8c..0x80fde0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10293,7 +10293,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fdd0..0x80fe10
+            - Range: 0x80fde0..0x80fe20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10306,86 +10306,62 @@ Subprograms:
         - Name: item
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x80fd6c..0x80fd7c
+            - Range: 0x80fd7c..0x80fd8c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fd7c..0x80fdd0
+            - Range: 0x80fd8c..0x80fde0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80fe10..0x80fe60]
+      OutOfLinePCRanges: [0x80fe20..0x80fe70]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80fe10..0x80fe38
+            - Range: 0x80fe20..0x80fe48
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 329 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x80fe10..0x80fe38
+            - Range: 0x80fe20..0x80fe48
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80fe10..0x80fe38
+            - Range: 0x80fe20..0x80fe48
               Pieces: []
-            - Range: 0x80fe38..0x80fe39
+            - Range: 0x80fe48..0x80fe49
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fe39..0x80fe60
+            - Range: 0x80fe49..0x80fe70
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 168
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x8100d0..0x8100e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 327 PointerType *go.shape.int
-          Locations:
-            - Range: 0x8100d0..0x8100e0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 327 PointerType *go.shape.int
-          Locations:
-            - Range: 0x8100d0..0x8100d4
-              Pieces: []
-            - Range: 0x8100d4..0x8100d5
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8100d5..0x8100e0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 169
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0x8100e0..0x8100f0]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 330 PointerType *go.shape.struct { Name string }
+          Type: 327 PointerType *go.shape.int
           Locations:
             - Range: 0x8100e0..0x8100f0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 330 PointerType *go.shape.struct { Name string }
+          Type: 327 PointerType *go.shape.int
           Locations:
             - Range: 0x8100e0..0x8100e4
               Pieces: []
@@ -10396,20 +10372,20 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 170
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+    - ID: 169
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0x8100f0..0x810100]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 332 PointerType *go.shape.struct { X int; Y int }
+          Type: 330 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0x8100f0..0x810100
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 332 PointerType *go.shape.struct { X int; Y int }
+          Type: 330 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0x8100f0..0x8100f4
               Pieces: []
@@ -10420,101 +10396,125 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 170
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0x810100..0x810110]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 332 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x810100..0x810110
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 332 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x810100..0x810104
+              Pieces: []
+            - Range: 0x810104..0x810105
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x810105..0x810110
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x810100..0x810110]
+      OutOfLinePCRanges: [0x810110..0x810120]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x810100..0x810110
+            - Range: 0x810110..0x810120
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810100..0x810104
+            - Range: 0x810110..0x810114
               Pieces: []
-            - Range: 0x810104..0x810105
+            - Range: 0x810114..0x810115
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810105..0x810110
+            - Range: 0x810115..0x810120
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x810190..0x8101a0]
+      OutOfLinePCRanges: [0x8101a0..0x8101b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 336 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x810190..0x8101a0
+            - Range: 0x8101a0..0x8101b0
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x810190..0x810194
+            - Range: 0x8101a0..0x8101a4
               Pieces: []
-            - Range: 0x810194..0x810195
+            - Range: 0x8101a4..0x8101a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810195..0x8101a0
+            - Range: 0x8101a5..0x8101b0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x810230..0x810240]
+      OutOfLinePCRanges: [0x810240..0x810250]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 337 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x810230..0x810240
+            - Range: 0x810240..0x810250
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x810230..0x810240
+            - Range: 0x810240..0x810250
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0x810230..0x810240
+            - Range: 0x810240..0x810250
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x8102c0..0x810330]
+      OutOfLinePCRanges: [0x8102d0..0x810340]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x8102c0..0x810330
+            - Range: 0x8102d0..0x810340
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8102c0..0x810330
+            - Range: 0x8102d0..0x810340
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10525,20 +10525,20 @@ Subprograms:
         - Name: v
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x8102c0..0x810330
+            - Range: 0x8102d0..0x810340
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x8103b0..0x8103c0]
+      OutOfLinePCRanges: [0x8103c0..0x8103d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8103b0..0x8103c0
+            - Range: 0x8103c0..0x8103d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10549,59 +10549,59 @@ Subprograms:
         - Name: b
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0x8103b0..0x8103c0
+            - Range: 0x8103c0..0x8103d0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0x8103b0..0x8103b8
+            - Range: 0x8103c0..0x8103c8
               Pieces: []
-            - Range: 0x8103b8..0x8103b9
+            - Range: 0x8103c8..0x8103c9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8103b9..0x8103c0
+            - Range: 0x8103c9..0x8103d0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8103b0..0x8103b8
+            - Range: 0x8103c0..0x8103c8
               Pieces: []
-            - Range: 0x8103b8..0x8103b9
+            - Range: 0x8103c8..0x8103c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8103b9..0x8103c0
+            - Range: 0x8103c9..0x8103d0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x8103c0..0x8103e0]
+      OutOfLinePCRanges: [0x8103d0..0x8103f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x8103c0..0x8103d0
+            - Range: 0x8103d0..0x8103e0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8103c0..0x8103cc
+            - Range: 0x8103d0..0x8103dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8103cc..0x8103e0
+            - Range: 0x8103dc..0x8103f0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10612,73 +10612,73 @@ Subprograms:
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8103c0..0x8103d0
+            - Range: 0x8103d0..0x8103e0
               Pieces: []
-            - Range: 0x8103d0..0x8103d1
+            - Range: 0x8103e0..0x8103e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8103d1..0x8103e0
+            - Range: 0x8103e1..0x8103f0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x8103c0..0x8103d0
+            - Range: 0x8103d0..0x8103e0
               Pieces: []
-            - Range: 0x8103d0..0x8103d1
+            - Range: 0x8103e0..0x8103e1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8103d1..0x8103e0
+            - Range: 0x8103e1..0x8103f0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x8103e0..0x810430]
+      OutOfLinePCRanges: [0x8103f0..0x810440]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 342 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x8103e0..0x810408
+            - Range: 0x8103f0..0x810418
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8103e0..0x810408
+            - Range: 0x8103f0..0x810418
               Pieces: []
-            - Range: 0x810408..0x810409
+            - Range: 0x810418..0x810419
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810409..0x810430
+            - Range: 0x810419..0x810440
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x810430..0x810490]
+      OutOfLinePCRanges: [0x810440..0x8104a0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 343 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x810430..0x81045c
+            - Range: 0x810440..0x81046c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x81045c..0x810460
+            - Range: 0x81046c..0x810470
               Pieces:
                 - Size: 8
                   Op: null
@@ -10689,65 +10689,65 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x810430..0x810460
+            - Range: 0x810440..0x810470
               Pieces: []
-            - Range: 0x810460..0x810461
+            - Range: 0x810470..0x810471
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810461..0x810490
+            - Range: 0x810471..0x8104a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x810490..0x8104a0]
+      OutOfLinePCRanges: [0x8104a0..0x8104b0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 344 PointerType *go.shape.string
           Locations:
-            - Range: 0x810490..0x810494
+            - Range: 0x8104a0..0x8104a4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810490..0x810494
+            - Range: 0x8104a0..0x8104a4
               Pieces: []
-            - Range: 0x810494..0x810495
+            - Range: 0x8104a4..0x8104a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810495..0x8104a0
+            - Range: 0x8104a5..0x8104b0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x8104a0..0x8104f0]
+      OutOfLinePCRanges: [0x8104b0..0x810500]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 345 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x8104a0..0x8104dc
+            - Range: 0x8104b0..0x8104ec
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 346 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x8104a0..0x8104e0
+            - Range: 0x8104b0..0x8104f0
               Pieces: []
-            - Range: 0x8104e0..0x8104e1
+            - Range: 0x8104f0..0x8104f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10761,20 +10761,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8104e1..0x8104f0
+            - Range: 0x8104f1..0x810500
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x8104f0..0x810530]
+      OutOfLinePCRanges: [0x810500..0x810540]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8104f0..0x8104fc
+            - Range: 0x810500..0x81050c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10782,7 +10782,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8104fc..0x810530
+            - Range: 0x81050c..0x810540
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10795,42 +10795,42 @@ Subprograms:
         - Name: needle
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x8104f0..0x810530
+            - Range: 0x810500..0x810540
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8104f0..0x810518
+            - Range: 0x810500..0x810528
               Pieces: []
-            - Range: 0x810518..0x810519
+            - Range: 0x810528..0x810529
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810519..0x810520
+            - Range: 0x810529..0x810530
               Pieces: []
-            - Range: 0x810520..0x810521
+            - Range: 0x810530..0x810531
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810521..0x810530
+            - Range: 0x810531..0x810540
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x81050c..0x81051c
+            - Range: 0x81051c..0x81052c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x810530..0x8105f0]
+      OutOfLinePCRanges: [0x810540..0x810600]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 347 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x810530..0x810554
+            - Range: 0x810540..0x810564
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10838,7 +10838,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x810554..0x810558
+            - Range: 0x810564..0x810568
               Pieces:
                 - Size: 8
                   Op: null
@@ -10851,13 +10851,13 @@ Subprograms:
         - Name: needle
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810530..0x810588
+            - Range: 0x810540..0x810598
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x810588..0x8105f0
+            - Range: 0x810598..0x810600
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10868,22 +10868,22 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x810530..0x8105a4
-              Pieces: []
-            - Range: 0x8105a4..0x8105a5
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8105a5..0x8105b4
+            - Range: 0x810540..0x8105b4
               Pieces: []
             - Range: 0x8105b4..0x8105b5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8105b5..0x8105f0
+            - Range: 0x8105b5..0x8105c4
+              Pieces: []
+            - Range: 0x8105c4..0x8105c5
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8105c5..0x810600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810570..0x810588
+            - Range: 0x810580..0x810598
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10894,56 +10894,56 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x8105f0..0x810600]
+      OutOfLinePCRanges: [0x810600..0x810610]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 348 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x8105f0..0x8105f8
+            - Range: 0x810600..0x810608
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x8105f0..0x810600
+            - Range: 0x810600..0x810610
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8105f0..0x8105f8
+            - Range: 0x810600..0x810608
               Pieces: []
-            - Range: 0x8105f8..0x8105f9
+            - Range: 0x810608..0x810609
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8105f9..0x810600
+            - Range: 0x810609..0x810610
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x810670..0x8106e0]
+      OutOfLinePCRanges: [0x810680..0x8106f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 349 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x810670..0x81069c
+            - Range: 0x810680..0x8106ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x81069c..0x8106a8
+            - Range: 0x8106ac..0x8106b8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8106a8..0x8106ac
+            - Range: 0x8106b8..0x8106bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10954,7 +10954,7 @@ Subprograms:
         - Name: value
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810670..0x8106ac
+            - Range: 0x810680..0x8106bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10965,11 +10965,11 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x810670..0x8106ac
+            - Range: 0x810680..0x8106bc
               Pieces: []
-            - Range: 0x8106ac..0x8106ad
+            - Range: 0x8106bc..0x8106bd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8106ad..0x8106e0
+            - Range: 0x8106bd..0x8106f0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11115,31 +11115,31 @@ Subprograms:
       DictRegister: 0
     - ID: 186
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x808ef0..0x808f60]
+      OutOfLinePCRanges: [0x808f00..0x808f70]
       InlinePCRanges:
-        - Ranges: [0x808f7c..0x808fb0]
-          RootRanges: [0x808f60..0x808fd0]
-        - Ranges: [0x8090b8..0x8090ec]
-          RootRanges: [0x809080..0x809110]
-        - Ranges: [0x809134..0x809168]
-          RootRanges: [0x809110..0x8091d0]
-        - Ranges: [0x8091ec..0x809220]
-          RootRanges: [0x8091d0..0x809240]
+        - Ranges: [0x808f8c..0x808fc0]
+          RootRanges: [0x808f70..0x808fe0]
+        - Ranges: [0x8090c8..0x8090fc]
+          RootRanges: [0x809090..0x809120]
+        - Ranges: [0x809144..0x809178]
+          RootRanges: [0x809120..0x8091e0]
+        - Ranges: [0x8091fc..0x809230]
+          RootRanges: [0x8091e0..0x809250]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808ef0..0x808f10
+            - Range: 0x808f00..0x808f20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808f7c..0x808f84
+            - Range: 0x808f8c..0x808f94
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8090b8..0x8090c0
+            - Range: 0x8090c8..0x8090d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80912c..0x80913c
+            - Range: 0x80913c..0x80914c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80913c..0x8091d0
+            - Range: 0x80914c..0x8091e0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x8091d0..0x8091f4
+            - Range: 0x8091e0..0x809204
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11148,37 +11148,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x809174..0x8091a8]
-          RootRanges: [0x809110..0x8091d0]
+        - Ranges: [0x809184..0x8091b8]
+          RootRanges: [0x809120..0x8091e0]
       Variables: []
       DictRegister: null
     - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80925c..0x809290, 0x809298..0x80929c]
-          RootRanges: [0x809240..0x809350]
+        - Ranges: [0x80926c..0x8092a0, 0x8092a8..0x8092ac]
+          RootRanges: [0x809250..0x809360]
       Variables: []
       DictRegister: null
     - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x809300..0x809334]
-          RootRanges: [0x809240..0x809350]
+        - Ranges: [0x809310..0x809344]
+          RootRanges: [0x809250..0x809360]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x809354..0x809358]
-          RootRanges: [0x809350..0x809360]
+        - Ranges: [0x809364..0x809368]
+          RootRanges: [0x809360..0x809370]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809350..0x809358
+            - Range: 0x809360..0x809368
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11187,32 +11187,32 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x809384..0x8093a0]
-          RootRanges: [0x809360..0x8093b0]
-        - Ranges: [0x80940c..0x80942c]
-          RootRanges: [0x8093b0..0x8094f0]
+        - Ranges: [0x809394..0x8093b0]
+          RootRanges: [0x809370..0x8093c0]
+        - Ranges: [0x80941c..0x80943c]
+          RootRanges: [0x8093c0..0x809500]
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x809370..0x8093b0
+            - Range: 0x809380..0x8093c0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x8093f8..0x8094f0
+            - Range: 0x809408..0x809500
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 192
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x8094f0..0x809550]
+      OutOfLinePCRanges: [0x809500..0x809560]
       InlinePCRanges:
-        - Ranges: [0x810788..0x8107ac]
-          RootRanges: [0x810760..0x8107f0]
+        - Ranges: [0x810798..0x8107bc]
+          RootRanges: [0x810770..0x810800]
       Variables:
         - Name: b
           Type: 354 StructureType main.firstBehavior
           Locations:
-            - Range: 0x8094f0..0x809514
+            - Range: 0x809500..0x809524
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11223,15 +11223,15 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8094f0..0x809530
+            - Range: 0x809500..0x809540
               Pieces: []
-            - Range: 0x809530..0x809531
+            - Range: 0x809540..0x809541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x809531..0x809550
+            - Range: 0x809541..0x809560
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11240,8 +11240,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x809b28..0x809b34, 0x809b38..0x809b40]
-          RootRanges: [0x809a10..0x809b80]
+        - Ranges: [0x809b38..0x809b44, 0x809b48..0x809b50]
+          RootRanges: [0x809a20..0x809b90]
         - Ranges: [0x12c238..0x12c23c, 0x12c240..0x12c248]
           RootRanges: [0x12c230..0x12c250]
       Variables: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x80e0c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e218", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1594 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x80e0f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e248", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x8095f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x809748", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1433 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x809620", Frameless: false}]
+              InjectionPoints: [{PC: "0x809770", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x809668", Frameless: false}]
+              InjectionPoints: [{PC: "0x8097b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1436 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x809690", Frameless: false}]
+              InjectionPoints: [{PC: "0x8097e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x80cfcc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d11c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1565 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80d058", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d1a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0x806ff0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0x806fb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0x806fd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x809c60", Frameless: true}]
+              InjectionPoints: [{PC: "0x809db0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0x806fc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807110", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0x806fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807130", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x80b3b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b500", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1467 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x80b3ec", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b53c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x807530", Frameless: true}]
+              InjectionPoints: [{PC: "0x807680", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1401 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0x80753c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80768c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0x806f00", Frameless: true}]
+              InjectionPoints: [{PC: "0x807050", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1364 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0x806ed0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80e3b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e500", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1613 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x80e3c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e510", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1673 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x808f18"
+                - PC: "0x809068"
                   Frameless: false
-                - PC: "0x808f8c"
+                - PC: "0x8090dc"
                   Frameless: false
-                - PC: "0x8090c8"
+                - PC: "0x809218"
                   Frameless: false
-                - PC: "0x809144"
+                - PC: "0x809294"
                   Frameless: false
-                - PC: "0x8091fc"
+                - PC: "0x80934c"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1674 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x808f18"
+                - PC: "0x809068"
                   Frameless: false
-                - PC: "0x808f8c"
+                - PC: "0x8090dc"
                   Frameless: false
-                - PC: "0x8090c8"
+                - PC: "0x809218"
                   Frameless: false
-                - PC: "0x809144"
+                - PC: "0x809294"
                   Frameless: false
-                - PC: "0x8091fc"
+                - PC: "0x80934c"
                   Frameless: false
               Condition:
                 Type: 4 BaseType bool
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 1675 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x808f18"
+                - PC: "0x809068"
                   Frameless: false
-                - PC: "0x808f8c"
+                - PC: "0x8090dc"
                   Frameless: false
-                - PC: "0x8090c8"
+                - PC: "0x809218"
                   Frameless: false
-                - PC: "0x809144"
+                - PC: "0x809294"
                   Frameless: false
-                - PC: "0x8091fc"
+                - PC: "0x80934c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -474,7 +474,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80b150", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b2a0", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -493,7 +493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80b150", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -519,7 +519,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1620 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x80e450", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e5a0", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -554,7 +554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x80b3f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -584,7 +584,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x80b130", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -613,11 +613,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1529 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x80c2c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c418", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1530 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x80c368", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c4b8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -639,7 +639,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x80b680", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b7d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -661,7 +661,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1407 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x8079d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807b20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -683,7 +683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x8079e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807b30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -705,7 +705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x8076f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -727,7 +727,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x807700", Frameless: true}]
+              InjectionPoints: [{PC: "0x807850", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -749,7 +749,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x807870", Frameless: true}]
+              InjectionPoints: [{PC: "0x8079c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -771,7 +771,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x807880", Frameless: true}]
+              InjectionPoints: [{PC: "0x8079d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -793,7 +793,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x80dd20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80de70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -820,7 +820,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1584 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x80dd50", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -848,7 +848,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x80e180", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e2d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -870,7 +870,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1621 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x80e480", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e5d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -891,7 +891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1622 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x80e490", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -913,7 +913,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x809640", Frameless: true}]
+              InjectionPoints: [{PC: "0x809790", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -947,7 +947,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1402 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x80757c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8076cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -975,11 +975,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x807ff8", Frameless: false}]
+              InjectionPoints: [{PC: "0x808148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x808030", Frameless: false}]
+              InjectionPoints: [{PC: "0x808180", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1001,11 +1001,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x807f3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80808c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1415 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x807f98", Frameless: false}]
+              InjectionPoints: [{PC: "0x8080e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1027,11 +1027,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x809360", Frameless: true}]
+              InjectionPoints: [{PC: "0x8094b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1427 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x809368", Frameless: true}]
+              InjectionPoints: [{PC: "0x8094b8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1053,11 +1053,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x80937c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8094cc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1429 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x8093b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x809500", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1082,7 +1082,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1430 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x80937c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8094cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1104,11 +1104,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1659 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x8104a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8105f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1660 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8104a4", Frameless: true}]
+              InjectionPoints: [{PC: "0x8105f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1122,11 +1122,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1661 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x8104c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x810610", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1662 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x8104f0", Frameless: false}]
+              InjectionPoints: [{PC: "0x810640", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1149,11 +1149,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1655 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x810408", Frameless: false}]
+              InjectionPoints: [{PC: "0x810558", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1656 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x810418", Frameless: false}]
+              InjectionPoints: [{PC: "0x810568", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1167,11 +1167,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x810458", Frameless: false}]
+              InjectionPoints: [{PC: "0x8105a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x810470", Frameless: false}]
+              InjectionPoints: [{PC: "0x8105c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1194,14 +1194,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1663 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x810500", Frameless: true}]
+              InjectionPoints: [{PC: "0x810650", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1664 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x810528"
+                - PC: "0x810678"
                   Frameless: true
-                - PC: "0x810530"
+                - PC: "0x810680"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1216,14 +1216,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1665 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x810558", Frameless: false}]
+              InjectionPoints: [{PC: "0x8106a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1666 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x8105b4"
+                - PC: "0x810704"
                   Frameless: false
-                - PC: "0x8105c4"
+                - PC: "0x810714"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1250,7 +1250,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1667 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x810504", Frameless: true}]
+              InjectionPoints: [{PC: "0x810654", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1262,7 +1262,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1668 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x810568", Frameless: false}]
+              InjectionPoints: [{PC: "0x8106b8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1283,11 +1283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1643 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x810110", Frameless: true}]
+              InjectionPoints: [{PC: "0x810260", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1644 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x810114", Frameless: true}]
+              InjectionPoints: [{PC: "0x810264", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1301,11 +1301,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1645 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x8101a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8102f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1646 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x8101a4", Frameless: true}]
+              InjectionPoints: [{PC: "0x8102f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1329,11 +1329,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1631 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x80fd18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80fe68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1632 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80fdec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ff3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1375,11 +1375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1635 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80fe38", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ff88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1636 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80fe48", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ff98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1402,11 +1402,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1669 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x810600", Frameless: true}]
+              InjectionPoints: [{PC: "0x810750", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1670 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x810608", Frameless: true}]
+              InjectionPoints: [{PC: "0x810758", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1420,11 +1420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1671 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x810698", Frameless: false}]
+              InjectionPoints: [{PC: "0x8107e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1672 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x8106bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x81080c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1447,11 +1447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x80fc80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fdd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1628 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80fc84", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fdd4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1465,11 +1465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x80fc90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fde0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1630 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80fc9c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fdec", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1492,11 +1492,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1647 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x810240", Frameless: true}]
+              InjectionPoints: [{PC: "0x810390", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1648 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x810248", Frameless: true}]
+              InjectionPoints: [{PC: "0x810398", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1510,11 +1510,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1649 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x8102e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x810438", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1650 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x810310", Frameless: false}]
+              InjectionPoints: [{PC: "0x810460", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1537,11 +1537,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1637 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x8100e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810230", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1638 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8100e4", Frameless: true}]
+              InjectionPoints: [{PC: "0x810234", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1555,11 +1555,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1639 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x8100f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810240", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1640 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x8100f4", Frameless: true}]
+              InjectionPoints: [{PC: "0x810244", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1573,11 +1573,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1641 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x810100", Frameless: true}]
+              InjectionPoints: [{PC: "0x810250", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1642 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x810104", Frameless: true}]
+              InjectionPoints: [{PC: "0x810254", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1600,11 +1600,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1651 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x8103c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810510", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1652 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x8103c8", Frameless: true}]
+              InjectionPoints: [{PC: "0x810518", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1618,11 +1618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1653 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x8103d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810520", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1654 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8103e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1645,11 +1645,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x80fc60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fdb0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1624 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80fc64", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fdb4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1663,11 +1663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x80fc70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fdc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1626 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80fc7c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fdcc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1690,11 +1690,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x8090a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8091f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1419 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x8090fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80924c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1721,11 +1721,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x809138", Frameless: false}]
+              InjectionPoints: [{PC: "0x809288", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1421 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x8091b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x809308", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1752,11 +1752,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x8091f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x809348", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1423 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x809230", Frameless: false}]
+              InjectionPoints: [{PC: "0x809380", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1778,7 +1778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1679 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x809184", Frameless: false}]
+              InjectionPoints: [{PC: "0x8092d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1796,11 +1796,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1424 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x809268", Frameless: false}]
+              InjectionPoints: [{PC: "0x8093b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1425 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x809344", Frameless: false}]
+              InjectionPoints: [{PC: "0x809494", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1818,7 +1818,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1680 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x80926c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8093bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1839,7 +1839,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1681 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x80926c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8093bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1857,7 +1857,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1682 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x809310", Frameless: false}]
+              InjectionPoints: [{PC: "0x809460", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1878,7 +1878,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1683 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x809310", Frameless: false}]
+              InjectionPoints: [{PC: "0x809460", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1899,7 +1899,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x12c238"
                   Frameless: true
-                - PC: "0x809b38"
+                - PC: "0x809c8c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1920,20 +1920,20 @@ Probes:
             - Kind: Entry
               Type: 1676 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x808f18"
+                - PC: "0x809068"
                   Frameless: false
-                - PC: "0x808f8c"
+                - PC: "0x8090dc"
                   Frameless: false
-                - PC: "0x8090c8"
+                - PC: "0x809218"
                   Frameless: false
-                - PC: "0x809144"
+                - PC: "0x809294"
                   Frameless: false
-                - PC: "0x8091fc"
+                - PC: "0x80934c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1677 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x808f4c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80909c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1959,15 +1959,15 @@ Probes:
             - Kind: Line
               Type: 1678 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x808f18"
+                - PC: "0x809068"
                   Frameless: false
-                - PC: "0x808f8c"
+                - PC: "0x8090dc"
                   Frameless: false
-                - PC: "0x8090c8"
+                - PC: "0x809218"
                   Frameless: false
-                - PC: "0x809144"
+                - PC: "0x809294"
                   Frameless: false
-                - PC: "0x8091fc"
+                - PC: "0x80934c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1990,7 +1990,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1684 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x809364", Frameless: true}]
+              InjectionPoints: [{PC: "0x8094b4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2015,7 +2015,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1685 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x809364", Frameless: true}]
+              InjectionPoints: [{PC: "0x8094b4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2039,9 +2039,9 @@ Probes:
             - Kind: Entry
               Type: 1686 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x809394"
+                - PC: "0x8094e4"
                   Frameless: false
-                - PC: "0x80941c"
+                - PC: "0x80956c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2064,7 +2064,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0x806f30", Frameless: true}]
+              InjectionPoints: [{PC: "0x807080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2086,7 +2086,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0x806f40", Frameless: true}]
+              InjectionPoints: [{PC: "0x807090", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2108,7 +2108,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0x806f50", Frameless: true}]
+              InjectionPoints: [{PC: "0x8070a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2130,7 +2130,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0x806f20", Frameless: true}]
+              InjectionPoints: [{PC: "0x807070", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2152,7 +2152,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0x806f10", Frameless: true}]
+              InjectionPoints: [{PC: "0x807060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2174,7 +2174,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x8095d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2195,11 +2195,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x80ce40", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cf90", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1563 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80cf68", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d0b8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2221,7 +2221,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x80b590", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b6e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2246,7 +2246,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1411 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x807a2c", Frameless: false}]
+              InjectionPoints: [{PC: "0x807b7c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2268,7 +2268,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1412 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x807ab0", Frameless: false}]
+              InjectionPoints: [{PC: "0x807c00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2290,7 +2290,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1413 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x807b4c", Frameless: false}]
+              InjectionPoints: [{PC: "0x807c9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2333,11 +2333,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x80d29c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d3ec", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1569 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x80d3dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d52c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2399,7 +2399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x809c40", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2421,7 +2421,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809df0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2443,7 +2443,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x809d40", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2465,7 +2465,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x809d60", Frameless: true}]
+              InjectionPoints: [{PC: "0x809eb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2487,7 +2487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x809d50", Frameless: true}]
+              InjectionPoints: [{PC: "0x809ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2509,7 +2509,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x809c80", Frameless: true}]
+              InjectionPoints: [{PC: "0x809dd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2531,7 +2531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x809d30", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2553,7 +2553,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x809d20", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2577,7 +2577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x809c90", Frameless: true}]
+              InjectionPoints: [{PC: "0x809de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2601,7 +2601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x809c90", Frameless: true}]
+              InjectionPoints: [{PC: "0x809de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2623,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x809d10", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2645,7 +2645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x809d00", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2667,7 +2667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x809c20", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2689,7 +2689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x809c30", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2711,7 +2711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x809c10", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2733,7 +2733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x809cb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2755,7 +2755,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x809ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2777,7 +2777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x809cf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2799,7 +2799,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x809cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2823,7 +2823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x809cd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2845,7 +2845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80e160", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e2b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2868,7 +2868,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80e160", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e2b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2915,11 +2915,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x80d440", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d590", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1571 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x80d5c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d718", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2985,11 +2985,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x80d6bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d80c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1575 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x80d754", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d8a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3020,11 +3020,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x80d090", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d1e0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1567 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x80d234", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d384", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3050,11 +3050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1507 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c298", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1508 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c318", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3090,7 +3090,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x80b210", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3131,11 +3131,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1501 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80c0b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c208", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1502 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c110", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c260", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3159,11 +3159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1503 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80c0b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c208", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1504 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c110", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c260", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3182,11 +3182,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1509 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c298", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1510 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c318", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3206,11 +3206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1511 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c298", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1512 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c318", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3243,11 +3243,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1505 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80c0b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c208", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1506 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c110", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c260", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3275,7 +3275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80e440", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3300,7 +3300,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80e440", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3331,7 +3331,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1618 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80e440", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3356,7 +3356,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80e440", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3383,7 +3383,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x80b660", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b7b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3410,7 +3410,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x80dd90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3437,7 +3437,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x80dd60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80deb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3472,7 +3472,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x80dd80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ded0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3504,7 +3504,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x80e150", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3526,7 +3526,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x80b5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b6f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3548,7 +3548,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x809c70", Frameless: true}]
+              InjectionPoints: [{PC: "0x809dc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3570,7 +3570,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x80b580", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b6d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3594,11 +3594,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80b9a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80baf8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1478 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80b9e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bb38", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3618,11 +3618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1521 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80c208", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c358", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1522 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c28c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c3dc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3663,11 +3663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1487 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80bac8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bc18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1488 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80bb54", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bca4", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3705,11 +3705,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80b9a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80baf8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1480 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80b9e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bb38", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3750,11 +3750,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1489 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80bac8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bc18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1490 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80bb54", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bca4", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3794,11 +3794,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1523 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80c208", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c358", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1524 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c28c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c3dc", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3815,11 +3815,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1525 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80c208", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c358", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1526 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c28c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c3dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3841,11 +3841,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80b9a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80baf8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1482 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80b9e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bb38", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3868,18 +3868,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1497 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x80bd88", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bed8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1498 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x80be10"
+                - PC: "0x80bf60"
                   Frameless: false
-                - PC: "0x80be64"
+                - PC: "0x80bfb4"
                   Frameless: false
-                - PC: "0x80bf14"
+                - PC: "0x80c064"
                   Frameless: false
-                - PC: "0x80bf28"
+                - PC: "0x80c078"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3907,18 +3907,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1495 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x80bc18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bd68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1496 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x80bc6c"
+                - PC: "0x80bdbc"
                   Frameless: false
-                - PC: "0x80bcc8"
+                - PC: "0x80be18"
                   Frameless: false
-                - PC: "0x80bd08"
+                - PC: "0x80be58"
                   Frameless: false
-                - PC: "0x80bd44"
+                - PC: "0x80be94"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3945,11 +3945,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1540 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x80c89c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c9ec", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1541 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x80c8e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ca38", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3966,11 +3966,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1542 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x80c918", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ca68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1543 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x80c950", Frameless: false}]
+              InjectionPoints: [{PC: "0x80caa0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3987,11 +3987,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1544 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x80c988", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cad8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1545 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x80c9bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cb0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4008,11 +4008,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x80ca78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cbc8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1549 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x80cad8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cc28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4029,11 +4029,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x80cdc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cf18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1561 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x80ce04", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cf54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4050,11 +4050,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x80c758", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c8a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x80c7a0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c8f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4072,14 +4072,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x80bb98", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bce8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1494 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x80bbc4"
+                - PC: "0x80bd14"
                   Frameless: false
-                - PC: "0x80bbd8"
+                - PC: "0x80bd28"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4101,11 +4101,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80b9a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80baf8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1484 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80b9e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bb38", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4126,11 +4126,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1491 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80bac8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bc18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1492 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80bb54", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bca4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4151,11 +4151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1485 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x80ba28", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bb78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1486 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x80ba84", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bbd4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4177,14 +4177,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1499 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x80bf68", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c0b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1500 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x80c020"
+                - PC: "0x80c170"
                   Frameless: false
-                - PC: "0x80c034"
+                - PC: "0x80c184"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4206,11 +4206,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x80c7e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c930", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1539 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x80c85c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c9ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4227,11 +4227,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x80c6a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c7f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x80c728", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c878", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4248,11 +4248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1552 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x80cbd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cd28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1553 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x80cc2c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cd7c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4269,11 +4269,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x80c9f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cb48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1547 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x80ca3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cb8c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4290,11 +4290,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x80cd58", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1559 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x80cd98", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cee8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4314,7 +4314,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1531 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x80c470", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c5c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4335,11 +4335,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x80cce8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ce38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1557 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x80cd24", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ce74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4356,11 +4356,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x80c618", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c768", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x80c66c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c7bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4377,11 +4377,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x80cc6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cdbc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1555 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x80ccb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ce08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4398,11 +4398,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1550 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x80cb10", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cc60", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1551 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x80cb9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ccec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4420,7 +4420,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0x806ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807030", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1513 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c298", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c318", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4505,7 +4505,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x807360", Frameless: true}]
+              InjectionPoints: [{PC: "0x8074b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4527,7 +4527,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x807340", Frameless: true}]
+              InjectionPoints: [{PC: "0x807490", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4549,7 +4549,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x807410", Frameless: true}]
+              InjectionPoints: [{PC: "0x807560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4567,7 +4567,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x807420", Frameless: true}]
+              InjectionPoints: [{PC: "0x807570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x807370", Frameless: true}]
+              InjectionPoints: [{PC: "0x8074c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x807390", Frameless: true}]
+              InjectionPoints: [{PC: "0x8074e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4630,7 +4630,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x8073a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8074f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4652,7 +4652,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x8073b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4681,7 +4681,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x807380", Frameless: true}]
+              InjectionPoints: [{PC: "0x8074d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4712,7 +4712,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x807350", Frameless: true}]
+              InjectionPoints: [{PC: "0x8074a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4734,7 +4734,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x80e110", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4756,7 +4756,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x8073c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4778,7 +4778,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x8073e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4800,7 +4800,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x8073f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4822,7 +4822,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x807400", Frameless: true}]
+              InjectionPoints: [{PC: "0x807550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4844,7 +4844,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x8073d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4866,7 +4866,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x80ddb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80df00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4888,7 +4888,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1582 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x80dd30", Frameless: true}]
+              InjectionPoints: [{PC: "0x80de80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4910,7 +4910,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x809c50", Frameless: true}]
+              InjectionPoints: [{PC: "0x809da0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4931,11 +4931,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1527 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80c208", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c358", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c28c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c3dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4956,11 +4956,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1572 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x80d628", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d778", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1573 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x80d680", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d7d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4982,7 +4982,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0x806ef0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5004,7 +5004,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1474 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x80b640", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b790", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5026,7 +5026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1586 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x80dd70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80dec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5048,7 +5048,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x8079f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807b40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5070,7 +5070,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x807a00", Frameless: true}]
+              InjectionPoints: [{PC: "0x807b50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5092,11 +5092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80e3b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e500", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1615 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x80e3c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5123,7 +5123,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x80dd40", Frameless: true}]
+              InjectionPoints: [{PC: "0x80de90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5150,7 +5150,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x8096b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5171,11 +5171,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1576 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x80d78c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d8dc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1577 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x80d810", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d960", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5197,11 +5197,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x80e300", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e450", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1611 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x80e30c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e45c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5222,7 +5222,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x80e2f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5249,7 +5249,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x809c00", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5281,7 +5281,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x80ddc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80df10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5321,7 +5321,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x80e190", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e2e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5354,11 +5354,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c298", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c318", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5379,11 +5379,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c298", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c318", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5406,11 +5406,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80c148", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c298", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c318", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5439,7 +5439,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x80e120", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e270", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5471,11 +5471,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80e130", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e280", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1598 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x80e13c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e28c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5505,11 +5505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80e130", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e280", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1600 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x80e13c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e28c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5541,7 +5541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1601 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80e140", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e290", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80e140", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e290", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x807430", Frameless: true}]
+              InjectionPoints: [{PC: "0x807580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5625,7 +5625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0x806f80", Frameless: true}]
+              InjectionPoints: [{PC: "0x8070d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5647,7 +5647,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0x806f90", Frameless: true}]
+              InjectionPoints: [{PC: "0x8070e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5669,7 +5669,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0x806fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8070f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5691,7 +5691,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0x806f70", Frameless: true}]
+              InjectionPoints: [{PC: "0x8070c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5713,7 +5713,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0x806f60", Frameless: true}]
+              InjectionPoints: [{PC: "0x8070b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5735,7 +5735,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x80b5d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5757,7 +5757,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1580 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x80dd10", Frameless: true}]
+              InjectionPoints: [{PC: "0x80de60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5779,7 +5779,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x80e170", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e2c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5801,7 +5801,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x80b5b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5823,7 +5823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0x807010", Frameless: true}]
+              InjectionPoints: [{PC: "0x807160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5845,7 +5845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80dda0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80def0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5867,7 +5867,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80dda0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80def0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5890,14 +5890,14 @@ Probes:
             - Kind: Entry
               Type: 1687 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x809518"
+                - PC: "0x809668"
                   Frameless: false
-                - PC: "0x810798"
+                - PC: "0x8108e8"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1688 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x809540", Frameless: false}]
+              InjectionPoints: [{PC: "0x809690", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5919,11 +5919,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x80d848", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d998", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1579 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80d8a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d9f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5940,481 +5940,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x806ed0..0x806ee0]
+      OutOfLinePCRanges: [0x807020..0x807030]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]uint8
           Locations:
-            - Range: 0x806ed0..0x806ee0
+            - Range: 0x807020..0x807030
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x806ee0..0x806ef0]
+      OutOfLinePCRanges: [0x807030..0x807040]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]int32
           Locations:
-            - Range: 0x806ee0..0x806ef0
+            - Range: 0x807030..0x807040
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x806ef0..0x806f00]
+      OutOfLinePCRanges: [0x807040..0x807050]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]string
           Locations:
-            - Range: 0x806ef0..0x806f00
+            - Range: 0x807040..0x807050
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x806f00..0x806f10]
+      OutOfLinePCRanges: [0x807050..0x807060]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]bool
           Locations:
-            - Range: 0x806f00..0x806f10
+            - Range: 0x807050..0x807060
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x806f10..0x806f20]
+      OutOfLinePCRanges: [0x807060..0x807070]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x806f10..0x806f20
+            - Range: 0x807060..0x807070
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x806f20..0x806f30]
+      OutOfLinePCRanges: [0x807070..0x807080]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 114 ArrayType [2]int8
           Locations:
-            - Range: 0x806f20..0x806f30
+            - Range: 0x807070..0x807080
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x806f30..0x806f40]
+      OutOfLinePCRanges: [0x807080..0x807090]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 ArrayType [2]int16
           Locations:
-            - Range: 0x806f30..0x806f40
+            - Range: 0x807080..0x807090
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x806f40..0x806f50]
+      OutOfLinePCRanges: [0x807090..0x8070a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]int32
           Locations:
-            - Range: 0x806f40..0x806f50
+            - Range: 0x807090..0x8070a0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x806f50..0x806f60]
+      OutOfLinePCRanges: [0x8070a0..0x8070b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]int64
           Locations:
-            - Range: 0x806f50..0x806f60
+            - Range: 0x8070a0..0x8070b0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x806f60..0x806f70]
+      OutOfLinePCRanges: [0x8070b0..0x8070c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]uint
           Locations:
-            - Range: 0x806f60..0x806f70
+            - Range: 0x8070b0..0x8070c0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x806f70..0x806f80]
+      OutOfLinePCRanges: [0x8070c0..0x8070d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]uint8
           Locations:
-            - Range: 0x806f70..0x806f80
+            - Range: 0x8070c0..0x8070d0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x806f80..0x806f90]
+      OutOfLinePCRanges: [0x8070d0..0x8070e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 ArrayType [2]uint16
           Locations:
-            - Range: 0x806f80..0x806f90
+            - Range: 0x8070d0..0x8070e0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x806f90..0x806fa0]
+      OutOfLinePCRanges: [0x8070e0..0x8070f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 ArrayType [2]uint32
           Locations:
-            - Range: 0x806f90..0x806fa0
+            - Range: 0x8070e0..0x8070f0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x806fa0..0x806fb0]
+      OutOfLinePCRanges: [0x8070f0..0x807100]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 54 ArrayType [2]uint64
           Locations:
-            - Range: 0x806fa0..0x806fb0
+            - Range: 0x8070f0..0x807100
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x806fb0..0x806fc0]
+      OutOfLinePCRanges: [0x807100..0x807110]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 120 ArrayType [2][2]int
           Locations:
-            - Range: 0x806fb0..0x806fc0
+            - Range: 0x807100..0x807110
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x806fc0..0x806fd0]
+      OutOfLinePCRanges: [0x807110..0x807120]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 111 ArrayType [2]string
           Locations:
-            - Range: 0x806fc0..0x806fd0
+            - Range: 0x807110..0x807120
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x806fd0..0x806fe0]
+      OutOfLinePCRanges: [0x807120..0x807130]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 121 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x806fd0..0x806fe0
+            - Range: 0x807120..0x807130
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0x806fe0..0x806ff0]
+      OutOfLinePCRanges: [0x807130..0x807140]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 122 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0x806fe0..0x806ff0
+            - Range: 0x807130..0x807140
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0x806ff0..0x807000]
+      OutOfLinePCRanges: [0x807140..0x807150]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 124 ArrayType [2]struct {}
           Locations:
-            - Range: 0x806ff0..0x807000
+            - Range: 0x807140..0x807150
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x807010..0x807020]
+      OutOfLinePCRanges: [0x807160..0x807170]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 126 ArrayType [100]uint
           Locations:
-            - Range: 0x807010..0x807020
+            - Range: 0x807160..0x807170
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x807340..0x807350]
+      OutOfLinePCRanges: [0x807490..0x8074a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x807340..0x807350
+            - Range: 0x807490..0x8074a0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x807350..0x807360]
+      OutOfLinePCRanges: [0x8074a0..0x8074b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x807350..0x807360
+            - Range: 0x8074a0..0x8074b0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x807360..0x807370]
+      OutOfLinePCRanges: [0x8074b0..0x8074c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x807360..0x807370
+            - Range: 0x8074b0..0x8074c0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x807370..0x807380]
+      OutOfLinePCRanges: [0x8074c0..0x8074d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807370..0x807380
+            - Range: 0x8074c0..0x8074d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x807380..0x807390]
+      OutOfLinePCRanges: [0x8074d0..0x8074e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x807380..0x807390
+            - Range: 0x8074d0..0x8074e0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x807390..0x8073a0]
+      OutOfLinePCRanges: [0x8074e0..0x8074f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 96 BaseType int16
           Locations:
-            - Range: 0x807390..0x8073a0
+            - Range: 0x8074e0..0x8074f0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x8073a0..0x8073b0]
+      OutOfLinePCRanges: [0x8074f0..0x807500]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x8073a0..0x8073b0
+            - Range: 0x8074f0..0x807500
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x8073b0..0x8073c0]
+      OutOfLinePCRanges: [0x807500..0x807510]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x8073b0..0x8073c0
+            - Range: 0x807500..0x807510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x8073c0..0x8073d0]
+      OutOfLinePCRanges: [0x807510..0x807520]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x8073c0..0x8073d0
+            - Range: 0x807510..0x807520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x8073d0..0x8073e0]
+      OutOfLinePCRanges: [0x807520..0x807530]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8073d0..0x8073e0
+            - Range: 0x807520..0x807530
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x8073e0..0x8073f0]
+      OutOfLinePCRanges: [0x807530..0x807540]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x8073e0..0x8073f0
+            - Range: 0x807530..0x807540
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x8073f0..0x807400]
+      OutOfLinePCRanges: [0x807540..0x807550]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x8073f0..0x807400
+            - Range: 0x807540..0x807550
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x807400..0x807410]
+      OutOfLinePCRanges: [0x807550..0x807560]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x807400..0x807410
+            - Range: 0x807550..0x807560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x807410..0x807420]
+      OutOfLinePCRanges: [0x807560..0x807570]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x807410..0x807420
+            - Range: 0x807560..0x807570
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x807420..0x807430]
+      OutOfLinePCRanges: [0x807570..0x807580]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x807420..0x807430
+            - Range: 0x807570..0x807580
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x807430..0x807440]
+      OutOfLinePCRanges: [0x807580..0x807590]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 127 BaseType main.typeAlias
           Locations:
-            - Range: 0x807430..0x807440
+            - Range: 0x807580..0x807590
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x807530..0x807540]
+      OutOfLinePCRanges: [0x807680..0x807690]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 128 StructureType main.bigStruct
           Locations:
-            - Range: 0x807530..0x807540
+            - Range: 0x807680..0x807690
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6433,89 +6433,89 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x807560..0x807660]
+      OutOfLinePCRanges: [0x8076b0..0x8077b0]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x807560..0x807580
+            - Range: 0x8076b0..0x8076d0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x807560..0x807660, Pieces: []}]
+          Locations: [{Range: 0x8076b0..0x8077b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
-          Locations: [{Range: 0x807560..0x807660, Pieces: []}]
+          Locations: [{Range: 0x8076b0..0x8077b0, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x807578..0x8075b4
+            - Range: 0x8076c8..0x807704
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x8075b4..0x8075bc
+            - Range: 0x807704..0x80770c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x8075bc..0x807608
+            - Range: 0x80770c..0x807758
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807608..0x807610
+            - Range: 0x807758..0x807760
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}, {Size: 8, Op: null}]
-            - Range: 0x807610..0x807660
+            - Range: 0x807760..0x8077b0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}, {Size: 8, Op: null}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x8076f0..0x807700]
+      OutOfLinePCRanges: [0x807840..0x807850]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 132 StructureType main.deepPtr1
           Locations:
-            - Range: 0x8076f0..0x807700
+            - Range: 0x807840..0x807850
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x807700..0x807710]
+      OutOfLinePCRanges: [0x807850..0x807860]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 135 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x807700..0x807710
+            - Range: 0x807850..0x807860
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x807870..0x807880]
+      OutOfLinePCRanges: [0x8079c0..0x8079d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 137 StructureType main.deepSlice1
           Locations:
-            - Range: 0x807870..0x807880
+            - Range: 0x8079c0..0x8079d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6528,129 +6528,129 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x807880..0x807890]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 141 PointerType *main.deepSlice7
-          Locations:
-            - Range: 0x807880..0x807890
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 43
-      Name: main.testDeepMap1
       OutOfLinePCRanges: [0x8079d0..0x8079e0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 143 StructureType main.deepMap1
+          Type: 141 PointerType *main.deepSlice7
           Locations:
             - Range: 0x8079d0..0x8079e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 43
+      Name: main.testDeepMap1
+      OutOfLinePCRanges: [0x807b20..0x807b30]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 143 StructureType main.deepMap1
+          Locations:
+            - Range: 0x807b20..0x807b30
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x8079e0..0x8079f0]
+      OutOfLinePCRanges: [0x807b30..0x807b40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 PointerType *main.deepMap7
           Locations:
-            - Range: 0x8079e0..0x8079f0
+            - Range: 0x807b30..0x807b40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x8079f0..0x807a00]
+      OutOfLinePCRanges: [0x807b40..0x807b50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 151 PointerType *main.stringType1
           Locations:
-            - Range: 0x8079f0..0x807a00
+            - Range: 0x807b40..0x807b50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x807a00..0x807a10]
+      OutOfLinePCRanges: [0x807b50..0x807b60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 153 PointerType **main.stringType2
           Locations:
-            - Range: 0x807a00..0x807a10
+            - Range: 0x807b50..0x807b60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x807a10..0x807bf0]
+      OutOfLinePCRanges: [0x807b60..0x807d40]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ac8..0x807ad8
+            - Range: 0x807c18..0x807c28
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807b68..0x807b78
+            - Range: 0x807cb8..0x807cc8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ab0..0x807ab4
+            - Range: 0x807c00..0x807c04
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807ab4..0x807ad8
+            - Range: 0x807c04..0x807c28
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807ad8..0x807b5c
+            - Range: 0x807c28..0x807cac
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x807b5c..0x807b64
+            - Range: 0x807cac..0x807cb4
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x807b64..0x807bf0
+            - Range: 0x807cb4..0x807d40
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807aa8..0x807ab4
+            - Range: 0x807bf8..0x807c04
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807ab4..0x807ab4
+            - Range: 0x807c04..0x807c04
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x807ab4..0x807ad8
+            - Range: 0x807c04..0x807c28
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807ad8..0x807b5c
+            - Range: 0x807c28..0x807cac
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x807b5c..0x807b60
+            - Range: 0x807cac..0x807cb0
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x807b60..0x807b64
+            - Range: 0x807cb0..0x807cb4
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x807b64..0x807b78
+            - Range: 0x807cb4..0x807cc8
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x807b78..0x807bf0
+            - Range: 0x807cc8..0x807d40
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x807f20..0x807fe0]
+      OutOfLinePCRanges: [0x808070..0x808130]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 155 StructureType main.esotericStack
           Locations:
-            - Range: 0x807f20..0x807f58
+            - Range: 0x808070..0x8080a8
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6670,7 +6670,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x807f58..0x807f5c
+            - Range: 0x8080a8..0x8080ac
               Pieces:
                 - Size: 4
                   Op: null
@@ -6690,7 +6690,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x807f5c..0x807f60
+            - Range: 0x8080ac..0x8080b0
               Pieces:
                 - Size: 4
                   Op: null
@@ -6715,153 +6715,153 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x807fe0..0x808050]
+      OutOfLinePCRanges: [0x808130..0x8081a0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 159 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x807fe0..0x808014
+            - Range: 0x808130..0x808164
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 50
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x809090..0x809120]
+      OutOfLinePCRanges: [0x8091e0..0x809270]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809090..0x8090c8
+            - Range: 0x8091e0..0x809218
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 51
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x809120..0x8091e0]
+      OutOfLinePCRanges: [0x809270..0x809330]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809120..0x80913c
+            - Range: 0x809270..0x80928c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809120..0x80914c
+            - Range: 0x809270..0x80929c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80913c..0x80914c
+            - Range: 0x80928c..0x80929c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80914c..0x8091e0
+            - Range: 0x80929c..0x809330
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x8091e0..0x809250]
+      OutOfLinePCRanges: [0x809330..0x8093a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8091e0..0x809204
+            - Range: 0x809330..0x809354
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x809250..0x809360]
+      OutOfLinePCRanges: [0x8093a0..0x8094b0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80926c..0x8092d8
+            - Range: 0x8093bc..0x809428
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8092d8..0x8092e0
+            - Range: 0x809428..0x809430
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80926c..0x8092d8
+            - Range: 0x8093bc..0x809428
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8092d8..0x8092dc
+            - Range: 0x809428..0x80942c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x809360..0x809370]
+      OutOfLinePCRanges: [0x8094b0..0x8094c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809360..0x809368
+            - Range: 0x8094b0..0x8094b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809360..0x809368
+            - Range: 0x8094b0..0x8094b8
               Pieces: []
-            - Range: 0x809368..0x809369
+            - Range: 0x8094b8..0x8094b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809369..0x809370
+            - Range: 0x8094b9..0x8094c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x809370..0x8093c0]
+      OutOfLinePCRanges: [0x8094c0..0x809510]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x809370..0x8093c0
+            - Range: 0x8094c0..0x809510
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809370..0x8093b0
+            - Range: 0x8094c0..0x809500
               Pieces: []
-            - Range: 0x8093b0..0x8093b1
+            - Range: 0x809500..0x809501
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8093b1..0x8093c0
+            - Range: 0x809501..0x809510
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0x8095d0..0x8095e0]
+      OutOfLinePCRanges: [0x809720..0x809730]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8095d0..0x8095e0
+            - Range: 0x809720..0x809730
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6872,19 +6872,19 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0x8095e0..0x809640]
+      OutOfLinePCRanges: [0x809730..0x809790]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8095e0..0x80960c
+            - Range: 0x809730..0x80975c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80960c..0x809610
+            - Range: 0x80975c..0x809760
               Pieces:
                 - Size: 8
                   Op: null
@@ -6895,28 +6895,28 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8095e0..0x809620
+            - Range: 0x809730..0x809770
               Pieces: []
-            - Range: 0x809620..0x809621
+            - Range: 0x809770..0x809771
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x809621..0x809640
+            - Range: 0x809771..0x809790
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0x809640..0x809650]
+      OutOfLinePCRanges: [0x809790..0x8097a0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x809640..0x809650
+            - Range: 0x809790..0x8097a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6927,41 +6927,41 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x809650..0x8096b0]
+      OutOfLinePCRanges: [0x8097a0..0x809800]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 163 PointerType *interface {}
           Locations:
-            - Range: 0x809650..0x80967c
+            - Range: 0x8097a0..0x8097cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809650..0x809690
+            - Range: 0x8097a0..0x8097e0
               Pieces: []
-            - Range: 0x809690..0x809691
+            - Range: 0x8097e0..0x8097e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x809691..0x8096b0
+            - Range: 0x8097e1..0x809800
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x8096b0..0x8096c0]
+      OutOfLinePCRanges: [0x809800..0x809810]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 164 StructureType main.structWithAny
           Locations:
-            - Range: 0x8096b0..0x8096c0
+            - Range: 0x809800..0x809810
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6972,346 +6972,346 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x809c00..0x809c10]
+      OutOfLinePCRanges: [0x809d50..0x809d60]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 165 StructureType main.structWithMap
-          Locations:
-            - Range: 0x809c00..0x809c10
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x809c10..0x809c20]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 171 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x809c10..0x809c20
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 63
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x809c20..0x809c30]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 176 GoMapType map[string]int
-          Locations:
-            - Range: 0x809c20..0x809c30
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x809c30..0x809c40]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 181 GoMapType map[string][]string
-          Locations:
-            - Range: 0x809c30..0x809c40
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x809c40..0x809c50]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 186 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0x809c40..0x809c50
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 66
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0x809c50..0x809c60]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 176 GoMapType map[string]int
-          Locations:
-            - Range: 0x809c50..0x809c60
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x809c60..0x809c70]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 191 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0x809c60..0x809c70
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x809c70..0x809c80]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 192 PointerType *map[string]int
-          Locations:
-            - Range: 0x809c70..0x809c80
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x809c80..0x809c90]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 166 GoMapType map[int]int
-          Locations:
-            - Range: 0x809c80..0x809c90
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0x809c90..0x809ca0]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 193 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x809c90..0x809ca0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 71
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x809ca0..0x809cb0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 193 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x809ca0..0x809cb0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 72
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x809cb0..0x809cc0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 198 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0x809cb0..0x809cc0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 73
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x809cc0..0x809cd0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 203 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x809cc0..0x809cd0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 74
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x809cd0..0x809ce0]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 203 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x809cd0..0x809ce0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x809ce0..0x809cf0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 208 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x809ce0..0x809cf0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x809cf0..0x809d00]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 208 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x809cf0..0x809d00
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 77
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x809d00..0x809d10]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 208 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x809d00..0x809d10
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 78
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x809d10..0x809d20]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 213 GoMapType map[uint8][4]int
-          Locations:
-            - Range: 0x809d10..0x809d20
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 79
-      Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x809d20..0x809d30]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 218 GoMapType map[[4]int]uint8
-          Locations:
-            - Range: 0x809d20..0x809d30
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 80
-      Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x809d30..0x809d40]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 223 GoMapType map[[4]int][4]int
-          Locations:
-            - Range: 0x809d30..0x809d40
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 81
-      Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x809d40..0x809d50]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 228 GoMapType map[struct {}]int
-          Locations:
-            - Range: 0x809d40..0x809d50
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 82
-      Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x809d50..0x809d60]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 233 GoMapType map[int]struct {}
           Locations:
             - Range: 0x809d50..0x809d60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 62
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x809d60..0x809d70]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 238 GoMapType map[struct {}]struct {}
+          Type: 171 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x809d60..0x809d70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 63
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0x809d70..0x809d80]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 176 GoMapType map[string]int
+          Locations:
+            - Range: 0x809d70..0x809d80
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 64
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0x809d80..0x809d90]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 181 GoMapType map[string][]string
+          Locations:
+            - Range: 0x809d80..0x809d90
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 65
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0x809d90..0x809da0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 186 GoMapType map[[4]string][2]int
+          Locations:
+            - Range: 0x809d90..0x809da0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 66
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x809da0..0x809db0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 176 GoMapType map[string]int
+          Locations:
+            - Range: 0x809da0..0x809db0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 67
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x809db0..0x809dc0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 191 ArrayType [2]map[string]int
+          Locations:
+            - Range: 0x809db0..0x809dc0
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 68
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x809dc0..0x809dd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 192 PointerType *map[string]int
+          Locations:
+            - Range: 0x809dc0..0x809dd0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 69
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x809dd0..0x809de0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 166 GoMapType map[int]int
+          Locations:
+            - Range: 0x809dd0..0x809de0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 70
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x809de0..0x809df0]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 193 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x809de0..0x809df0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 71
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x809df0..0x809e00]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 193 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x809df0..0x809e00
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 72
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x809e00..0x809e10]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 198 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0x809e00..0x809e10
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x809e10..0x809e20]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 203 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x809e10..0x809e20
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x809e20..0x809e30]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 203 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x809e20..0x809e30
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 75
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x809e30..0x809e40]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x809e30..0x809e40
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 76
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x809e40..0x809e50]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x809e40..0x809e50
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x809e50..0x809e60]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x809e50..0x809e60
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 78
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x809e60..0x809e70]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 213 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x809e60..0x809e70
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 79
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x809e70..0x809e80]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 218 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x809e70..0x809e80
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 80
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x809e80..0x809e90]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 223 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x809e80..0x809e90
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 81
+      Name: main.testMapEmptyKey
+      OutOfLinePCRanges: [0x809e90..0x809ea0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 228 GoMapType map[struct {}]int
+          Locations:
+            - Range: 0x809e90..0x809ea0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 82
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0x809ea0..0x809eb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 233 GoMapType map[int]struct {}
+          Locations:
+            - Range: 0x809ea0..0x809eb0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x809eb0..0x809ec0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 238 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x809eb0..0x809ec0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x80b130..0x80b140]
+      OutOfLinePCRanges: [0x80b280..0x80b290]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x80b130..0x80b140
+            - Range: 0x80b280..0x80b290
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x80b130..0x80b140
+            - Range: 0x80b280..0x80b290
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x80b130..0x80b140
+            - Range: 0x80b280..0x80b290
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x80b150..0x80b160]
+      OutOfLinePCRanges: [0x80b2a0..0x80b2b0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x80b150..0x80b160
+            - Range: 0x80b2a0..0x80b2b0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80b150..0x80b160
+            - Range: 0x80b2a0..0x80b2b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7322,48 +7322,48 @@ Subprograms:
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x80b150..0x80b160
+            - Range: 0x80b2a0..0x80b2b0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x80b210..0x80b220]
+      OutOfLinePCRanges: [0x80b360..0x80b370]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80b210..0x80b220
+            - Range: 0x80b360..0x80b370
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x80b210..0x80b220
+            - Range: 0x80b360..0x80b370
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x80b210..0x80b220
+            - Range: 0x80b360..0x80b370
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x80b210..0x80b220
+            - Range: 0x80b360..0x80b370
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80b210..0x80b220
+            - Range: 0x80b360..0x80b370
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7374,63 +7374,63 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x80b3b0..0x80b3f0]
+      OutOfLinePCRanges: [0x80b500..0x80b540]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x80b3b0..0x80b3ec
+            - Range: 0x80b500..0x80b53c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x80b3b0..0x80b3ec
+            - Range: 0x80b500..0x80b53c
               Pieces: []
-            - Range: 0x80b3ec..0x80b3ed
+            - Range: 0x80b53c..0x80b53d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b3ed..0x80b3f0
+            - Range: 0x80b53d..0x80b540
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0x80b3f0..0x80b400]
+      OutOfLinePCRanges: [0x80b540..0x80b550]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 243 GoChannelType chan bool
           Locations:
-            - Range: 0x80b3f0..0x80b400
+            - Range: 0x80b540..0x80b550
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x80b580..0x80b590]
+      OutOfLinePCRanges: [0x80b6d0..0x80b6e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x80b580..0x80b590
+            - Range: 0x80b6d0..0x80b6e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x80b590..0x80b5a0]
+      OutOfLinePCRanges: [0x80b6e0..0x80b6f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 246 StructureType main.node
           Locations:
-            - Range: 0x80b590..0x80b5a0
+            - Range: 0x80b6e0..0x80b6f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7441,267 +7441,267 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x80b5a0..0x80b5b0]
+      OutOfLinePCRanges: [0x80b6f0..0x80b700]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.node
           Locations:
-            - Range: 0x80b5a0..0x80b5b0
+            - Range: 0x80b6f0..0x80b700
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x80b5b0..0x80b5c0]
+      OutOfLinePCRanges: [0x80b700..0x80b710]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x80b5b0..0x80b5c0
+            - Range: 0x80b700..0x80b710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x80b5d0..0x80b5e0]
+      OutOfLinePCRanges: [0x80b720..0x80b730]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 PointerType *uint
           Locations:
-            - Range: 0x80b5d0..0x80b5e0
+            - Range: 0x80b720..0x80b730
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x80b640..0x80b650]
+      OutOfLinePCRanges: [0x80b790..0x80b7a0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 95 PointerType *string
           Locations:
-            - Range: 0x80b640..0x80b650
+            - Range: 0x80b790..0x80b7a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x80b660..0x80b670]
+      OutOfLinePCRanges: [0x80b7b0..0x80b7c0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x80b660..0x80b670
+            - Range: 0x80b7b0..0x80b7c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x80b660..0x80b670
+            - Range: 0x80b7b0..0x80b7c0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0x80b680..0x80b690]
+      OutOfLinePCRanges: [0x80b7d0..0x80b7e0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 248 PointerType *main.t
           Locations:
-            - Range: 0x80b680..0x80b690
+            - Range: 0x80b7d0..0x80b7e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x80b990..0x80ba10]
+      OutOfLinePCRanges: [0x80bae0..0x80bb60]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b990..0x80b9ac
+            - Range: 0x80bae0..0x80bafc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b990..0x80b9e8
+            - Range: 0x80bae0..0x80bb38
               Pieces: []
-            - Range: 0x80b9e8..0x80b9e9
+            - Range: 0x80bb38..0x80bb39
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b9e9..0x80ba10
+            - Range: 0x80bb39..0x80bb60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b9ac..0x80b9b8
+            - Range: 0x80bafc..0x80bb08
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b9b8..0x80ba10
+            - Range: 0x80bb08..0x80bb60
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x80ba10..0x80bab0]
+      OutOfLinePCRanges: [0x80bb60..0x80bc00]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ba10..0x80ba34
+            - Range: 0x80bb60..0x80bb84
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ba34..0x80bab0
+            - Range: 0x80bb84..0x80bc00
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x80ba10..0x80ba84
+            - Range: 0x80bb60..0x80bbd4
               Pieces: []
-            - Range: 0x80ba84..0x80ba85
+            - Range: 0x80bbd4..0x80bbd5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ba85..0x80bab0
+            - Range: 0x80bbd5..0x80bc00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x80ba38..0x80ba50
+            - Range: 0x80bb88..0x80bba0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ba50..0x80bab0
+            - Range: 0x80bba0..0x80bc00
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x80bab0..0x80bb80]
+      OutOfLinePCRanges: [0x80bc00..0x80bcd0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80bab0..0x80bb04
+            - Range: 0x80bc00..0x80bc54
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80bab0..0x80bb54
+            - Range: 0x80bc00..0x80bca4
               Pieces: []
-            - Range: 0x80bb54..0x80bb55
+            - Range: 0x80bca4..0x80bca5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bb55..0x80bb80
+            - Range: 0x80bca5..0x80bcd0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bab0..0x80bb80, Pieces: []}]
+          Locations: [{Range: 0x80bc00..0x80bcd0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80bacc..0x80bb08
+            - Range: 0x80bc1c..0x80bc58
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80bb08..0x80bb80
+            - Range: 0x80bc58..0x80bcd0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x80badc..0x80bb08
+            - Range: 0x80bc2c..0x80bc58
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80bb08..0x80bb80
+            - Range: 0x80bc58..0x80bcd0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x80bb80..0x80bc00]
+      OutOfLinePCRanges: [0x80bcd0..0x80bd50]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80bb80..0x80bba4
+            - Range: 0x80bcd0..0x80bcf4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x80bb80..0x80bbc4
+            - Range: 0x80bcd0..0x80bd14
               Pieces: []
-            - Range: 0x80bbc4..0x80bbc5
+            - Range: 0x80bd14..0x80bd15
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bbc5..0x80bbd8
+            - Range: 0x80bd15..0x80bd28
               Pieces: []
-            - Range: 0x80bbd8..0x80bbd9
+            - Range: 0x80bd28..0x80bd29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bbd9..0x80bc00
+            - Range: 0x80bd29..0x80bd50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x80bc00..0x80bd70]
+      OutOfLinePCRanges: [0x80bd50..0x80bec0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80bc00..0x80bc50
+            - Range: 0x80bd50..0x80bda0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bc50..0x80bc54
+            - Range: 0x80bda0..0x80bda4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x80bcdc..0x80bce0
+            - Range: 0x80be2c..0x80be30
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bd1c..0x80bd20
+            - Range: 0x80be6c..0x80be70
               Pieces:
                 - Size: 8
                   Op: null
@@ -7712,117 +7712,117 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80bc00..0x80bc44
+            - Range: 0x80bd50..0x80bd94
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80bc00..0x80bc6c
+            - Range: 0x80bd50..0x80bdbc
               Pieces: []
-            - Range: 0x80bc6c..0x80bc6d
+            - Range: 0x80bdbc..0x80bdbd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bc6d..0x80bcc8
+            - Range: 0x80bdbd..0x80be18
               Pieces: []
-            - Range: 0x80bcc8..0x80bcc9
+            - Range: 0x80be18..0x80be19
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bcc9..0x80bd08
+            - Range: 0x80be19..0x80be58
               Pieces: []
-            - Range: 0x80bd08..0x80bd09
+            - Range: 0x80be58..0x80be59
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bd09..0x80bd44
+            - Range: 0x80be59..0x80be94
               Pieces: []
-            - Range: 0x80bd44..0x80bd45
+            - Range: 0x80be94..0x80be95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bd45..0x80bd70
+            - Range: 0x80be95..0x80bec0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x80bc00..0x80bc6c
+            - Range: 0x80bd50..0x80bdbc
               Pieces: []
-            - Range: 0x80bc6c..0x80bc6d
+            - Range: 0x80bdbc..0x80bdbd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80bc6d..0x80bcc8
+            - Range: 0x80bdbd..0x80be18
               Pieces: []
-            - Range: 0x80bcc8..0x80bcc9
+            - Range: 0x80be18..0x80be19
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80bcc9..0x80bd08
+            - Range: 0x80be19..0x80be58
               Pieces: []
-            - Range: 0x80bd08..0x80bd09
+            - Range: 0x80be58..0x80be59
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80bd09..0x80bd44
+            - Range: 0x80be59..0x80be94
               Pieces: []
-            - Range: 0x80bd44..0x80bd45
+            - Range: 0x80be94..0x80be95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80bd45..0x80bd70
+            - Range: 0x80be95..0x80bec0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80bc50..0x80bc58
+            - Range: 0x80bda0..0x80bda8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x80bd70..0x80bf50]
+      OutOfLinePCRanges: [0x80bec0..0x80c0a0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80bd70..0x80bdb0
+            - Range: 0x80bec0..0x80bf00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bdb0..0x80bdb8
+            - Range: 0x80bf00..0x80bf08
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80bdb8..0x80bf50
+            - Range: 0x80bf08..0x80c0a0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7833,549 +7833,549 @@ Subprograms:
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80bd70..0x80be10
+            - Range: 0x80bec0..0x80bf60
               Pieces: []
-            - Range: 0x80be10..0x80be11
+            - Range: 0x80bf60..0x80bf61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80be11..0x80be64
+            - Range: 0x80bf61..0x80bfb4
               Pieces: []
-            - Range: 0x80be64..0x80be65
+            - Range: 0x80bfb4..0x80bfb5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80be65..0x80bf14
+            - Range: 0x80bfb5..0x80c064
               Pieces: []
-            - Range: 0x80bf14..0x80bf15
+            - Range: 0x80c064..0x80c065
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bf15..0x80bf28
+            - Range: 0x80c065..0x80c078
               Pieces: []
-            - Range: 0x80bf28..0x80bf29
+            - Range: 0x80c078..0x80c079
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bf29..0x80bf50
+            - Range: 0x80c079..0x80c0a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80bdfc..0x80be04
+            - Range: 0x80bf4c..0x80bf54
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x80be48..0x80be64
+            - Range: 0x80bf98..0x80bfb4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x80bf50..0x80c0a0]
+      OutOfLinePCRanges: [0x80c0a0..0x80c1f0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80bf50..0x80bf8c
+            - Range: 0x80c0a0..0x80c0dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bf8c..0x80bfcc
+            - Range: 0x80c0dc..0x80c11c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80bfcc..0x80c040
+            - Range: 0x80c11c..0x80c190
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80c040..0x80c068
+            - Range: 0x80c190..0x80c1b8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80c068..0x80c06c
+            - Range: 0x80c1b8..0x80c1bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80c06c..0x80c0a0
+            - Range: 0x80c1bc..0x80c1f0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80bf50..0x80c020
+            - Range: 0x80c0a0..0x80c170
               Pieces: []
-            - Range: 0x80c020..0x80c021
+            - Range: 0x80c170..0x80c171
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c021..0x80c034
+            - Range: 0x80c171..0x80c184
               Pieces: []
-            - Range: 0x80c034..0x80c035
+            - Range: 0x80c184..0x80c185
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c035..0x80c0a0
+            - Range: 0x80c185..0x80c1f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80bf50..0x80bf8c
+            - Range: 0x80c0a0..0x80c0dc
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bf8c..0x80bfcc
+            - Range: 0x80c0dc..0x80c11c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80bfcc..0x80bfd4
+            - Range: 0x80c11c..0x80c124
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80bfd4..0x80c02c
+            - Range: 0x80c124..0x80c17c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80c02c..0x80c030
+            - Range: 0x80c17c..0x80c180
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80c030..0x80c034
+            - Range: 0x80c180..0x80c184
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80c034..0x80c0a0
+            - Range: 0x80c184..0x80c1f0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x80c0a0..0x80c130]
+      OutOfLinePCRanges: [0x80c1f0..0x80c280]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c0a0..0x80c0bc
+            - Range: 0x80c1f0..0x80c20c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c0a0..0x80c110
+            - Range: 0x80c1f0..0x80c260
               Pieces: []
-            - Range: 0x80c110..0x80c111
+            - Range: 0x80c260..0x80c261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c111..0x80c130
+            - Range: 0x80c261..0x80c280
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x80c130..0x80c1f0]
+      OutOfLinePCRanges: [0x80c280..0x80c340]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c130..0x80c17c
+            - Range: 0x80c280..0x80c2cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c130..0x80c1c8
+            - Range: 0x80c280..0x80c318
               Pieces: []
-            - Range: 0x80c1c8..0x80c1c9
+            - Range: 0x80c318..0x80c319
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c1c9..0x80c1f0
+            - Range: 0x80c319..0x80c340
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c130..0x80c1c8
+            - Range: 0x80c280..0x80c318
               Pieces: []
-            - Range: 0x80c1c8..0x80c1c9
+            - Range: 0x80c318..0x80c319
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c1c9..0x80c1f0
+            - Range: 0x80c319..0x80c340
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x80c1f0..0x80c2b0]
+      OutOfLinePCRanges: [0x80c340..0x80c400]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c1f0..0x80c22c
+            - Range: 0x80c340..0x80c37c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c22c..0x80c2b0
+            - Range: 0x80c37c..0x80c400
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c1f0..0x80c28c
+            - Range: 0x80c340..0x80c3dc
               Pieces: []
-            - Range: 0x80c28c..0x80c28d
+            - Range: 0x80c3dc..0x80c3dd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c28d..0x80c2b0
+            - Range: 0x80c3dd..0x80c400
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c1f0..0x80c28c
+            - Range: 0x80c340..0x80c3dc
               Pieces: []
-            - Range: 0x80c28c..0x80c28d
+            - Range: 0x80c3dc..0x80c3dd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c28d..0x80c2b0
+            - Range: 0x80c3dd..0x80c400
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c1f0..0x80c28c
+            - Range: 0x80c340..0x80c3dc
               Pieces: []
-            - Range: 0x80c28c..0x80c28d
+            - Range: 0x80c3dc..0x80c3dd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80c28d..0x80c2b0
+            - Range: 0x80c3dd..0x80c400
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x80c2b0..0x80c390]
+      OutOfLinePCRanges: [0x80c400..0x80c4e0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c2b0..0x80c2ec
+            - Range: 0x80c400..0x80c43c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c2ec..0x80c390
+            - Range: 0x80c43c..0x80c4e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c2b0..0x80c368
+            - Range: 0x80c400..0x80c4b8
               Pieces: []
-            - Range: 0x80c368..0x80c369
+            - Range: 0x80c4b8..0x80c4b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c369..0x80c390
+            - Range: 0x80c4b9..0x80c4e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c2b0..0x80c368
+            - Range: 0x80c400..0x80c4b8
               Pieces: []
-            - Range: 0x80c368..0x80c369
+            - Range: 0x80c4b8..0x80c4b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c369..0x80c390
+            - Range: 0x80c4b9..0x80c4e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x80c390..0x80c540]
+      OutOfLinePCRanges: [0x80c4e0..0x80c690]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c390..0x80c3f8
+            - Range: 0x80c4e0..0x80c548
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c3f8..0x80c540
+            - Range: 0x80c548..0x80c690
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c3bc..0x80c540
+            - Range: 0x80c50c..0x80c690
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c3c0..0x80c540
+            - Range: 0x80c510..0x80c690
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x80c600..0x80c690]
+      OutOfLinePCRanges: [0x80c750..0x80c7e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x80c600..0x80c66c
+            - Range: 0x80c750..0x80c7bc
               Pieces: []
-            - Range: 0x80c66c..0x80c66d
+            - Range: 0x80c7bc..0x80c7bd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c66d..0x80c690
+            - Range: 0x80c7bd..0x80c7e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 96 BaseType int16
           Locations:
-            - Range: 0x80c600..0x80c66c
+            - Range: 0x80c750..0x80c7bc
               Pieces: []
-            - Range: 0x80c66c..0x80c66d
+            - Range: 0x80c7bc..0x80c7bd
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c66d..0x80c690
+            - Range: 0x80c7bd..0x80c7e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x80c600..0x80c66c
+            - Range: 0x80c750..0x80c7bc
               Pieces: []
-            - Range: 0x80c66c..0x80c66d
+            - Range: 0x80c7bc..0x80c7bd
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80c66d..0x80c690
+            - Range: 0x80c7bd..0x80c7e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x80c600..0x80c66c
+            - Range: 0x80c750..0x80c7bc
               Pieces: []
-            - Range: 0x80c66c..0x80c66d
+            - Range: 0x80c7bc..0x80c7bd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80c66d..0x80c690
+            - Range: 0x80c7bd..0x80c7e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x80c600..0x80c66c
+            - Range: 0x80c750..0x80c7bc
               Pieces: []
-            - Range: 0x80c66c..0x80c66d
+            - Range: 0x80c7bc..0x80c7bd
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80c66d..0x80c690
+            - Range: 0x80c7bd..0x80c7e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x80c600..0x80c66c
+            - Range: 0x80c750..0x80c7bc
               Pieces: []
-            - Range: 0x80c66c..0x80c66d
+            - Range: 0x80c7bc..0x80c7bd
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80c66d..0x80c690
+            - Range: 0x80c7bd..0x80c7e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x80c600..0x80c66c
+            - Range: 0x80c750..0x80c7bc
               Pieces: []
-            - Range: 0x80c66c..0x80c66d
+            - Range: 0x80c7bc..0x80c7bd
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80c66d..0x80c690
+            - Range: 0x80c7bd..0x80c7e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x80c600..0x80c66c
+            - Range: 0x80c750..0x80c7bc
               Pieces: []
-            - Range: 0x80c66c..0x80c66d
+            - Range: 0x80c7bc..0x80c7bd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80c66d..0x80c690
+            - Range: 0x80c7bd..0x80c7e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x80c690..0x80c740]
+      OutOfLinePCRanges: [0x80c7e0..0x80c890]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c690..0x80c740, Pieces: []}]
+          Locations: [{Range: 0x80c7e0..0x80c890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x80c690..0x80c728
+            - Range: 0x80c7e0..0x80c878
               Pieces: []
-            - Range: 0x80c728..0x80c729
+            - Range: 0x80c878..0x80c879
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80c729..0x80c740
+            - Range: 0x80c879..0x80c890
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x80c740..0x80c7c0]
+      OutOfLinePCRanges: [0x80c890..0x80c910]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 97 BaseType complex64
-          Locations: [{Range: 0x80c740..0x80c7c0, Pieces: []}]
+          Locations: [{Range: 0x80c890..0x80c910, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 98 BaseType complex128
-          Locations: [{Range: 0x80c740..0x80c7c0, Pieces: []}]
+          Locations: [{Range: 0x80c890..0x80c910, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x80c7c0..0x80c880]
+      OutOfLinePCRanges: [0x80c910..0x80c9d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80c7c0..0x80c85c
+            - Range: 0x80c910..0x80c9ac
               Pieces: []
-            - Range: 0x80c85c..0x80c85d
+            - Range: 0x80c9ac..0x80c9ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8397,193 +8397,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80c85d..0x80c880
+            - Range: 0x80c9ad..0x80c9d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x80c880..0x80c900]
+      OutOfLinePCRanges: [0x80c9d0..0x80ca50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80c880..0x80c8e8
+            - Range: 0x80c9d0..0x80ca38
               Pieces: []
-            - Range: 0x80c8e8..0x80c8e9
+            - Range: 0x80ca38..0x80ca39
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80c8e9..0x80c900
+            - Range: 0x80ca39..0x80ca50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x80c900..0x80c970]
+      OutOfLinePCRanges: [0x80ca50..0x80cac0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 ArrayType [1]int
           Locations:
-            - Range: 0x80c900..0x80c950
+            - Range: 0x80ca50..0x80caa0
               Pieces: []
-            - Range: 0x80c950..0x80c951
+            - Range: 0x80caa0..0x80caa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c951..0x80c970
+            - Range: 0x80caa1..0x80cac0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x80c970..0x80c9e0]
+      OutOfLinePCRanges: [0x80cac0..0x80cb30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0x80c970..0x80c9bc
+            - Range: 0x80cac0..0x80cb0c
               Pieces: []
-            - Range: 0x80c9bc..0x80c9bd
+            - Range: 0x80cb0c..0x80cb0d
               Pieces: []
-            - Range: 0x80c9bd..0x80c9e0
+            - Range: 0x80cb0d..0x80cb30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x80c9e0..0x80ca60]
+      OutOfLinePCRanges: [0x80cb30..0x80cbb0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
-          Locations: [{Range: 0x80c9e0..0x80ca60, Pieces: []}]
+          Locations: [{Range: 0x80cb30..0x80cbb0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x80ca60..0x80caf0]
+      OutOfLinePCRanges: [0x80cbb0..0x80cc40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca60..0x80cad8
+            - Range: 0x80cbb0..0x80cc28
               Pieces: []
-            - Range: 0x80cad8..0x80cad9
+            - Range: 0x80cc28..0x80cc29
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cad9..0x80caf0
+            - Range: 0x80cc29..0x80cc40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca60..0x80cad8
+            - Range: 0x80cbb0..0x80cc28
               Pieces: []
-            - Range: 0x80cad8..0x80cad9
+            - Range: 0x80cc28..0x80cc29
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80cad9..0x80caf0
+            - Range: 0x80cc29..0x80cc40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca60..0x80cad8
+            - Range: 0x80cbb0..0x80cc28
               Pieces: []
-            - Range: 0x80cad8..0x80cad9
+            - Range: 0x80cc28..0x80cc29
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80cad9..0x80caf0
+            - Range: 0x80cc29..0x80cc40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca60..0x80cad8
+            - Range: 0x80cbb0..0x80cc28
               Pieces: []
-            - Range: 0x80cad8..0x80cad9
+            - Range: 0x80cc28..0x80cc29
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80cad9..0x80caf0
+            - Range: 0x80cc29..0x80cc40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca60..0x80cad8
+            - Range: 0x80cbb0..0x80cc28
               Pieces: []
-            - Range: 0x80cad8..0x80cad9
+            - Range: 0x80cc28..0x80cc29
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80cad9..0x80caf0
+            - Range: 0x80cc29..0x80cc40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca60..0x80cad8
+            - Range: 0x80cbb0..0x80cc28
               Pieces: []
-            - Range: 0x80cad8..0x80cad9
+            - Range: 0x80cc28..0x80cc29
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80cad9..0x80caf0
+            - Range: 0x80cc29..0x80cc40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca60..0x80cad8
+            - Range: 0x80cbb0..0x80cc28
               Pieces: []
-            - Range: 0x80cad8..0x80cad9
+            - Range: 0x80cc28..0x80cc29
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80cad9..0x80caf0
+            - Range: 0x80cc29..0x80cc40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ca60..0x80cad8
+            - Range: 0x80cbb0..0x80cc28
               Pieces: []
-            - Range: 0x80cad8..0x80cad9
+            - Range: 0x80cc28..0x80cc29
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80cad9..0x80caf0
+            - Range: 0x80cc29..0x80cc40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80ca60..0x80cad8
+            - Range: 0x80cbb0..0x80cc28
               Pieces: []
-            - Range: 0x80cad8..0x80cad9
+            - Range: 0x80cc28..0x80cc29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80cad9..0x80caf0
+            - Range: 0x80cc29..0x80cc40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x80caf0..0x80cbc0]
+      OutOfLinePCRanges: [0x80cc40..0x80cd10]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.wideStruct
           Locations:
-            - Range: 0x80caf0..0x80cb9c
+            - Range: 0x80cc40..0x80ccec
               Pieces: []
-            - Range: 0x80cb9c..0x80cb9d
+            - Range: 0x80ccec..0x80cced
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8607,145 +8607,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x80cb9d..0x80cbc0
+            - Range: 0x80cced..0x80cd10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x80cbc0..0x80cc50]
+      OutOfLinePCRanges: [0x80cd10..0x80cda0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80cbc0..0x80cc2c
+            - Range: 0x80cd10..0x80cd7c
               Pieces: []
-            - Range: 0x80cc2c..0x80cc2d
+            - Range: 0x80cd7c..0x80cd7d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cc2d..0x80cc50
+            - Range: 0x80cd7d..0x80cda0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80cbc0..0x80cc50, Pieces: []}]
+          Locations: [{Range: 0x80cd10..0x80cda0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80cbc0..0x80cc2c
+            - Range: 0x80cd10..0x80cd7c
               Pieces: []
-            - Range: 0x80cc2c..0x80cc2d
+            - Range: 0x80cd7c..0x80cd7d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80cc2d..0x80cc50
+            - Range: 0x80cd7d..0x80cda0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80cbc0..0x80cc50, Pieces: []}]
+          Locations: [{Range: 0x80cd10..0x80cda0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80cbc0..0x80cc2c
+            - Range: 0x80cd10..0x80cd7c
               Pieces: []
-            - Range: 0x80cc2c..0x80cc2d
+            - Range: 0x80cd7c..0x80cd7d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80cc2d..0x80cc50
+            - Range: 0x80cd7d..0x80cda0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x80cc50..0x80ccd0]
+      OutOfLinePCRanges: [0x80cda0..0x80ce20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80cc50..0x80ccb8
+            - Range: 0x80cda0..0x80ce08
               Pieces: []
-            - Range: 0x80ccb8..0x80ccb9
+            - Range: 0x80ce08..0x80ce09
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80ccb9..0x80ccd0
+            - Range: 0x80ce09..0x80ce20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x80ccd0..0x80cd40]
+      OutOfLinePCRanges: [0x80ce20..0x80ce90]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80ccd0..0x80cd40, Pieces: []}]
+          Locations: [{Range: 0x80ce20..0x80ce90, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x80cd40..0x80cdb0]
+      OutOfLinePCRanges: [0x80ce90..0x80cf00]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0x80cd40..0x80cdb0, Pieces: []}]
+          Locations: [{Range: 0x80ce90..0x80cf00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80cd40..0x80cdb0, Pieces: []}]
+          Locations: [{Range: 0x80ce90..0x80cf00, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x80cdb0..0x80ce20]
+      OutOfLinePCRanges: [0x80cf00..0x80cf70]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80cdb0..0x80ce04
+            - Range: 0x80cf00..0x80cf54
               Pieces: []
-            - Range: 0x80ce04..0x80ce05
+            - Range: 0x80cf54..0x80cf55
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ce05..0x80ce20
+            - Range: 0x80cf55..0x80cf70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x80cdb0..0x80ce04
+            - Range: 0x80cf00..0x80cf54
               Pieces: []
-            - Range: 0x80ce04..0x80ce05
+            - Range: 0x80cf54..0x80cf55
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80ce05..0x80ce20
+            - Range: 0x80cf55..0x80cf70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x80ce20..0x80cfb0]
+      OutOfLinePCRanges: [0x80cf70..0x80d100]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80ce20..0x80ce78
+            - Range: 0x80cf70..0x80cfc8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8767,7 +8767,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ce78..0x80ce80
+            - Range: 0x80cfc8..0x80cfd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8789,7 +8789,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ce80..0x80ce88
+            - Range: 0x80cfd0..0x80cfd8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8811,7 +8811,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ce88..0x80ce8c
+            - Range: 0x80cfd8..0x80cfdc
               Pieces:
                 - Size: 8
                   Op: null
@@ -8838,9 +8838,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80ce20..0x80cf68
+            - Range: 0x80cf70..0x80d0b8
               Pieces: []
-            - Range: 0x80cf68..0x80cf69
+            - Range: 0x80d0b8..0x80d0b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8862,44 +8862,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80cf69..0x80cfb0
+            - Range: 0x80d0b9..0x80d100
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x80cfb0..0x80d070]
+      OutOfLinePCRanges: [0x80d100..0x80d1c0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80cfb0..0x80d070
+            - Range: 0x80d100..0x80d1c0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80cfb0..0x80d058
+            - Range: 0x80d100..0x80d1a8
               Pieces: []
-            - Range: 0x80d058..0x80d059
+            - Range: 0x80d1a8..0x80d1a9
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80d059..0x80d070
+            - Range: 0x80d1a9..0x80d1c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x80d070..0x80d280]
+      OutOfLinePCRanges: [0x80d1c0..0x80d3d0]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80d070..0x80d0cc
+            - Range: 0x80d1c0..0x80d21c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8921,7 +8921,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d0cc..0x80d0d4
+            - Range: 0x80d21c..0x80d224
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8943,7 +8943,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d0d4..0x80d0dc
+            - Range: 0x80d224..0x80d22c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8965,7 +8965,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d0dc..0x80d0e0
+            - Range: 0x80d22c..0x80d230
               Pieces:
                 - Size: 8
                   Op: null
@@ -8992,16 +8992,16 @@ Subprograms:
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80d070..0x80d280
+            - Range: 0x80d1c0..0x80d3d0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80d070..0x80d234
+            - Range: 0x80d1c0..0x80d384
               Pieces: []
-            - Range: 0x80d234..0x80d235
+            - Range: 0x80d384..0x80d385
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9023,196 +9023,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d235..0x80d280
+            - Range: 0x80d385..0x80d3d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x80d280..0x80d420]
+      OutOfLinePCRanges: [0x80d3d0..0x80d570]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d280..0x80d2f4
+            - Range: 0x80d3d0..0x80d444
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d2f4..0x80d420
+            - Range: 0x80d444..0x80d570
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d280..0x80d2e4
+            - Range: 0x80d3d0..0x80d434
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80d2e4..0x80d420
+            - Range: 0x80d434..0x80d570
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d280..0x80d2ec
+            - Range: 0x80d3d0..0x80d43c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80d2ec..0x80d420
+            - Range: 0x80d43c..0x80d570
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d280..0x80d2f4
+            - Range: 0x80d3d0..0x80d444
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80d2f4..0x80d420
+            - Range: 0x80d444..0x80d570
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d280..0x80d2f4
+            - Range: 0x80d3d0..0x80d444
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80d2f4..0x80d420
+            - Range: 0x80d444..0x80d570
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d280..0x80d2f4
+            - Range: 0x80d3d0..0x80d444
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80d2f4..0x80d420
+            - Range: 0x80d444..0x80d570
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d280..0x80d2f4
+            - Range: 0x80d3d0..0x80d444
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80d2f4..0x80d420
+            - Range: 0x80d444..0x80d570
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d280..0x80d2f4
+            - Range: 0x80d3d0..0x80d444
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80d2f4..0x80d420
+            - Range: 0x80d444..0x80d570
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d280..0x80d2f4
+            - Range: 0x80d3d0..0x80d444
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x80d2f4..0x80d420
+            - Range: 0x80d444..0x80d570
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80d280..0x80d3dc
+            - Range: 0x80d3d0..0x80d52c
               Pieces: []
-            - Range: 0x80d3dc..0x80d3dd
+            - Range: 0x80d52c..0x80d52d
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x80d3dd..0x80d420
+            - Range: 0x80d52d..0x80d570
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x80d420..0x80d610]
+      OutOfLinePCRanges: [0x80d570..0x80d760]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d420..0x80d4a4
+            - Range: 0x80d570..0x80d5f4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d4a4..0x80d610
+            - Range: 0x80d5f4..0x80d760
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d420..0x80d494
+            - Range: 0x80d570..0x80d5e4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80d494..0x80d610
+            - Range: 0x80d5e4..0x80d760
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d420..0x80d49c
+            - Range: 0x80d570..0x80d5ec
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80d49c..0x80d610
+            - Range: 0x80d5ec..0x80d760
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d420..0x80d4a4
+            - Range: 0x80d570..0x80d5f4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80d4a4..0x80d610
+            - Range: 0x80d5f4..0x80d760
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d420..0x80d4a4
+            - Range: 0x80d570..0x80d5f4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80d4a4..0x80d610
+            - Range: 0x80d5f4..0x80d760
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d420..0x80d4a4
+            - Range: 0x80d570..0x80d5f4
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80d4a4..0x80d610
+            - Range: 0x80d5f4..0x80d760
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d420..0x80d4a4
+            - Range: 0x80d570..0x80d5f4
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80d4a4..0x80d610
+            - Range: 0x80d5f4..0x80d760
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d420..0x80d4a4
+            - Range: 0x80d570..0x80d5f4
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80d4a4..0x80d610
+            - Range: 0x80d5f4..0x80d760
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80d420..0x80d4a4
+            - Range: 0x80d570..0x80d5f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d4a4..0x80d610
+            - Range: 0x80d5f4..0x80d760
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9223,9 +9223,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80d420..0x80d5c8
+            - Range: 0x80d570..0x80d718
               Pieces: []
-            - Range: 0x80d5c8..0x80d5c9
+            - Range: 0x80d718..0x80d719
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9247,196 +9247,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d5c9..0x80d610
+            - Range: 0x80d719..0x80d760
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x80d610..0x80d6a0]
+      OutOfLinePCRanges: [0x80d760..0x80d7f0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x80d610..0x80d6a0
+            - Range: 0x80d760..0x80d7f0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d610..0x80d680
+            - Range: 0x80d760..0x80d7d0
               Pieces: []
-            - Range: 0x80d680..0x80d681
+            - Range: 0x80d7d0..0x80d7d1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d681..0x80d6a0
+            - Range: 0x80d7d1..0x80d7f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d610..0x80d680
+            - Range: 0x80d760..0x80d7d0
               Pieces: []
-            - Range: 0x80d680..0x80d681
+            - Range: 0x80d7d0..0x80d7d1
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80d681..0x80d6a0
+            - Range: 0x80d7d1..0x80d7f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d610..0x80d680
+            - Range: 0x80d760..0x80d7d0
               Pieces: []
-            - Range: 0x80d680..0x80d681
+            - Range: 0x80d7d0..0x80d7d1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80d681..0x80d6a0
+            - Range: 0x80d7d1..0x80d7f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x80d6a0..0x80d770]
+      OutOfLinePCRanges: [0x80d7f0..0x80d8c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80d6a0..0x80d770
+            - Range: 0x80d7f0..0x80d8c0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80d6a0..0x80d770
+            - Range: 0x80d7f0..0x80d8c0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d6a0..0x80d754
+            - Range: 0x80d7f0..0x80d8a4
               Pieces: []
-            - Range: 0x80d754..0x80d755
+            - Range: 0x80d8a4..0x80d8a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d755..0x80d770
+            - Range: 0x80d8a5..0x80d8c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80d6a0..0x80d754
+            - Range: 0x80d7f0..0x80d8a4
               Pieces: []
-            - Range: 0x80d754..0x80d755
+            - Range: 0x80d8a4..0x80d8a5
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x80d755..0x80d770
+            - Range: 0x80d8a5..0x80d8c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x80d770..0x80d830]
+      OutOfLinePCRanges: [0x80d8c0..0x80d980]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80d770..0x80d830
+            - Range: 0x80d8c0..0x80d980
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d770..0x80d810
+            - Range: 0x80d8c0..0x80d960
               Pieces: []
-            - Range: 0x80d810..0x80d811
+            - Range: 0x80d960..0x80d961
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d811..0x80d830
+            - Range: 0x80d961..0x80d980
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80d770..0x80d810
+            - Range: 0x80d8c0..0x80d960
               Pieces: []
-            - Range: 0x80d810..0x80d811
+            - Range: 0x80d960..0x80d961
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80d811..0x80d830
+            - Range: 0x80d961..0x80d980
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d7e8..0x80d830
+            - Range: 0x80d938..0x80d980
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x80d830..0x80d8d0]
+      OutOfLinePCRanges: [0x80d980..0x80da20]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 ArrayType [0]int
-          Locations: [{Range: 0x80d830..0x80d8d0, Pieces: []}]
+          Locations: [{Range: 0x80d980..0x80da20, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d830..0x80d86c
+            - Range: 0x80d980..0x80d9bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d86c..0x80d884
+            - Range: 0x80d9bc..0x80d9d4
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80d884..0x80d88c
+            - Range: 0x80d9d4..0x80d9dc
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80d88c..0x80d8d0
+            - Range: 0x80d9dc..0x80da20
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d830..0x80d8a8
+            - Range: 0x80d980..0x80d9f8
               Pieces: []
-            - Range: 0x80d8a8..0x80d8a9
+            - Range: 0x80d9f8..0x80d9f9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d8a9..0x80d8d0
+            - Range: 0x80d9f9..0x80da20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0x80d830..0x80d8a8
+            - Range: 0x80d980..0x80d9f8
               Pieces: []
-            - Range: 0x80d8a8..0x80d8a9
+            - Range: 0x80d9f8..0x80d9f9
               Pieces: []
-            - Range: 0x80d8a9..0x80d8d0
+            - Range: 0x80d9f9..0x80da20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80dd10..0x80dd20]
+      OutOfLinePCRanges: [0x80de60..0x80de70]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80dd10..0x80dd20
+            - Range: 0x80de60..0x80de70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9449,13 +9449,13 @@ Subprograms:
       DictRegister: null
     - ID: 134
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x80dd20..0x80dd30]
+      OutOfLinePCRanges: [0x80de70..0x80de80]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80dd20..0x80dd30
+            - Range: 0x80de70..0x80de80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9468,13 +9468,13 @@ Subprograms:
       DictRegister: null
     - ID: 135
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x80dd30..0x80dd40]
+      OutOfLinePCRanges: [0x80de80..0x80de90]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 258 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x80dd30..0x80dd40
+            - Range: 0x80de80..0x80de90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9487,13 +9487,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x80dd40..0x80dd50]
+      OutOfLinePCRanges: [0x80de90..0x80dea0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80dd40..0x80dd50
+            - Range: 0x80de90..0x80dea0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9506,20 +9506,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80dd40..0x80dd50
+            - Range: 0x80de90..0x80dea0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 137
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x80dd50..0x80dd60]
+      OutOfLinePCRanges: [0x80dea0..0x80deb0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80dd50..0x80dd60
+            - Range: 0x80dea0..0x80deb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9532,20 +9532,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80dd50..0x80dd60
+            - Range: 0x80dea0..0x80deb0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 138
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x80dd60..0x80dd70]
+      OutOfLinePCRanges: [0x80deb0..0x80dec0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80dd60..0x80dd70
+            - Range: 0x80deb0..0x80dec0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9558,20 +9558,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80dd60..0x80dd70
+            - Range: 0x80deb0..0x80dec0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x80dd70..0x80dd80]
+      OutOfLinePCRanges: [0x80dec0..0x80ded0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 263 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80dd70..0x80dd80
+            - Range: 0x80dec0..0x80ded0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9584,20 +9584,20 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x80dd80..0x80dd90]
+      OutOfLinePCRanges: [0x80ded0..0x80dee0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x80dd80..0x80dd90
+            - Range: 0x80ded0..0x80dee0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 264 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80dd80..0x80dd90
+            - Range: 0x80ded0..0x80dee0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9610,20 +9610,20 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x80dd80..0x80dd90
+            - Range: 0x80ded0..0x80dee0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80dd90..0x80dda0]
+      OutOfLinePCRanges: [0x80dee0..0x80def0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x80dd90..0x80dda0
+            - Range: 0x80dee0..0x80def0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9636,13 +9636,13 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x80dda0..0x80ddb0]
+      OutOfLinePCRanges: [0x80def0..0x80df00]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80dda0..0x80ddb0
+            - Range: 0x80def0..0x80df00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9655,13 +9655,13 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x80ddb0..0x80ddc0]
+      OutOfLinePCRanges: [0x80df00..0x80df10]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 266 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x80ddb0..0x80ddc0
+            - Range: 0x80df00..0x80df10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9674,13 +9674,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80ddc0..0x80ddd0]
+      OutOfLinePCRanges: [0x80df10..0x80df20]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80ddc0..0x80ddd0
+            - Range: 0x80df10..0x80df20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9693,7 +9693,7 @@ Subprograms:
         - Name: bs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80ddc0..0x80ddd0
+            - Range: 0x80df10..0x80df20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9706,7 +9706,7 @@ Subprograms:
         - Name: cs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80ddc0..0x80ddd0
+            - Range: 0x80df10..0x80df20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9719,34 +9719,34 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0x80e0b0..0x80e110]
+      OutOfLinePCRanges: [0x80e200..0x80e260]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e0b0..0x80e0f8
+            - Range: 0x80e200..0x80e248
               Pieces: []
-            - Range: 0x80e0f8..0x80e0f9
+            - Range: 0x80e248..0x80e249
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e0f9..0x80e110
+            - Range: 0x80e249..0x80e260
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80e110..0x80e120]
+      OutOfLinePCRanges: [0x80e260..0x80e270]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e110..0x80e120
+            - Range: 0x80e260..0x80e270
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9757,13 +9757,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x80e120..0x80e130]
+      OutOfLinePCRanges: [0x80e270..0x80e280]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e120..0x80e130
+            - Range: 0x80e270..0x80e280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9774,7 +9774,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e120..0x80e130
+            - Range: 0x80e270..0x80e280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9785,7 +9785,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e120..0x80e130
+            - Range: 0x80e270..0x80e280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9796,13 +9796,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80e130..0x80e140]
+      OutOfLinePCRanges: [0x80e280..0x80e290]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80e130..0x80e140
+            - Range: 0x80e280..0x80e290
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9821,39 +9821,39 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80e140..0x80e150]
+      OutOfLinePCRanges: [0x80e290..0x80e2a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 269 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x80e140..0x80e150
+            - Range: 0x80e290..0x80e2a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x80e150..0x80e160]
+      OutOfLinePCRanges: [0x80e2a0..0x80e2b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x80e150..0x80e160
+            - Range: 0x80e2a0..0x80e2b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x80e160..0x80e170]
+      OutOfLinePCRanges: [0x80e2b0..0x80e2c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e160..0x80e170
+            - Range: 0x80e2b0..0x80e2c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9864,13 +9864,13 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x80e170..0x80e180]
+      OutOfLinePCRanges: [0x80e2c0..0x80e2d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e170..0x80e180
+            - Range: 0x80e2c0..0x80e2d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9881,13 +9881,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x80e180..0x80e190]
+      OutOfLinePCRanges: [0x80e2d0..0x80e2e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e180..0x80e190
+            - Range: 0x80e2d0..0x80e2e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9898,13 +9898,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x80e190..0x80e1a0]
+      OutOfLinePCRanges: [0x80e2e0..0x80e2f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e190..0x80e1a0
+            - Range: 0x80e2e0..0x80e2f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9915,7 +9915,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e190..0x80e1a0
+            - Range: 0x80e2e0..0x80e2f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9926,7 +9926,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80e190..0x80e1a0
+            - Range: 0x80e2e0..0x80e2f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9937,26 +9937,26 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80e2f0..0x80e300]
+      OutOfLinePCRanges: [0x80e440..0x80e450]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80e2f0..0x80e300
+            - Range: 0x80e440..0x80e450
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80e300..0x80e310]
+      OutOfLinePCRanges: [0x80e450..0x80e460]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 285 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80e300..0x80e310
+            - Range: 0x80e450..0x80e460
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9975,13 +9975,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80e3b0..0x80e3d0]
+      OutOfLinePCRanges: [0x80e500..0x80e520]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 316 StructureType main.aStruct
           Locations:
-            - Range: 0x80e3b0..0x80e3d0
+            - Range: 0x80e500..0x80e520
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10002,93 +10002,93 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x80e440..0x80e450]
+      OutOfLinePCRanges: [0x80e590..0x80e5a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x80e440..0x80e450
+            - Range: 0x80e590..0x80e5a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x80e450..0x80e460]
+      OutOfLinePCRanges: [0x80e5a0..0x80e5b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 319 StructureType main.tenStrings
           Locations:
-            - Range: 0x80e450..0x80e460
+            - Range: 0x80e5a0..0x80e5b0
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80e480..0x80e490]
+      OutOfLinePCRanges: [0x80e5d0..0x80e5e0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 320 StructureType main.emptyStruct
-          Locations: [{Range: 0x80e480..0x80e490, Pieces: []}]
+          Locations: [{Range: 0x80e5d0..0x80e5e0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80e490..0x80e4a0]
+      OutOfLinePCRanges: [0x80e5e0..0x80e5f0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 321 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80e490..0x80e4a0
+            - Range: 0x80e5e0..0x80e5f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x80fc60..0x80fc70]
+      OutOfLinePCRanges: [0x80fdb0..0x80fdc0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x80fc60..0x80fc70
+            - Range: 0x80fdb0..0x80fdc0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80fc60..0x80fc64
+            - Range: 0x80fdb0..0x80fdb4
               Pieces: []
-            - Range: 0x80fc64..0x80fc65
+            - Range: 0x80fdb4..0x80fdb5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fc65..0x80fc70
+            - Range: 0x80fdb5..0x80fdc0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x80fc70..0x80fc80]
+      OutOfLinePCRanges: [0x80fdc0..0x80fdd0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80fc70..0x80fc7c
+            - Range: 0x80fdc0..0x80fdcc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80fc7c..0x80fc80
+            - Range: 0x80fdcc..0x80fdd0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10099,58 +10099,58 @@ Subprograms:
         - Name: ~r0
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80fc70..0x80fc7c
+            - Range: 0x80fdc0..0x80fdcc
               Pieces: []
-            - Range: 0x80fc7c..0x80fc7d
+            - Range: 0x80fdcc..0x80fdcd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fc7d..0x80fc80
+            - Range: 0x80fdcd..0x80fdd0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x80fc80..0x80fc90]
+      OutOfLinePCRanges: [0x80fdd0..0x80fde0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80fc80..0x80fc90
+            - Range: 0x80fdd0..0x80fde0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x80fc80..0x80fc84
+            - Range: 0x80fdd0..0x80fdd4
               Pieces: []
-            - Range: 0x80fc84..0x80fc85
+            - Range: 0x80fdd4..0x80fdd5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fc85..0x80fc90
+            - Range: 0x80fdd5..0x80fde0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x80fc90..0x80fca0]
+      OutOfLinePCRanges: [0x80fde0..0x80fdf0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80fc90..0x80fc9c
+            - Range: 0x80fde0..0x80fdec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80fc9c..0x80fca0
+            - Range: 0x80fdec..0x80fdf0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10161,28 +10161,28 @@ Subprograms:
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80fc90..0x80fc9c
+            - Range: 0x80fde0..0x80fdec
               Pieces: []
-            - Range: 0x80fc9c..0x80fc9d
+            - Range: 0x80fdec..0x80fded
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fc9d..0x80fca0
+            - Range: 0x80fded..0x80fdf0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x80fd00..0x80fe20]
+      OutOfLinePCRanges: [0x80fe50..0x80ff70]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80fd00..0x80fd2c
+            - Range: 0x80fe50..0x80fe7c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10190,7 +10190,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80fd2c..0x80fd3c
+            - Range: 0x80fe7c..0x80fe8c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10198,7 +10198,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x80fd3c..0x80fe20
+            - Range: 0x80fe8c..0x80ff70
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10211,18 +10211,18 @@ Subprograms:
         - Name: pred
           Type: 328 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x80fd00..0x80fd3c
+            - Range: 0x80fe50..0x80fe8c
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80fd3c..0x80fe20
+            - Range: 0x80fe8c..0x80ff70
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80fd00..0x80fdec
+            - Range: 0x80fe50..0x80ff3c
               Pieces: []
-            - Range: 0x80fdec..0x80fded
+            - Range: 0x80ff3c..0x80ff3d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10230,14 +10230,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80fded..0x80fe20
+            - Range: 0x80ff3d..0x80ff70
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80fd2c..0x80fd3c
+            - Range: 0x80fe7c..0x80fe8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10245,7 +10245,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80fd3c..0x80fd58
+            - Range: 0x80fe8c..0x80fea8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10253,7 +10253,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fd58..0x80fd5c
+            - Range: 0x80fea8..0x80feac
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10261,7 +10261,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fd5c..0x80fd60
+            - Range: 0x80feac..0x80feb0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10269,7 +10269,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fd60..0x80fd60
+            - Range: 0x80feb0..0x80feb0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10277,7 +10277,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fd60..0x80fd8c
+            - Range: 0x80feb0..0x80fedc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10285,7 +10285,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80fd8c..0x80fde0
+            - Range: 0x80fedc..0x80ff30
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10293,7 +10293,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fde0..0x80fe20
+            - Range: 0x80ff30..0x80ff70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10306,215 +10306,215 @@ Subprograms:
         - Name: item
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x80fd7c..0x80fd8c
+            - Range: 0x80fecc..0x80fedc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fd8c..0x80fde0
+            - Range: 0x80fedc..0x80ff30
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80fe20..0x80fe70]
+      OutOfLinePCRanges: [0x80ff70..0x80ffc0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80fe20..0x80fe48
+            - Range: 0x80ff70..0x80ff98
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 329 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x80fe20..0x80fe48
+            - Range: 0x80ff70..0x80ff98
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80fe20..0x80fe48
+            - Range: 0x80ff70..0x80ff98
               Pieces: []
-            - Range: 0x80fe48..0x80fe49
+            - Range: 0x80ff98..0x80ff99
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fe49..0x80fe70
+            - Range: 0x80ff99..0x80ffc0
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 168
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x8100e0..0x8100f0]
+      OutOfLinePCRanges: [0x810230..0x810240]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 327 PointerType *go.shape.int
           Locations:
-            - Range: 0x8100e0..0x8100f0
+            - Range: 0x810230..0x810240
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 327 PointerType *go.shape.int
           Locations:
-            - Range: 0x8100e0..0x8100e4
+            - Range: 0x810230..0x810234
               Pieces: []
-            - Range: 0x8100e4..0x8100e5
+            - Range: 0x810234..0x810235
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8100e5..0x8100f0
+            - Range: 0x810235..0x810240
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x8100f0..0x810100]
+      OutOfLinePCRanges: [0x810240..0x810250]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 330 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x8100f0..0x810100
+            - Range: 0x810240..0x810250
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x8100f0..0x8100f4
+            - Range: 0x810240..0x810244
               Pieces: []
-            - Range: 0x8100f4..0x8100f5
+            - Range: 0x810244..0x810245
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8100f5..0x810100
+            - Range: 0x810245..0x810250
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x810100..0x810110]
+      OutOfLinePCRanges: [0x810250..0x810260]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 332 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x810100..0x810110
+            - Range: 0x810250..0x810260
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 332 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x810100..0x810104
+            - Range: 0x810250..0x810254
               Pieces: []
-            - Range: 0x810104..0x810105
+            - Range: 0x810254..0x810255
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810105..0x810110
+            - Range: 0x810255..0x810260
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x810110..0x810120]
+      OutOfLinePCRanges: [0x810260..0x810270]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x810110..0x810120
+            - Range: 0x810260..0x810270
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810110..0x810114
+            - Range: 0x810260..0x810264
               Pieces: []
-            - Range: 0x810114..0x810115
+            - Range: 0x810264..0x810265
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810115..0x810120
+            - Range: 0x810265..0x810270
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x8101a0..0x8101b0]
+      OutOfLinePCRanges: [0x8102f0..0x810300]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 336 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x8101a0..0x8101b0
+            - Range: 0x8102f0..0x810300
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x8101a0..0x8101a4
+            - Range: 0x8102f0..0x8102f4
               Pieces: []
-            - Range: 0x8101a4..0x8101a5
+            - Range: 0x8102f4..0x8102f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8101a5..0x8101b0
+            - Range: 0x8102f5..0x810300
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x810240..0x810250]
+      OutOfLinePCRanges: [0x810390..0x8103a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 337 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x810240..0x810250
+            - Range: 0x810390..0x8103a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x810240..0x810250
+            - Range: 0x810390..0x8103a0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0x810240..0x810250
+            - Range: 0x810390..0x8103a0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x8102d0..0x810340]
+      OutOfLinePCRanges: [0x810420..0x810490]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x8102d0..0x810340
+            - Range: 0x810420..0x810490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8102d0..0x810340
+            - Range: 0x810420..0x810490
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10525,20 +10525,20 @@ Subprograms:
         - Name: v
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x8102d0..0x810340
+            - Range: 0x810420..0x810490
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x8103c0..0x8103d0]
+      OutOfLinePCRanges: [0x810510..0x810520]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8103c0..0x8103d0
+            - Range: 0x810510..0x810520
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10549,59 +10549,59 @@ Subprograms:
         - Name: b
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0x8103c0..0x8103d0
+            - Range: 0x810510..0x810520
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0x8103c0..0x8103c8
+            - Range: 0x810510..0x810518
               Pieces: []
-            - Range: 0x8103c8..0x8103c9
+            - Range: 0x810518..0x810519
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8103c9..0x8103d0
+            - Range: 0x810519..0x810520
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8103c0..0x8103c8
+            - Range: 0x810510..0x810518
               Pieces: []
-            - Range: 0x8103c8..0x8103c9
+            - Range: 0x810518..0x810519
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8103c9..0x8103d0
+            - Range: 0x810519..0x810520
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x8103d0..0x8103f0]
+      OutOfLinePCRanges: [0x810520..0x810540]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x8103d0..0x8103e0
+            - Range: 0x810520..0x810530
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8103d0..0x8103dc
+            - Range: 0x810520..0x81052c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8103dc..0x8103f0
+            - Range: 0x81052c..0x810540
               Pieces:
                 - Size: 8
                   Op: null
@@ -10612,73 +10612,73 @@ Subprograms:
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8103d0..0x8103e0
+            - Range: 0x810520..0x810530
               Pieces: []
-            - Range: 0x8103e0..0x8103e1
+            - Range: 0x810530..0x810531
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8103e1..0x8103f0
+            - Range: 0x810531..0x810540
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x8103d0..0x8103e0
+            - Range: 0x810520..0x810530
               Pieces: []
-            - Range: 0x8103e0..0x8103e1
+            - Range: 0x810530..0x810531
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8103e1..0x8103f0
+            - Range: 0x810531..0x810540
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x8103f0..0x810440]
+      OutOfLinePCRanges: [0x810540..0x810590]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 342 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x8103f0..0x810418
+            - Range: 0x810540..0x810568
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8103f0..0x810418
+            - Range: 0x810540..0x810568
               Pieces: []
-            - Range: 0x810418..0x810419
+            - Range: 0x810568..0x810569
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810419..0x810440
+            - Range: 0x810569..0x810590
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x810440..0x8104a0]
+      OutOfLinePCRanges: [0x810590..0x8105f0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 343 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x810440..0x81046c
+            - Range: 0x810590..0x8105bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x81046c..0x810470
+            - Range: 0x8105bc..0x8105c0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10689,65 +10689,65 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x810440..0x810470
+            - Range: 0x810590..0x8105c0
               Pieces: []
-            - Range: 0x810470..0x810471
+            - Range: 0x8105c0..0x8105c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810471..0x8104a0
+            - Range: 0x8105c1..0x8105f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x8104a0..0x8104b0]
+      OutOfLinePCRanges: [0x8105f0..0x810600]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 344 PointerType *go.shape.string
           Locations:
-            - Range: 0x8104a0..0x8104a4
+            - Range: 0x8105f0..0x8105f4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8104a0..0x8104a4
+            - Range: 0x8105f0..0x8105f4
               Pieces: []
-            - Range: 0x8104a4..0x8104a5
+            - Range: 0x8105f4..0x8105f5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8104a5..0x8104b0
+            - Range: 0x8105f5..0x810600
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x8104b0..0x810500]
+      OutOfLinePCRanges: [0x810600..0x810650]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 345 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x8104b0..0x8104ec
+            - Range: 0x810600..0x81063c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 346 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x8104b0..0x8104f0
+            - Range: 0x810600..0x810640
               Pieces: []
-            - Range: 0x8104f0..0x8104f1
+            - Range: 0x810640..0x810641
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10761,20 +10761,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8104f1..0x810500
+            - Range: 0x810641..0x810650
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x810500..0x810540]
+      OutOfLinePCRanges: [0x810650..0x810690]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x810500..0x81050c
+            - Range: 0x810650..0x81065c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10782,7 +10782,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x81050c..0x810540
+            - Range: 0x81065c..0x810690
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10795,42 +10795,42 @@ Subprograms:
         - Name: needle
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x810500..0x810540
+            - Range: 0x810650..0x810690
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x810500..0x810528
+            - Range: 0x810650..0x810678
               Pieces: []
-            - Range: 0x810528..0x810529
+            - Range: 0x810678..0x810679
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810529..0x810530
+            - Range: 0x810679..0x810680
               Pieces: []
-            - Range: 0x810530..0x810531
+            - Range: 0x810680..0x810681
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810531..0x810540
+            - Range: 0x810681..0x810690
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x81051c..0x81052c
+            - Range: 0x81066c..0x81067c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x810540..0x810600]
+      OutOfLinePCRanges: [0x810690..0x810750]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 347 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x810540..0x810564
+            - Range: 0x810690..0x8106b4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10838,7 +10838,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x810564..0x810568
+            - Range: 0x8106b4..0x8106b8
               Pieces:
                 - Size: 8
                   Op: null
@@ -10851,13 +10851,13 @@ Subprograms:
         - Name: needle
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810540..0x810598
+            - Range: 0x810690..0x8106e8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x810598..0x810600
+            - Range: 0x8106e8..0x810750
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10868,22 +10868,22 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x810540..0x8105b4
+            - Range: 0x810690..0x810704
               Pieces: []
-            - Range: 0x8105b4..0x8105b5
+            - Range: 0x810704..0x810705
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8105b5..0x8105c4
+            - Range: 0x810705..0x810714
               Pieces: []
-            - Range: 0x8105c4..0x8105c5
+            - Range: 0x810714..0x810715
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8105c5..0x810600
+            - Range: 0x810715..0x810750
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810580..0x810598
+            - Range: 0x8106d0..0x8106e8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10894,56 +10894,56 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x810600..0x810610]
+      OutOfLinePCRanges: [0x810750..0x810760]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 348 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x810600..0x810608
+            - Range: 0x810750..0x810758
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x810600..0x810610
+            - Range: 0x810750..0x810760
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x810600..0x810608
+            - Range: 0x810750..0x810758
               Pieces: []
-            - Range: 0x810608..0x810609
+            - Range: 0x810758..0x810759
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810609..0x810610
+            - Range: 0x810759..0x810760
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x810680..0x8106f0]
+      OutOfLinePCRanges: [0x8107d0..0x810840]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 349 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x810680..0x8106ac
+            - Range: 0x8107d0..0x8107fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8106ac..0x8106b8
+            - Range: 0x8107fc..0x810808
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8106b8..0x8106bc
+            - Range: 0x810808..0x81080c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10954,7 +10954,7 @@ Subprograms:
         - Name: value
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810680..0x8106bc
+            - Range: 0x8107d0..0x81080c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10965,11 +10965,11 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x810680..0x8106bc
+            - Range: 0x8107d0..0x81080c
               Pieces: []
-            - Range: 0x8106bc..0x8106bd
+            - Range: 0x81080c..0x81080d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8106bd..0x8106f0
+            - Range: 0x81080d..0x810840
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11115,31 +11115,31 @@ Subprograms:
       DictRegister: 0
     - ID: 186
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x808f00..0x808f70]
+      OutOfLinePCRanges: [0x809050..0x8090c0]
       InlinePCRanges:
-        - Ranges: [0x808f8c..0x808fc0]
-          RootRanges: [0x808f70..0x808fe0]
-        - Ranges: [0x8090c8..0x8090fc]
-          RootRanges: [0x809090..0x809120]
-        - Ranges: [0x809144..0x809178]
-          RootRanges: [0x809120..0x8091e0]
-        - Ranges: [0x8091fc..0x809230]
-          RootRanges: [0x8091e0..0x809250]
+        - Ranges: [0x8090dc..0x809110]
+          RootRanges: [0x8090c0..0x809130]
+        - Ranges: [0x809218..0x80924c]
+          RootRanges: [0x8091e0..0x809270]
+        - Ranges: [0x809294..0x8092c8]
+          RootRanges: [0x809270..0x809330]
+        - Ranges: [0x80934c..0x809380]
+          RootRanges: [0x809330..0x8093a0]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808f00..0x808f20
+            - Range: 0x809050..0x809070
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808f8c..0x808f94
+            - Range: 0x8090dc..0x8090e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8090c8..0x8090d0
+            - Range: 0x809218..0x809220
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80913c..0x80914c
+            - Range: 0x80928c..0x80929c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80914c..0x8091e0
+            - Range: 0x80929c..0x809330
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x8091e0..0x809204
+            - Range: 0x809330..0x809354
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11148,37 +11148,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x809184..0x8091b8]
-          RootRanges: [0x809120..0x8091e0]
+        - Ranges: [0x8092d4..0x809308]
+          RootRanges: [0x809270..0x809330]
       Variables: []
       DictRegister: null
     - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80926c..0x8092a0, 0x8092a8..0x8092ac]
-          RootRanges: [0x809250..0x809360]
+        - Ranges: [0x8093bc..0x8093f0, 0x8093f8..0x8093fc]
+          RootRanges: [0x8093a0..0x8094b0]
       Variables: []
       DictRegister: null
     - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x809310..0x809344]
-          RootRanges: [0x809250..0x809360]
+        - Ranges: [0x809460..0x809494]
+          RootRanges: [0x8093a0..0x8094b0]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x809364..0x809368]
-          RootRanges: [0x809360..0x809370]
+        - Ranges: [0x8094b4..0x8094b8]
+          RootRanges: [0x8094b0..0x8094c0]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809360..0x809368
+            - Range: 0x8094b0..0x8094b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11187,32 +11187,32 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x809394..0x8093b0]
-          RootRanges: [0x809370..0x8093c0]
-        - Ranges: [0x80941c..0x80943c]
-          RootRanges: [0x8093c0..0x809500]
+        - Ranges: [0x8094e4..0x809500]
+          RootRanges: [0x8094c0..0x809510]
+        - Ranges: [0x80956c..0x80958c]
+          RootRanges: [0x809510..0x809650]
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x809380..0x8093c0
+            - Range: 0x8094d0..0x809510
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x809408..0x809500
+            - Range: 0x809558..0x809650
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 192
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x809500..0x809560]
+      OutOfLinePCRanges: [0x809650..0x8096b0]
       InlinePCRanges:
-        - Ranges: [0x810798..0x8107bc]
-          RootRanges: [0x810770..0x810800]
+        - Ranges: [0x8108e8..0x81090c]
+          RootRanges: [0x8108c0..0x810950]
       Variables:
         - Name: b
           Type: 354 StructureType main.firstBehavior
           Locations:
-            - Range: 0x809500..0x809524
+            - Range: 0x809650..0x809674
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11223,15 +11223,15 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809500..0x809540
+            - Range: 0x809650..0x809690
               Pieces: []
-            - Range: 0x809540..0x809541
+            - Range: 0x809690..0x809691
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x809541..0x809560
+            - Range: 0x809691..0x8096b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11240,8 +11240,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x809b38..0x809b44, 0x809b48..0x809b50]
-          RootRanges: [0x809a20..0x809b90]
+        - Ranges: [0x809c8c..0x809c98, 0x809c9c..0x809ca4]
+          RootRanges: [0x809b70..0x809ce0]
         - Ranges: [0x12c238..0x12c23c, 0x12c240..0x12c248]
           RootRanges: [0x12c230..0x12c250]
       Variables: []
@@ -11288,7 +11288,7 @@ Types:
       ID: 130
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 533504
+      GoRuntimeType: 533536
       GoKind: 22
       Pointee: 95 PointerType *string
     - __kind: PointerType
@@ -11560,7 +11560,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 492160
+      GoRuntimeType: 492192
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11602,14 +11602,14 @@ Types:
       ID: 1189
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.995552e+06
+      GoRuntimeType: 1.99584e+06
       GoKind: 22
       Pointee: 1190 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
       ID: 824
       Name: '*archive/tar.headerError'
       ByteSize: 8
-      GoRuntimeType: 934944
+      GoRuntimeType: 934976
       GoKind: 22
       Pointee: 825 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
@@ -11621,84 +11621,84 @@ Types:
       ID: 1124
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.442304e+06
+      GoRuntimeType: 1.442432e+06
       GoKind: 22
       Pointee: 1125 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
       ID: 1072
       Name: '*archive/zip.countWriter'
       ByteSize: 8
-      GoRuntimeType: 935136
+      GoRuntimeType: 935168
       GoKind: 22
       Pointee: 1073 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
       ID: 1074
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
-      GoRuntimeType: 935232
+      GoRuntimeType: 935264
       GoKind: 22
       Pointee: 1075 StructureType archive/zip.dirWriter
     - __kind: PointerType
       ID: 1168
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.913696e+06
+      GoRuntimeType: 1.913984e+06
       GoKind: 22
       Pointee: 1169 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 1100
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.062208e+06
+      GoRuntimeType: 1.062336e+06
       GoKind: 22
       Pointee: 1101 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 1102
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.062464e+06
+      GoRuntimeType: 1.062592e+06
       GoKind: 22
       Pointee: 1103 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 395456
+      GoRuntimeType: 395488
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 1147
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.184352e+06
+      GoRuntimeType: 2.18464e+06
       GoKind: 22
       Pointee: 1148 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1178
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.958944e+06
+      GoRuntimeType: 1.959232e+06
       GoKind: 22
       Pointee: 1179 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1227
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.277216e+06
+      GoRuntimeType: 2.277504e+06
       GoKind: 22
       Pointee: 1228 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
       ID: 734
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 917472
+      GoRuntimeType: 917504
       GoKind: 22
       Pointee: 623 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
       ID: 735
       Name: '*compress/flate.InternalError'
       ByteSize: 8
-      GoRuntimeType: 917568
+      GoRuntimeType: 917600
       GoKind: 22
       Pointee: 624 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
@@ -11710,371 +11710,371 @@ Types:
       ID: 1122
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.431904e+06
+      GoRuntimeType: 1.432032e+06
       GoKind: 22
       Pointee: 1123 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
       ID: 1068
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
-      GoRuntimeType: 917664
+      GoRuntimeType: 917696
       GoKind: 22
       Pointee: 1069 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
       ID: 1144
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.7352e+06
+      GoRuntimeType: 1.735488e+06
       GoKind: 22
       Pointee: 1145 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 972
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.20928e+06
+      GoRuntimeType: 1.209408e+06
       GoKind: 22
       Pointee: 973 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 816
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 929568
+      GoRuntimeType: 929600
       GoKind: 22
       Pointee: 637 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
       ID: 817
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 929760
+      GoRuntimeType: 929792
       GoKind: 22
       Pointee: 638 BaseType crypto/des.KeySizeError
     - __kind: PointerType
       ID: 818
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 930048
+      GoRuntimeType: 930080
       GoKind: 22
       Pointee: 639 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
       ID: 1139
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
-      GoRuntimeType: 1.675936e+06
+      GoRuntimeType: 1.676224e+06
       GoKind: 22
       Pointee: 1140 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
       ID: 921
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
-      GoRuntimeType: 1.070016e+06
+      GoRuntimeType: 1.070144e+06
       GoKind: 22
       Pointee: 922 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
       ID: 1170
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.914208e+06
+      GoRuntimeType: 1.914496e+06
       GoKind: 22
       Pointee: 1171 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
       ID: 1200
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
-      GoRuntimeType: 2.129504e+06
+      GoRuntimeType: 2.129792e+06
       GoKind: 22
       Pointee: 1201 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
       ID: 1174
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.91472e+06
+      GoRuntimeType: 1.915008e+06
       GoKind: 22
       Pointee: 1175 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
       ID: 1172
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.914464e+06
+      GoRuntimeType: 1.914752e+06
       GoKind: 22
       Pointee: 1173 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
       ID: 1166
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.911904e+06
+      GoRuntimeType: 1.912192e+06
       GoKind: 22
       Pointee: 1167 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
       ID: 819
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 930336
+      GoRuntimeType: 930368
       GoKind: 22
       Pointee: 640 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
       ID: 1187
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 1.992672e+06
+      GoRuntimeType: 1.99296e+06
       GoKind: 22
       Pointee: 1188 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1162
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
-      GoRuntimeType: 1.88128e+06
+      GoRuntimeType: 1.881568e+06
       GoKind: 22
       Pointee: 1163 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
       ID: 742
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
-      GoRuntimeType: 919200
+      GoRuntimeType: 919232
       GoKind: 22
       Pointee: 627 BaseType crypto/tls.AlertError
     - __kind: PointerType
       ID: 910
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.050816e+06
+      GoRuntimeType: 1.050944e+06
       GoKind: 22
       Pointee: 911 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1253
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.388736e+06
+      GoRuntimeType: 2.389024e+06
       GoKind: 22
       Pointee: 1254 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
       ID: 738
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
-      GoRuntimeType: 918912
+      GoRuntimeType: 918944
       GoKind: 22
       Pointee: 739 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
       ID: 736
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
-      GoRuntimeType: 918816
+      GoRuntimeType: 918848
       GoKind: 22
       Pointee: 737 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
       ID: 909
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.049152e+06
+      GoRuntimeType: 1.04928e+06
       GoKind: 22
       Pointee: 864 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 1132
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.567328e+06
+      GoRuntimeType: 1.567616e+06
       GoKind: 22
       Pointee: 1133 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
       ID: 740
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
-      GoRuntimeType: 919008
+      GoRuntimeType: 919040
       GoKind: 22
       Pointee: 741 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
       ID: 1137
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.650976e+06
+      GoRuntimeType: 1.651264e+06
       GoKind: 22
       Pointee: 1138 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 1007
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.432384e+06
+      GoRuntimeType: 1.432512e+06
       GoKind: 22
       Pointee: 1008 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 1024
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.05184e+06
+      GoRuntimeType: 2.052128e+06
       GoKind: 22
       Pointee: 1025 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
       ID: 812
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
-      GoRuntimeType: 928608
+      GoRuntimeType: 928640
       GoKind: 22
       Pointee: 813 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
       ID: 806
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
-      GoRuntimeType: 928128
+      GoRuntimeType: 928160
       GoKind: 22
       Pointee: 807 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
       ID: 808
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
-      GoRuntimeType: 928224
+      GoRuntimeType: 928256
       GoKind: 22
       Pointee: 809 StructureType crypto/x509.HostnameError
     - __kind: PointerType
       ID: 805
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
-      GoRuntimeType: 928032
+      GoRuntimeType: 928064
       GoKind: 22
       Pointee: 636 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
       ID: 915
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.056576e+06
+      GoRuntimeType: 1.056704e+06
       GoKind: 22
       Pointee: 916 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
       ID: 814
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
-      GoRuntimeType: 928704
+      GoRuntimeType: 928736
       GoKind: 22
       Pointee: 815 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
       ID: 810
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
-      GoRuntimeType: 928512
+      GoRuntimeType: 928544
       GoKind: 22
       Pointee: 811 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
       ID: 828
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
-      GoRuntimeType: 935424
+      GoRuntimeType: 935456
       GoKind: 22
       Pointee: 829 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
       ID: 832
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 935616
+      GoRuntimeType: 935648
       GoKind: 22
       Pointee: 833 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
       ID: 830
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 935520
+      GoRuntimeType: 935552
       GoKind: 22
       Pointee: 831 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
       ID: 723
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 915744
+      GoRuntimeType: 915776
       GoKind: 22
       Pointee: 618 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 1090
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.046592e+06
+      GoRuntimeType: 1.04672e+06
       GoKind: 22
       Pointee: 1091 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
       ID: 726
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
-      GoRuntimeType: 916608
+      GoRuntimeType: 916640
       GoKind: 22
       Pointee: 619 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
       ID: 694
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 910560
+      GoRuntimeType: 910592
       GoKind: 22
       Pointee: 695 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 899
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.042752e+06
+      GoRuntimeType: 1.04288e+06
       GoKind: 22
       Pointee: 900 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 686
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 910176
+      GoRuntimeType: 910208
       GoKind: 22
       Pointee: 687 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 692
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 910464
+      GoRuntimeType: 910496
       GoKind: 22
       Pointee: 693 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 690
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
-      GoRuntimeType: 910368
+      GoRuntimeType: 910400
       GoKind: 22
       Pointee: 691 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
       ID: 688
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 910272
+      GoRuntimeType: 910304
       GoKind: 22
       Pointee: 689 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1233
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.302752e+06
+      GoRuntimeType: 2.30304e+06
       GoKind: 22
       Pointee: 1234 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
       ID: 696
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 910944
+      GoRuntimeType: 910976
       GoKind: 22
       Pointee: 697 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 1098
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.059136e+06
+      GoRuntimeType: 1.059264e+06
       GoKind: 22
       Pointee: 1099 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
       ID: 800
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 927072
+      GoRuntimeType: 927104
       GoKind: 22
       Pointee: 801 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 798
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
-      GoRuntimeType: 926976
+      GoRuntimeType: 927008
       GoKind: 22
       Pointee: 799 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
       ID: 802
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 927168
+      GoRuntimeType: 927200
       GoKind: 22
       Pointee: 633 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
@@ -12086,119 +12086,119 @@ Types:
       ID: 803
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
-      GoRuntimeType: 927264
+      GoRuntimeType: 927296
       GoKind: 22
       Pointee: 804 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 1211
       Name: '*encoding/xml.printer'
       ByteSize: 8
-      GoRuntimeType: 2.169344e+06
+      GoRuntimeType: 2.169632e+06
       GoKind: 22
       Pointee: 1212 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 106
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 394368
+      GoRuntimeType: 394400
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 662
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 900288
+      GoRuntimeType: 900320
       GoKind: 22
       Pointee: 663 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 866
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1.027264e+06
+      GoRuntimeType: 1.027392e+06
       GoKind: 22
       Pointee: 867 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 395328
+      GoRuntimeType: 395360
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 99
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 395392
+      GoRuntimeType: 395424
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
       ID: 1221
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.269536e+06
+      GoRuntimeType: 2.269824e+06
       GoKind: 22
       Pointee: 1222 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 868
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.027392e+06
+      GoRuntimeType: 1.02752e+06
       GoKind: 22
       Pointee: 869 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 870
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.02752e+06
+      GoRuntimeType: 1.027648e+06
       GoKind: 22
       Pointee: 871 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
       ID: 724
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 916128
+      GoRuntimeType: 916160
       GoKind: 22
       Pointee: 725 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 705
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 913344
+      GoRuntimeType: 913376
       GoKind: 22
       Pointee: 706 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
       ID: 707
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 913440
+      GoRuntimeType: 913472
       GoKind: 22
       Pointee: 708 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 1036
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 913152
+      GoRuntimeType: 913184
       GoKind: 22
       Pointee: 1037 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
       ID: 711
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 913728
+      GoRuntimeType: 913760
       GoKind: 22
       Pointee: 712 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 1038
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 913248
+      GoRuntimeType: 913280
       GoKind: 22
       Pointee: 1039 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
       ID: 709
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 913536
+      GoRuntimeType: 913568
       GoKind: 22
       Pointee: 612 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -12210,7 +12210,7 @@ Types:
       ID: 704
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 913056
+      GoRuntimeType: 913088
       GoKind: 22
       Pointee: 609 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -12222,7 +12222,7 @@ Types:
       ID: 710
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 913632
+      GoRuntimeType: 913664
       GoKind: 22
       Pointee: 615 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -12234,98 +12234,98 @@ Types:
       ID: 1110
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.214784e+06
+      GoRuntimeType: 1.214912e+06
       GoKind: 22
       Pointee: 1111 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1197
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 2.067168e+06
+      GoRuntimeType: 2.067456e+06
       GoKind: 22
       Pointee: 1198 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
       ID: 822
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
-      GoRuntimeType: 933888
+      GoRuntimeType: 933920
       GoKind: 22
       Pointee: 823 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 981
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.218368e+06
+      GoRuntimeType: 1.218496e+06
       GoKind: 22
       Pointee: 982 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1229
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.279264e+06
+      GoRuntimeType: 2.279552e+06
       GoKind: 22
       Pointee: 1230 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
       ID: 749
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
-      GoRuntimeType: 922560
+      GoRuntimeType: 922592
       GoKind: 22
       Pointee: 750 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
       ID: 756
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
-      GoRuntimeType: 923616
+      GoRuntimeType: 923648
       GoKind: 22
       Pointee: 757 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
       ID: 751
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
-      GoRuntimeType: 923328
+      GoRuntimeType: 923360
       GoKind: 22
       Pointee: 632 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
       ID: 754
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
-      GoRuntimeType: 923520
+      GoRuntimeType: 923552
       GoKind: 22
       Pointee: 755 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
       ID: 752
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
-      GoRuntimeType: 923424
+      GoRuntimeType: 923456
       GoKind: 22
       Pointee: 753 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
       ID: 772
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
-      GoRuntimeType: 925536
+      GoRuntimeType: 925568
       GoKind: 22
       Pointee: 773 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
       ID: 776
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
-      GoRuntimeType: 925728
+      GoRuntimeType: 925760
       GoKind: 22
       Pointee: 777 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
       ID: 774
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
-      GoRuntimeType: 925632
+      GoRuntimeType: 925664
       GoKind: 22
       Pointee: 775 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
       ID: 770
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
-      GoRuntimeType: 925440
+      GoRuntimeType: 925472
       GoKind: 22
       Pointee: 771 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
@@ -12337,357 +12337,357 @@ Types:
       ID: 784
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
-      GoRuntimeType: 926112
+      GoRuntimeType: 926144
       GoKind: 22
       Pointee: 785 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
       ID: 778
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
-      GoRuntimeType: 925824
+      GoRuntimeType: 925856
       GoKind: 22
       Pointee: 779 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
       ID: 782
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
-      GoRuntimeType: 926016
+      GoRuntimeType: 926048
       GoKind: 22
       Pointee: 783 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
       ID: 780
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
-      GoRuntimeType: 925920
+      GoRuntimeType: 925952
       GoKind: 22
       Pointee: 781 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
       ID: 786
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
-      GoRuntimeType: 926208
+      GoRuntimeType: 926240
       GoKind: 22
       Pointee: 787 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
       ID: 792
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
-      GoRuntimeType: 926496
+      GoRuntimeType: 926528
       GoKind: 22
       Pointee: 793 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
       ID: 794
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
-      GoRuntimeType: 926592
+      GoRuntimeType: 926624
       GoKind: 22
       Pointee: 795 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
       ID: 790
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
-      GoRuntimeType: 926400
+      GoRuntimeType: 926432
       GoKind: 22
       Pointee: 791 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
       ID: 788
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
-      GoRuntimeType: 926304
+      GoRuntimeType: 926336
       GoKind: 22
       Pointee: 789 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
       ID: 796
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
-      GoRuntimeType: 926784
+      GoRuntimeType: 926816
       GoKind: 22
       Pointee: 797 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 713
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 914880
+      GoRuntimeType: 914912
       GoKind: 22
       Pointee: 714 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 1150
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.812064e+06
+      GoRuntimeType: 1.812352e+06
       GoKind: 22
       Pointee: 1151 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
       ID: 715
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 914976
+      GoRuntimeType: 915008
       GoKind: 22
       Pointee: 716 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 1130
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.566048e+06
+      GoRuntimeType: 1.566336e+06
       GoKind: 22
       Pointee: 1131 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 1086
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.04544e+06
+      GoRuntimeType: 1.045568e+06
       GoKind: 22
       Pointee: 1087 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1120
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.429984e+06
+      GoRuntimeType: 1.430112e+06
       GoKind: 22
       Pointee: 1121 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 719
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 915168
+      GoRuntimeType: 915200
       GoKind: 22
       Pointee: 720 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1185
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.985184e+06
+      GoRuntimeType: 1.985472e+06
       GoKind: 22
       Pointee: 1186 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1204
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.142528e+06
+      GoRuntimeType: 2.142816e+06
       GoKind: 22
       Pointee: 1199 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1203
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.142144e+06
+      GoRuntimeType: 2.142432e+06
       GoKind: 22
       Pointee: 1202 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 1088
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.045568e+06
+      GoRuntimeType: 1.045696e+06
       GoKind: 22
       Pointee: 1089 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 717
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 915072
+      GoRuntimeType: 915104
       GoKind: 22
       Pointee: 718 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
       ID: 721
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 915264
+      GoRuntimeType: 915296
       GoKind: 22
       Pointee: 722 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 1152
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.813856e+06
+      GoRuntimeType: 1.814144e+06
       GoKind: 22
       Pointee: 1153 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1193
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.021024e+06
+      GoRuntimeType: 2.021312e+06
       GoKind: 22
       Pointee: 1194 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1195
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.05152e+06
+      GoRuntimeType: 2.051808e+06
       GoKind: 22
       Pointee: 1196 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 1012
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.444704e+06
+      GoRuntimeType: 1.444832e+06
       GoKind: 22
       Pointee: 1013 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 925
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.070784e+06
+      GoRuntimeType: 1.070912e+06
       GoKind: 22
       Pointee: 926 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 923
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.070656e+06
+      GoRuntimeType: 1.070784e+06
       GoKind: 22
       Pointee: 924 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 927
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.074752e+06
+      GoRuntimeType: 1.07488e+06
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 929
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.07488e+06
+      GoRuntimeType: 1.075008e+06
       GoKind: 22
       Pointee: 930 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 1141
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.67824e+06
+      GoRuntimeType: 1.678528e+06
       GoKind: 22
       Pointee: 1142 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 917
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.057216e+06
+      GoRuntimeType: 1.057344e+06
       GoKind: 22
       Pointee: 918 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 727
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
-      GoRuntimeType: 916800
+      GoRuntimeType: 916832
       GoKind: 22
       Pointee: 728 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
       ID: 1245
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.365184e+06
+      GoRuntimeType: 2.365472e+06
       GoKind: 22
       Pointee: 1246 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 983
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.226944e+06
+      GoRuntimeType: 1.227072e+06
       GoKind: 22
       Pointee: 984 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 956
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.205824e+06
+      GoRuntimeType: 1.205952e+06
       GoKind: 22
       Pointee: 957 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 950
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.20544e+06
+      GoRuntimeType: 1.205568e+06
       GoKind: 22
       Pointee: 951 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 885
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.036736e+06
+      GoRuntimeType: 1.036864e+06
       GoKind: 22
       Pointee: 886 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 962
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.206208e+06
+      GoRuntimeType: 1.206336e+06
       GoKind: 22
       Pointee: 963 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 884
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1.036608e+06
+      GoRuntimeType: 1.036736e+06
       GoKind: 22
       Pointee: 863 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 954
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.205696e+06
+      GoRuntimeType: 1.205824e+06
       GoKind: 22
       Pointee: 955 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 952
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.205568e+06
+      GoRuntimeType: 1.205696e+06
       GoKind: 22
       Pointee: 953 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 960
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.20608e+06
+      GoRuntimeType: 1.206208e+06
       GoKind: 22
       Pointee: 961 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 958
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.205952e+06
+      GoRuntimeType: 1.20608e+06
       GoKind: 22
       Pointee: 959 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1249
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.377792e+06
+      GoRuntimeType: 2.37808e+06
       GoKind: 22
       Pointee: 1250 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 966
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.206592e+06
+      GoRuntimeType: 1.20672e+06
       GoKind: 22
       Pointee: 967 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 889
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1.036992e+06
+      GoRuntimeType: 1.03712e+06
       GoKind: 22
       Pointee: 890 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 887
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1.036864e+06
+      GoRuntimeType: 1.036992e+06
       GoKind: 22
       Pointee: 888 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 964
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.206464e+06
+      GoRuntimeType: 1.206592e+06
       GoKind: 22
       Pointee: 965 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
       ID: 844
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
-      GoRuntimeType: 948384
+      GoRuntimeType: 948416
       GoKind: 22
       Pointee: 645 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
@@ -12699,21 +12699,21 @@ Types:
       ID: 351
       Name: '*go.shape.float64'
       ByteSize: 8
-      GoRuntimeType: 481984
+      GoRuntimeType: 482016
       GoKind: 22
       Pointee: 352 BaseType go.shape.float64
     - __kind: PointerType
       ID: 327
       Name: '*go.shape.int'
       ByteSize: 8
-      GoRuntimeType: 481536
+      GoRuntimeType: 481568
       GoKind: 22
       Pointee: 322 BaseType go.shape.int
     - __kind: PointerType
       ID: 344
       Name: '*go.shape.string'
       ByteSize: 8
-      GoRuntimeType: 481600
+      GoRuntimeType: 481632
       GoKind: 22
       Pointee: 324 GoStringHeaderType go.shape.string
     - __kind: PointerType
@@ -12743,63 +12743,63 @@ Types:
       ID: 1027
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.676704e+06
+      GoRuntimeType: 1.676992e+06
       GoKind: 22
       Pointee: 1028 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 933
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.0896e+06
+      GoRuntimeType: 1.089728e+06
       GoKind: 22
       Pointee: 934 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 1116
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.266752e+06
+      GoRuntimeType: 1.26688e+06
       GoKind: 22
       Pointee: 1117 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1209
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.157504e+06
+      GoRuntimeType: 2.157792e+06
       GoKind: 22
       Pointee: 1210 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 1104
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.091904e+06
+      GoRuntimeType: 1.092032e+06
       GoKind: 22
       Pointee: 1105 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
       ID: 845
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 949632
+      GoRuntimeType: 949664
       GoKind: 22
       Pointee: 648 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
       ID: 991
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.268416e+06
+      GoRuntimeType: 1.268544e+06
       GoKind: 22
       Pointee: 992 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
       ID: 848
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
-      GoRuntimeType: 949920
+      GoRuntimeType: 949952
       GoKind: 22
       Pointee: 849 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
       ID: 847
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 949824
+      GoRuntimeType: 949856
       GoKind: 22
       Pointee: 652 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
@@ -12811,7 +12811,7 @@ Types:
       ID: 851
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 950112
+      GoRuntimeType: 950144
       GoKind: 22
       Pointee: 658 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
@@ -12823,7 +12823,7 @@ Types:
       ID: 850
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 950016
+      GoRuntimeType: 950048
       GoKind: 22
       Pointee: 655 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
@@ -12835,7 +12835,7 @@ Types:
       ID: 846
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 949728
+      GoRuntimeType: 949760
       GoKind: 22
       Pointee: 649 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
@@ -12847,245 +12847,245 @@ Types:
       ID: 1207
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.155584e+06
+      GoRuntimeType: 2.155872e+06
       GoKind: 22
       Pointee: 1208 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
       ID: 852
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
-      GoRuntimeType: 950208
+      GoRuntimeType: 950240
       GoKind: 22
       Pointee: 853 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
       ID: 854
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
-      GoRuntimeType: 950304
+      GoRuntimeType: 950336
       GoKind: 22
       Pointee: 661 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
       ID: 840
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
-      GoRuntimeType: 943584
+      GoRuntimeType: 943616
       GoKind: 22
       Pointee: 841 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
       ID: 989
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.265472e+06
+      GoRuntimeType: 1.2656e+06
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 1014
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.452064e+06
+      GoRuntimeType: 1.452192e+06
       GoKind: 22
       Pointee: 1015 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
       ID: 842
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
-      GoRuntimeType: 946656
+      GoRuntimeType: 946688
       GoKind: 22
       Pointee: 843 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 1156
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.819456e+06
+      GoRuntimeType: 1.819744e+06
       GoKind: 22
       Pointee: 1157 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 1114
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.262016e+06
+      GoRuntimeType: 1.262144e+06
       GoKind: 22
       Pointee: 1115 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 931
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.08384e+06
+      GoRuntimeType: 1.083968e+06
       GoKind: 22
       Pointee: 932 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 1076
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
-      GoRuntimeType: 946752
+      GoRuntimeType: 946784
       GoKind: 22
       Pointee: 1077 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
       ID: 820
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
-      GoRuntimeType: 931776
+      GoRuntimeType: 931808
       GoKind: 22
       Pointee: 821 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
       ID: 919
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.060544e+06
+      GoRuntimeType: 1.060672e+06
       GoKind: 22
       Pointee: 920 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 987
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.233344e+06
+      GoRuntimeType: 1.233472e+06
       GoKind: 22
       Pointee: 988 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 985
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.233088e+06
+      GoRuntimeType: 1.233216e+06
       GoKind: 22
       Pointee: 986 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
       ID: 834
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
-      GoRuntimeType: 936480
+      GoRuntimeType: 936512
       GoKind: 22
       Pointee: 835 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
       ID: 836
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
-      GoRuntimeType: 936576
+      GoRuntimeType: 936608
       GoKind: 22
       Pointee: 837 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
       ID: 764
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
-      GoRuntimeType: 924000
+      GoRuntimeType: 924032
       GoKind: 22
       Pointee: 765 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
       ID: 1164
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.909856e+06
+      GoRuntimeType: 1.910144e+06
       GoKind: 22
       Pointee: 1165 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 855
       Name: '*html/template.Error'
       ByteSize: 8
-      GoRuntimeType: 951072
+      GoRuntimeType: 951104
       GoKind: 22
       Pointee: 856 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 100
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 395008
+      GoRuntimeType: 395040
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 104
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 394624
+      GoRuntimeType: 394656
       GoKind: 22
       Pointee: 96 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 394752
+      GoRuntimeType: 394784
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 102
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 394880
+      GoRuntimeType: 394912
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 105
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 394496
+      GoRuntimeType: 394528
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
       ID: 163
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 395584
+      GoRuntimeType: 395616
       GoKind: 22
       Pointee: 157 GoEmptyInterfaceType interface {}
     - __kind: PointerType
       ID: 1016
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 2.221856e+06
+      GoRuntimeType: 2.222144e+06
       GoKind: 22
       Pointee: 1017 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
       ID: 732
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 917184
+      GoRuntimeType: 917216
       GoKind: 22
       Pointee: 733 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 730
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
-      GoRuntimeType: 917088
+      GoRuntimeType: 917120
       GoKind: 22
       Pointee: 731 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
       ID: 1062
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 905376
+      GoRuntimeType: 905408
       GoKind: 22
       Pointee: 1063 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
       ID: 948
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.204672e+06
+      GoRuntimeType: 1.2048e+06
       GoKind: 22
       Pointee: 949 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1251
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.383456e+06
+      GoRuntimeType: 2.383744e+06
       GoKind: 22
       Pointee: 1252 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 946
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.204544e+06
+      GoRuntimeType: 1.204672e+06
       GoKind: 22
       Pointee: 947 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 666
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 904320
+      GoRuntimeType: 904352
       GoKind: 22
       Pointee: 667 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 729
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
-      GoRuntimeType: 916896
+      GoRuntimeType: 916928
       GoKind: 22
       Pointee: 620 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
@@ -13097,42 +13097,42 @@ Types:
       ID: 903
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.047488e+06
+      GoRuntimeType: 1.047616e+06
       GoKind: 22
       Pointee: 904 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
       ID: 1108
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.196224e+06
+      GoRuntimeType: 1.196352e+06
       GoKind: 22
       Pointee: 1109 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1106
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.19584e+06
+      GoRuntimeType: 1.195968e+06
       GoKind: 22
       Pointee: 1107 StructureType io.discard
     - __kind: PointerType
       ID: 1080
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.028288e+06
+      GoRuntimeType: 1.028416e+06
       GoKind: 22
       Pointee: 1081 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 944
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.204032e+06
+      GoRuntimeType: 1.20416e+06
       GoKind: 22
       Pointee: 945 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 1154
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.81408e+06
+      GoRuntimeType: 1.814368e+06
       GoKind: 22
       Pointee: 1155 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13157,105 +13157,105 @@ Types:
       ID: 375
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 387968
+      GoRuntimeType: 388000
       GoKind: 22
       Pointee: 376 StructureType main.deepMap2
     - __kind: PointerType
       ID: 1295
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 387904
+      GoRuntimeType: 387936
       GoKind: 22
       Pointee: 1296 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 149
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 387648
+      GoRuntimeType: 387680
       GoKind: 22
       Pointee: 150 StructureType main.deepMap7
     - __kind: PointerType
       ID: 1329
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 387584
+      GoRuntimeType: 387616
       GoKind: 22
       Pointee: 1330 StructureType main.deepMap8
     - __kind: PointerType
       ID: 1344
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 387520
+      GoRuntimeType: 387552
       GoKind: 22
       Pointee: 1345 StructureType main.deepMap9
     - __kind: PointerType
       ID: 133
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 388544
+      GoRuntimeType: 388576
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr2
     - __kind: PointerType
       ID: 1255
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 388480
+      GoRuntimeType: 388512
       GoKind: 22
       Pointee: 1256 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 135
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 388224
+      GoRuntimeType: 388256
       GoKind: 22
       Pointee: 136 StructureType main.deepPtr7
     - __kind: PointerType
       ID: 1299
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 388160
+      GoRuntimeType: 388192
       GoKind: 22
       Pointee: 1300 StructureType main.deepPtr8
     - __kind: PointerType
       ID: 1301
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 388096
+      GoRuntimeType: 388128
       GoKind: 22
       Pointee: 1302 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 140
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 389120
+      GoRuntimeType: 389152
       GoKind: 22
       Pointee: 366 StructureType main.deepSlice2
     - __kind: PointerType
       ID: 1280
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 389056
+      GoRuntimeType: 389088
       GoKind: 22
       Pointee: 1281 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 141
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 388800
+      GoRuntimeType: 388832
       GoKind: 22
       Pointee: 142 StructureType main.deepSlice7
     - __kind: PointerType
       ID: 1305
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 388736
+      GoRuntimeType: 388768
       GoKind: 22
       Pointee: 1306 StructureType main.deepSlice8
     - __kind: PointerType
       ID: 1311
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 388672
+      GoRuntimeType: 388704
       GoKind: 22
       Pointee: 1312 StructureType main.deepSlice9
     - __kind: PointerType
@@ -13268,28 +13268,28 @@ Types:
       ID: 159
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 389248
+      GoRuntimeType: 389280
       GoKind: 22
       Pointee: 160 StructureType main.esotericHeap
     - __kind: PointerType
       ID: 1272
       Name: '*main.firstBehavior'
       ByteSize: 8
-      GoRuntimeType: 900000
+      GoRuntimeType: 900032
       GoKind: 22
       Pointee: 354 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 1361
       Name: '*main.nestedStruct'
       ByteSize: 8
-      GoRuntimeType: 389504
+      GoRuntimeType: 389536
       GoKind: 22
       Pointee: 123 StructureType main.nestedStruct
     - __kind: PointerType
       ID: 247
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 389312
+      GoRuntimeType: 389344
       GoKind: 22
       Pointee: 246 StructureType main.node
     - __kind: PointerType
@@ -13302,14 +13302,14 @@ Types:
       ID: 1273
       Name: '*main.secondBehavior'
       ByteSize: 8
-      GoRuntimeType: 900096
+      GoRuntimeType: 900128
       GoKind: 22
       Pointee: 1274 StructureType main.secondBehavior
     - __kind: PointerType
       ID: 1260
       Name: '*main.somethingImpl'
       ByteSize: 8
-      GoRuntimeType: 900192
+      GoRuntimeType: 900224
       GoKind: 22
       Pointee: 1261 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
@@ -13343,7 +13343,7 @@ Types:
       ID: 427
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 387456
+      GoRuntimeType: 387488
       GoKind: 22
       Pointee: 165 StructureType main.structWithMap
     - __kind: PointerType
@@ -13519,77 +13519,77 @@ Types:
       ID: 768
       Name: '*math/big.ErrNaN'
       ByteSize: 8
-      GoRuntimeType: 924864
+      GoRuntimeType: 924896
       GoKind: 22
       Pointee: 769 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 1070
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
-      GoRuntimeType: 919680
+      GoRuntimeType: 919712
       GoKind: 22
       Pointee: 1071 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
       ID: 975
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.212608e+06
+      GoRuntimeType: 1.212736e+06
       GoKind: 22
       Pointee: 976 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1001
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.428224e+06
+      GoRuntimeType: 1.428352e+06
       GoKind: 22
       Pointee: 1002 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1215
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.242208e+06
+      GoRuntimeType: 2.242496e+06
       GoKind: 22
       Pointee: 1216 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 999
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.427904e+06
+      GoRuntimeType: 1.428032e+06
       GoKind: 22
       Pointee: 1000 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 977
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.212736e+06
+      GoRuntimeType: 1.212864e+06
       GoKind: 22
       Pointee: 978 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1225
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.27056e+06
+      GoRuntimeType: 2.270848e+06
       GoKind: 22
       Pointee: 1226 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1235
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.316064e+06
+      GoRuntimeType: 2.316352e+06
       GoKind: 22
       Pointee: 1236 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1223
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.270048e+06
+      GoRuntimeType: 2.270336e+06
       GoKind: 22
       Pointee: 1224 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 974
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.21184e+06
+      GoRuntimeType: 1.211968e+06
       GoKind: 22
       Pointee: 937 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13601,126 +13601,126 @@ Types:
       ID: 901
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.043648e+06
+      GoRuntimeType: 1.043776e+06
       GoKind: 22
       Pointee: 902 StructureType net.canceledError
     - __kind: PointerType
       ID: 1191
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2.018432e+06
+      GoRuntimeType: 2.01872e+06
       GoKind: 22
       Pointee: 1192 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1045
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.857312e+06
+      GoRuntimeType: 1.8576e+06
       GoKind: 22
       Pointee: 1046 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1237
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.32032e+06
+      GoRuntimeType: 2.320608e+06
       GoKind: 22
       Pointee: 1238 UnresolvedPointeeType net.netFD
     - __kind: PointerType
       ID: 698
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 911904
+      GoRuntimeType: 911936
       GoKind: 22
       Pointee: 699 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 700
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 912576
+      GoRuntimeType: 912608
       GoKind: 22
       Pointee: 701 StructureType net.result·2
     - __kind: PointerType
       ID: 1219
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.256096e+06
+      GoRuntimeType: 2.256384e+06
       GoKind: 22
       Pointee: 1220 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1217
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.255616e+06
+      GoRuntimeType: 2.255904e+06
       GoKind: 22
       Pointee: 1218 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 979
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.213376e+06
+      GoRuntimeType: 1.213504e+06
       GoKind: 22
       Pointee: 980 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1003
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.428384e+06
+      GoRuntimeType: 1.428512e+06
       GoKind: 22
       Pointee: 1004 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 891
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1.039424e+06
+      GoRuntimeType: 1.039552e+06
       GoKind: 22
       Pointee: 892 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 1064
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 907680
+      GoRuntimeType: 907712
       GoKind: 22
       Pointee: 1065 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 675
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 908352
+      GoRuntimeType: 908384
       GoKind: 22
       Pointee: 590 BaseType net/http.http2ConnectionError
     - __kind: PointerType
       ID: 676
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 908448
+      GoRuntimeType: 908480
       GoKind: 22
       Pointee: 677 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 995
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.423904e+06
+      GoRuntimeType: 1.424032e+06
       GoKind: 22
       Pointee: 996 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 680
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 909024
+      GoRuntimeType: 909056
       GoKind: 22
       Pointee: 681 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 1126
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.562528e+06
+      GoRuntimeType: 1.562816e+06
       GoKind: 22
       Pointee: 1127 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
       ID: 679
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 908928
+      GoRuntimeType: 908960
       GoKind: 22
       Pointee: 594 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -13732,7 +13732,7 @@ Types:
       ID: 683
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 909216
+      GoRuntimeType: 909248
       GoKind: 22
       Pointee: 600 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -13744,7 +13744,7 @@ Types:
       ID: 682
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 909120
+      GoRuntimeType: 909152
       GoKind: 22
       Pointee: 597 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -13756,28 +13756,28 @@ Types:
       ID: 970
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.208512e+06
+      GoRuntimeType: 1.20864e+06
       GoKind: 22
       Pointee: 971 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 897
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1.040064e+06
+      GoRuntimeType: 1.040192e+06
       GoKind: 22
       Pointee: 898 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1180
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.960736e+06
+      GoRuntimeType: 1.961024e+06
       GoKind: 22
       Pointee: 1181 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
       ID: 678
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 908832
+      GoRuntimeType: 908864
       GoKind: 22
       Pointee: 591 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -13789,133 +13789,133 @@ Types:
       ID: 1066
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 909312
+      GoRuntimeType: 909344
       GoKind: 22
       Pointee: 1067 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 893
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1.03968e+06
+      GoRuntimeType: 1.039808e+06
       GoKind: 22
       Pointee: 894 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1128
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.186016e+06
+      GoRuntimeType: 2.186304e+06
       GoKind: 22
       Pointee: 1129 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1084
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1.039552e+06
+      GoRuntimeType: 1.03968e+06
       GoKind: 22
       Pointee: 1085 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 1118
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.424064e+06
+      GoRuntimeType: 1.424192e+06
       GoKind: 22
       Pointee: 1119 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
       ID: 684
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 909408
+      GoRuntimeType: 909440
       GoKind: 22
       Pointee: 685 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 997
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.425184e+06
+      GoRuntimeType: 1.425312e+06
       GoKind: 22
       Pointee: 998 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 968
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.208384e+06
+      GoRuntimeType: 1.208512e+06
       GoKind: 22
       Pointee: 969 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 895
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1.039808e+06
+      GoRuntimeType: 1.039936e+06
       GoKind: 22
       Pointee: 896 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1160
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1.853952e+06
+      GoRuntimeType: 1.85424e+06
       GoKind: 22
       Pointee: 1161 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
       ID: 673
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 907584
+      GoRuntimeType: 907616
       GoKind: 22
       Pointee: 674 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 1182
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.962528e+06
+      GoRuntimeType: 1.962816e+06
       GoKind: 22
       Pointee: 1183 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 1094
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.051968e+06
+      GoRuntimeType: 1.052096e+06
       GoKind: 22
       Pointee: 1095 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
       ID: 760
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
-      GoRuntimeType: 923808
+      GoRuntimeType: 923840
       GoKind: 22
       Pointee: 761 StructureType net/netip.parseAddrError
     - __kind: PointerType
       ID: 758
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
-      GoRuntimeType: 923712
+      GoRuntimeType: 923744
       GoKind: 22
       Pointee: 759 StructureType net/netip.parsePrefixError
     - __kind: PointerType
       ID: 1134
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 2.128096e+06
+      GoRuntimeType: 2.128384e+06
       GoKind: 22
       Pointee: 1135 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 1096
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.056832e+06
+      GoRuntimeType: 1.05696e+06
       GoKind: 22
       Pointee: 1097 StructureType net/smtp.dataCloser
     - __kind: PointerType
       ID: 744
       Name: '*net/textproto.Error'
       ByteSize: 8
-      GoRuntimeType: 919872
+      GoRuntimeType: 919904
       GoKind: 22
       Pointee: 745 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
       ID: 743
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 919776
+      GoRuntimeType: 919808
       GoKind: 22
       Pointee: 628 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
@@ -13927,21 +13927,21 @@ Types:
       ID: 1092
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.0512e+06
+      GoRuntimeType: 1.051328e+06
       GoKind: 22
       Pointee: 1093 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 1005
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.428704e+06
+      GoRuntimeType: 1.428832e+06
       GoKind: 22
       Pointee: 1006 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
       ID: 702
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 912672
+      GoRuntimeType: 912704
       GoKind: 22
       Pointee: 603 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -13953,7 +13953,7 @@ Types:
       ID: 703
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 912768
+      GoRuntimeType: 912800
       GoKind: 22
       Pointee: 606 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -14100,70 +14100,70 @@ Types:
       ID: 1243
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.359808e+06
+      GoRuntimeType: 2.360096e+06
       GoKind: 22
       Pointee: 1244 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 874
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 1.030976e+06
+      GoRuntimeType: 1.031104e+06
       GoKind: 22
       Pointee: 875 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 940
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.197504e+06
+      GoRuntimeType: 1.197632e+06
       GoKind: 22
       Pointee: 941 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1241
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.358336e+06
+      GoRuntimeType: 2.358624e+06
       GoKind: 22
       Pointee: 1242 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1239
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.3576e+06
+      GoRuntimeType: 2.357888e+06
       GoKind: 22
       Pointee: 1240 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 905
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.047872e+06
+      GoRuntimeType: 1.048e+06
       GoKind: 22
       Pointee: 906 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 1048
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 2.098656e+06
+      GoRuntimeType: 2.098944e+06
       GoKind: 22
       Pointee: 1049 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 1112
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.219648e+06
+      GoRuntimeType: 1.219776e+06
       GoKind: 22
       Pointee: 1113 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 907
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.048e+06
+      GoRuntimeType: 1.048128e+06
       GoKind: 22
       Pointee: 908 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 839
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
-      GoRuntimeType: 941664
+      GoRuntimeType: 941696
       GoKind: 22
       Pointee: 642 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
@@ -14175,84 +14175,84 @@ Types:
       ID: 838
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
-      GoRuntimeType: 941568
+      GoRuntimeType: 941600
       GoKind: 22
       Pointee: 641 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
       ID: 668
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 904992
+      GoRuntimeType: 905024
       GoKind: 22
       Pointee: 669 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 766
       Name: '*regexp/syntax.Error'
       ByteSize: 8
-      GoRuntimeType: 924480
+      GoRuntimeType: 924512
       GoKind: 22
       Pointee: 767 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
       ID: 878
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1.032512e+06
+      GoRuntimeType: 1.03264e+06
       GoKind: 22
       Pointee: 879 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 882
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1.034304e+06
+      GoRuntimeType: 1.034432e+06
       GoKind: 22
       Pointee: 883 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 395648
+      GoRuntimeType: 395680
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.421664e+06
+      GoRuntimeType: 1.421792e+06
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 880
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1.03264e+06
+      GoRuntimeType: 1.032768e+06
       GoKind: 22
       Pointee: 881 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 396288
+      GoRuntimeType: 396320
       GoKind: 22
       Pointee: 66 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 396352
+      GoRuntimeType: 396384
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 942
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.203008e+06
+      GoRuntimeType: 1.203136e+06
       GoKind: 22
       Pointee: 943 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 876
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1.032128e+06
+      GoRuntimeType: 1.032256e+06
       GoKind: 22
       Pointee: 857 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14264,28 +14264,28 @@ Types:
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 903360
+      GoRuntimeType: 903392
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.422304e+06
+      GoRuntimeType: 1.422432e+06
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.033664e+06
+      GoRuntimeType: 1.033792e+06
       GoKind: 22
       Pointee: 361 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 877
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1.032256e+06
+      GoRuntimeType: 1.032384e+06
       GoKind: 22
       Pointee: 860 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14297,49 +14297,49 @@ Types:
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 396992
+      GoRuntimeType: 397024
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.560288e+06
+      GoRuntimeType: 1.560576e+06
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 664
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
-      GoRuntimeType: 904032
+      GoRuntimeType: 904064
       GoKind: 22
       Pointee: 665 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.063648e+06
+      GoRuntimeType: 2.063936e+06
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.62832e+06
+      GoRuntimeType: 1.628608e+06
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 872
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 1.030336e+06
+      GoRuntimeType: 1.030464e+06
       GoKind: 22
       Pointee: 873 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 394432
+      GoRuntimeType: 394464
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -14351,35 +14351,35 @@ Types:
       ID: 1176
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.958432e+06
+      GoRuntimeType: 1.95872e+06
       GoKind: 22
       Pointee: 1177 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 1082
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 1.030464e+06
+      GoRuntimeType: 1.030592e+06
       GoKind: 22
       Pointee: 1083 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
       ID: 1078
       Name: '*struct { io.Writer }'
       ByteSize: 8
-      GoRuntimeType: 975520
+      GoRuntimeType: 975648
       GoKind: 22
       Pointee: 1079 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 267
       Name: '*struct {}'
       ByteSize: 8
-      GoRuntimeType: 478400
+      GoRuntimeType: 478432
       GoKind: 22
       Pointee: 125 StructureType struct {}
     - __kind: PointerType
       ID: 994
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.423264e+06
+      GoRuntimeType: 1.423392e+06
       GoKind: 22
       Pointee: 993 BaseType syscall.Errno
     - __kind: PointerType
@@ -14521,35 +14521,35 @@ Types:
       ID: 1213
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.169728e+06
+      GoRuntimeType: 2.170016e+06
       GoKind: 22
       Pointee: 1214 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 935
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.09344e+06
+      GoRuntimeType: 1.093568e+06
       GoKind: 22
       Pointee: 936 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 1010
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.633312e+06
+      GoRuntimeType: 1.6336e+06
       GoKind: 22
       Pointee: 1011 UnresolvedPointeeType time.Location
     - __kind: PointerType
       ID: 671
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 906144
+      GoRuntimeType: 906176
       GoKind: 22
       Pointee: 672 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 670
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 906048
+      GoRuntimeType: 906080
       GoKind: 22
       Pointee: 587 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -14561,84 +14561,84 @@ Types:
       ID: 107
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 395072
+      GoRuntimeType: 395104
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 103
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 394688
+      GoRuntimeType: 394720
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 394816
+      GoRuntimeType: 394848
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 101
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 394944
+      GoRuntimeType: 394976
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 394560
+      GoRuntimeType: 394592
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 395136
+      GoRuntimeType: 395168
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
       ID: 762
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
-      GoRuntimeType: 923904
+      GoRuntimeType: 923936
       GoKind: 22
       Pointee: 763 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
       ID: 1205
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.145216e+06
+      GoRuntimeType: 2.145504e+06
       GoKind: 22
       Pointee: 1206 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
       ID: 746
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
-      GoRuntimeType: 920064
+      GoRuntimeType: 920096
       GoKind: 22
       Pointee: 747 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
       ID: 748
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
-      GoRuntimeType: 920160
+      GoRuntimeType: 920192
       GoKind: 22
       Pointee: 631 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
       ID: 912
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.051712e+06
+      GoRuntimeType: 1.05184e+06
       GoKind: 22
       Pointee: 913 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 914
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.05184e+06
+      GoRuntimeType: 1.051968e+06
       GoKind: 22
       Pointee: 865 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -23659,7 +23659,7 @@ Types:
       ID: 92
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 705088
+      GoRuntimeType: 705120
       GoKind: 17
       Count: 10
       HasCount: true
@@ -23668,7 +23668,7 @@ Types:
       ID: 335
       Name: '[16]uint8'
       ByteSize: 16
-      GoRuntimeType: 683808
+      GoRuntimeType: 683840
       GoKind: 17
       Count: 16
       HasCount: true
@@ -23677,7 +23677,7 @@ Types:
       ID: 252
       Name: '[1]int'
       ByteSize: 8
-      GoRuntimeType: 690240
+      GoRuntimeType: 690272
       GoKind: 17
       Count: 1
       HasCount: true
@@ -23686,7 +23686,7 @@ Types:
       ID: 78
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 704704
+      GoRuntimeType: 704736
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23695,7 +23695,7 @@ Types:
       ID: 77
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 704800
+      GoRuntimeType: 704832
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23720,7 +23720,7 @@ Types:
       ID: 84
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 704992
+      GoRuntimeType: 705024
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23737,7 +23737,7 @@ Types:
       ID: 113
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 686880
+      GoRuntimeType: 686912
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23754,7 +23754,7 @@ Types:
       ID: 110
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 688512
+      GoRuntimeType: 688544
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23795,7 +23795,7 @@ Types:
       ID: 111
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 688608
+      GoRuntimeType: 688640
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23835,7 +23835,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 688704
+      GoRuntimeType: 688736
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23844,7 +23844,7 @@ Types:
       ID: 109
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 688416
+      GoRuntimeType: 688448
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23853,7 +23853,7 @@ Types:
       ID: 90
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 738752
+      GoRuntimeType: 738784
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23862,7 +23862,7 @@ Types:
       ID: 68
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 704512
+      GoRuntimeType: 704544
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23871,7 +23871,7 @@ Types:
       ID: 251
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 688800
+      GoRuntimeType: 688832
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23880,7 +23880,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 703936
+      GoRuntimeType: 703968
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23889,7 +23889,7 @@ Types:
       ID: 460
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 686496
+      GoRuntimeType: 686528
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23898,7 +23898,7 @@ Types:
       ID: 417
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 686784
+      GoRuntimeType: 686816
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23907,7 +23907,7 @@ Types:
       ID: 91
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 696000
+      GoRuntimeType: 696032
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23924,7 +23924,7 @@ Types:
       ID: 1040
       Name: '[5]uint8'
       ByteSize: 5
-      GoRuntimeType: 688320
+      GoRuntimeType: 688352
       GoKind: 17
       Count: 5
       HasCount: true
@@ -23933,7 +23933,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 689856
+      GoRuntimeType: 689888
       GoKind: 17
       Count: 6
       HasCount: true
@@ -23942,7 +23942,7 @@ Types:
       ID: 85
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 704896
+      GoRuntimeType: 704928
       GoKind: 17
       Count: 8
       HasCount: true
@@ -23951,7 +23951,7 @@ Types:
       ID: 138
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 480000
+      GoRuntimeType: 480032
       GoKind: 23
       RawFields:
         - Name: array
@@ -23974,7 +23974,7 @@ Types:
       ID: 1278
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 479936
+      GoRuntimeType: 479968
       GoKind: 23
       RawFields:
         - Name: array
@@ -23997,7 +23997,7 @@ Types:
       ID: 1303
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 479616
+      GoRuntimeType: 479648
       GoKind: 23
       RawFields:
         - Name: array
@@ -24020,7 +24020,7 @@ Types:
       ID: 1309
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 479552
+      GoRuntimeType: 479584
       GoKind: 23
       RawFields:
         - Name: array
@@ -24043,7 +24043,7 @@ Types:
       ID: 62
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 491712
+      GoRuntimeType: 491744
       GoKind: 23
       RawFields:
         - Name: array
@@ -24066,7 +24066,7 @@ Types:
       ID: 129
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 478272
+      GoRuntimeType: 478304
       GoKind: 23
       RawFields:
         - Name: array
@@ -24383,7 +24383,7 @@ Types:
       ID: 264
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 490112
+      GoRuntimeType: 490144
       GoKind: 23
       RawFields:
         - Name: array
@@ -24406,7 +24406,7 @@ Types:
       ID: 1035
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 489984
+      GoRuntimeType: 490016
       GoKind: 23
       RawFields:
         - Name: array
@@ -24429,7 +24429,7 @@ Types:
       ID: 350
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 484992
+      GoRuntimeType: 485024
       GoKind: 23
       RawFields:
         - Name: array
@@ -24496,7 +24496,7 @@ Types:
       ID: 1315
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 490432
+      GoRuntimeType: 490464
       GoKind: 23
       RawFields:
         - Name: array
@@ -24541,7 +24541,7 @@ Types:
       ID: 426
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 480576
+      GoRuntimeType: 480608
       GoKind: 23
       RawFields:
         - Name: array
@@ -24752,7 +24752,7 @@ Types:
       ID: 263
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 490240
+      GoRuntimeType: 490272
       GoKind: 23
       RawFields:
         - Name: array
@@ -24796,7 +24796,7 @@ Types:
       ID: 257
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 489728
+      GoRuntimeType: 489760
       GoKind: 23
       RawFields:
         - Name: array
@@ -24819,7 +24819,7 @@ Types:
       ID: 265
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 489088
+      GoRuntimeType: 489120
       GoKind: 23
       RawFields:
         - Name: array
@@ -24842,7 +24842,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 488960
+      GoRuntimeType: 488992
       GoKind: 23
       RawFields:
         - Name: array
@@ -24865,7 +24865,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 489792
+      GoRuntimeType: 489824
       GoKind: 23
       RawFields:
         - Name: array
@@ -24892,7 +24892,7 @@ Types:
       ID: 825
       Name: archive/tar.headerError
       ByteSize: 24
-      GoRuntimeType: 935040
+      GoRuntimeType: 935072
       GoKind: 23
       RawFields:
         - Name: array
@@ -24922,7 +24922,7 @@ Types:
     - __kind: StructureType
       ID: 1075
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.125632e+06
+      GoRuntimeType: 1.12576e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24933,7 +24933,7 @@ Types:
       ID: 1101
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.573248e+06
+      GoRuntimeType: 1.573536e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -24947,7 +24947,7 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 588000
+      GoRuntimeType: 588032
       GoKind: 1
     - __kind: UnresolvedPointeeType
       ID: 1148
@@ -24964,36 +24964,36 @@ Types:
     - __kind: GoChannelType
       ID: 243
       Name: chan bool
-      GoRuntimeType: 599648
+      GoRuntimeType: 599680
       GoKind: 18
     - __kind: GoChannelType
       ID: 156
       Name: chan struct {}
-      GoRuntimeType: 598688
+      GoRuntimeType: 598720
       GoKind: 18
     - __kind: BaseType
       ID: 98
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 587808
+      GoRuntimeType: 587840
       GoKind: 16
     - __kind: BaseType
       ID: 97
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 587744
+      GoRuntimeType: 587776
       GoKind: 15
     - __kind: BaseType
       ID: 623
       Name: compress/flate.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 838016
+      GoRuntimeType: 838048
       GoKind: 6
     - __kind: GoStringHeaderType
       ID: 624
       Name: compress/flate.InternalError
       ByteSize: 16
-      GoRuntimeType: 838112
+      GoRuntimeType: 838144
       GoKind: 24
       RawFields:
         - Name: str
@@ -25023,26 +25023,26 @@ Types:
     - __kind: StructureType
       ID: 973
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.487648e+06
+      GoRuntimeType: 1.487936e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 637
       Name: crypto/aes.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 840608
+      GoRuntimeType: 840640
       GoKind: 2
     - __kind: BaseType
       ID: 638
       Name: crypto/des.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 840704
+      GoRuntimeType: 840736
       GoKind: 2
     - __kind: BaseType
       ID: 639
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 840800
+      GoRuntimeType: 840832
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1140
@@ -25051,7 +25051,7 @@ Types:
     - __kind: StructureType
       ID: 922
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
-      GoRuntimeType: 1.295488e+06
+      GoRuntimeType: 1.295616e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25078,7 +25078,7 @@ Types:
       ID: 640
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 840896
+      GoRuntimeType: 840928
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1188
@@ -25092,7 +25092,7 @@ Types:
       ID: 627
       Name: crypto/tls.AlertError
       ByteSize: 1
-      GoRuntimeType: 838592
+      GoRuntimeType: 838624
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 911
@@ -25110,7 +25110,7 @@ Types:
       ID: 737
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.739808e+06
+      GoRuntimeType: 1.740096e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25126,7 +25126,7 @@ Types:
       ID: 864
       Name: crypto/tls.alert
       ByteSize: 1
-      GoRuntimeType: 997888
+      GoRuntimeType: 998016
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1133
@@ -25152,7 +25152,7 @@ Types:
       ID: 813
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.742688e+06
+      GoRuntimeType: 1.742976e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25167,14 +25167,14 @@ Types:
     - __kind: StructureType
       ID: 807
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.1232e+06
+      GoRuntimeType: 1.123328e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 809
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.60736e+06
+      GoRuntimeType: 1.607648e+06
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -25187,19 +25187,19 @@ Types:
       ID: 636
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
-      GoRuntimeType: 840224
+      GoRuntimeType: 840256
       GoKind: 2
     - __kind: BaseType
       ID: 1043
       Name: crypto/x509.InvalidReason
       ByteSize: 8
-      GoRuntimeType: 593184
+      GoRuntimeType: 593216
       GoKind: 2
     - __kind: StructureType
       ID: 916
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.569248e+06
+      GoRuntimeType: 1.569536e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -25208,14 +25208,14 @@ Types:
     - __kind: StructureType
       ID: 815
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.123456e+06
+      GoRuntimeType: 1.123584e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 811
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.742496e+06
+      GoRuntimeType: 1.742784e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25231,7 +25231,7 @@ Types:
       ID: 829
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.442944e+06
+      GoRuntimeType: 1.443072e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25241,7 +25241,7 @@ Types:
       ID: 833
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.443104e+06
+      GoRuntimeType: 1.443232e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25255,7 +25255,7 @@ Types:
       ID: 618
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 837632
+      GoRuntimeType: 837664
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1091
@@ -25265,7 +25265,7 @@ Types:
       ID: 619
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
-      GoRuntimeType: 837824
+      GoRuntimeType: 837856
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 695
@@ -25299,7 +25299,7 @@ Types:
       ID: 697
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.426944e+06
+      GoRuntimeType: 1.427072e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -25321,7 +25321,7 @@ Types:
       ID: 633
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
-      GoRuntimeType: 840128
+      GoRuntimeType: 840160
       GoKind: 24
       RawFields:
         - Name: str
@@ -25348,7 +25348,7 @@ Types:
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.032e+06
+      GoRuntimeType: 1.032128e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25369,13 +25369,13 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 587872
+      GoRuntimeType: 587904
       GoKind: 13
     - __kind: BaseType
       ID: 16
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 587936
+      GoRuntimeType: 587968
       GoKind: 14
     - __kind: UnresolvedPointeeType
       ID: 1222
@@ -25393,13 +25393,13 @@ Types:
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 478016
+      GoRuntimeType: 478048
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 73
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 852320
+      GoRuntimeType: 852352
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 353
@@ -25442,7 +25442,7 @@ Types:
       ID: 706
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.738656e+06
+      GoRuntimeType: 1.738944e+06
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25465,7 +25465,7 @@ Types:
     - __kind: StructureType
       ID: 712
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.119488e+06
+      GoRuntimeType: 1.119616e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25476,7 +25476,7 @@ Types:
       ID: 612
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 837056
+      GoRuntimeType: 837088
       GoKind: 24
       RawFields:
         - Name: str
@@ -25495,7 +25495,7 @@ Types:
       ID: 1033
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.229024e+06
+      GoRuntimeType: 2.229312e+06
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25544,13 +25544,13 @@ Types:
       ID: 1034
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 590240
+      GoRuntimeType: 590272
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 609
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 836960
+      GoRuntimeType: 836992
       GoKind: 24
       RawFields:
         - Name: str
@@ -25569,7 +25569,7 @@ Types:
       ID: 615
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 837152
+      GoRuntimeType: 837184
       GoKind: 24
       RawFields:
         - Name: str
@@ -25611,26 +25611,26 @@ Types:
     - __kind: StructureType
       ID: 757
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.122432e+06
+      GoRuntimeType: 1.12256e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 632
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
-      GoRuntimeType: 839264
+      GoRuntimeType: 839296
       GoKind: 2
     - __kind: StructureType
       ID: 755
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.122304e+06
+      GoRuntimeType: 1.122432e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 753
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.60544e+06
+      GoRuntimeType: 1.605728e+06
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25643,7 +25643,7 @@ Types:
       ID: 773
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.60624e+06
+      GoRuntimeType: 1.606528e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25656,7 +25656,7 @@ Types:
       ID: 777
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.74192e+06
+      GoRuntimeType: 1.742208e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25672,7 +25672,7 @@ Types:
       ID: 775
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.436864e+06
+      GoRuntimeType: 1.436992e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25682,7 +25682,7 @@ Types:
       ID: 771
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.436544e+06
+      GoRuntimeType: 1.436672e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25692,14 +25692,14 @@ Types:
       ID: 1019
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.508128e+06
+      GoRuntimeType: 1.508416e+06
       GoKind: 21
       HeaderType: 1021 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 1042
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.055296e+06
+      GoRuntimeType: 1.055424e+06
       GoKind: 23
       RawFields:
         - Name: array
@@ -25722,7 +25722,7 @@ Types:
       ID: 785
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.60656e+06
+      GoRuntimeType: 1.606848e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25735,7 +25735,7 @@ Types:
       ID: 779
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.437024e+06
+      GoRuntimeType: 1.437152e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25745,7 +25745,7 @@ Types:
       ID: 783
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.742112e+06
+      GoRuntimeType: 1.7424e+06
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25761,7 +25761,7 @@ Types:
       ID: 781
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.6064e+06
+      GoRuntimeType: 1.606688e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25774,7 +25774,7 @@ Types:
       ID: 787
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.437184e+06
+      GoRuntimeType: 1.437312e+06
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25784,7 +25784,7 @@ Types:
       ID: 793
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.60688e+06
+      GoRuntimeType: 1.607168e+06
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25797,7 +25797,7 @@ Types:
       ID: 795
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.437504e+06
+      GoRuntimeType: 1.437632e+06
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25807,7 +25807,7 @@ Types:
       ID: 791
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.60672e+06
+      GoRuntimeType: 1.607008e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25820,7 +25820,7 @@ Types:
       ID: 789
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.437344e+06
+      GoRuntimeType: 1.437472e+06
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25830,7 +25830,7 @@ Types:
       ID: 797
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.60704e+06
+      GoRuntimeType: 1.607328e+06
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25843,7 +25843,7 @@ Types:
       ID: 714
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.429184e+06
+      GoRuntimeType: 1.429312e+06
       GoKind: 25
       RawFields:
         - Name: message
@@ -25857,7 +25857,7 @@ Types:
       ID: 716
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.429344e+06
+      GoRuntimeType: 1.429472e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25879,7 +25879,7 @@ Types:
       ID: 720
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.429664e+06
+      GoRuntimeType: 1.429792e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25893,7 +25893,7 @@ Types:
       ID: 1199
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 2.116512e+06
+      GoRuntimeType: 2.1168e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25906,7 +25906,7 @@ Types:
       ID: 1202
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.14176e+06
+      GoRuntimeType: 2.142048e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25926,7 +25926,7 @@ Types:
       ID: 718
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.429504e+06
+      GoRuntimeType: 1.429632e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25936,7 +25936,7 @@ Types:
       ID: 722
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.429824e+06
+      GoRuntimeType: 1.429952e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25986,7 +25986,7 @@ Types:
       ID: 728
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.430784e+06
+      GoRuntimeType: 1.430912e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -26001,7 +26001,7 @@ Types:
       ID: 957
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.85216e+06
+      GoRuntimeType: 1.852448e+06
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -26021,7 +26021,7 @@ Types:
       ID: 886
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.71136e+06
+      GoRuntimeType: 1.711648e+06
       GoKind: 25
       RawFields:
         - Name: Got
@@ -26034,7 +26034,7 @@ Types:
       ID: 963
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.852608e+06
+      GoRuntimeType: 1.852896e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26050,13 +26050,13 @@ Types:
       ID: 863
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 995200
+      GoRuntimeType: 995328
       GoKind: 8
     - __kind: StructureType
       ID: 955
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.851936e+06
+      GoRuntimeType: 1.852224e+06
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -26072,13 +26072,13 @@ Types:
       ID: 1044
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 835232
+      GoRuntimeType: 835264
       GoKind: 8
     - __kind: StructureType
       ID: 953
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.851712e+06
+      GoRuntimeType: 1.852e+06
       GoKind: 25
       RawFields:
         - Name: Method
@@ -26094,7 +26094,7 @@ Types:
       ID: 961
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.76608e+06
+      GoRuntimeType: 1.766368e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26107,7 +26107,7 @@ Types:
       ID: 959
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.852384e+06
+      GoRuntimeType: 1.852672e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26127,7 +26127,7 @@ Types:
       ID: 967
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.634272e+06
+      GoRuntimeType: 1.63456e+06
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -26136,20 +26136,20 @@ Types:
     - __kind: StructureType
       ID: 890
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.289472e+06
+      GoRuntimeType: 1.2896e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 888
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.289344e+06
+      GoRuntimeType: 1.289472e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 965
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.766272e+06
+      GoRuntimeType: 1.76656e+06
       GoKind: 25
       RawFields:
         - Name: cause
@@ -26162,7 +26162,7 @@ Types:
       ID: 645
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
-      GoRuntimeType: 842720
+      GoRuntimeType: 842752
       GoKind: 24
       RawFields:
         - Name: str
@@ -26181,25 +26181,25 @@ Types:
       ID: 339
       Name: go.shape.bool
       ByteSize: 1
-      GoRuntimeType: 599840
+      GoRuntimeType: 599872
       GoKind: 1
     - __kind: BaseType
       ID: 352
       Name: go.shape.float64
       ByteSize: 8
-      GoRuntimeType: 599904
+      GoRuntimeType: 599936
       GoKind: 14
     - __kind: BaseType
       ID: 322
       Name: go.shape.int
       ByteSize: 8
-      GoRuntimeType: 599712
+      GoRuntimeType: 599744
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 324
       Name: go.shape.string
       ByteSize: 16
-      GoRuntimeType: 599776
+      GoRuntimeType: 599808
       GoKind: 24
       RawFields:
         - Name: str
@@ -26273,7 +26273,7 @@ Types:
       ID: 934
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.454784e+06
+      GoRuntimeType: 1.454912e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26283,7 +26283,7 @@ Types:
       ID: 1117
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.687072e+06
+      GoRuntimeType: 1.68736e+06
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -26297,7 +26297,7 @@ Types:
       ID: 1143
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.133184e+06
+      GoRuntimeType: 1.133312e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26310,7 +26310,7 @@ Types:
       ID: 1105
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.578048e+06
+      GoRuntimeType: 1.578336e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -26320,19 +26320,19 @@ Types:
       ID: 648
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
-      GoRuntimeType: 843296
+      GoRuntimeType: 843328
       GoKind: 10
     - __kind: BaseType
       ID: 1026
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.008352e+06
+      GoRuntimeType: 1.00848e+06
       GoKind: 10
     - __kind: StructureType
       ID: 992
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.890016e+06
+      GoRuntimeType: 1.890304e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26348,7 +26348,7 @@ Types:
       ID: 849
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.61408e+06
+      GoRuntimeType: 1.614368e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26361,7 +26361,7 @@ Types:
       ID: 652
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 843488
+      GoRuntimeType: 843520
       GoKind: 24
       RawFields:
         - Name: str
@@ -26380,7 +26380,7 @@ Types:
       ID: 658
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 843680
+      GoRuntimeType: 843712
       GoKind: 24
       RawFields:
         - Name: str
@@ -26399,7 +26399,7 @@ Types:
       ID: 655
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 843584
+      GoRuntimeType: 843616
       GoKind: 24
       RawFields:
         - Name: str
@@ -26418,7 +26418,7 @@ Types:
       ID: 649
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 843392
+      GoRuntimeType: 843424
       GoKind: 24
       RawFields:
         - Name: str
@@ -26441,7 +26441,7 @@ Types:
       ID: 853
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.455424e+06
+      GoRuntimeType: 1.455552e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26451,13 +26451,13 @@ Types:
       ID: 661
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
-      GoRuntimeType: 843776
+      GoRuntimeType: 843808
       GoKind: 2
     - __kind: StructureType
       ID: 841
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.450464e+06
+      GoRuntimeType: 1.450592e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26471,7 +26471,7 @@ Types:
       ID: 1015
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.917792e+06
+      GoRuntimeType: 1.91808e+06
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26487,7 +26487,7 @@ Types:
       ID: 843
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.6136e+06
+      GoRuntimeType: 1.613888e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26500,7 +26500,7 @@ Types:
       ID: 1157
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.97584e+06
+      GoRuntimeType: 1.976128e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26517,7 +26517,7 @@ Types:
       ID: 932
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.575648e+06
+      GoRuntimeType: 1.575936e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26542,14 +26542,14 @@ Types:
     - __kind: StructureType
       ID: 986
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.518848e+06
+      GoRuntimeType: 1.519136e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 835
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.443744e+06
+      GoRuntimeType: 1.443872e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26559,7 +26559,7 @@ Types:
       ID: 837
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.443904e+06
+      GoRuntimeType: 1.444032e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26959,37 +26959,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 587552
+      GoRuntimeType: 587584
       GoKind: 2
     - __kind: BaseType
       ID: 96
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 587168
+      GoRuntimeType: 587200
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 587296
+      GoRuntimeType: 587328
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 587424
+      GoRuntimeType: 587456
       GoKind: 6
     - __kind: BaseType
       ID: 17
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 587040
+      GoRuntimeType: 587072
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 157
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 852032
+      GoRuntimeType: 852064
       GoKind: 20
       RawFields:
         - Name: _type
@@ -27010,7 +27010,7 @@ Types:
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.860224e+06
+      GoRuntimeType: 1.860512e+06
       GoKind: 25
       RawFields:
         - Name: buf
@@ -27047,7 +27047,7 @@ Types:
     - __kind: StructureType
       ID: 947
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.484448e+06
+      GoRuntimeType: 1.484736e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27058,7 +27058,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.219136e+06
+      GoRuntimeType: 1.219264e+06
       GoKind: 25
       RawFields:
         - Name: u
@@ -27068,7 +27068,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.648864e+06
+      GoRuntimeType: 1.649152e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27084,7 +27084,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.498208e+06
+      GoRuntimeType: 1.498496e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27097,7 +27097,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.498048e+06
+      GoRuntimeType: 1.498336e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27110,7 +27110,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.498368e+06
+      GoRuntimeType: 1.498656e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27122,20 +27122,20 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 997600
+      GoRuntimeType: 997728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 997504
+      GoRuntimeType: 997632
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 620
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
-      GoRuntimeType: 837920
+      GoRuntimeType: 837952
       GoKind: 24
       RawFields:
         - Name: str
@@ -27154,7 +27154,7 @@ Types:
       ID: 904
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
-      GoRuntimeType: 1.567008e+06
+      GoRuntimeType: 1.567296e+06
       GoKind: 25
       RawFields:
         - Name: typ
@@ -27164,7 +27164,7 @@ Types:
       ID: 1264
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.481408e+06
+      GoRuntimeType: 1.481696e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -27181,7 +27181,7 @@ Types:
       ID: 1149
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.195968e+06
+      GoRuntimeType: 1.196096e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27194,7 +27194,7 @@ Types:
       ID: 1184
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.028416e+06
+      GoRuntimeType: 1.028544e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27207,7 +27207,7 @@ Types:
       ID: 1136
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.115776e+06
+      GoRuntimeType: 1.115904e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27220,7 +27220,7 @@ Types:
       ID: 131
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.02816e+06
+      GoRuntimeType: 1.028288e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27232,7 +27232,7 @@ Types:
     - __kind: StructureType
       ID: 1107
       Name: io.discard
-      GoRuntimeType: 1.471008e+06
+      GoRuntimeType: 1.471296e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27302,7 +27302,7 @@ Types:
       ID: 162
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.027008e+06
+      GoRuntimeType: 1.027136e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27315,7 +27315,7 @@ Types:
       ID: 128
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.621216e+06
+      GoRuntimeType: 1.621504e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -27331,7 +27331,7 @@ Types:
       ID: 143
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.192256e+06
+      GoRuntimeType: 1.192384e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27341,7 +27341,7 @@ Types:
       ID: 376
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.192128e+06
+      GoRuntimeType: 1.192256e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27355,7 +27355,7 @@ Types:
       ID: 150
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.191488e+06
+      GoRuntimeType: 1.191616e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27365,7 +27365,7 @@ Types:
       ID: 1330
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.19136e+06
+      GoRuntimeType: 1.191488e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27375,7 +27375,7 @@ Types:
       ID: 1345
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.191232e+06
+      GoRuntimeType: 1.19136e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27385,7 +27385,7 @@ Types:
       ID: 132
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.193408e+06
+      GoRuntimeType: 1.193536e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27395,7 +27395,7 @@ Types:
       ID: 134
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.19328e+06
+      GoRuntimeType: 1.193408e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27409,7 +27409,7 @@ Types:
       ID: 136
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.19264e+06
+      GoRuntimeType: 1.192768e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27419,7 +27419,7 @@ Types:
       ID: 1300
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.192512e+06
+      GoRuntimeType: 1.19264e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27429,7 +27429,7 @@ Types:
       ID: 1302
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.192384e+06
+      GoRuntimeType: 1.192512e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27439,7 +27439,7 @@ Types:
       ID: 137
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.19456e+06
+      GoRuntimeType: 1.194688e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27449,7 +27449,7 @@ Types:
       ID: 366
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.194432e+06
+      GoRuntimeType: 1.19456e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27463,7 +27463,7 @@ Types:
       ID: 142
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.193792e+06
+      GoRuntimeType: 1.19392e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27473,7 +27473,7 @@ Types:
       ID: 1306
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.193664e+06
+      GoRuntimeType: 1.193792e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27483,7 +27483,7 @@ Types:
       ID: 1312
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.193536e+06
+      GoRuntimeType: 1.193664e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27498,7 +27498,7 @@ Types:
       ID: 160
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.84432e+06
+      GoRuntimeType: 1.844608e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27520,7 +27520,7 @@ Types:
       ID: 155
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.977408e+06
+      GoRuntimeType: 1.977696e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -27548,7 +27548,7 @@ Types:
       ID: 354
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.419424e+06
+      GoRuntimeType: 1.419552e+06
       GoKind: 25
       RawFields:
         - Name: s
@@ -27675,7 +27675,7 @@ Types:
       ID: 123
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.470048e+06
+      GoRuntimeType: 1.470336e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -27688,7 +27688,7 @@ Types:
       ID: 246
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.469728e+06
+      GoRuntimeType: 1.470016e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -27710,14 +27710,14 @@ Types:
       ID: 1274
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.419584e+06
+      GoRuntimeType: 1.419712e+06
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 158
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.027136e+06
+      GoRuntimeType: 1.027264e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27770,7 +27770,7 @@ Types:
       ID: 164
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.190976e+06
+      GoRuntimeType: 1.191104e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27840,7 +27840,7 @@ Types:
       ID: 165
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.191104e+06
+      GoRuntimeType: 1.191232e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -28954,119 +28954,119 @@ Types:
       ID: 223
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.135232e+06
+      GoRuntimeType: 1.13536e+06
       GoKind: 21
       HeaderType: 225 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 218
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.13536e+06
+      GoRuntimeType: 1.135488e+06
       GoKind: 21
       HeaderType: 220 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 186
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.135488e+06
+      GoRuntimeType: 1.135616e+06
       GoKind: 21
       HeaderType: 188 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 198
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.135616e+06
+      GoRuntimeType: 1.135744e+06
       GoKind: 21
       HeaderType: 200 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 144
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.135104e+06
+      GoRuntimeType: 1.135232e+06
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1284
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.134976e+06
+      GoRuntimeType: 1.135104e+06
       GoKind: 21
       HeaderType: 1286 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1318
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.134336e+06
+      GoRuntimeType: 1.134464e+06
       GoKind: 21
       HeaderType: 1320 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1333
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.134208e+06
+      GoRuntimeType: 1.134336e+06
       GoKind: 21
       HeaderType: 1335 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 166
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.133568e+06
+      GoRuntimeType: 1.133696e+06
       GoKind: 21
       HeaderType: 168 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 1348
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.13408e+06
+      GoRuntimeType: 1.134208e+06
       GoKind: 21
       HeaderType: 1350 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 233
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.135744e+06
+      GoRuntimeType: 1.135872e+06
       GoKind: 21
       HeaderType: 235 GoSwissMapHeaderType map<int,struct {}>
     - __kind: GoMapType
       ID: 203
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.135872e+06
+      GoRuntimeType: 1.136e+06
       GoKind: 21
       HeaderType: 205 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 193
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.136e+06
+      GoRuntimeType: 1.136128e+06
       GoKind: 21
       HeaderType: 195 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 181
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.136128e+06
+      GoRuntimeType: 1.136256e+06
       GoKind: 21
       HeaderType: 183 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 176
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.136256e+06
+      GoRuntimeType: 1.136384e+06
       GoKind: 21
       HeaderType: 178 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 171
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.136384e+06
+      GoRuntimeType: 1.136512e+06
       GoKind: 21
       HeaderType: 173 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 228
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 1.136512e+06
+      GoRuntimeType: 1.13664e+06
       GoKind: 21
       HeaderType: 230 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
@@ -29109,28 +29109,28 @@ Types:
       ID: 238
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.13664e+06
+      GoRuntimeType: 1.136768e+06
       GoKind: 21
       HeaderType: 240 GoSwissMapHeaderType map<struct {},struct {}>
     - __kind: GoMapType
       ID: 213
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.136768e+06
+      GoRuntimeType: 1.136896e+06
       GoKind: 21
       HeaderType: 215 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 208
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.136896e+06
+      GoRuntimeType: 1.137024e+06
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
       ID: 769
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.436064e+06
+      GoRuntimeType: 1.436192e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -29140,7 +29140,7 @@ Types:
       ID: 1071
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.432864e+06
+      GoRuntimeType: 1.432992e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29154,7 +29154,7 @@ Types:
       ID: 1041
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.60416e+06
+      GoRuntimeType: 1.604448e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29195,7 +29195,7 @@ Types:
       ID: 937
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.119104e+06
+      GoRuntimeType: 1.119232e+06
       GoKind: 24
       RawFields:
         - Name: str
@@ -29213,7 +29213,7 @@ Types:
     - __kind: StructureType
       ID: 902
       Name: net.canceledError
-      GoRuntimeType: 1.290496e+06
+      GoRuntimeType: 1.290624e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29224,7 +29224,7 @@ Types:
       ID: 1046
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 2.115808e+06
+      GoRuntimeType: 2.116096e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29246,13 +29246,13 @@ Types:
     - __kind: StructureType
       ID: 1232
       Name: net.noReadFrom
-      GoRuntimeType: 1.11936e+06
+      GoRuntimeType: 1.119488e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1231
       Name: net.noWriteTo
-      GoRuntimeType: 1.119232e+06
+      GoRuntimeType: 1.11936e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29263,7 +29263,7 @@ Types:
       ID: 701
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.738464e+06
+      GoRuntimeType: 1.738752e+06
       GoKind: 25
       RawFields:
         - Name: p
@@ -29279,7 +29279,7 @@ Types:
       ID: 1220
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.298816e+06
+      GoRuntimeType: 2.299104e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29292,7 +29292,7 @@ Types:
       ID: 1218
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.298272e+06
+      GoRuntimeType: 2.29856e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29317,7 +29317,7 @@ Types:
       ID: 1065
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.424384e+06
+      GoRuntimeType: 1.424512e+06
       GoKind: 25
       RawFields:
         - Name: w
@@ -29327,19 +29327,19 @@ Types:
       ID: 590
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 835712
+      GoRuntimeType: 835744
       GoKind: 10
     - __kind: BaseType
       ID: 1018
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 995296
+      GoRuntimeType: 995424
       GoKind: 10
     - __kind: StructureType
       ID: 677
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.736736e+06
+      GoRuntimeType: 1.737024e+06
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -29355,7 +29355,7 @@ Types:
       ID: 996
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.90832e+06
+      GoRuntimeType: 1.908608e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -29371,7 +29371,7 @@ Types:
       ID: 681
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.60368e+06
+      GoRuntimeType: 1.603968e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29388,7 +29388,7 @@ Types:
       ID: 594
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 835904
+      GoRuntimeType: 835936
       GoKind: 24
       RawFields:
         - Name: str
@@ -29407,7 +29407,7 @@ Types:
       ID: 600
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 836096
+      GoRuntimeType: 836128
       GoKind: 24
       RawFields:
         - Name: str
@@ -29426,7 +29426,7 @@ Types:
       ID: 597
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 836000
+      GoRuntimeType: 836032
       GoKind: 24
       RawFields:
         - Name: str
@@ -29448,7 +29448,7 @@ Types:
     - __kind: StructureType
       ID: 898
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.289728e+06
+      GoRuntimeType: 1.289856e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29459,7 +29459,7 @@ Types:
       ID: 591
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 835808
+      GoRuntimeType: 835840
       GoKind: 24
       RawFields:
         - Name: str
@@ -29478,7 +29478,7 @@ Types:
       ID: 1067
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
-      GoRuntimeType: 1.8344e+06
+      GoRuntimeType: 1.834688e+06
       GoKind: 25
       RawFields:
         - Name: group
@@ -29497,7 +29497,7 @@ Types:
       ID: 1158
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
-      GoRuntimeType: 1.423584e+06
+      GoRuntimeType: 1.423712e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29509,7 +29509,7 @@ Types:
     - __kind: ArrayType
       ID: 1146
       Name: net/http.incomparable
-      GoRuntimeType: 907392
+      GoRuntimeType: 907424
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
@@ -29517,7 +29517,7 @@ Types:
       ID: 894
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.563168e+06
+      GoRuntimeType: 1.563456e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -29531,7 +29531,7 @@ Types:
       ID: 1085
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.563008e+06
+      GoRuntimeType: 1.563296e+06
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29541,7 +29541,7 @@ Types:
       ID: 1119
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.809376e+06
+      GoRuntimeType: 1.809664e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -29557,7 +29557,7 @@ Types:
       ID: 685
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.425344e+06
+      GoRuntimeType: 1.425472e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -29570,14 +29570,14 @@ Types:
     - __kind: StructureType
       ID: 969
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.487328e+06
+      GoRuntimeType: 1.487616e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 896
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.563328e+06
+      GoRuntimeType: 1.563616e+06
       GoKind: 25
       RawFields:
         - Name: err
@@ -29587,7 +29587,7 @@ Types:
       ID: 1161
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2.034816e+06
+      GoRuntimeType: 2.035104e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29604,7 +29604,7 @@ Types:
       ID: 1183
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 2.05056e+06
+      GoRuntimeType: 2.050848e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29618,7 +29618,7 @@ Types:
       ID: 761
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.741536e+06
+      GoRuntimeType: 1.741824e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29634,7 +29634,7 @@ Types:
       ID: 759
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.6056e+06
+      GoRuntimeType: 1.605888e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29651,7 +29651,7 @@ Types:
       ID: 1097
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.60752e+06
+      GoRuntimeType: 1.607808e+06
       GoKind: 25
       RawFields:
         - Name: c
@@ -29668,7 +29668,7 @@ Types:
       ID: 628
       Name: net/textproto.ProtocolError
       ByteSize: 16
-      GoRuntimeType: 838688
+      GoRuntimeType: 838720
       GoKind: 24
       RawFields:
         - Name: str
@@ -29695,7 +29695,7 @@ Types:
       ID: 603
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 836672
+      GoRuntimeType: 836704
       GoKind: 24
       RawFields:
         - Name: str
@@ -29714,7 +29714,7 @@ Types:
       ID: 606
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 836768
+      GoRuntimeType: 836800
       GoKind: 24
       RawFields:
         - Name: str
@@ -29733,7 +29733,7 @@ Types:
       ID: 475
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 686592
+      GoRuntimeType: 686624
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29742,7 +29742,7 @@ Types:
       ID: 467
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 686688
+      GoRuntimeType: 686720
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29751,7 +29751,7 @@ Types:
       ID: 415
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 686976
+      GoRuntimeType: 687008
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29760,7 +29760,7 @@ Types:
       ID: 434
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 687072
+      GoRuntimeType: 687104
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29769,7 +29769,7 @@ Types:
       ID: 373
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
-      GoRuntimeType: 685824
+      GoRuntimeType: 685856
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29778,7 +29778,7 @@ Types:
       ID: 1293
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
-      GoRuntimeType: 685728
+      GoRuntimeType: 685760
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29787,7 +29787,7 @@ Types:
       ID: 1327
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
-      GoRuntimeType: 685248
+      GoRuntimeType: 685280
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29796,7 +29796,7 @@ Types:
       ID: 1342
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
-      GoRuntimeType: 685152
+      GoRuntimeType: 685184
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29805,7 +29805,7 @@ Types:
       ID: 383
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 683904
+      GoRuntimeType: 683936
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29814,7 +29814,7 @@ Types:
       ID: 1357
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
-      GoRuntimeType: 685056
+      GoRuntimeType: 685088
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29823,7 +29823,7 @@ Types:
       ID: 491
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
-      GoRuntimeType: 687168
+      GoRuntimeType: 687200
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29832,7 +29832,7 @@ Types:
       ID: 442
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 687264
+      GoRuntimeType: 687296
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29841,7 +29841,7 @@ Types:
       ID: 424
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 687360
+      GoRuntimeType: 687392
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29850,7 +29850,7 @@ Types:
       ID: 407
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 687456
+      GoRuntimeType: 687488
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29859,7 +29859,7 @@ Types:
       ID: 1054
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
-      GoRuntimeType: 762912
+      GoRuntimeType: 762944
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29868,7 +29868,7 @@ Types:
       ID: 399
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 687552
+      GoRuntimeType: 687584
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29877,7 +29877,7 @@ Types:
       ID: 391
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 687648
+      GoRuntimeType: 687680
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29886,7 +29886,7 @@ Types:
       ID: 483
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
-      GoRuntimeType: 687744
+      GoRuntimeType: 687776
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29942,7 +29942,7 @@ Types:
     - __kind: ArrayType
       ID: 499
       Name: noalg.[8]struct { key struct {}; elem struct {} }
-      GoRuntimeType: 687840
+      GoRuntimeType: 687872
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29951,7 +29951,7 @@ Types:
       ID: 458
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 687936
+      GoRuntimeType: 687968
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29960,7 +29960,7 @@ Types:
       ID: 450
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 688032
+      GoRuntimeType: 688064
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29969,7 +29969,7 @@ Types:
       ID: 474
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.30176e+06
+      GoRuntimeType: 1.301888e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29982,7 +29982,7 @@ Types:
       ID: 466
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.302016e+06
+      GoRuntimeType: 1.302144e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29995,7 +29995,7 @@ Types:
       ID: 414
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.302272e+06
+      GoRuntimeType: 1.3024e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30008,7 +30008,7 @@ Types:
       ID: 433
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.302528e+06
+      GoRuntimeType: 1.302656e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30021,7 +30021,7 @@ Types:
       ID: 372
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.301504e+06
+      GoRuntimeType: 1.301632e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30034,7 +30034,7 @@ Types:
       ID: 1292
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.301248e+06
+      GoRuntimeType: 1.301376e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30047,7 +30047,7 @@ Types:
       ID: 1326
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.299968e+06
+      GoRuntimeType: 1.300096e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30060,7 +30060,7 @@ Types:
       ID: 1341
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.299712e+06
+      GoRuntimeType: 1.29984e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30073,7 +30073,7 @@ Types:
       ID: 382
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.298432e+06
+      GoRuntimeType: 1.29856e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30086,7 +30086,7 @@ Types:
       ID: 1356
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.299456e+06
+      GoRuntimeType: 1.299584e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30099,7 +30099,7 @@ Types:
       ID: 490
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
-      GoRuntimeType: 1.302784e+06
+      GoRuntimeType: 1.302912e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30112,7 +30112,7 @@ Types:
       ID: 441
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.30304e+06
+      GoRuntimeType: 1.303168e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30125,7 +30125,7 @@ Types:
       ID: 423
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.303296e+06
+      GoRuntimeType: 1.303424e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30138,7 +30138,7 @@ Types:
       ID: 406
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.303552e+06
+      GoRuntimeType: 1.30368e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30151,7 +30151,7 @@ Types:
       ID: 1053
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
-      GoRuntimeType: 1.364992e+06
+      GoRuntimeType: 1.36512e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30164,7 +30164,7 @@ Types:
       ID: 398
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.303808e+06
+      GoRuntimeType: 1.303936e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30177,7 +30177,7 @@ Types:
       ID: 390
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.304064e+06
+      GoRuntimeType: 1.304192e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30190,7 +30190,7 @@ Types:
       ID: 482
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
-      GoRuntimeType: 1.30432e+06
+      GoRuntimeType: 1.304448e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30275,7 +30275,7 @@ Types:
       ID: 498
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
-      GoRuntimeType: 1.304576e+06
+      GoRuntimeType: 1.304704e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30288,7 +30288,7 @@ Types:
       ID: 457
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.304832e+06
+      GoRuntimeType: 1.30496e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30301,7 +30301,7 @@ Types:
       ID: 449
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.305088e+06
+      GoRuntimeType: 1.305216e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30314,7 +30314,7 @@ Types:
       ID: 476
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.301632e+06
+      GoRuntimeType: 1.30176e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30327,7 +30327,7 @@ Types:
       ID: 468
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.301888e+06
+      GoRuntimeType: 1.302016e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30340,7 +30340,7 @@ Types:
       ID: 416
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.302144e+06
+      GoRuntimeType: 1.302272e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30353,7 +30353,7 @@ Types:
       ID: 435
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.3024e+06
+      GoRuntimeType: 1.302528e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30366,7 +30366,7 @@ Types:
       ID: 374
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.301376e+06
+      GoRuntimeType: 1.301504e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30379,7 +30379,7 @@ Types:
       ID: 1294
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.30112e+06
+      GoRuntimeType: 1.301248e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30392,7 +30392,7 @@ Types:
       ID: 1328
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.29984e+06
+      GoRuntimeType: 1.299968e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30405,7 +30405,7 @@ Types:
       ID: 1343
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.299584e+06
+      GoRuntimeType: 1.299712e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30418,7 +30418,7 @@ Types:
       ID: 384
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.298304e+06
+      GoRuntimeType: 1.298432e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30431,7 +30431,7 @@ Types:
       ID: 1358
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.299328e+06
+      GoRuntimeType: 1.299456e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30444,7 +30444,7 @@ Types:
       ID: 492
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
-      GoRuntimeType: 1.302656e+06
+      GoRuntimeType: 1.302784e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30457,7 +30457,7 @@ Types:
       ID: 443
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.302912e+06
+      GoRuntimeType: 1.30304e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30470,7 +30470,7 @@ Types:
       ID: 425
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.303168e+06
+      GoRuntimeType: 1.303296e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30483,7 +30483,7 @@ Types:
       ID: 408
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.303424e+06
+      GoRuntimeType: 1.303552e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30496,7 +30496,7 @@ Types:
       ID: 1055
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
-      GoRuntimeType: 1.364864e+06
+      GoRuntimeType: 1.364992e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30509,7 +30509,7 @@ Types:
       ID: 400
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.30368e+06
+      GoRuntimeType: 1.303808e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30522,7 +30522,7 @@ Types:
       ID: 392
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.303936e+06
+      GoRuntimeType: 1.304064e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30535,7 +30535,7 @@ Types:
       ID: 484
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
-      GoRuntimeType: 1.304192e+06
+      GoRuntimeType: 1.30432e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30619,7 +30619,7 @@ Types:
     - __kind: StructureType
       ID: 500
       Name: noalg.struct { key struct {}; elem struct {} }
-      GoRuntimeType: 1.304448e+06
+      GoRuntimeType: 1.304576e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30632,7 +30632,7 @@ Types:
       ID: 459
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.304704e+06
+      GoRuntimeType: 1.304832e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30645,7 +30645,7 @@ Types:
       ID: 451
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.30496e+06
+      GoRuntimeType: 1.305088e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30670,7 +30670,7 @@ Types:
       ID: 1242
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.369184e+06
+      GoRuntimeType: 2.369472e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -30683,7 +30683,7 @@ Types:
       ID: 1240
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.368384e+06
+      GoRuntimeType: 2.368672e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -30695,13 +30695,13 @@ Types:
     - __kind: StructureType
       ID: 1248
       Name: os.noReadFrom
-      GoRuntimeType: 1.1168e+06
+      GoRuntimeType: 1.116928e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1247
       Name: os.noWriteTo
-      GoRuntimeType: 1.116672e+06
+      GoRuntimeType: 1.1168e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -30720,7 +30720,7 @@ Types:
       ID: 908
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.711936e+06
+      GoRuntimeType: 1.712224e+06
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -30733,7 +30733,7 @@ Types:
       ID: 642
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
-      GoRuntimeType: 841952
+      GoRuntimeType: 841984
       GoKind: 24
       RawFields:
         - Name: str
@@ -30752,7 +30752,7 @@ Types:
       ID: 641
       Name: os/user.UnknownUserIdError
       ByteSize: 8
-      GoRuntimeType: 841856
+      GoRuntimeType: 841888
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 669
@@ -30782,7 +30782,7 @@ Types:
       ID: 881
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.897184e+06
+      GoRuntimeType: 1.897472e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -30801,7 +30801,7 @@ Types:
       ID: 1047
       Name: runtime.boundsErrorCode
       ByteSize: 1
-      GoRuntimeType: 588128
+      GoRuntimeType: 588160
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 66
@@ -30814,14 +30814,14 @@ Types:
     - __kind: StructureType
       ID: 87
       Name: runtime.dlogPerM
-      GoRuntimeType: 994432
+      GoRuntimeType: 994560
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 943
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.76224e+06
+      GoRuntimeType: 1.762528e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30834,7 +30834,7 @@ Types:
       ID: 857
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 993856
+      GoRuntimeType: 993984
       GoKind: 24
       RawFields:
         - Name: str
@@ -30853,7 +30853,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.416e+06
+      GoRuntimeType: 2.416288e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31043,7 +31043,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.202752e+06
+      GoRuntimeType: 1.20288e+06
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -31053,7 +31053,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.923104e+06
+      GoRuntimeType: 1.923392e+06
       GoKind: 25
       RawFields:
         - Name: sp
@@ -31078,7 +31078,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.479008e+06
+      GoRuntimeType: 1.479296e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31091,7 +31091,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.761088e+06
+      GoRuntimeType: 1.761376e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31110,13 +31110,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 834464
+      GoRuntimeType: 834496
       GoKind: 12
     - __kind: StructureType
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.478848e+06
+      GoRuntimeType: 1.479136e+06
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -31129,7 +31129,7 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.923872e+06
+      GoRuntimeType: 1.92416e+06
       GoKind: 25
       RawFields:
         - Name: fn
@@ -31154,13 +31154,13 @@ Types:
       ID: 94
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 834368
+      GoRuntimeType: 834400
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 2.419296e+06
+      GoRuntimeType: 2.419584e+06
       GoKind: 25
       RawFields:
         - Name: g0
@@ -31380,7 +31380,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.923616e+06
+      GoRuntimeType: 1.923904e+06
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31405,7 +31405,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.849248e+06
+      GoRuntimeType: 1.849536e+06
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31427,7 +31427,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.849024e+06
+      GoRuntimeType: 1.849312e+06
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -31449,7 +31449,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.478528e+06
+      GoRuntimeType: 1.478816e+06
       GoKind: 25
       RawFields:
         - Name: next
@@ -31462,13 +31462,13 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 834080
+      GoRuntimeType: 834112
       GoKind: 12
     - __kind: StructureType
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.202496e+06
+      GoRuntimeType: 1.202624e+06
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -31479,7 +31479,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.478688e+06
+      GoRuntimeType: 1.478976e+06
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31492,7 +31492,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.762048e+06
+      GoRuntimeType: 1.762336e+06
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -31511,7 +31511,7 @@ Types:
       ID: 860
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 993952
+      GoRuntimeType: 994080
       GoKind: 24
       RawFields:
         - Name: str
@@ -31530,13 +31530,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 834272
+      GoRuntimeType: 834304
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 902880
+      GoRuntimeType: 902912
       GoKind: 17
       Count: 2
       HasCount: true
@@ -31545,7 +31545,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.476768e+06
+      GoRuntimeType: 1.477056e+06
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31566,7 +31566,7 @@ Types:
       ID: 665
       Name: runtime.synctestDeadlockError
       ByteSize: 24
-      GoRuntimeType: 1.60336e+06
+      GoRuntimeType: 1.603648e+06
       GoKind: 25
       RawFields:
         - Name: reason
@@ -31579,7 +31579,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 588256
+      GoRuntimeType: 588288
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -31589,7 +31589,7 @@ Types:
       ID: 74
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 588320
+      GoRuntimeType: 588352
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 80
@@ -31599,7 +31599,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.477728e+06
+      GoRuntimeType: 1.478016e+06
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -31612,12 +31612,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.288704e+06
+      GoRuntimeType: 1.288832e+06
       GoKind: 8
     - __kind: StructureType
       ID: 82
       Name: runtime.winlibcall
-      GoRuntimeType: 994336
+      GoRuntimeType: 994464
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -31628,7 +31628,7 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 586976
+      GoRuntimeType: 587008
       GoKind: 24
       RawFields:
         - Name: str
@@ -31655,7 +31655,7 @@ Types:
       ID: 1079
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.462624e+06
+      GoRuntimeType: 1.462912e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -31664,14 +31664,14 @@ Types:
     - __kind: StructureType
       ID: 125
       Name: struct {}
-      GoRuntimeType: 845600
+      GoRuntimeType: 845632
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1262
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.471328e+06
+      GoRuntimeType: 1.471616e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31684,7 +31684,7 @@ Types:
       ID: 1265
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.622176e+06
+      GoRuntimeType: 1.622464e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31700,7 +31700,7 @@ Types:
       ID: 1268
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.621984e+06
+      GoRuntimeType: 1.622272e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31715,14 +31715,14 @@ Types:
     - __kind: StructureType
       ID: 1263
       Name: sync.noCopy
-      GoRuntimeType: 992800
+      GoRuntimeType: 992928
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1266
       Name: sync/atomic.Bool
       ByteSize: 4
-      GoRuntimeType: 1.472448e+06
+      GoRuntimeType: 1.472736e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31735,7 +31735,7 @@ Types:
       ID: 1271
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.472608e+06
+      GoRuntimeType: 1.472896e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31748,7 +31748,7 @@ Types:
       ID: 1269
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.62256e+06
+      GoRuntimeType: 1.622848e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31763,20 +31763,20 @@ Types:
     - __kind: StructureType
       ID: 1270
       Name: sync/atomic.align64
-      GoRuntimeType: 992992
+      GoRuntimeType: 993120
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1267
       Name: sync/atomic.noCopy
-      GoRuntimeType: 992896
+      GoRuntimeType: 993024
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 993
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.289088e+06
+      GoRuntimeType: 1.289216e+06
       GoKind: 12
     - __kind: StructureType
       ID: 471
@@ -32434,7 +32434,7 @@ Types:
       ID: 936
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.716352e+06
+      GoRuntimeType: 1.71664e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -32447,7 +32447,7 @@ Types:
       ID: 1159
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.92464e+06
+      GoRuntimeType: 1.924928e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1011
@@ -32461,7 +32461,7 @@ Types:
       ID: 1009
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.382496e+06
+      GoRuntimeType: 2.382784e+06
       GoKind: 25
       RawFields:
         - Name: wall
@@ -32477,7 +32477,7 @@ Types:
       ID: 587
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 834848
+      GoRuntimeType: 834880
       GoKind: 24
       RawFields:
         - Name: str
@@ -32496,49 +32496,49 @@ Types:
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 587616
+      GoRuntimeType: 587648
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 587232
+      GoRuntimeType: 587264
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 587360
+      GoRuntimeType: 587392
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 587488
+      GoRuntimeType: 587520
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 587104
+      GoRuntimeType: 587136
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 587680
+      GoRuntimeType: 587712
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 588064
+      GoRuntimeType: 588096
       GoKind: 26
     - __kind: StructureType
       ID: 1029
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 2.072288e+06
+      GoRuntimeType: 2.072576e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -32572,13 +32572,13 @@ Types:
       ID: 1032
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
-      GoRuntimeType: 999520
+      GoRuntimeType: 999648
       GoKind: 9
     - __kind: StructureType
       ID: 1030
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.935648e+06
+      GoRuntimeType: 1.935936e+06
       GoKind: 25
       RawFields:
         - Name: id
@@ -32607,7 +32607,7 @@ Types:
       ID: 1031
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
-      GoRuntimeType: 591712
+      GoRuntimeType: 591744
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1206
@@ -32617,7 +32617,7 @@ Types:
       ID: 747
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.433184e+06
+      GoRuntimeType: 1.433312e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -32627,13 +32627,13 @@ Types:
       ID: 631
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
-      GoRuntimeType: 838784
+      GoRuntimeType: 838816
       GoKind: 2
     - __kind: StructureType
       ID: 913
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.712128e+06
+      GoRuntimeType: 1.712416e+06
       GoKind: 25
       RawFields:
         - Name: label
@@ -32646,7 +32646,7 @@ Types:
       ID: 865
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
-      GoRuntimeType: 998368
+      GoRuntimeType: 998496
       GoKind: 5
 MaxTypeID: 1689
 Issues:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x80a768", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a778", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1594 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x80a798", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a7a8", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x805c98", Frameless: false}]
+              InjectionPoints: [{PC: "0x805ca8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1433 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x805cc0", Frameless: false}]
+              InjectionPoints: [{PC: "0x805cd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x805d08", Frameless: false}]
+              InjectionPoints: [{PC: "0x805d18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1436 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x805d30", Frameless: false}]
+              InjectionPoints: [{PC: "0x805d40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x80965c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80966c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1565 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8096f0", Frameless: false}]
+              InjectionPoints: [{PC: "0x809700", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0x8036e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8036f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0x8036a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8036b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0x8036c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8036d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x806350", Frameless: true}]
+              InjectionPoints: [{PC: "0x806360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0x8036b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8036c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0x8036d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8036e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x807a40", Frameless: true}]
+              InjectionPoints: [{PC: "0x807a50", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1467 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x807a7c", Frameless: true}]
+              InjectionPoints: [{PC: "0x807a8c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,7 +267,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x803c30", Frameless: true}]
+              InjectionPoints: [{PC: "0x803c40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -289,7 +289,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0x8035f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -311,7 +311,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0x8035c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8035d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80aa30", Frameless: true}]
+              InjectionPoints: [{PC: "0x80aa40", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -358,15 +358,15 @@ Probes:
             - Kind: Line
               Type: 1668 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x8055b8"
+                - PC: "0x8055c8"
                   Frameless: false
-                - PC: "0x80562c"
+                - PC: "0x80563c"
                   Frameless: false
-                - PC: "0x805760"
+                - PC: "0x805770"
                   Frameless: false
-                - PC: "0x8057e4"
+                - PC: "0x8057f4"
                   Frameless: false
-                - PC: "0x80589c"
+                - PC: "0x8058ac"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -388,15 +388,15 @@ Probes:
             - Kind: Line
               Type: 1669 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x8055b8"
+                - PC: "0x8055c8"
                   Frameless: false
-                - PC: "0x80562c"
+                - PC: "0x80563c"
                   Frameless: false
-                - PC: "0x805760"
+                - PC: "0x805770"
                   Frameless: false
-                - PC: "0x8057e4"
+                - PC: "0x8057f4"
                   Frameless: false
-                - PC: "0x80589c"
+                - PC: "0x8058ac"
                   Frameless: false
               Condition:
                 Type: 4 BaseType bool
@@ -430,15 +430,15 @@ Probes:
             - Kind: Line
               Type: 1670 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x8055b8"
+                - PC: "0x8055c8"
                   Frameless: false
-                - PC: "0x80562c"
+                - PC: "0x80563c"
                   Frameless: false
-                - PC: "0x805760"
+                - PC: "0x805770"
                   Frameless: false
-                - PC: "0x8057e4"
+                - PC: "0x8057f4"
                   Frameless: false
-                - PC: "0x80589c"
+                - PC: "0x8058ac"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -466,7 +466,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x8077e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8077f0", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -485,7 +485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x8077e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8077f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -511,7 +511,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80aab0", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -546,7 +546,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x807a80", Frameless: true}]
+              InjectionPoints: [{PC: "0x807a90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -576,7 +576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x8077c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8077d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -605,11 +605,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1529 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x808958", Frameless: false}]
+              InjectionPoints: [{PC: "0x808968", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1530 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x8089fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x808a0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -631,7 +631,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x807d00", Frameless: true}]
+              InjectionPoints: [{PC: "0x807d10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -653,7 +653,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1407 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x804090", Frameless: true}]
+              InjectionPoints: [{PC: "0x8040a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -675,7 +675,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x8040a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8040b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -697,7 +697,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x803e00", Frameless: true}]
+              InjectionPoints: [{PC: "0x803e10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -719,7 +719,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x803e10", Frameless: true}]
+              InjectionPoints: [{PC: "0x803e20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -741,7 +741,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x803f30", Frameless: true}]
+              InjectionPoints: [{PC: "0x803f40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -763,7 +763,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x803f40", Frameless: true}]
+              InjectionPoints: [{PC: "0x803f50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -785,7 +785,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x80a3e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a3f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -812,7 +812,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1584 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x80a410", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -840,7 +840,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x80a820", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a830", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -862,7 +862,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x80aad0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80aae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -883,7 +883,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x80aae0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80aaf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -905,7 +905,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x805ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0x805cf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -939,7 +939,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1402 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x803cc0", Frameless: false}]
+              InjectionPoints: [{PC: "0x803cd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -967,11 +967,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x804698", Frameless: false}]
+              InjectionPoints: [{PC: "0x8046a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x8046d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8046e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -993,11 +993,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x8045dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8045ec", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1415 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x804638", Frameless: false}]
+              InjectionPoints: [{PC: "0x804648", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1019,11 +1019,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x805a00", Frameless: true}]
+              InjectionPoints: [{PC: "0x805a10", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1427 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x805a08", Frameless: true}]
+              InjectionPoints: [{PC: "0x805a18", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1045,11 +1045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x805a1c", Frameless: false}]
+              InjectionPoints: [{PC: "0x805a2c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1429 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x805a50", Frameless: false}]
+              InjectionPoints: [{PC: "0x805a60", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1074,7 +1074,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1430 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x805a1c", Frameless: false}]
+              InjectionPoints: [{PC: "0x805a2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1096,11 +1096,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1654 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x80c8b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c8c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1655 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80c8b4", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c8c4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1114,11 +1114,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1656 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x80c8d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c8e0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1657 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x80c904", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c914", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1141,11 +1141,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1650 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x80c818", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c828", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1651 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x80c828", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c838", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1159,11 +1159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1652 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x80c868", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c878", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1653 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x80c880", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c890", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1186,14 +1186,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1658 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x80c910", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c920", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1659 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x80c938"
+                - PC: "0x80c948"
                   Frameless: true
-                - PC: "0x80c940"
+                - PC: "0x80c950"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1208,14 +1208,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1660 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x80c968", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c978", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1661 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x80c9c8"
-                  Frameless: false
                 - PC: "0x80c9d8"
+                  Frameless: false
+                - PC: "0x80c9e8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1242,7 +1242,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1662 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x80c914", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c924", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1254,7 +1254,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1663 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x80c978", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c988", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1275,11 +1275,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1638 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x80c590", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c5a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1639 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x80c594", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c5a4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1293,11 +1293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1640 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x80c610", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c620", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1641 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x80c614", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c624", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1321,11 +1321,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1626 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x80c19c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c1ac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1627 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80c2e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c2f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1367,11 +1367,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1630 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80c338", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c348", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1631 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80c348", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c358", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1394,11 +1394,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1664 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x80ca10", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ca20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1665 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x80ca18", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ca28", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1412,11 +1412,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1666 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x80ca88", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ca98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1667 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x80caac", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cabc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1439,11 +1439,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1622 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x80c100", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c110", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1623 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80c104", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c114", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1457,11 +1457,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x80c110", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c120", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1625 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80c11c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c12c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1484,11 +1484,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1642 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x80c690", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c6a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1643 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x80c698", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c6a8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1502,11 +1502,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1644 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x80c718", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c728", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1645 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x80c740", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c750", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1529,11 +1529,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1632 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x80c560", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c570", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1633 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80c564", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c574", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1547,11 +1547,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1634 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x80c570", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c580", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1635 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x80c574", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c584", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1565,11 +1565,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1636 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x80c580", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c590", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1637 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x80c584", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c594", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1592,11 +1592,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1646 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x80c7d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c7e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1647 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x80c7d8", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c7e8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1610,11 +1610,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1648 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80c7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c7f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1649 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80c7f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1637,11 +1637,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1618 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x80c0e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c0f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1619 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80c0e4", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c0f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1655,11 +1655,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1620 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x80c0f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c100", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1621 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80c0fc", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c10c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1682,11 +1682,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x805748", Frameless: false}]
+              InjectionPoints: [{PC: "0x805758", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1419 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x805794", Frameless: false}]
+              InjectionPoints: [{PC: "0x8057a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1713,11 +1713,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x8057d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8057e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1421 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x805858", Frameless: false}]
+              InjectionPoints: [{PC: "0x805868", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1744,11 +1744,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x805898", Frameless: false}]
+              InjectionPoints: [{PC: "0x8058a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1423 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x8058d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8058e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1770,7 +1770,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1674 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x805824", Frameless: false}]
+              InjectionPoints: [{PC: "0x805834", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1788,11 +1788,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1424 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x805908", Frameless: false}]
+              InjectionPoints: [{PC: "0x805918", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1425 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x8059e4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8059f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1810,7 +1810,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1675 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x80590c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80591c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1831,7 +1831,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1676 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x80590c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80591c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1849,7 +1849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1677 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x8059b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8059c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1870,7 +1870,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1678 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x8059b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8059c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1891,7 +1891,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x139638"
                   Frameless: true
-                - PC: "0x806220"
+                - PC: "0x806230"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1912,20 +1912,20 @@ Probes:
             - Kind: Entry
               Type: 1671 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x8055b8"
+                - PC: "0x8055c8"
                   Frameless: false
-                - PC: "0x80562c"
+                - PC: "0x80563c"
                   Frameless: false
-                - PC: "0x805760"
+                - PC: "0x805770"
                   Frameless: false
-                - PC: "0x8057e4"
+                - PC: "0x8057f4"
                   Frameless: false
-                - PC: "0x80589c"
+                - PC: "0x8058ac"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1672 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x8055ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x8055fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1951,15 +1951,15 @@ Probes:
             - Kind: Line
               Type: 1673 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x8055b8"
+                - PC: "0x8055c8"
                   Frameless: false
-                - PC: "0x80562c"
+                - PC: "0x80563c"
                   Frameless: false
-                - PC: "0x805760"
+                - PC: "0x805770"
                   Frameless: false
-                - PC: "0x8057e4"
+                - PC: "0x8057f4"
                   Frameless: false
-                - PC: "0x80589c"
+                - PC: "0x8058ac"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1982,7 +1982,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1679 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x805a04", Frameless: true}]
+              InjectionPoints: [{PC: "0x805a14", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2007,7 +2007,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1680 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x805a04", Frameless: true}]
+              InjectionPoints: [{PC: "0x805a14", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2031,9 +2031,9 @@ Probes:
             - Kind: Entry
               Type: 1681 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x805a34"
+                - PC: "0x805a44"
                   Frameless: false
-                - PC: "0x805abc"
+                - PC: "0x805acc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2056,7 +2056,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0x803620", Frameless: true}]
+              InjectionPoints: [{PC: "0x803630", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2078,7 +2078,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0x803630", Frameless: true}]
+              InjectionPoints: [{PC: "0x803640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2100,7 +2100,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0x803640", Frameless: true}]
+              InjectionPoints: [{PC: "0x803650", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2122,7 +2122,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0x803610", Frameless: true}]
+              InjectionPoints: [{PC: "0x803620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2144,7 +2144,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0x803600", Frameless: true}]
+              InjectionPoints: [{PC: "0x803610", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2166,7 +2166,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x805c70", Frameless: true}]
+              InjectionPoints: [{PC: "0x805c80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2187,11 +2187,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x8094d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8094e0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1563 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x809600", Frameless: false}]
+              InjectionPoints: [{PC: "0x809610", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2213,7 +2213,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x807c10", Frameless: true}]
+              InjectionPoints: [{PC: "0x807c20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2238,7 +2238,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1411 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x8040ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x8040fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2260,7 +2260,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1412 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x80418c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80419c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2282,7 +2282,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1413 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x804230", Frameless: false}]
+              InjectionPoints: [{PC: "0x804240", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2325,11 +2325,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x80993c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80994c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1569 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x809a90", Frameless: false}]
+              InjectionPoints: [{PC: "0x809aa0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2391,7 +2391,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x806330", Frameless: true}]
+              InjectionPoints: [{PC: "0x806340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2413,7 +2413,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x806390", Frameless: true}]
+              InjectionPoints: [{PC: "0x8063a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2435,7 +2435,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x806430", Frameless: true}]
+              InjectionPoints: [{PC: "0x806440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2457,7 +2457,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x806450", Frameless: true}]
+              InjectionPoints: [{PC: "0x806460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2479,7 +2479,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x806440", Frameless: true}]
+              InjectionPoints: [{PC: "0x806450", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2501,7 +2501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x806370", Frameless: true}]
+              InjectionPoints: [{PC: "0x806380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2523,7 +2523,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x806420", Frameless: true}]
+              InjectionPoints: [{PC: "0x806430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2545,7 +2545,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x806410", Frameless: true}]
+              InjectionPoints: [{PC: "0x806420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2569,7 +2569,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x806380", Frameless: true}]
+              InjectionPoints: [{PC: "0x806390", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2593,7 +2593,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x806380", Frameless: true}]
+              InjectionPoints: [{PC: "0x806390", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2615,7 +2615,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x806400", Frameless: true}]
+              InjectionPoints: [{PC: "0x806410", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2637,7 +2637,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x8063f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2659,7 +2659,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x806310", Frameless: true}]
+              InjectionPoints: [{PC: "0x806320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2681,7 +2681,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x806320", Frameless: true}]
+              InjectionPoints: [{PC: "0x806330", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2703,7 +2703,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x806300", Frameless: true}]
+              InjectionPoints: [{PC: "0x806310", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2725,7 +2725,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x8063a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2747,7 +2747,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x8063d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8063e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2769,7 +2769,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x8063e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8063f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2791,7 +2791,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8063c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2815,7 +2815,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x8063c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8063d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2837,7 +2837,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80a800", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a810", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2860,7 +2860,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80a800", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a810", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2907,11 +2907,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x809af0", Frameless: false}]
+              InjectionPoints: [{PC: "0x809b00", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1571 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x809c7c", Frameless: false}]
+              InjectionPoints: [{PC: "0x809c8c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2977,11 +2977,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x809d6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x809d7c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1575 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x809e08", Frameless: false}]
+              InjectionPoints: [{PC: "0x809e18", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3012,11 +3012,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x809730", Frameless: false}]
+              InjectionPoints: [{PC: "0x809740", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1567 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x8098d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8098e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3042,11 +3042,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1507 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1508 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80885c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3082,7 +3082,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x8078a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8078b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3123,11 +3123,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1501 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x808738", Frameless: false}]
+              InjectionPoints: [{PC: "0x808748", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1502 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x808794", Frameless: false}]
+              InjectionPoints: [{PC: "0x8087a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3151,11 +3151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1503 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x808738", Frameless: false}]
+              InjectionPoints: [{PC: "0x808748", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1504 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x808794", Frameless: false}]
+              InjectionPoints: [{PC: "0x8087a4", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3174,11 +3174,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1509 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1510 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80885c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3198,11 +3198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1511 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1512 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80885c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3235,11 +3235,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1505 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x808738", Frameless: false}]
+              InjectionPoints: [{PC: "0x808748", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1506 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x808794", Frameless: false}]
+              InjectionPoints: [{PC: "0x8087a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3267,7 +3267,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80aa90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3292,7 +3292,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80aa90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3323,7 +3323,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80aa90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3348,7 +3348,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80aa90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3375,7 +3375,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x807ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807cf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3402,7 +3402,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x80a450", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3429,7 +3429,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x80a420", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3464,7 +3464,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x80a440", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a450", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3496,7 +3496,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1601 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x80a7f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3518,7 +3518,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x807c20", Frameless: true}]
+              InjectionPoints: [{PC: "0x807c30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3540,7 +3540,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x806360", Frameless: true}]
+              InjectionPoints: [{PC: "0x806370", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3562,7 +3562,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x807c00", Frameless: true}]
+              InjectionPoints: [{PC: "0x807c10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3586,11 +3586,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x808018", Frameless: false}]
+              InjectionPoints: [{PC: "0x808028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1478 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x808058", Frameless: false}]
+              InjectionPoints: [{PC: "0x808068", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3610,11 +3610,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1521 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x808898", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1522 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x808920", Frameless: false}]
+              InjectionPoints: [{PC: "0x808930", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3655,11 +3655,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1487 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x808138", Frameless: false}]
+              InjectionPoints: [{PC: "0x808148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1488 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x8081c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8081d8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3697,11 +3697,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x808018", Frameless: false}]
+              InjectionPoints: [{PC: "0x808028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1480 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x808058", Frameless: false}]
+              InjectionPoints: [{PC: "0x808068", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3742,11 +3742,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1489 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x808138", Frameless: false}]
+              InjectionPoints: [{PC: "0x808148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1490 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x8081c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8081d8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3786,11 +3786,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1523 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x808898", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1524 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x808920", Frameless: false}]
+              InjectionPoints: [{PC: "0x808930", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3807,11 +3807,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1525 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x808898", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1526 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x808920", Frameless: false}]
+              InjectionPoints: [{PC: "0x808930", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3833,11 +3833,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x808018", Frameless: false}]
+              InjectionPoints: [{PC: "0x808028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1482 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x808058", Frameless: false}]
+              InjectionPoints: [{PC: "0x808068", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3860,18 +3860,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1497 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x808408", Frameless: false}]
+              InjectionPoints: [{PC: "0x808418", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1498 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x808490"
+                - PC: "0x8084a0"
                   Frameless: false
-                - PC: "0x8084e4"
+                - PC: "0x8084f4"
                   Frameless: false
-                - PC: "0x80859c"
+                - PC: "0x8085ac"
                   Frameless: false
-                - PC: "0x8085b0"
+                - PC: "0x8085c0"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3899,18 +3899,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1495 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x808288", Frameless: false}]
+              InjectionPoints: [{PC: "0x808298", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1496 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x8082dc"
+                - PC: "0x8082ec"
                   Frameless: false
-                - PC: "0x808338"
+                - PC: "0x808348"
                   Frameless: false
-                - PC: "0x808380"
+                - PC: "0x808390"
                   Frameless: false
-                - PC: "0x8083c4"
+                - PC: "0x8083d4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3937,11 +3937,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1540 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x808f0c", Frameless: false}]
+              InjectionPoints: [{PC: "0x808f1c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1541 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x808f5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x808f6c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3958,11 +3958,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1542 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x808f98", Frameless: false}]
+              InjectionPoints: [{PC: "0x808fa8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1543 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x808fd0", Frameless: false}]
+              InjectionPoints: [{PC: "0x808fe0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3979,11 +3979,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1544 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x809008", Frameless: false}]
+              InjectionPoints: [{PC: "0x809018", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1545 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x80903c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80904c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4000,11 +4000,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x8090f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x809108", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1549 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x809158", Frameless: false}]
+              InjectionPoints: [{PC: "0x809168", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4021,11 +4021,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x809458", Frameless: false}]
+              InjectionPoints: [{PC: "0x809468", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1561 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x809494", Frameless: false}]
+              InjectionPoints: [{PC: "0x8094a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4042,11 +4042,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x808dc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x808dd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x808e10", Frameless: false}]
+              InjectionPoints: [{PC: "0x808e20", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4064,14 +4064,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x808208", Frameless: false}]
+              InjectionPoints: [{PC: "0x808218", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1494 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x80823c"
+                - PC: "0x80824c"
                   Frameless: false
-                - PC: "0x808250"
+                - PC: "0x808260"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4093,11 +4093,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x808018", Frameless: false}]
+              InjectionPoints: [{PC: "0x808028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1484 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x808058", Frameless: false}]
+              InjectionPoints: [{PC: "0x808068", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4118,11 +4118,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1491 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x808138", Frameless: false}]
+              InjectionPoints: [{PC: "0x808148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1492 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x8081c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8081d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4143,11 +4143,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1485 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x808098", Frameless: false}]
+              InjectionPoints: [{PC: "0x8080a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1486 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x8080f4", Frameless: false}]
+              InjectionPoints: [{PC: "0x808104", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4169,14 +4169,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1499 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x8085e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8085f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1500 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x8086a0"
+                - PC: "0x8086b0"
                   Frameless: false
-                - PC: "0x8086b4"
+                - PC: "0x8086c4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4198,11 +4198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x808e50", Frameless: false}]
+              InjectionPoints: [{PC: "0x808e60", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1539 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x808ed0", Frameless: false}]
+              InjectionPoints: [{PC: "0x808ee0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4219,11 +4219,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x808d18", Frameless: false}]
+              InjectionPoints: [{PC: "0x808d28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x808d98", Frameless: false}]
+              InjectionPoints: [{PC: "0x808da8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4240,11 +4240,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1552 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x809258", Frameless: false}]
+              InjectionPoints: [{PC: "0x809268", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1553 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x8092ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x8092bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4261,11 +4261,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x809078", Frameless: false}]
+              InjectionPoints: [{PC: "0x809088", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1547 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x8090bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8090cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4282,11 +4282,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x8093e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8093f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1559 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x809428", Frameless: false}]
+              InjectionPoints: [{PC: "0x809438", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4306,7 +4306,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1531 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x808ae4", Frameless: false}]
+              InjectionPoints: [{PC: "0x808af4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x809378", Frameless: false}]
+              InjectionPoints: [{PC: "0x809388", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1557 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x8093b4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8093c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x808c88", Frameless: false}]
+              InjectionPoints: [{PC: "0x808c98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x808cdc", Frameless: false}]
+              InjectionPoints: [{PC: "0x808cec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4369,11 +4369,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x8092ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x8092fc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1555 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x80933c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80934c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4390,11 +4390,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1550 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x809190", Frameless: false}]
+              InjectionPoints: [{PC: "0x8091a0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1551 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x809220", Frameless: false}]
+              InjectionPoints: [{PC: "0x809230", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4412,7 +4412,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0x8035d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8035e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4447,11 +4447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1513 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80885c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4497,7 +4497,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x803a60", Frameless: true}]
+              InjectionPoints: [{PC: "0x803a70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4519,7 +4519,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x803a40", Frameless: true}]
+              InjectionPoints: [{PC: "0x803a50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4541,7 +4541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x803b10", Frameless: true}]
+              InjectionPoints: [{PC: "0x803b20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4559,7 +4559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x803b20", Frameless: true}]
+              InjectionPoints: [{PC: "0x803b30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4577,7 +4577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x803a70", Frameless: true}]
+              InjectionPoints: [{PC: "0x803a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4599,7 +4599,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x803a90", Frameless: true}]
+              InjectionPoints: [{PC: "0x803aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4622,7 +4622,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x803aa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803ab0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4644,7 +4644,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x803ab0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4673,7 +4673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x803a80", Frameless: true}]
+              InjectionPoints: [{PC: "0x803a90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4704,7 +4704,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x803a50", Frameless: true}]
+              InjectionPoints: [{PC: "0x803a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4726,7 +4726,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x80a7b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a7c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4748,7 +4748,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x803ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803ad0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4770,7 +4770,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x803ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803af0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x803af0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4814,7 +4814,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x803b00", Frameless: true}]
+              InjectionPoints: [{PC: "0x803b10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4836,7 +4836,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x803ad0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803ae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4858,7 +4858,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x80a470", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4880,7 +4880,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1582 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x80a3f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4902,7 +4902,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x806340", Frameless: true}]
+              InjectionPoints: [{PC: "0x806350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4923,11 +4923,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1527 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x808898", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x808920", Frameless: false}]
+              InjectionPoints: [{PC: "0x808930", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4948,11 +4948,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1572 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x809cd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x809ce8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1573 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x809d34", Frameless: false}]
+              InjectionPoints: [{PC: "0x809d44", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4974,7 +4974,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0x8035e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8035f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4996,7 +4996,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1474 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x807cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807cd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5018,7 +5018,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1586 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x80a430", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5040,7 +5040,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x8040b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8040c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x8040c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8040d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80aa30", Frameless: true}]
+              InjectionPoints: [{PC: "0x80aa40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5111,7 +5111,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x80a400", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a410", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5138,7 +5138,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x805d50", Frameless: true}]
+              InjectionPoints: [{PC: "0x805d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5159,11 +5159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1576 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x809e3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x809e4c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1577 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x809ec4", Frameless: false}]
+              InjectionPoints: [{PC: "0x809ed4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5185,7 +5185,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x80a990", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a9a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5206,7 +5206,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x80a980", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a990", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5233,7 +5233,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x8062f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5265,7 +5265,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x80a480", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a490", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5305,7 +5305,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x80a830", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5338,11 +5338,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80885c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5363,11 +5363,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80885c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5390,11 +5390,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80885c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5423,7 +5423,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x80a7c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a7d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5455,7 +5455,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80a7d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a7e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5485,7 +5485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80a7d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a7e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5517,7 +5517,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80a7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a7f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5547,7 +5547,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80a7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a7f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5579,7 +5579,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x803b30", Frameless: true}]
+              InjectionPoints: [{PC: "0x803b40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5601,7 +5601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0x803670", Frameless: true}]
+              InjectionPoints: [{PC: "0x803680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5623,7 +5623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0x803680", Frameless: true}]
+              InjectionPoints: [{PC: "0x803690", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5645,7 +5645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0x803690", Frameless: true}]
+              InjectionPoints: [{PC: "0x8036a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5667,7 +5667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0x803660", Frameless: true}]
+              InjectionPoints: [{PC: "0x803670", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5689,7 +5689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0x803650", Frameless: true}]
+              InjectionPoints: [{PC: "0x803660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5711,7 +5711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x807c50", Frameless: true}]
+              InjectionPoints: [{PC: "0x807c60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5733,7 +5733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1580 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x80a3d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a3e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5755,7 +5755,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x80a810", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5777,7 +5777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x807c30", Frameless: true}]
+              InjectionPoints: [{PC: "0x807c40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5799,7 +5799,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0x803700", Frameless: true}]
+              InjectionPoints: [{PC: "0x803710", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5821,7 +5821,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80a460", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a470", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5843,7 +5843,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80a460", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a470", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5866,14 +5866,14 @@ Probes:
             - Kind: Entry
               Type: 1682 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x805bb8"
+                - PC: "0x805bc8"
                   Frameless: false
-                - PC: "0x80cb60"
+                - PC: "0x80cb70"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1683 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x805be0", Frameless: false}]
+              InjectionPoints: [{PC: "0x805bf0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5895,11 +5895,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x809ef8", Frameless: false}]
+              InjectionPoints: [{PC: "0x809f08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1579 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x809f5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x809f6c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5916,481 +5916,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x8035c0..0x8035d0]
+      OutOfLinePCRanges: [0x8035d0..0x8035e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 ArrayType [2]uint8
           Locations:
-            - Range: 0x8035c0..0x8035d0
+            - Range: 0x8035d0..0x8035e0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x8035d0..0x8035e0]
+      OutOfLinePCRanges: [0x8035e0..0x8035f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]int32
           Locations:
-            - Range: 0x8035d0..0x8035e0
+            - Range: 0x8035e0..0x8035f0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x8035e0..0x8035f0]
+      OutOfLinePCRanges: [0x8035f0..0x803600]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]string
           Locations:
-            - Range: 0x8035e0..0x8035f0
+            - Range: 0x8035f0..0x803600
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x8035f0..0x803600]
+      OutOfLinePCRanges: [0x803600..0x803610]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 ArrayType [2]bool
           Locations:
-            - Range: 0x8035f0..0x803600
+            - Range: 0x803600..0x803610
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x803600..0x803610]
+      OutOfLinePCRanges: [0x803610..0x803620]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x803600..0x803610
+            - Range: 0x803610..0x803620
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x803610..0x803620]
+      OutOfLinePCRanges: [0x803620..0x803630]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 120 ArrayType [2]int8
           Locations:
-            - Range: 0x803610..0x803620
+            - Range: 0x803620..0x803630
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x803620..0x803630]
+      OutOfLinePCRanges: [0x803630..0x803640]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 ArrayType [2]int16
           Locations:
-            - Range: 0x803620..0x803630
+            - Range: 0x803630..0x803640
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x803630..0x803640]
+      OutOfLinePCRanges: [0x803640..0x803650]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]int32
           Locations:
-            - Range: 0x803630..0x803640
+            - Range: 0x803640..0x803650
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x803640..0x803650]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 122 ArrayType [2]int64
-          Locations:
-            - Range: 0x803640..0x803650
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 10
-      Name: main.testUintArray
       OutOfLinePCRanges: [0x803650..0x803660]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 123 ArrayType [2]uint
+          Type: 122 ArrayType [2]int64
           Locations:
             - Range: 0x803650..0x803660
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 10
+      Name: main.testUintArray
+      OutOfLinePCRanges: [0x803660..0x803670]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 123 ArrayType [2]uint
+          Locations:
+            - Range: 0x803660..0x803670
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x803660..0x803670]
+      OutOfLinePCRanges: [0x803670..0x803680]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 ArrayType [2]uint8
           Locations:
-            - Range: 0x803660..0x803670
+            - Range: 0x803670..0x803680
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x803670..0x803680]
+      OutOfLinePCRanges: [0x803680..0x803690]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 124 ArrayType [2]uint16
           Locations:
-            - Range: 0x803670..0x803680
+            - Range: 0x803680..0x803690
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x803680..0x803690]
+      OutOfLinePCRanges: [0x803690..0x8036a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 125 ArrayType [2]uint32
           Locations:
-            - Range: 0x803680..0x803690
+            - Range: 0x803690..0x8036a0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x803690..0x8036a0]
+      OutOfLinePCRanges: [0x8036a0..0x8036b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 58 ArrayType [2]uint64
           Locations:
-            - Range: 0x803690..0x8036a0
+            - Range: 0x8036a0..0x8036b0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x8036a0..0x8036b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 126 ArrayType [2][2]int
-          Locations:
-            - Range: 0x8036a0..0x8036b0
-              Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 16
-      Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0x8036b0..0x8036c0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 117 ArrayType [2]string
+          Type: 126 ArrayType [2][2]int
           Locations:
             - Range: 0x8036b0..0x8036c0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 16
+      Name: main.testArrayOfStrings
+      OutOfLinePCRanges: [0x8036c0..0x8036d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 117 ArrayType [2]string
+          Locations:
+            - Range: 0x8036c0..0x8036d0
+              Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x8036c0..0x8036d0]
+      OutOfLinePCRanges: [0x8036d0..0x8036e0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 127 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x8036c0..0x8036d0
+            - Range: 0x8036d0..0x8036e0
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0x8036d0..0x8036e0]
+      OutOfLinePCRanges: [0x8036e0..0x8036f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 128 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0x8036d0..0x8036e0
+            - Range: 0x8036e0..0x8036f0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0x8036e0..0x8036f0]
+      OutOfLinePCRanges: [0x8036f0..0x803700]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 130 ArrayType [2]struct {}
           Locations:
-            - Range: 0x8036e0..0x8036f0
+            - Range: 0x8036f0..0x803700
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x803700..0x803710]
+      OutOfLinePCRanges: [0x803710..0x803720]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 132 ArrayType [100]uint
           Locations:
-            - Range: 0x803700..0x803710
+            - Range: 0x803710..0x803720
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x803a40..0x803a50]
+      OutOfLinePCRanges: [0x803a50..0x803a60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x803a40..0x803a50
+            - Range: 0x803a50..0x803a60
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x803a50..0x803a60]
+      OutOfLinePCRanges: [0x803a60..0x803a70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x803a50..0x803a60
+            - Range: 0x803a60..0x803a70
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x803a60..0x803a70]
+      OutOfLinePCRanges: [0x803a70..0x803a80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x803a60..0x803a70
+            - Range: 0x803a70..0x803a80
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x803a70..0x803a80]
+      OutOfLinePCRanges: [0x803a80..0x803a90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x803a70..0x803a80
+            - Range: 0x803a80..0x803a90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x803a80..0x803a90]
+      OutOfLinePCRanges: [0x803a90..0x803aa0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x803a80..0x803a90
+            - Range: 0x803a90..0x803aa0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x803a90..0x803aa0]
+      OutOfLinePCRanges: [0x803aa0..0x803ab0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 102 BaseType int16
           Locations:
-            - Range: 0x803a90..0x803aa0
+            - Range: 0x803aa0..0x803ab0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x803aa0..0x803ab0]
+      OutOfLinePCRanges: [0x803ab0..0x803ac0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x803aa0..0x803ab0
+            - Range: 0x803ab0..0x803ac0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x803ab0..0x803ac0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 13 BaseType int64
-          Locations:
-            - Range: 0x803ab0..0x803ac0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 29
-      Name: main.testSingleUint
       OutOfLinePCRanges: [0x803ac0..0x803ad0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 11 BaseType uint
+          Type: 13 BaseType int64
           Locations:
             - Range: 0x803ac0..0x803ad0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 29
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0x803ad0..0x803ae0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 BaseType uint
+          Locations:
+            - Range: 0x803ad0..0x803ae0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x803ad0..0x803ae0]
+      OutOfLinePCRanges: [0x803ae0..0x803af0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x803ad0..0x803ae0
+            - Range: 0x803ae0..0x803af0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x803ae0..0x803af0]
+      OutOfLinePCRanges: [0x803af0..0x803b00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x803ae0..0x803af0
+            - Range: 0x803af0..0x803b00
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x803af0..0x803b00]
+      OutOfLinePCRanges: [0x803b00..0x803b10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x803af0..0x803b00
+            - Range: 0x803b00..0x803b10
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x803b00..0x803b10]
+      OutOfLinePCRanges: [0x803b10..0x803b20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x803b00..0x803b10
+            - Range: 0x803b10..0x803b20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x803b10..0x803b20]
+      OutOfLinePCRanges: [0x803b20..0x803b30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x803b10..0x803b20
+            - Range: 0x803b20..0x803b30
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x803b20..0x803b30]
+      OutOfLinePCRanges: [0x803b30..0x803b40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType float64
           Locations:
-            - Range: 0x803b20..0x803b30
+            - Range: 0x803b30..0x803b40
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x803b30..0x803b40]
+      OutOfLinePCRanges: [0x803b40..0x803b50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 133 BaseType main.typeAlias
           Locations:
-            - Range: 0x803b30..0x803b40
+            - Range: 0x803b40..0x803b50
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x803c30..0x803c40]
+      OutOfLinePCRanges: [0x803c40..0x803c50]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 134 StructureType main.bigStruct
           Locations:
-            - Range: 0x803c30..0x803c40
+            - Range: 0x803c40..0x803c50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6409,42 +6409,42 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x803c60..0x803d70]
+      OutOfLinePCRanges: [0x803c70..0x803d80]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x803c60..0x803c80
+            - Range: 0x803c70..0x803c90
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x803c60..0x803d70, Pieces: []}]
+          Locations: [{Range: 0x803c70..0x803d80, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
-          Locations: [{Range: 0x803c60..0x803d70, Pieces: []}]
+          Locations: [{Range: 0x803c70..0x803d80, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x803c78..0x803cbc
+            - Range: 0x803c88..0x803ccc
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x803cbc..0x803d1c
+            - Range: 0x803ccc..0x803d2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x803d1c..0x803d70
+            - Range: 0x803d2c..0x803d80
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
@@ -6455,39 +6455,39 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x803e00..0x803e10]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 138 StructureType main.deepPtr1
-          Locations:
-            - Range: 0x803e00..0x803e10
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 40
-      Name: main.testDeepPtr7
       OutOfLinePCRanges: [0x803e10..0x803e20]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 141 PointerType *main.deepPtr7
+          Type: 138 StructureType main.deepPtr1
           Locations:
             - Range: 0x803e10..0x803e20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 40
+      Name: main.testDeepPtr7
+      OutOfLinePCRanges: [0x803e20..0x803e30]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 141 PointerType *main.deepPtr7
+          Locations:
+            - Range: 0x803e20..0x803e30
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x803f30..0x803f40]
+      OutOfLinePCRanges: [0x803f40..0x803f50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 143 StructureType main.deepSlice1
           Locations:
-            - Range: 0x803f30..0x803f40
+            - Range: 0x803f40..0x803f50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6500,121 +6500,121 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x803f40..0x803f50]
+      OutOfLinePCRanges: [0x803f50..0x803f60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 147 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x803f40..0x803f50
+            - Range: 0x803f50..0x803f60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x804090..0x8040a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 149 StructureType main.deepMap1
-          Locations:
-            - Range: 0x804090..0x8040a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 44
-      Name: main.testDeepMap7
       OutOfLinePCRanges: [0x8040a0..0x8040b0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 155 PointerType *main.deepMap7
+          Type: 149 StructureType main.deepMap1
           Locations:
             - Range: 0x8040a0..0x8040b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 45
-      Name: main.testStringType1
+    - ID: 44
+      Name: main.testDeepMap7
       OutOfLinePCRanges: [0x8040b0..0x8040c0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 157 PointerType *main.stringType1
+          Type: 155 PointerType *main.deepMap7
           Locations:
             - Range: 0x8040b0..0x8040c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 46
-      Name: main.testStringType2
+    - ID: 45
+      Name: main.testStringType1
       OutOfLinePCRanges: [0x8040c0..0x8040d0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 159 PointerType **main.stringType2
+          Type: 157 PointerType *main.stringType1
           Locations:
             - Range: 0x8040c0..0x8040d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 46
+      Name: main.testStringType2
+      OutOfLinePCRanges: [0x8040d0..0x8040e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 159 PointerType **main.stringType2
+          Locations:
+            - Range: 0x8040d0..0x8040e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x8040d0..0x8042b0]
+      OutOfLinePCRanges: [0x8040e0..0x8042c0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80418c..0x8041a0
+            - Range: 0x80419c..0x8041b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x804230..0x804244
+            - Range: 0x804240..0x804254
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8040f0..0x8042b0
+            - Range: 0x804100..0x8042c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80416c..0x804178
+            - Range: 0x80417c..0x804188
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x804178..0x804178
+            - Range: 0x804188..0x804188
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x804178..0x80418c
+            - Range: 0x804188..0x80419c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80418c..0x804224
+            - Range: 0x80419c..0x804234
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x804224..0x804228
+            - Range: 0x804234..0x804238
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x804228..0x80422c
+            - Range: 0x804238..0x80423c
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x80422c..0x804244
+            - Range: 0x80423c..0x804254
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x804244..0x8042b0
+            - Range: 0x804254..0x8042c0
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x8045c0..0x804680]
+      OutOfLinePCRanges: [0x8045d0..0x804690]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 161 StructureType main.esotericStack
           Locations:
-            - Range: 0x8045c0..0x8045f8
+            - Range: 0x8045d0..0x804608
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6634,7 +6634,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x8045f8..0x8045fc
+            - Range: 0x804608..0x80460c
               Pieces:
                 - Size: 4
                   Op: null
@@ -6654,7 +6654,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x8045fc..0x804600
+            - Range: 0x80460c..0x804610
               Pieces:
                 - Size: 4
                   Op: null
@@ -6679,153 +6679,153 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x804680..0x8046f0]
+      OutOfLinePCRanges: [0x804690..0x804700]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 165 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x804680..0x8046b4
+            - Range: 0x804690..0x8046c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 50
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x805730..0x8057c0]
+      OutOfLinePCRanges: [0x805740..0x8057d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x805730..0x805760
+            - Range: 0x805740..0x805770
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 51
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x8057c0..0x805880]
+      OutOfLinePCRanges: [0x8057d0..0x805890]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8057c0..0x8057dc
+            - Range: 0x8057d0..0x8057ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8057c0..0x8057ec
+            - Range: 0x8057d0..0x8057fc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8057dc..0x8057ec
+            - Range: 0x8057ec..0x8057fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8057ec..0x805880
+            - Range: 0x8057fc..0x805890
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x805880..0x8058f0]
+      OutOfLinePCRanges: [0x805890..0x805900]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x805880..0x8058a4
+            - Range: 0x805890..0x8058b4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x8058f0..0x805a00]
+      OutOfLinePCRanges: [0x805900..0x805a10]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80590c..0x805978
+            - Range: 0x80591c..0x805988
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x805978..0x805980
+            - Range: 0x805988..0x805990
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80590c..0x805978
+            - Range: 0x80591c..0x805988
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x805978..0x80597c
+            - Range: 0x805988..0x80598c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x805a00..0x805a10]
+      OutOfLinePCRanges: [0x805a10..0x805a20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x805a00..0x805a08
+            - Range: 0x805a10..0x805a18
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x805a00..0x805a08
+            - Range: 0x805a10..0x805a18
               Pieces: []
-            - Range: 0x805a08..0x805a09
+            - Range: 0x805a18..0x805a19
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x805a09..0x805a10
+            - Range: 0x805a19..0x805a20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x805a10..0x805a60]
+      OutOfLinePCRanges: [0x805a20..0x805a70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0x805a10..0x805a60
+            - Range: 0x805a20..0x805a70
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x805a10..0x805a50
+            - Range: 0x805a20..0x805a60
               Pieces: []
-            - Range: 0x805a50..0x805a51
+            - Range: 0x805a60..0x805a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x805a51..0x805a60
+            - Range: 0x805a61..0x805a70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0x805c70..0x805c80]
+      OutOfLinePCRanges: [0x805c80..0x805c90]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x805c70..0x805c80
+            - Range: 0x805c80..0x805c90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6836,19 +6836,19 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0x805c80..0x805ce0]
+      OutOfLinePCRanges: [0x805c90..0x805cf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x805c80..0x805cac
+            - Range: 0x805c90..0x805cbc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x805cac..0x805cb0
+            - Range: 0x805cbc..0x805cc0
               Pieces:
                 - Size: 8
                   Op: null
@@ -6859,28 +6859,28 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x805c80..0x805cc0
+            - Range: 0x805c90..0x805cd0
               Pieces: []
-            - Range: 0x805cc0..0x805cc1
+            - Range: 0x805cd0..0x805cd1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x805cc1..0x805ce0
+            - Range: 0x805cd1..0x805cf0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0x805ce0..0x805cf0]
+      OutOfLinePCRanges: [0x805cf0..0x805d00]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x805ce0..0x805cf0
+            - Range: 0x805cf0..0x805d00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6891,41 +6891,41 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x805cf0..0x805d50]
+      OutOfLinePCRanges: [0x805d00..0x805d60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 169 PointerType *interface {}
           Locations:
-            - Range: 0x805cf0..0x805d1c
+            - Range: 0x805d00..0x805d2c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x805cf0..0x805d30
+            - Range: 0x805d00..0x805d40
               Pieces: []
-            - Range: 0x805d30..0x805d31
+            - Range: 0x805d40..0x805d41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x805d31..0x805d50
+            - Range: 0x805d41..0x805d60
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x805d50..0x805d60]
+      OutOfLinePCRanges: [0x805d60..0x805d70]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 170 StructureType main.structWithAny
           Locations:
-            - Range: 0x805d50..0x805d60
+            - Range: 0x805d60..0x805d70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6936,140 +6936,127 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x8062f0..0x806300]
+      OutOfLinePCRanges: [0x806300..0x806310]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 171 StructureType main.structWithMap
-          Locations:
-            - Range: 0x8062f0..0x806300
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x806300..0x806310]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 177 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x806300..0x806310
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 63
-      Name: main.testMapStringToInt
+    - ID: 62
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x806310..0x806320]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 182 GoMapType map[string]int
+          Type: 177 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x806310..0x806320
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToSlice
+    - ID: 63
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x806320..0x806330]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 187 GoMapType map[string][]string
+          Type: 182 GoMapType map[string]int
           Locations:
             - Range: 0x806320..0x806330
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 65
-      Name: main.testMapArrayToArray
+    - ID: 64
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x806330..0x806340]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 192 GoMapType map[[4]string][2]int
+          Type: 187 GoMapType map[string][]string
           Locations:
             - Range: 0x806330..0x806340
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testSmallMap
+    - ID: 65
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x806340..0x806350]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 182 GoMapType map[string]int
+          Type: 192 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x806340..0x806350
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 66
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x806350..0x806360]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 182 GoMapType map[string]int
+          Locations:
+            - Range: 0x806350..0x806360
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 67
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x806350..0x806360]
+      OutOfLinePCRanges: [0x806360..0x806370]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 197 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x806350..0x806360
+            - Range: 0x806360..0x806370
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 68
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x806360..0x806370]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 198 PointerType *map[string]int
-          Locations:
-            - Range: 0x806360..0x806370
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x806370..0x806380]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 172 GoMapType map[int]int
+          Type: 198 PointerType *map[string]int
           Locations:
             - Range: 0x806370..0x806380
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 70
-      Name: main.testMapMassive
+    - ID: 69
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x806380..0x806390]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 199 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 172 GoMapType map[int]int
           Locations:
             - Range: 0x806380..0x806390
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 71
-      Name: main.testMapEmbeddedMaps
+    - ID: 70
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0x806390..0x8063a0]
       InlinePCRanges: []
       Variables:
-        - Name: m
+        - Name: redactMyEntries
           Type: 199 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x806390..0x8063a0
@@ -7077,38 +7064,38 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapWithLinkedList
+    - ID: 71
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x8063a0..0x8063b0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 204 GoMapType map[bool]main.node
+          Type: 199 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x8063a0..0x8063b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapWithSmallValue
+    - ID: 72
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x8063b0..0x8063c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 209 GoMapType map[int]uint8
+          Type: 204 GoMapType map[bool]main.node
           Locations:
             - Range: 0x8063b0..0x8063c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithSmallValueMassive
+    - ID: 73
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x8063c0..0x8063d0]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
+        - Name: m
           Type: 209 GoMapType map[int]uint8
           Locations:
             - Range: 0x8063c0..0x8063d0
@@ -7116,21 +7103,21 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 74
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x8063d0..0x8063e0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 214 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 209 GoMapType map[int]uint8
           Locations:
             - Range: 0x8063d0..0x8063e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 75
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x8063e0..0x8063f0]
       InlinePCRanges: []
       Variables:
@@ -7142,8 +7129,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapSmallKeySmallValue
+    - ID: 76
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x8063f0..0x806400]
       InlinePCRanges: []
       Variables:
@@ -7155,127 +7142,140 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 77
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x806400..0x806410]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 219 GoMapType map[uint8][4]int
+          Type: 214 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x806400..0x806410
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapLargeKeySmallValue
+    - ID: 78
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x806410..0x806420]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 224 GoMapType map[[4]int]uint8
+          Type: 219 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x806410..0x806420
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 79
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x806420..0x806430]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 229 GoMapType map[[4]int][4]int
+          Type: 224 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x806420..0x806430
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapEmptyKey
+    - ID: 80
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x806430..0x806440]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 234 GoMapType map[struct {}]int
+          Type: 229 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x806430..0x806440
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapEmptyValue
+    - ID: 81
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0x806440..0x806450]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 239 GoMapType map[int]struct {}
+          Type: 234 GoMapType map[struct {}]int
           Locations:
             - Range: 0x806440..0x806450
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 82
+      Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0x806450..0x806460]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 244 GoMapType map[struct {}]struct {}
+          Type: 239 GoMapType map[int]struct {}
           Locations:
             - Range: 0x806450..0x806460
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x806460..0x806470]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 244 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x806460..0x806470
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x8077c0..0x8077d0]
+      OutOfLinePCRanges: [0x8077d0..0x8077e0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8077c0..0x8077d0
+            - Range: 0x8077d0..0x8077e0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8077c0..0x8077d0
+            - Range: 0x8077d0..0x8077e0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x8077c0..0x8077d0
+            - Range: 0x8077d0..0x8077e0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x8077e0..0x8077f0]
+      OutOfLinePCRanges: [0x8077f0..0x807800]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8077e0..0x8077f0
+            - Range: 0x8077f0..0x807800
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8077e0..0x8077f0
+            - Range: 0x8077f0..0x807800
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7286,48 +7286,48 @@ Subprograms:
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x8077e0..0x8077f0
+            - Range: 0x8077f0..0x807800
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x8078a0..0x8078b0]
+      OutOfLinePCRanges: [0x8078b0..0x8078c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8078a0..0x8078b0
+            - Range: 0x8078b0..0x8078c0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8078a0..0x8078b0
+            - Range: 0x8078b0..0x8078c0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x8078a0..0x8078b0
+            - Range: 0x8078b0..0x8078c0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x8078a0..0x8078b0
+            - Range: 0x8078b0..0x8078c0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8078a0..0x8078b0
+            - Range: 0x8078b0..0x8078c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7338,63 +7338,63 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x807a40..0x807a80]
+      OutOfLinePCRanges: [0x807a50..0x807a90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x807a40..0x807a7c
+            - Range: 0x807a50..0x807a8c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x807a40..0x807a7c
+            - Range: 0x807a50..0x807a8c
               Pieces: []
-            - Range: 0x807a7c..0x807a7d
+            - Range: 0x807a8c..0x807a8d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807a7d..0x807a80
+            - Range: 0x807a8d..0x807a90
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0x807a80..0x807a90]
+      OutOfLinePCRanges: [0x807a90..0x807aa0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 249 GoChannelType chan bool
           Locations:
-            - Range: 0x807a80..0x807a90
+            - Range: 0x807a90..0x807aa0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x807c00..0x807c10]
+      OutOfLinePCRanges: [0x807c10..0x807c20]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 250 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x807c00..0x807c10
+            - Range: 0x807c10..0x807c20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x807c10..0x807c20]
+      OutOfLinePCRanges: [0x807c20..0x807c30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 StructureType main.node
           Locations:
-            - Range: 0x807c10..0x807c20
+            - Range: 0x807c20..0x807c30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7405,267 +7405,267 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x807c20..0x807c30]
+      OutOfLinePCRanges: [0x807c30..0x807c40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 PointerType *main.node
-          Locations:
-            - Range: 0x807c20..0x807c30
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 92
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x807c30..0x807c40]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 16 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x807c30..0x807c40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 92
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0x807c40..0x807c50]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 16 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0x807c40..0x807c50
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x807c50..0x807c60]
+      OutOfLinePCRanges: [0x807c60..0x807c70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 PointerType *uint
           Locations:
-            - Range: 0x807c50..0x807c60
+            - Range: 0x807c60..0x807c70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x807cc0..0x807cd0]
+      OutOfLinePCRanges: [0x807cd0..0x807ce0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 101 PointerType *string
           Locations:
-            - Range: 0x807cc0..0x807cd0
+            - Range: 0x807cd0..0x807ce0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x807ce0..0x807cf0]
+      OutOfLinePCRanges: [0x807cf0..0x807d00]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 10 PointerType *bool
           Locations:
-            - Range: 0x807ce0..0x807cf0
+            - Range: 0x807cf0..0x807d00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x807ce0..0x807cf0
+            - Range: 0x807cf0..0x807d00
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0x807d00..0x807d10]
+      OutOfLinePCRanges: [0x807d10..0x807d20]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 254 PointerType *main.t
           Locations:
-            - Range: 0x807d00..0x807d10
+            - Range: 0x807d10..0x807d20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x808000..0x808080]
+      OutOfLinePCRanges: [0x808010..0x808090]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808000..0x80801c
+            - Range: 0x808010..0x80802c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808000..0x808058
+            - Range: 0x808010..0x808068
               Pieces: []
-            - Range: 0x808058..0x808059
+            - Range: 0x808068..0x808069
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808059..0x808080
+            - Range: 0x808069..0x808090
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80801c..0x808028
+            - Range: 0x80802c..0x808038
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808028..0x808080
+            - Range: 0x808038..0x808090
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x808080..0x808120]
+      OutOfLinePCRanges: [0x808090..0x808130]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808080..0x8080a4
+            - Range: 0x808090..0x8080b4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8080a4..0x808120
+            - Range: 0x8080b4..0x808130
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 105 PointerType *int
           Locations:
-            - Range: 0x808080..0x8080f4
+            - Range: 0x808090..0x808104
               Pieces: []
-            - Range: 0x8080f4..0x8080f5
+            - Range: 0x808104..0x808105
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8080f5..0x808120
+            - Range: 0x808105..0x808130
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 105 PointerType *int
           Locations:
-            - Range: 0x8080a8..0x8080c0
+            - Range: 0x8080b8..0x8080d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8080c0..0x808120
+            - Range: 0x8080d0..0x808130
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x808120..0x8081f0]
+      OutOfLinePCRanges: [0x808130..0x808200]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808120..0x808178
+            - Range: 0x808130..0x808188
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808120..0x8081c8
+            - Range: 0x808130..0x8081d8
               Pieces: []
-            - Range: 0x8081c8..0x8081c9
+            - Range: 0x8081d8..0x8081d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8081c9..0x8081f0
+            - Range: 0x8081d9..0x808200
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808120..0x8081f0, Pieces: []}]
+          Locations: [{Range: 0x808130..0x808200, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80813c..0x80817c
+            - Range: 0x80814c..0x80818c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80817c..0x8081f0
+            - Range: 0x80818c..0x808200
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 14 BaseType float64
           Locations:
-            - Range: 0x80814c..0x80817c
+            - Range: 0x80815c..0x80818c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80817c..0x8081f0
+            - Range: 0x80818c..0x808200
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x8081f0..0x808270]
+      OutOfLinePCRanges: [0x808200..0x808280]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8081f0..0x808210
+            - Range: 0x808200..0x808220
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x8081f0..0x80823c
+            - Range: 0x808200..0x80824c
               Pieces: []
-            - Range: 0x80823c..0x80823d
+            - Range: 0x80824c..0x80824d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80823d..0x808250
+            - Range: 0x80824d..0x808260
               Pieces: []
-            - Range: 0x808250..0x808251
+            - Range: 0x808260..0x808261
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x808251..0x808270
+            - Range: 0x808261..0x808280
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x808270..0x8083f0]
+      OutOfLinePCRanges: [0x808280..0x808400]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x808270..0x8082c0
+            - Range: 0x808280..0x8082d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8082c0..0x8082c4
+            - Range: 0x8082d0..0x8082d4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x808348..0x808350
+            - Range: 0x808358..0x808360
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x808390..0x808398
+            - Range: 0x8083a0..0x8083a8
               Pieces:
                 - Size: 8
                   Op: null
@@ -7676,117 +7676,117 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x808270..0x8082c8
+            - Range: 0x808280..0x8082d8
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x808270..0x8082dc
+            - Range: 0x808280..0x8082ec
               Pieces: []
-            - Range: 0x8082dc..0x8082dd
+            - Range: 0x8082ec..0x8082ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8082dd..0x808338
+            - Range: 0x8082ed..0x808348
               Pieces: []
-            - Range: 0x808338..0x808339
+            - Range: 0x808348..0x808349
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x808339..0x808380
+            - Range: 0x808349..0x808390
               Pieces: []
-            - Range: 0x808380..0x808381
+            - Range: 0x808390..0x808391
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x808381..0x8083c4
+            - Range: 0x808391..0x8083d4
               Pieces: []
-            - Range: 0x8083c4..0x8083c5
+            - Range: 0x8083d4..0x8083d5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8083c5..0x8083f0
+            - Range: 0x8083d5..0x808400
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x808270..0x8082dc
+            - Range: 0x808280..0x8082ec
               Pieces: []
-            - Range: 0x8082dc..0x8082dd
+            - Range: 0x8082ec..0x8082ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8082dd..0x808338
+            - Range: 0x8082ed..0x808348
               Pieces: []
-            - Range: 0x808338..0x808339
+            - Range: 0x808348..0x808349
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x808339..0x808380
+            - Range: 0x808349..0x808390
               Pieces: []
-            - Range: 0x808380..0x808381
+            - Range: 0x808390..0x808391
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x808381..0x8083c4
+            - Range: 0x808391..0x8083d4
               Pieces: []
-            - Range: 0x8083c4..0x8083c5
+            - Range: 0x8083d4..0x8083d5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8083c5..0x8083f0
+            - Range: 0x8083d5..0x808400
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8082c0..0x8082c8
+            - Range: 0x8082d0..0x8082d8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x8083f0..0x8085d0]
+      OutOfLinePCRanges: [0x808400..0x8085e0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8083f0..0x808430
+            - Range: 0x808400..0x808440
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x808430..0x808438
+            - Range: 0x808440..0x808448
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x808438..0x8085d0
+            - Range: 0x808448..0x8085e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7797,549 +7797,549 @@ Subprograms:
         - Name: ~r0
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8083f0..0x808490
+            - Range: 0x808400..0x8084a0
               Pieces: []
-            - Range: 0x808490..0x808491
+            - Range: 0x8084a0..0x8084a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x808491..0x8084e4
+            - Range: 0x8084a1..0x8084f4
               Pieces: []
-            - Range: 0x8084e4..0x8084e5
+            - Range: 0x8084f4..0x8084f5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8084e5..0x80859c
+            - Range: 0x8084f5..0x8085ac
               Pieces: []
-            - Range: 0x80859c..0x80859d
+            - Range: 0x8085ac..0x8085ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80859d..0x8085b0
+            - Range: 0x8085ad..0x8085c0
               Pieces: []
-            - Range: 0x8085b0..0x8085b1
+            - Range: 0x8085c0..0x8085c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8085b1..0x8085d0
+            - Range: 0x8085c1..0x8085e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80847c..0x808484
+            - Range: 0x80848c..0x808494
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 105 PointerType *int
           Locations:
-            - Range: 0x8084c8..0x8084e4
+            - Range: 0x8084d8..0x8084f4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x8085d0..0x808720]
+      OutOfLinePCRanges: [0x8085e0..0x808730]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8085d0..0x80860c
+            - Range: 0x8085e0..0x80861c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80860c..0x808650
+            - Range: 0x80861c..0x808660
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x808650..0x8086c0
+            - Range: 0x808660..0x8086d0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8086c0..0x8086e8
+            - Range: 0x8086d0..0x8086f8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8086e8..0x8086ec
+            - Range: 0x8086f8..0x8086fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8086ec..0x808720
+            - Range: 0x8086fc..0x808730
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8085d0..0x8086a0
+            - Range: 0x8085e0..0x8086b0
               Pieces: []
-            - Range: 0x8086a0..0x8086a1
+            - Range: 0x8086b0..0x8086b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8086a1..0x8086b4
+            - Range: 0x8086b1..0x8086c4
               Pieces: []
-            - Range: 0x8086b4..0x8086b5
+            - Range: 0x8086c4..0x8086c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8086b5..0x808720
+            - Range: 0x8086c5..0x808730
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8085d0..0x80860c
+            - Range: 0x8085e0..0x80861c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80860c..0x808650
+            - Range: 0x80861c..0x808660
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x808650..0x808658
+            - Range: 0x808660..0x808668
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x808658..0x8086ac
+            - Range: 0x808668..0x8086bc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8086ac..0x8086b0
+            - Range: 0x8086bc..0x8086c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8086b0..0x8086b4
+            - Range: 0x8086c0..0x8086c4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8086b4..0x808720
+            - Range: 0x8086c4..0x808730
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x808720..0x8087c0]
+      OutOfLinePCRanges: [0x808730..0x8087d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808720..0x80873c
+            - Range: 0x808730..0x80874c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808720..0x808794
+            - Range: 0x808730..0x8087a4
               Pieces: []
-            - Range: 0x808794..0x808795
+            - Range: 0x8087a4..0x8087a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808795..0x8087c0
+            - Range: 0x8087a5..0x8087d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x8087c0..0x808880]
+      OutOfLinePCRanges: [0x8087d0..0x808890]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8087c0..0x808810
+            - Range: 0x8087d0..0x808820
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8087c0..0x80885c
+            - Range: 0x8087d0..0x80886c
               Pieces: []
-            - Range: 0x80885c..0x80885d
+            - Range: 0x80886c..0x80886d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80885d..0x808880
+            - Range: 0x80886d..0x808890
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8087c0..0x80885c
+            - Range: 0x8087d0..0x80886c
               Pieces: []
-            - Range: 0x80885c..0x80885d
+            - Range: 0x80886c..0x80886d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80885d..0x808880
+            - Range: 0x80886d..0x808890
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x808880..0x808940]
+      OutOfLinePCRanges: [0x808890..0x808950]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808880..0x8088c0
+            - Range: 0x808890..0x8088d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8088c0..0x808940
+            - Range: 0x8088d0..0x808950
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808880..0x808920
+            - Range: 0x808890..0x808930
               Pieces: []
-            - Range: 0x808920..0x808921
+            - Range: 0x808930..0x808931
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808921..0x808940
+            - Range: 0x808931..0x808950
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808880..0x808920
+            - Range: 0x808890..0x808930
               Pieces: []
-            - Range: 0x808920..0x808921
+            - Range: 0x808930..0x808931
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x808921..0x808940
+            - Range: 0x808931..0x808950
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808880..0x808920
+            - Range: 0x808890..0x808930
               Pieces: []
-            - Range: 0x808920..0x808921
+            - Range: 0x808930..0x808931
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x808921..0x808940
+            - Range: 0x808931..0x808950
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x808940..0x808a20]
+      OutOfLinePCRanges: [0x808950..0x808a30]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808940..0x808980
+            - Range: 0x808950..0x808990
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808980..0x808a20
+            - Range: 0x808990..0x808a30
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808940..0x8089fc
+            - Range: 0x808950..0x808a0c
               Pieces: []
-            - Range: 0x8089fc..0x8089fd
+            - Range: 0x808a0c..0x808a0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8089fd..0x808a20
+            - Range: 0x808a0d..0x808a30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808940..0x8089fc
+            - Range: 0x808950..0x808a0c
               Pieces: []
-            - Range: 0x8089fc..0x8089fd
+            - Range: 0x808a0c..0x808a0d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8089fd..0x808a20
+            - Range: 0x808a0d..0x808a30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x808a20..0x808bb0]
+      OutOfLinePCRanges: [0x808a30..0x808bc0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808a20..0x808a80
+            - Range: 0x808a30..0x808a90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808a80..0x808bb0
+            - Range: 0x808a90..0x808bc0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808a4c..0x808bb0
+            - Range: 0x808a5c..0x808bc0
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808a50..0x808bb0
+            - Range: 0x808a60..0x808bc0
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x808c70..0x808d00]
+      OutOfLinePCRanges: [0x808c80..0x808d10]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x808c70..0x808cdc
+            - Range: 0x808c80..0x808cec
               Pieces: []
-            - Range: 0x808cdc..0x808cdd
+            - Range: 0x808cec..0x808ced
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808cdd..0x808d00
+            - Range: 0x808ced..0x808d10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 102 BaseType int16
           Locations:
-            - Range: 0x808c70..0x808cdc
+            - Range: 0x808c80..0x808cec
               Pieces: []
-            - Range: 0x808cdc..0x808cdd
+            - Range: 0x808cec..0x808ced
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x808cdd..0x808d00
+            - Range: 0x808ced..0x808d10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x808c70..0x808cdc
+            - Range: 0x808c80..0x808cec
               Pieces: []
-            - Range: 0x808cdc..0x808cdd
+            - Range: 0x808cec..0x808ced
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x808cdd..0x808d00
+            - Range: 0x808ced..0x808d10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x808c70..0x808cdc
+            - Range: 0x808c80..0x808cec
               Pieces: []
-            - Range: 0x808cdc..0x808cdd
+            - Range: 0x808cec..0x808ced
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x808cdd..0x808d00
+            - Range: 0x808ced..0x808d10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x808c70..0x808cdc
+            - Range: 0x808c80..0x808cec
               Pieces: []
-            - Range: 0x808cdc..0x808cdd
+            - Range: 0x808cec..0x808ced
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x808cdd..0x808d00
+            - Range: 0x808ced..0x808d10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x808c70..0x808cdc
+            - Range: 0x808c80..0x808cec
               Pieces: []
-            - Range: 0x808cdc..0x808cdd
+            - Range: 0x808cec..0x808ced
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x808cdd..0x808d00
+            - Range: 0x808ced..0x808d10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x808c70..0x808cdc
+            - Range: 0x808c80..0x808cec
               Pieces: []
-            - Range: 0x808cdc..0x808cdd
+            - Range: 0x808cec..0x808ced
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x808cdd..0x808d00
+            - Range: 0x808ced..0x808d10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x808c70..0x808cdc
+            - Range: 0x808c80..0x808cec
               Pieces: []
-            - Range: 0x808cdc..0x808cdd
+            - Range: 0x808cec..0x808ced
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x808cdd..0x808d00
+            - Range: 0x808ced..0x808d10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x808d00..0x808db0]
+      OutOfLinePCRanges: [0x808d10..0x808dc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 14 BaseType float64
           Locations:
-            - Range: 0x808d00..0x808d98
+            - Range: 0x808d10..0x808da8
               Pieces: []
-            - Range: 0x808d98..0x808d99
+            - Range: 0x808da8..0x808da9
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x808d99..0x808db0
+            - Range: 0x808da9..0x808dc0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x808db0..0x808e30]
+      OutOfLinePCRanges: [0x808dc0..0x808e40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 103 BaseType complex64
-          Locations: [{Range: 0x808db0..0x808e30, Pieces: []}]
+          Locations: [{Range: 0x808dc0..0x808e40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType complex128
-          Locations: [{Range: 0x808db0..0x808e30, Pieces: []}]
+          Locations: [{Range: 0x808dc0..0x808e40, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x808e30..0x808ef0]
+      OutOfLinePCRanges: [0x808e40..0x808f00]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x808e30..0x808ed0
+            - Range: 0x808e40..0x808ee0
               Pieces: []
-            - Range: 0x808ed0..0x808ed1
+            - Range: 0x808ee0..0x808ee1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8361,193 +8361,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x808ed1..0x808ef0
+            - Range: 0x808ee1..0x808f00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x808ef0..0x808f80]
+      OutOfLinePCRanges: [0x808f00..0x808f90]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x808ef0..0x808f5c
+            - Range: 0x808f00..0x808f6c
               Pieces: []
-            - Range: 0x808f5c..0x808f5d
+            - Range: 0x808f6c..0x808f6d
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x808f5d..0x808f80
+            - Range: 0x808f6d..0x808f90
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x808f80..0x808ff0]
+      OutOfLinePCRanges: [0x808f90..0x809000]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 ArrayType [1]int
           Locations:
-            - Range: 0x808f80..0x808fd0
+            - Range: 0x808f90..0x808fe0
               Pieces: []
-            - Range: 0x808fd0..0x808fd1
+            - Range: 0x808fe0..0x808fe1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808fd1..0x808ff0
+            - Range: 0x808fe1..0x809000
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x808ff0..0x809060]
+      OutOfLinePCRanges: [0x809000..0x809070]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0x808ff0..0x80903c
+            - Range: 0x809000..0x80904c
               Pieces: []
-            - Range: 0x80903c..0x80903d
+            - Range: 0x80904c..0x80904d
               Pieces: []
-            - Range: 0x80903d..0x809060
+            - Range: 0x80904d..0x809070
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x809060..0x8090e0]
+      OutOfLinePCRanges: [0x809070..0x8090f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 260 StructureType main.mixedStruct
-          Locations: [{Range: 0x809060..0x8090e0, Pieces: []}]
+          Locations: [{Range: 0x809070..0x8090f0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x8090e0..0x809170]
+      OutOfLinePCRanges: [0x8090f0..0x809180]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090e0..0x809158
+            - Range: 0x8090f0..0x809168
               Pieces: []
-            - Range: 0x809158..0x809159
+            - Range: 0x809168..0x809169
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809159..0x809170
+            - Range: 0x809169..0x809180
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090e0..0x809158
+            - Range: 0x8090f0..0x809168
               Pieces: []
-            - Range: 0x809158..0x809159
+            - Range: 0x809168..0x809169
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x809159..0x809170
+            - Range: 0x809169..0x809180
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090e0..0x809158
+            - Range: 0x8090f0..0x809168
               Pieces: []
-            - Range: 0x809158..0x809159
+            - Range: 0x809168..0x809169
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x809159..0x809170
+            - Range: 0x809169..0x809180
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090e0..0x809158
+            - Range: 0x8090f0..0x809168
               Pieces: []
-            - Range: 0x809158..0x809159
+            - Range: 0x809168..0x809169
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x809159..0x809170
+            - Range: 0x809169..0x809180
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090e0..0x809158
+            - Range: 0x8090f0..0x809168
               Pieces: []
-            - Range: 0x809158..0x809159
+            - Range: 0x809168..0x809169
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x809159..0x809170
+            - Range: 0x809169..0x809180
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090e0..0x809158
+            - Range: 0x8090f0..0x809168
               Pieces: []
-            - Range: 0x809158..0x809159
+            - Range: 0x809168..0x809169
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x809159..0x809170
+            - Range: 0x809169..0x809180
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090e0..0x809158
+            - Range: 0x8090f0..0x809168
               Pieces: []
-            - Range: 0x809158..0x809159
+            - Range: 0x809168..0x809169
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x809159..0x809170
+            - Range: 0x809169..0x809180
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090e0..0x809158
+            - Range: 0x8090f0..0x809168
               Pieces: []
-            - Range: 0x809158..0x809159
+            - Range: 0x809168..0x809169
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x809159..0x809170
+            - Range: 0x809169..0x809180
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8090e0..0x809158
+            - Range: 0x8090f0..0x809168
               Pieces: []
-            - Range: 0x809158..0x809159
+            - Range: 0x809168..0x809169
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809159..0x809170
+            - Range: 0x809169..0x809180
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x809170..0x809240]
+      OutOfLinePCRanges: [0x809180..0x809250]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.wideStruct
           Locations:
-            - Range: 0x809170..0x809220
+            - Range: 0x809180..0x809230
               Pieces: []
-            - Range: 0x809220..0x809221
+            - Range: 0x809230..0x809231
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8571,145 +8571,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x809221..0x809240
+            - Range: 0x809231..0x809250
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x809240..0x8092d0]
+      OutOfLinePCRanges: [0x809250..0x8092e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809240..0x8092ac
+            - Range: 0x809250..0x8092bc
               Pieces: []
-            - Range: 0x8092ac..0x8092ad
+            - Range: 0x8092bc..0x8092bd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8092ad..0x8092d0
+            - Range: 0x8092bd..0x8092e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x809240..0x8092d0, Pieces: []}]
+          Locations: [{Range: 0x809250..0x8092e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809240..0x8092ac
+            - Range: 0x809250..0x8092bc
               Pieces: []
-            - Range: 0x8092ac..0x8092ad
+            - Range: 0x8092bc..0x8092bd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8092ad..0x8092d0
+            - Range: 0x8092bd..0x8092e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType float64
-          Locations: [{Range: 0x809240..0x8092d0, Pieces: []}]
+          Locations: [{Range: 0x809250..0x8092e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809240..0x8092ac
+            - Range: 0x809250..0x8092bc
               Pieces: []
-            - Range: 0x8092ac..0x8092ad
+            - Range: 0x8092bc..0x8092bd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8092ad..0x8092d0
+            - Range: 0x8092bd..0x8092e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x8092d0..0x809360]
+      OutOfLinePCRanges: [0x8092e0..0x809370]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x8092d0..0x80933c
+            - Range: 0x8092e0..0x80934c
               Pieces: []
-            - Range: 0x80933c..0x80933d
+            - Range: 0x80934c..0x80934d
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80933d..0x809360
+            - Range: 0x80934d..0x809370
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x809360..0x8093d0]
+      OutOfLinePCRanges: [0x809370..0x8093e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType float64
-          Locations: [{Range: 0x809360..0x8093d0, Pieces: []}]
+          Locations: [{Range: 0x809370..0x8093e0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x8093d0..0x809440]
+      OutOfLinePCRanges: [0x8093e0..0x809450]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0x8093d0..0x809440, Pieces: []}]
+          Locations: [{Range: 0x8093e0..0x809450, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x8093d0..0x809440, Pieces: []}]
+          Locations: [{Range: 0x8093e0..0x809450, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x809440..0x8094b0]
+      OutOfLinePCRanges: [0x809450..0x8094c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x809440..0x809494
+            - Range: 0x809450..0x8094a4
               Pieces: []
-            - Range: 0x809494..0x809495
+            - Range: 0x8094a4..0x8094a5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809495..0x8094b0
+            - Range: 0x8094a5..0x8094c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x809440..0x809494
+            - Range: 0x809450..0x8094a4
               Pieces: []
-            - Range: 0x809494..0x809495
+            - Range: 0x8094a4..0x8094a5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x809495..0x8094b0
+            - Range: 0x8094a5..0x8094c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x8094b0..0x809640]
+      OutOfLinePCRanges: [0x8094c0..0x809650]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x8094b0..0x8094e4
+            - Range: 0x8094c0..0x8094f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8731,7 +8731,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8094e4..0x809514
+            - Range: 0x8094f4..0x809524
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8753,7 +8753,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809514..0x80951c
+            - Range: 0x809524..0x80952c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8775,7 +8775,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80951c..0x809520
+            - Range: 0x80952c..0x809530
               Pieces:
                 - Size: 8
                   Op: null
@@ -8802,9 +8802,9 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x8094b0..0x809600
+            - Range: 0x8094c0..0x809610
               Pieces: []
-            - Range: 0x809600..0x809601
+            - Range: 0x809610..0x809611
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8826,44 +8826,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809601..0x809640
+            - Range: 0x809611..0x809650
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x809640..0x809710]
+      OutOfLinePCRanges: [0x809650..0x809720]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x809640..0x809710
+            - Range: 0x809650..0x809720
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x809640..0x8096f0
+            - Range: 0x809650..0x809700
               Pieces: []
-            - Range: 0x8096f0..0x8096f1
+            - Range: 0x809700..0x809701
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x8096f1..0x809710
+            - Range: 0x809701..0x809720
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x809710..0x809920]
+      OutOfLinePCRanges: [0x809720..0x809930]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x809710..0x809744
+            - Range: 0x809720..0x809754
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8885,7 +8885,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809744..0x809778
+            - Range: 0x809754..0x809788
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8907,7 +8907,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809778..0x809780
+            - Range: 0x809788..0x809790
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8929,7 +8929,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809780..0x809784
+            - Range: 0x809790..0x809794
               Pieces:
                 - Size: 8
                   Op: null
@@ -8956,16 +8956,16 @@ Subprograms:
         - Name: s2
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x809710..0x809920
+            - Range: 0x809720..0x809930
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x809710..0x8098d8
+            - Range: 0x809720..0x8098e8
               Pieces: []
-            - Range: 0x8098d8..0x8098d9
+            - Range: 0x8098e8..0x8098e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8987,196 +8987,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8098d9..0x809920
+            - Range: 0x8098e9..0x809930
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x809920..0x809ad0]
+      OutOfLinePCRanges: [0x809930..0x809ae0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809920..0x8099a8
+            - Range: 0x809930..0x8099b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8099a8..0x809ad0
+            - Range: 0x8099b8..0x809ae0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809920..0x809968
+            - Range: 0x809930..0x809978
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x809968..0x809ad0
+            - Range: 0x809978..0x809ae0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809920..0x8099a0
+            - Range: 0x809930..0x8099b0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8099a0..0x809ad0
+            - Range: 0x8099b0..0x809ae0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809920..0x8099a8
+            - Range: 0x809930..0x8099b8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8099a8..0x809ad0
+            - Range: 0x8099b8..0x809ae0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809920..0x8099a8
+            - Range: 0x809930..0x8099b8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8099a8..0x809ad0
+            - Range: 0x8099b8..0x809ae0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809920..0x8099a8
+            - Range: 0x809930..0x8099b8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8099a8..0x809ad0
+            - Range: 0x8099b8..0x809ae0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809920..0x8099a8
+            - Range: 0x809930..0x8099b8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8099a8..0x809ad0
+            - Range: 0x8099b8..0x809ae0
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809920..0x8099a8
+            - Range: 0x809930..0x8099b8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8099a8..0x809ad0
+            - Range: 0x8099b8..0x809ae0
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809920..0x8099a8
+            - Range: 0x809930..0x8099b8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x8099a8..0x809ad0
+            - Range: 0x8099b8..0x809ae0
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x809920..0x809a90
+            - Range: 0x809930..0x809aa0
               Pieces: []
-            - Range: 0x809a90..0x809a91
+            - Range: 0x809aa0..0x809aa1
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x809a91..0x809ad0
+            - Range: 0x809aa1..0x809ae0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x809ad0..0x809cc0]
+      OutOfLinePCRanges: [0x809ae0..0x809cd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ad0..0x809b58
+            - Range: 0x809ae0..0x809b68
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809b58..0x809cc0
+            - Range: 0x809b68..0x809cd0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ad0..0x809b1c
+            - Range: 0x809ae0..0x809b2c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x809b1c..0x809cc0
+            - Range: 0x809b2c..0x809cd0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ad0..0x809b50
+            - Range: 0x809ae0..0x809b60
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x809b50..0x809cc0
+            - Range: 0x809b60..0x809cd0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ad0..0x809b58
+            - Range: 0x809ae0..0x809b68
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x809b58..0x809cc0
+            - Range: 0x809b68..0x809cd0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ad0..0x809b58
+            - Range: 0x809ae0..0x809b68
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x809b58..0x809cc0
+            - Range: 0x809b68..0x809cd0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ad0..0x809b58
+            - Range: 0x809ae0..0x809b68
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x809b58..0x809cc0
+            - Range: 0x809b68..0x809cd0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ad0..0x809b58
+            - Range: 0x809ae0..0x809b68
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x809b58..0x809cc0
+            - Range: 0x809b68..0x809cd0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ad0..0x809b58
+            - Range: 0x809ae0..0x809b68
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x809b58..0x809cc0
+            - Range: 0x809b68..0x809cd0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809ad0..0x809b58
+            - Range: 0x809ae0..0x809b68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809b58..0x809cc0
+            - Range: 0x809b68..0x809cd0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9187,9 +9187,9 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x809ad0..0x809c7c
+            - Range: 0x809ae0..0x809c8c
               Pieces: []
-            - Range: 0x809c7c..0x809c7d
+            - Range: 0x809c8c..0x809c8d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9211,208 +9211,189 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809c7d..0x809cc0
+            - Range: 0x809c8d..0x809cd0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x809cc0..0x809d50]
+      OutOfLinePCRanges: [0x809cd0..0x809d60]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0x809cc0..0x809d50
+            - Range: 0x809cd0..0x809d60
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809cc0..0x809d34
+            - Range: 0x809cd0..0x809d44
               Pieces: []
-            - Range: 0x809d34..0x809d35
+            - Range: 0x809d44..0x809d45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809d35..0x809d50
+            - Range: 0x809d45..0x809d60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809cc0..0x809d34
+            - Range: 0x809cd0..0x809d44
               Pieces: []
-            - Range: 0x809d34..0x809d35
+            - Range: 0x809d44..0x809d45
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x809d35..0x809d50
+            - Range: 0x809d45..0x809d60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809cc0..0x809d34
+            - Range: 0x809cd0..0x809d44
               Pieces: []
-            - Range: 0x809d34..0x809d35
+            - Range: 0x809d44..0x809d45
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x809d35..0x809d50
+            - Range: 0x809d45..0x809d60
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x809d50..0x809e20]
+      OutOfLinePCRanges: [0x809d60..0x809e30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x809d50..0x809e20
+            - Range: 0x809d60..0x809e30
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x809d50..0x809e20
+            - Range: 0x809d60..0x809e30
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809d50..0x809e08
+            - Range: 0x809d60..0x809e18
               Pieces: []
-            - Range: 0x809e08..0x809e09
+            - Range: 0x809e18..0x809e19
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809e09..0x809e20
+            - Range: 0x809e19..0x809e30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x809d50..0x809e08
+            - Range: 0x809d60..0x809e18
               Pieces: []
-            - Range: 0x809e08..0x809e09
+            - Range: 0x809e18..0x809e19
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x809e09..0x809e20
+            - Range: 0x809e19..0x809e30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x809e20..0x809ee0]
+      OutOfLinePCRanges: [0x809e30..0x809ef0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x809e20..0x809ee0
+            - Range: 0x809e30..0x809ef0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809e20..0x809ec4
+            - Range: 0x809e30..0x809ed4
               Pieces: []
-            - Range: 0x809ec4..0x809ec5
+            - Range: 0x809ed4..0x809ed5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809ec5..0x809ee0
+            - Range: 0x809ed5..0x809ef0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x809e20..0x809ec4
+            - Range: 0x809e30..0x809ed4
               Pieces: []
-            - Range: 0x809ec4..0x809ec5
+            - Range: 0x809ed4..0x809ed5
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x809ec5..0x809ee0
+            - Range: 0x809ed5..0x809ef0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ea0..0x809ee0
+            - Range: 0x809eb0..0x809ef0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x809ee0..0x809f80]
+      OutOfLinePCRanges: [0x809ef0..0x809f90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 259 ArrayType [0]int
-          Locations: [{Range: 0x809ee0..0x809f80, Pieces: []}]
+          Locations: [{Range: 0x809ef0..0x809f90, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ee0..0x809f20
+            - Range: 0x809ef0..0x809f30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809f20..0x809f38
+            - Range: 0x809f30..0x809f48
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x809f38..0x809f40
+            - Range: 0x809f48..0x809f50
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x809f40..0x809f80
+            - Range: 0x809f50..0x809f90
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ee0..0x809f5c
+            - Range: 0x809ef0..0x809f6c
               Pieces: []
-            - Range: 0x809f5c..0x809f5d
+            - Range: 0x809f6c..0x809f6d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809f5d..0x809f80
+            - Range: 0x809f6d..0x809f90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0x809ee0..0x809f5c
+            - Range: 0x809ef0..0x809f6c
               Pieces: []
-            - Range: 0x809f5c..0x809f5d
+            - Range: 0x809f6c..0x809f6d
               Pieces: []
-            - Range: 0x809f5d..0x809f80
+            - Range: 0x809f6d..0x809f90
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80a3d0..0x80a3e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80a3d0..0x80a3e0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 134
-      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x80a3e0..0x80a3f0]
       InlinePCRanges: []
       Variables:
@@ -9430,13 +9411,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 135
-      Name: main.testSliceOfSlices
+    - ID: 134
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x80a3f0..0x80a400]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 264 GoSliceHeaderType [][]uint
+          Type: 263 GoSliceHeaderType []uint
           Locations:
             - Range: 0x80a3f0..0x80a400
               Pieces:
@@ -9449,13 +9430,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 136
-      Name: main.testStructSlice
+    - ID: 135
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x80a400..0x80a410]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 264 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x80a400..0x80a410
               Pieces:
@@ -9467,16 +9448,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80a400..0x80a410
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 137
-      Name: main.testEmptySliceOfStructs
+    - ID: 136
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0x80a410..0x80a420]
       InlinePCRanges: []
       Variables:
@@ -9501,8 +9475,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testNilSliceOfStructs
+    - ID: 137
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x80a420..0x80a430]
       InlinePCRanges: []
       Variables:
@@ -9527,15 +9501,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x80a430..0x80a440]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x80a430..0x80a440
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80a430..0x80a440
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x80a430..0x80a440]
+      OutOfLinePCRanges: [0x80a440..0x80a450]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 269 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80a430..0x80a440
+            - Range: 0x80a440..0x80a450
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9548,20 +9548,20 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x80a440..0x80a450]
+      OutOfLinePCRanges: [0x80a450..0x80a460]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x80a440..0x80a450
+            - Range: 0x80a450..0x80a460
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 270 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80a440..0x80a450
+            - Range: 0x80a450..0x80a460
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9574,37 +9574,18 @@ Subprograms:
         - Name: x
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x80a440..0x80a450
+            - Range: 0x80a450..0x80a460
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80a450..0x80a460]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 271 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0x80a450..0x80a460
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 142
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x80a460..0x80a470]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 263 GoSliceHeaderType []uint
+          Type: 271 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x80a460..0x80a470
               Pieces:
@@ -9617,13 +9598,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 143
-      Name: main.testSliceEmptyStructs
+    - ID: 142
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x80a470..0x80a480]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 272 GoSliceHeaderType []struct {}
+          Type: 263 GoSliceHeaderType []uint
           Locations:
             - Range: 0x80a470..0x80a480
               Pieces:
@@ -9636,15 +9617,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x80a480..0x80a490]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 272 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x80a480..0x80a490
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80a480..0x80a490]
+      OutOfLinePCRanges: [0x80a490..0x80a4a0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a480..0x80a490
+            - Range: 0x80a490..0x80a4a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9657,7 +9657,7 @@ Subprograms:
         - Name: bs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a480..0x80a490
+            - Range: 0x80a490..0x80a4a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9670,7 +9670,7 @@ Subprograms:
         - Name: cs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a480..0x80a490
+            - Range: 0x80a490..0x80a4a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9683,44 +9683,27 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0x80a750..0x80a7b0]
+      OutOfLinePCRanges: [0x80a760..0x80a7c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a750..0x80a798
+            - Range: 0x80a760..0x80a7a8
               Pieces: []
-            - Range: 0x80a798..0x80a799
+            - Range: 0x80a7a8..0x80a7a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a799..0x80a7b0
+            - Range: 0x80a7a9..0x80a7c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80a7b0..0x80a7c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x80a7b0..0x80a7c0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 147
-      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x80a7c0..0x80a7d0]
       InlinePCRanges: []
       Variables:
@@ -9735,10 +9718,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 147
+      Name: main.testThreeStrings
+      OutOfLinePCRanges: [0x80a7d0..0x80a7e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80a7d0..0x80a7e0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a7c0..0x80a7d0
+            - Range: 0x80a7d0..0x80a7e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9749,7 +9749,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a7c0..0x80a7d0
+            - Range: 0x80a7d0..0x80a7e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9760,13 +9760,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80a7d0..0x80a7e0]
+      OutOfLinePCRanges: [0x80a7e0..0x80a7f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80a7d0..0x80a7e0
+            - Range: 0x80a7e0..0x80a7f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9785,49 +9785,32 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80a7e0..0x80a7f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 275 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x80a7e0..0x80a7f0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 150
-      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x80a7f0..0x80a800]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 276 PointerType *main.oneStringStruct
+          Type: 275 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x80a7f0..0x80a800
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 151
-      Name: main.testMassiveString
+    - ID: 150
+      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x80a800..0x80a810]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 276 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x80a800..0x80a810
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 152
-      Name: main.testUnitializedString
+    - ID: 151
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0x80a810..0x80a820]
       InlinePCRanges: []
       Variables:
@@ -9843,8 +9826,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 153
-      Name: main.testEmptyString
+    - ID: 152
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0x80a820..0x80a830]
       InlinePCRanges: []
       Variables:
@@ -9860,12 +9843,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
-      Name: main.testSubstrings
+    - ID: 153
+      Name: main.testEmptyString
       OutOfLinePCRanges: [0x80a830..0x80a840]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x80a830..0x80a840
@@ -9876,10 +9859,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 154
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0x80a840..0x80a850]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80a840..0x80a850
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a830..0x80a840
+            - Range: 0x80a840..0x80a850
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9890,7 +9890,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a830..0x80a840
+            - Range: 0x80a840..0x80a850
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9901,26 +9901,26 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80a980..0x80a990]
+      OutOfLinePCRanges: [0x80a990..0x80a9a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80a980..0x80a990
+            - Range: 0x80a990..0x80a9a0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80a990..0x80a9a0]
+      OutOfLinePCRanges: [0x80a9a0..0x80a9b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 291 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80a990..0x80a9a0
+            - Range: 0x80a9a0..0x80a9b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9939,13 +9939,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80aa30..0x80aa40]
+      OutOfLinePCRanges: [0x80aa40..0x80aa50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 322 StructureType main.aStruct
           Locations:
-            - Range: 0x80aa30..0x80aa40
+            - Range: 0x80aa40..0x80aa50
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9966,93 +9966,93 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x80aa90..0x80aaa0]
+      OutOfLinePCRanges: [0x80aaa0..0x80aab0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x80aa90..0x80aaa0
+            - Range: 0x80aaa0..0x80aab0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x80aaa0..0x80aab0]
+      OutOfLinePCRanges: [0x80aab0..0x80aac0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 325 StructureType main.tenStrings
           Locations:
-            - Range: 0x80aaa0..0x80aab0
+            - Range: 0x80aab0..0x80aac0
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80aad0..0x80aae0]
+      OutOfLinePCRanges: [0x80aae0..0x80aaf0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 326 StructureType main.emptyStruct
-          Locations: [{Range: 0x80aad0..0x80aae0, Pieces: []}]
+          Locations: [{Range: 0x80aae0..0x80aaf0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80aae0..0x80aaf0]
+      OutOfLinePCRanges: [0x80aaf0..0x80ab00]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 327 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80aae0..0x80aaf0
+            - Range: 0x80aaf0..0x80ab00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x80c0e0..0x80c0f0]
+      OutOfLinePCRanges: [0x80c0f0..0x80c100]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c0e0..0x80c0f0
+            - Range: 0x80c0f0..0x80c100
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80c0e0..0x80c0e4
+            - Range: 0x80c0f0..0x80c0f4
               Pieces: []
-            - Range: 0x80c0e4..0x80c0e5
+            - Range: 0x80c0f4..0x80c0f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c0e5..0x80c0f0
+            - Range: 0x80c0f5..0x80c100
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x80c0f0..0x80c100]
+      OutOfLinePCRanges: [0x80c100..0x80c110]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c0f0..0x80c0fc
+            - Range: 0x80c100..0x80c10c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c0fc..0x80c100
+            - Range: 0x80c10c..0x80c110
               Pieces:
                 - Size: 8
                   Op: null
@@ -10063,58 +10063,58 @@ Subprograms:
         - Name: ~r0
           Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80c0f0..0x80c0fc
+            - Range: 0x80c100..0x80c10c
               Pieces: []
-            - Range: 0x80c0fc..0x80c0fd
+            - Range: 0x80c10c..0x80c10d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c0fd..0x80c100
+            - Range: 0x80c10d..0x80c110
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x80c100..0x80c110]
+      OutOfLinePCRanges: [0x80c110..0x80c120]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80c100..0x80c110
+            - Range: 0x80c110..0x80c120
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c100..0x80c104
+            - Range: 0x80c110..0x80c114
               Pieces: []
-            - Range: 0x80c104..0x80c105
+            - Range: 0x80c114..0x80c115
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c105..0x80c110
+            - Range: 0x80c115..0x80c120
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x80c110..0x80c120]
+      OutOfLinePCRanges: [0x80c120..0x80c130]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80c110..0x80c11c
+            - Range: 0x80c120..0x80c12c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c11c..0x80c120
+            - Range: 0x80c12c..0x80c130
               Pieces:
                 - Size: 8
                   Op: null
@@ -10125,28 +10125,28 @@ Subprograms:
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c110..0x80c11c
+            - Range: 0x80c120..0x80c12c
               Pieces: []
-            - Range: 0x80c11c..0x80c11d
+            - Range: 0x80c12c..0x80c12d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c11d..0x80c120
+            - Range: 0x80c12d..0x80c130
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x80c180..0x80c320]
+      OutOfLinePCRanges: [0x80c190..0x80c330]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80c180..0x80c1b0
+            - Range: 0x80c190..0x80c1c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10154,7 +10154,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80c1b0..0x80c1c4
+            - Range: 0x80c1c0..0x80c1d4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10162,7 +10162,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x80c1c4..0x80c320
+            - Range: 0x80c1d4..0x80c330
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10175,18 +10175,18 @@ Subprograms:
         - Name: pred
           Type: 334 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x80c180..0x80c1c4
+            - Range: 0x80c190..0x80c1d4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80c1c4..0x80c320
+            - Range: 0x80c1d4..0x80c330
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80c180..0x80c2e8
+            - Range: 0x80c190..0x80c2f8
               Pieces: []
-            - Range: 0x80c2e8..0x80c2e9
+            - Range: 0x80c2f8..0x80c2f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10194,14 +10194,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c2e9..0x80c320
+            - Range: 0x80c2f9..0x80c330
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80c1b0..0x80c1c4
+            - Range: 0x80c1c0..0x80c1d4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10209,7 +10209,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80c1c4..0x80c1e4
+            - Range: 0x80c1d4..0x80c1f4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10217,7 +10217,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80c1e4..0x80c1e8
+            - Range: 0x80c1f4..0x80c1f8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10225,7 +10225,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80c1e8..0x80c1e8
+            - Range: 0x80c1f8..0x80c1f8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10233,7 +10233,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80c1e8..0x80c218
+            - Range: 0x80c1f8..0x80c228
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10241,7 +10241,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80c218..0x80c2a8
+            - Range: 0x80c228..0x80c2b8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10249,7 +10249,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80c2a8..0x80c2bc
+            - Range: 0x80c2b8..0x80c2cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10257,7 +10257,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80c2bc..0x80c2d0
+            - Range: 0x80c2cc..0x80c2e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10265,7 +10265,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80c2d0..0x80c2dc
+            - Range: 0x80c2e0..0x80c2ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10273,7 +10273,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80c2dc..0x80c320
+            - Range: 0x80c2ec..0x80c330
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10286,86 +10286,62 @@ Subprograms:
         - Name: item
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c208..0x80c218
+            - Range: 0x80c218..0x80c228
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c218..0x80c2a8
+            - Range: 0x80c228..0x80c2b8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80c320..0x80c370]
+      OutOfLinePCRanges: [0x80c330..0x80c380]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80c320..0x80c348
+            - Range: 0x80c330..0x80c358
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 335 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x80c320..0x80c348
+            - Range: 0x80c330..0x80c358
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80c320..0x80c348
+            - Range: 0x80c330..0x80c358
               Pieces: []
-            - Range: 0x80c348..0x80c349
+            - Range: 0x80c358..0x80c359
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c349..0x80c370
+            - Range: 0x80c359..0x80c380
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 168
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x80c560..0x80c570]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 333 PointerType *go.shape.int
-          Locations:
-            - Range: 0x80c560..0x80c570
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 333 PointerType *go.shape.int
-          Locations:
-            - Range: 0x80c560..0x80c564
-              Pieces: []
-            - Range: 0x80c564..0x80c565
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c565..0x80c570
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 169
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0x80c570..0x80c580]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 336 PointerType *go.shape.struct { Name string }
+          Type: 333 PointerType *go.shape.int
           Locations:
             - Range: 0x80c570..0x80c580
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 336 PointerType *go.shape.struct { Name string }
+          Type: 333 PointerType *go.shape.int
           Locations:
             - Range: 0x80c570..0x80c574
               Pieces: []
@@ -10376,20 +10352,20 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 170
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+    - ID: 169
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0x80c580..0x80c590]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 338 PointerType *go.shape.struct { X int; Y int }
+          Type: 336 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0x80c580..0x80c590
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 338 PointerType *go.shape.struct { X int; Y int }
+          Type: 336 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0x80c580..0x80c584
               Pieces: []
@@ -10400,101 +10376,125 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 170
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0x80c590..0x80c5a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 338 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x80c590..0x80c5a0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 338 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x80c590..0x80c594
+              Pieces: []
+            - Range: 0x80c594..0x80c595
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80c595..0x80c5a0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x80c590..0x80c5a0]
+      OutOfLinePCRanges: [0x80c5a0..0x80c5b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x80c590..0x80c5a0
+            - Range: 0x80c5a0..0x80c5b0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c590..0x80c594
+            - Range: 0x80c5a0..0x80c5a4
               Pieces: []
-            - Range: 0x80c594..0x80c595
+            - Range: 0x80c5a4..0x80c5a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c595..0x80c5a0
+            - Range: 0x80c5a5..0x80c5b0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x80c610..0x80c620]
+      OutOfLinePCRanges: [0x80c620..0x80c630]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 342 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x80c610..0x80c620
+            - Range: 0x80c620..0x80c630
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c610..0x80c614
+            - Range: 0x80c620..0x80c624
               Pieces: []
-            - Range: 0x80c614..0x80c615
+            - Range: 0x80c624..0x80c625
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c615..0x80c620
+            - Range: 0x80c625..0x80c630
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x80c690..0x80c6a0]
+      OutOfLinePCRanges: [0x80c6a0..0x80c6b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 343 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x80c690..0x80c6a0
+            - Range: 0x80c6a0..0x80c6b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c690..0x80c6a0
+            - Range: 0x80c6a0..0x80c6b0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0x80c690..0x80c6a0
+            - Range: 0x80c6a0..0x80c6b0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x80c700..0x80c770]
+      OutOfLinePCRanges: [0x80c710..0x80c780]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x80c700..0x80c770
+            - Range: 0x80c710..0x80c780
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c700..0x80c770
+            - Range: 0x80c710..0x80c780
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10505,20 +10505,20 @@ Subprograms:
         - Name: v
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c700..0x80c770
+            - Range: 0x80c710..0x80c780
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x80c7d0..0x80c7e0]
+      OutOfLinePCRanges: [0x80c7e0..0x80c7f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c7d0..0x80c7e0
+            - Range: 0x80c7e0..0x80c7f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10529,59 +10529,59 @@ Subprograms:
         - Name: b
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0x80c7d0..0x80c7e0
+            - Range: 0x80c7e0..0x80c7f0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0x80c7d0..0x80c7d8
+            - Range: 0x80c7e0..0x80c7e8
               Pieces: []
-            - Range: 0x80c7d8..0x80c7d9
+            - Range: 0x80c7e8..0x80c7e9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c7d9..0x80c7e0
+            - Range: 0x80c7e9..0x80c7f0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c7d0..0x80c7d8
+            - Range: 0x80c7e0..0x80c7e8
               Pieces: []
-            - Range: 0x80c7d8..0x80c7d9
+            - Range: 0x80c7e8..0x80c7e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c7d9..0x80c7e0
+            - Range: 0x80c7e9..0x80c7f0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80c7e0..0x80c800]
+      OutOfLinePCRanges: [0x80c7f0..0x80c810]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c7e0..0x80c7f0
+            - Range: 0x80c7f0..0x80c800
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c7e0..0x80c7ec
+            - Range: 0x80c7f0..0x80c7fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80c7ec..0x80c800
+            - Range: 0x80c7fc..0x80c810
               Pieces:
                 - Size: 8
                   Op: null
@@ -10592,73 +10592,73 @@ Subprograms:
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c7e0..0x80c7f0
+            - Range: 0x80c7f0..0x80c800
               Pieces: []
-            - Range: 0x80c7f0..0x80c7f1
+            - Range: 0x80c800..0x80c801
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c7f1..0x80c800
+            - Range: 0x80c801..0x80c810
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c7e0..0x80c7f0
+            - Range: 0x80c7f0..0x80c800
               Pieces: []
-            - Range: 0x80c7f0..0x80c7f1
+            - Range: 0x80c800..0x80c801
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80c7f1..0x80c800
+            - Range: 0x80c801..0x80c810
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x80c800..0x80c850]
+      OutOfLinePCRanges: [0x80c810..0x80c860]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 348 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x80c800..0x80c828
+            - Range: 0x80c810..0x80c838
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c800..0x80c828
+            - Range: 0x80c810..0x80c838
               Pieces: []
-            - Range: 0x80c828..0x80c829
+            - Range: 0x80c838..0x80c839
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c829..0x80c850
+            - Range: 0x80c839..0x80c860
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x80c850..0x80c8b0]
+      OutOfLinePCRanges: [0x80c860..0x80c8c0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 349 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x80c850..0x80c87c
+            - Range: 0x80c860..0x80c88c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c87c..0x80c880
+            - Range: 0x80c88c..0x80c890
               Pieces:
                 - Size: 8
                   Op: null
@@ -10669,65 +10669,65 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c850..0x80c880
+            - Range: 0x80c860..0x80c890
               Pieces: []
-            - Range: 0x80c880..0x80c881
+            - Range: 0x80c890..0x80c891
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c881..0x80c8b0
+            - Range: 0x80c891..0x80c8c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x80c8b0..0x80c8c0]
+      OutOfLinePCRanges: [0x80c8c0..0x80c8d0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 350 PointerType *go.shape.string
           Locations:
-            - Range: 0x80c8b0..0x80c8b4
+            - Range: 0x80c8c0..0x80c8c4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c8b0..0x80c8b4
+            - Range: 0x80c8c0..0x80c8c4
               Pieces: []
-            - Range: 0x80c8b4..0x80c8b5
+            - Range: 0x80c8c4..0x80c8c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c8b5..0x80c8c0
+            - Range: 0x80c8c5..0x80c8d0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x80c8c0..0x80c910]
+      OutOfLinePCRanges: [0x80c8d0..0x80c920]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x80c8c0..0x80c900
+            - Range: 0x80c8d0..0x80c910
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 352 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x80c8c0..0x80c904
+            - Range: 0x80c8d0..0x80c914
               Pieces: []
-            - Range: 0x80c904..0x80c905
+            - Range: 0x80c914..0x80c915
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10741,20 +10741,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80c905..0x80c910
+            - Range: 0x80c915..0x80c920
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x80c910..0x80c950]
+      OutOfLinePCRanges: [0x80c920..0x80c960]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80c910..0x80c91c
+            - Range: 0x80c920..0x80c92c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10762,7 +10762,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80c91c..0x80c950
+            - Range: 0x80c92c..0x80c960
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10775,42 +10775,42 @@ Subprograms:
         - Name: needle
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c910..0x80c950
+            - Range: 0x80c920..0x80c960
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80c910..0x80c938
+            - Range: 0x80c920..0x80c948
               Pieces: []
-            - Range: 0x80c938..0x80c939
+            - Range: 0x80c948..0x80c949
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c939..0x80c940
+            - Range: 0x80c949..0x80c950
               Pieces: []
-            - Range: 0x80c940..0x80c941
+            - Range: 0x80c950..0x80c951
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c941..0x80c950
+            - Range: 0x80c951..0x80c960
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c92c..0x80c93c
+            - Range: 0x80c93c..0x80c94c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x80c950..0x80ca10]
+      OutOfLinePCRanges: [0x80c960..0x80ca20]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 353 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x80c950..0x80c974
+            - Range: 0x80c960..0x80c984
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10818,7 +10818,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80c974..0x80c978
+            - Range: 0x80c984..0x80c988
               Pieces:
                 - Size: 8
                   Op: null
@@ -10831,13 +10831,13 @@ Subprograms:
         - Name: needle
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c950..0x80c9ac
+            - Range: 0x80c960..0x80c9bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80c9ac..0x80ca10
+            - Range: 0x80c9bc..0x80ca20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10848,22 +10848,22 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80c950..0x80c9c8
-              Pieces: []
-            - Range: 0x80c9c8..0x80c9c9
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c9c9..0x80c9d8
+            - Range: 0x80c960..0x80c9d8
               Pieces: []
             - Range: 0x80c9d8..0x80c9d9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c9d9..0x80ca10
+            - Range: 0x80c9d9..0x80c9e8
+              Pieces: []
+            - Range: 0x80c9e8..0x80c9e9
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80c9e9..0x80ca20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c994..0x80c9ac
+            - Range: 0x80c9a4..0x80c9bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10874,56 +10874,56 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x80ca10..0x80ca20]
+      OutOfLinePCRanges: [0x80ca20..0x80ca30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 354 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x80ca10..0x80ca18
+            - Range: 0x80ca20..0x80ca28
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80ca10..0x80ca20
+            - Range: 0x80ca20..0x80ca30
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80ca10..0x80ca18
+            - Range: 0x80ca20..0x80ca28
               Pieces: []
-            - Range: 0x80ca18..0x80ca19
+            - Range: 0x80ca28..0x80ca29
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ca19..0x80ca20
+            - Range: 0x80ca29..0x80ca30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x80ca70..0x80cae0]
+      OutOfLinePCRanges: [0x80ca80..0x80caf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 355 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x80ca70..0x80ca9c
+            - Range: 0x80ca80..0x80caac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ca9c..0x80caa8
+            - Range: 0x80caac..0x80cab8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80caa8..0x80caac
+            - Range: 0x80cab8..0x80cabc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10934,7 +10934,7 @@ Subprograms:
         - Name: value
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80ca70..0x80caac
+            - Range: 0x80ca80..0x80cabc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10945,11 +10945,11 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80ca70..0x80caac
+            - Range: 0x80ca80..0x80cabc
               Pieces: []
-            - Range: 0x80caac..0x80caad
+            - Range: 0x80cabc..0x80cabd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80caad..0x80cae0
+            - Range: 0x80cabd..0x80caf0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11111,31 +11111,31 @@ Subprograms:
       DictRegister: 0
     - ID: 186
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x8055a0..0x805610]
+      OutOfLinePCRanges: [0x8055b0..0x805620]
       InlinePCRanges:
-        - Ranges: [0x80562c..0x805660]
-          RootRanges: [0x805610..0x805680]
-        - Ranges: [0x805760..0x805794]
-          RootRanges: [0x805730..0x8057c0]
-        - Ranges: [0x8057e4..0x805818]
-          RootRanges: [0x8057c0..0x805880]
-        - Ranges: [0x80589c..0x8058d0]
-          RootRanges: [0x805880..0x8058f0]
+        - Ranges: [0x80563c..0x805670]
+          RootRanges: [0x805620..0x805690]
+        - Ranges: [0x805770..0x8057a4]
+          RootRanges: [0x805740..0x8057d0]
+        - Ranges: [0x8057f4..0x805828]
+          RootRanges: [0x8057d0..0x805890]
+        - Ranges: [0x8058ac..0x8058e0]
+          RootRanges: [0x805890..0x805900]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8055a0..0x8055c0
+            - Range: 0x8055b0..0x8055d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80562c..0x805634
+            - Range: 0x80563c..0x805644
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x805760..0x805768
+            - Range: 0x805770..0x805778
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8057dc..0x8057ec
+            - Range: 0x8057ec..0x8057fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8057ec..0x805880
+            - Range: 0x8057fc..0x805890
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x805880..0x8058a4
+            - Range: 0x805890..0x8058b4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11144,37 +11144,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x805824..0x805858]
-          RootRanges: [0x8057c0..0x805880]
+        - Ranges: [0x805834..0x805868]
+          RootRanges: [0x8057d0..0x805890]
       Variables: []
       DictRegister: null
     - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80590c..0x805940, 0x805948..0x80594c]
-          RootRanges: [0x8058f0..0x805a00]
+        - Ranges: [0x80591c..0x805950, 0x805958..0x80595c]
+          RootRanges: [0x805900..0x805a10]
       Variables: []
       DictRegister: null
     - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8059b0..0x8059e4]
-          RootRanges: [0x8058f0..0x805a00]
+        - Ranges: [0x8059c0..0x8059f4]
+          RootRanges: [0x805900..0x805a10]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x805a04..0x805a08]
-          RootRanges: [0x805a00..0x805a10]
+        - Ranges: [0x805a14..0x805a18]
+          RootRanges: [0x805a10..0x805a20]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x805a00..0x805a08
+            - Range: 0x805a10..0x805a18
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11183,32 +11183,32 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x805a34..0x805a50]
-          RootRanges: [0x805a10..0x805a60]
-        - Ranges: [0x805abc..0x805adc]
-          RootRanges: [0x805a60..0x805ba0]
+        - Ranges: [0x805a44..0x805a60]
+          RootRanges: [0x805a20..0x805a70]
+        - Ranges: [0x805acc..0x805aec]
+          RootRanges: [0x805a70..0x805bb0]
       Variables:
         - Name: a
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0x805a20..0x805a60
+            - Range: 0x805a30..0x805a70
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x805aa8..0x805ba0
+            - Range: 0x805ab8..0x805bb0
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 192
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x805ba0..0x805c00]
+      OutOfLinePCRanges: [0x805bb0..0x805c10]
       InlinePCRanges:
-        - Ranges: [0x80cb60..0x80cb84]
-          RootRanges: [0x80cb40..0x80cbb0]
+        - Ranges: [0x80cb70..0x80cb94]
+          RootRanges: [0x80cb50..0x80cbc0]
       Variables:
         - Name: b
           Type: 360 StructureType main.firstBehavior
           Locations:
-            - Range: 0x805ba0..0x805bc4
+            - Range: 0x805bb0..0x805bd4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11219,15 +11219,15 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x805ba0..0x805be0
+            - Range: 0x805bb0..0x805bf0
               Pieces: []
-            - Range: 0x805be0..0x805be1
+            - Range: 0x805bf0..0x805bf1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x805be1..0x805c00
+            - Range: 0x805bf1..0x805c10
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11236,8 +11236,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x806220..0x80622c, 0x806230..0x806238]
-          RootRanges: [0x806100..0x806280]
+        - Ranges: [0x806230..0x80623c, 0x806240..0x806248]
+          RootRanges: [0x806110..0x806290]
         - Ranges: [0x139638..0x13963c, 0x139640..0x139648]
           RootRanges: [0x139630..0x139650]
       Variables: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x80a778", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a888", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1594 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x80a7a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a8b8", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x805ca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x805db8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1433 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x805cd0", Frameless: false}]
+              InjectionPoints: [{PC: "0x805de0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x805d18", Frameless: false}]
+              InjectionPoints: [{PC: "0x805e28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1436 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x805d40", Frameless: false}]
+              InjectionPoints: [{PC: "0x805e50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x80966c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80977c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1565 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x809700", Frameless: false}]
+              InjectionPoints: [{PC: "0x809810", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0x8036f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0x8036b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8037c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0x8036d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8037e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x806360", Frameless: true}]
+              InjectionPoints: [{PC: "0x806470", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0x8036c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8037d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0x8036e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8037f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x807a50", Frameless: true}]
+              InjectionPoints: [{PC: "0x807b60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1467 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x807a8c", Frameless: true}]
+              InjectionPoints: [{PC: "0x807b9c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,7 +267,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x803c40", Frameless: true}]
+              InjectionPoints: [{PC: "0x803d50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -289,7 +289,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0x803600", Frameless: true}]
+              InjectionPoints: [{PC: "0x803710", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -311,7 +311,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0x8035d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8036e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80aa40", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ab50", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -358,15 +358,15 @@ Probes:
             - Kind: Line
               Type: 1668 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x8055c8"
+                - PC: "0x8056d8"
                   Frameless: false
-                - PC: "0x80563c"
+                - PC: "0x80574c"
                   Frameless: false
-                - PC: "0x805770"
+                - PC: "0x805880"
                   Frameless: false
-                - PC: "0x8057f4"
+                - PC: "0x805904"
                   Frameless: false
-                - PC: "0x8058ac"
+                - PC: "0x8059bc"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -388,15 +388,15 @@ Probes:
             - Kind: Line
               Type: 1669 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x8055c8"
+                - PC: "0x8056d8"
                   Frameless: false
-                - PC: "0x80563c"
+                - PC: "0x80574c"
                   Frameless: false
-                - PC: "0x805770"
+                - PC: "0x805880"
                   Frameless: false
-                - PC: "0x8057f4"
+                - PC: "0x805904"
                   Frameless: false
-                - PC: "0x8058ac"
+                - PC: "0x8059bc"
                   Frameless: false
               Condition:
                 Type: 4 BaseType bool
@@ -430,15 +430,15 @@ Probes:
             - Kind: Line
               Type: 1670 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x8055c8"
+                - PC: "0x8056d8"
                   Frameless: false
-                - PC: "0x80563c"
+                - PC: "0x80574c"
                   Frameless: false
-                - PC: "0x805770"
+                - PC: "0x805880"
                   Frameless: false
-                - PC: "0x8057f4"
+                - PC: "0x805904"
                   Frameless: false
-                - PC: "0x8058ac"
+                - PC: "0x8059bc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -466,7 +466,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x8077f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807900", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -485,7 +485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x8077f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -511,7 +511,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x80aab0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80abc0", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -546,7 +546,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x807a90", Frameless: true}]
+              InjectionPoints: [{PC: "0x807ba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -576,7 +576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x8077d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8078e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -605,11 +605,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1529 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x808968", Frameless: false}]
+              InjectionPoints: [{PC: "0x808a78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1530 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x808a0c", Frameless: false}]
+              InjectionPoints: [{PC: "0x808b1c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -631,7 +631,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x807d10", Frameless: true}]
+              InjectionPoints: [{PC: "0x807e20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -653,7 +653,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1407 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x8040a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8041b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -675,7 +675,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x8040b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8041c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -697,7 +697,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x803e10", Frameless: true}]
+              InjectionPoints: [{PC: "0x803f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -719,7 +719,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x803e20", Frameless: true}]
+              InjectionPoints: [{PC: "0x803f30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -741,7 +741,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x803f40", Frameless: true}]
+              InjectionPoints: [{PC: "0x804050", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -763,7 +763,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x803f50", Frameless: true}]
+              InjectionPoints: [{PC: "0x804060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -785,7 +785,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x80a3f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -812,7 +812,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1584 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x80a420", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -840,7 +840,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x80a830", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -862,7 +862,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x80aae0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80abf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -883,7 +883,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x80aaf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ac00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -905,7 +905,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x805cf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x805e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -939,7 +939,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1402 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x803cd0", Frameless: false}]
+              InjectionPoints: [{PC: "0x803de0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -967,11 +967,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x8046a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8047b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x8046e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8047f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -993,11 +993,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x8045ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x8046fc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1415 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x804648", Frameless: false}]
+              InjectionPoints: [{PC: "0x804758", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1019,11 +1019,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x805a10", Frameless: true}]
+              InjectionPoints: [{PC: "0x805b20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1427 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x805a18", Frameless: true}]
+              InjectionPoints: [{PC: "0x805b28", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1045,11 +1045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x805a2c", Frameless: false}]
+              InjectionPoints: [{PC: "0x805b3c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1429 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x805a60", Frameless: false}]
+              InjectionPoints: [{PC: "0x805b70", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1074,7 +1074,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1430 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x805a2c", Frameless: false}]
+              InjectionPoints: [{PC: "0x805b3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1096,11 +1096,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1654 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x80c8c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c9d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1655 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80c8c4", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c9d4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1114,11 +1114,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1656 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x80c8e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c9f0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1657 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x80c914", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ca24", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1141,11 +1141,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1650 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x80c828", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c938", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1651 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x80c838", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c948", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1159,11 +1159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1652 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x80c878", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c988", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1653 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x80c890", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c9a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1186,14 +1186,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1658 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x80c920", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ca30", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1659 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x80c948"
+                - PC: "0x80ca58"
                   Frameless: true
-                - PC: "0x80c950"
+                - PC: "0x80ca60"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1208,14 +1208,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1660 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x80c978", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ca88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1661 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x80c9d8"
+                - PC: "0x80cae8"
                   Frameless: false
-                - PC: "0x80c9e8"
+                - PC: "0x80caf8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1242,7 +1242,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1662 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x80c924", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ca34", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1254,7 +1254,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1663 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x80c988", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ca98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1275,11 +1275,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1638 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x80c5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c6b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1639 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x80c5a4", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c6b4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1293,11 +1293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1640 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x80c620", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c730", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1641 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x80c624", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c734", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1321,11 +1321,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1626 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x80c1ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c2bc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1627 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80c2f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c408", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1367,11 +1367,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1630 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80c348", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c458", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1631 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80c358", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c468", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1394,11 +1394,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1664 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x80ca20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cb30", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1665 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x80ca28", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cb38", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1412,11 +1412,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1666 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x80ca98", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cba8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1667 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x80cabc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cbcc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1439,11 +1439,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1622 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x80c110", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c220", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1623 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80c114", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c224", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1457,11 +1457,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x80c120", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c230", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1625 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80c12c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c23c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1484,11 +1484,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1642 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x80c6a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c7b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1643 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x80c6a8", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c7b8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1502,11 +1502,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1644 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x80c728", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c838", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1645 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x80c750", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c860", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1529,11 +1529,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1632 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x80c570", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c680", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1633 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80c574", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c684", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1547,11 +1547,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1634 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x80c580", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c690", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1635 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x80c584", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c694", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1565,11 +1565,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1636 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x80c590", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c6a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1637 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x80c594", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c6a4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1592,11 +1592,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1646 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x80c7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c8f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1647 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x80c7e8", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c8f8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1610,11 +1610,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1648 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80c7f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c900", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1649 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80c800", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c910", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1637,11 +1637,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1618 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x80c0f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c200", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1619 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80c0f4", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c204", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1655,11 +1655,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1620 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x80c100", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c210", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1621 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80c10c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c21c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1682,11 +1682,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x805758", Frameless: false}]
+              InjectionPoints: [{PC: "0x805868", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1419 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x8057a4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8058b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1713,11 +1713,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x8057e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8058f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1421 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x805868", Frameless: false}]
+              InjectionPoints: [{PC: "0x805978", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1744,11 +1744,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x8058a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8059b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1423 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x8058e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8059f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1770,7 +1770,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1674 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x805834", Frameless: false}]
+              InjectionPoints: [{PC: "0x805944", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1788,11 +1788,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1424 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x805918", Frameless: false}]
+              InjectionPoints: [{PC: "0x805a28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1425 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x8059f4", Frameless: false}]
+              InjectionPoints: [{PC: "0x805b04", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1810,7 +1810,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1675 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x80591c", Frameless: false}]
+              InjectionPoints: [{PC: "0x805a2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1831,7 +1831,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1676 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x80591c", Frameless: false}]
+              InjectionPoints: [{PC: "0x805a2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1849,7 +1849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1677 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x8059c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x805ad0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1870,7 +1870,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1678 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x8059c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x805ad0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1891,7 +1891,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x139638"
                   Frameless: true
-                - PC: "0x806230"
+                - PC: "0x806344"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1912,20 +1912,20 @@ Probes:
             - Kind: Entry
               Type: 1671 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x8055c8"
+                - PC: "0x8056d8"
                   Frameless: false
-                - PC: "0x80563c"
+                - PC: "0x80574c"
                   Frameless: false
-                - PC: "0x805770"
+                - PC: "0x805880"
                   Frameless: false
-                - PC: "0x8057f4"
+                - PC: "0x805904"
                   Frameless: false
-                - PC: "0x8058ac"
+                - PC: "0x8059bc"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1672 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x8055fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80570c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1951,15 +1951,15 @@ Probes:
             - Kind: Line
               Type: 1673 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x8055c8"
+                - PC: "0x8056d8"
                   Frameless: false
-                - PC: "0x80563c"
+                - PC: "0x80574c"
                   Frameless: false
-                - PC: "0x805770"
+                - PC: "0x805880"
                   Frameless: false
-                - PC: "0x8057f4"
+                - PC: "0x805904"
                   Frameless: false
-                - PC: "0x8058ac"
+                - PC: "0x8059bc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1982,7 +1982,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1679 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x805a14", Frameless: true}]
+              InjectionPoints: [{PC: "0x805b24", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2007,7 +2007,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1680 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x805a14", Frameless: true}]
+              InjectionPoints: [{PC: "0x805b24", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2031,9 +2031,9 @@ Probes:
             - Kind: Entry
               Type: 1681 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x805a44"
+                - PC: "0x805b54"
                   Frameless: false
-                - PC: "0x805acc"
+                - PC: "0x805bdc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2056,7 +2056,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0x803630", Frameless: true}]
+              InjectionPoints: [{PC: "0x803740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2078,7 +2078,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0x803640", Frameless: true}]
+              InjectionPoints: [{PC: "0x803750", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2100,7 +2100,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0x803650", Frameless: true}]
+              InjectionPoints: [{PC: "0x803760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2122,7 +2122,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0x803620", Frameless: true}]
+              InjectionPoints: [{PC: "0x803730", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2144,7 +2144,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0x803610", Frameless: true}]
+              InjectionPoints: [{PC: "0x803720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2166,7 +2166,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x805c80", Frameless: true}]
+              InjectionPoints: [{PC: "0x805d90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2187,11 +2187,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x8094e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8095f0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1563 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x809610", Frameless: false}]
+              InjectionPoints: [{PC: "0x809720", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2213,7 +2213,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x807c20", Frameless: true}]
+              InjectionPoints: [{PC: "0x807d30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2238,7 +2238,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1411 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x8040fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80420c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2260,7 +2260,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1412 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x80419c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8042ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2282,7 +2282,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1413 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x804240", Frameless: false}]
+              InjectionPoints: [{PC: "0x804350", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2325,11 +2325,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x80994c", Frameless: false}]
+              InjectionPoints: [{PC: "0x809a5c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1569 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x809aa0", Frameless: false}]
+              InjectionPoints: [{PC: "0x809bb0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2391,7 +2391,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x806340", Frameless: true}]
+              InjectionPoints: [{PC: "0x806450", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2413,7 +2413,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x8063a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8064b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2435,7 +2435,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x806440", Frameless: true}]
+              InjectionPoints: [{PC: "0x806550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2457,7 +2457,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x806460", Frameless: true}]
+              InjectionPoints: [{PC: "0x806570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2479,7 +2479,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x806450", Frameless: true}]
+              InjectionPoints: [{PC: "0x806560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2501,7 +2501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x806380", Frameless: true}]
+              InjectionPoints: [{PC: "0x806490", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2523,7 +2523,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x806430", Frameless: true}]
+              InjectionPoints: [{PC: "0x806540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2545,7 +2545,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x806420", Frameless: true}]
+              InjectionPoints: [{PC: "0x806530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2569,7 +2569,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x806390", Frameless: true}]
+              InjectionPoints: [{PC: "0x8064a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2593,7 +2593,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x806390", Frameless: true}]
+              InjectionPoints: [{PC: "0x8064a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2615,7 +2615,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x806410", Frameless: true}]
+              InjectionPoints: [{PC: "0x806520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2637,7 +2637,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x806400", Frameless: true}]
+              InjectionPoints: [{PC: "0x806510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2659,7 +2659,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x806320", Frameless: true}]
+              InjectionPoints: [{PC: "0x806430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2681,7 +2681,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x806330", Frameless: true}]
+              InjectionPoints: [{PC: "0x806440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2703,7 +2703,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x806310", Frameless: true}]
+              InjectionPoints: [{PC: "0x806420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2725,7 +2725,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8064c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2747,7 +2747,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x8063e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8064f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2769,7 +2769,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x8063f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2791,7 +2791,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x8063c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8064d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2815,7 +2815,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x8063d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8064e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2837,7 +2837,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80a810", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2860,7 +2860,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80a810", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2907,11 +2907,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x809b00", Frameless: false}]
+              InjectionPoints: [{PC: "0x809c10", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1571 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x809c8c", Frameless: false}]
+              InjectionPoints: [{PC: "0x809d9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2977,11 +2977,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x809d7c", Frameless: false}]
+              InjectionPoints: [{PC: "0x809e8c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1575 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x809e18", Frameless: false}]
+              InjectionPoints: [{PC: "0x809f28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3012,11 +3012,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x809740", Frameless: false}]
+              InjectionPoints: [{PC: "0x809850", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1567 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x8098e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8099f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3042,11 +3042,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1507 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1508 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80897c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3082,7 +3082,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x8078b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8079c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3123,11 +3123,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1501 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x808748", Frameless: false}]
+              InjectionPoints: [{PC: "0x808858", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1502 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x8087a4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3151,11 +3151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1503 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x808748", Frameless: false}]
+              InjectionPoints: [{PC: "0x808858", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1504 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x8087a4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088b4", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3174,11 +3174,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1509 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1510 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80897c", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3198,11 +3198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1511 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1512 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80897c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3235,11 +3235,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1505 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x808748", Frameless: false}]
+              InjectionPoints: [{PC: "0x808858", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1506 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x8087a4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3267,7 +3267,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80abb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3292,7 +3292,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80abb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3323,7 +3323,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80abb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3348,7 +3348,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80abb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3375,7 +3375,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x807cf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3402,7 +3402,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x80a460", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3429,7 +3429,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x80a430", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3464,7 +3464,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x80a450", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3496,7 +3496,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1601 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x80a800", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a910", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3518,7 +3518,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x807c30", Frameless: true}]
+              InjectionPoints: [{PC: "0x807d40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3540,7 +3540,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x806370", Frameless: true}]
+              InjectionPoints: [{PC: "0x806480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3562,7 +3562,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x807c10", Frameless: true}]
+              InjectionPoints: [{PC: "0x807d20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3586,11 +3586,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x808028", Frameless: false}]
+              InjectionPoints: [{PC: "0x808138", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1478 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x808068", Frameless: false}]
+              InjectionPoints: [{PC: "0x808178", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3610,11 +3610,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1521 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x8088a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8089b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1522 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x808930", Frameless: false}]
+              InjectionPoints: [{PC: "0x808a40", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3655,11 +3655,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1487 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x808148", Frameless: false}]
+              InjectionPoints: [{PC: "0x808258", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1488 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x8081d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8082e8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3697,11 +3697,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x808028", Frameless: false}]
+              InjectionPoints: [{PC: "0x808138", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1480 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x808068", Frameless: false}]
+              InjectionPoints: [{PC: "0x808178", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3742,11 +3742,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1489 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x808148", Frameless: false}]
+              InjectionPoints: [{PC: "0x808258", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1490 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x8081d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8082e8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -3786,11 +3786,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1523 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x8088a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8089b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1524 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x808930", Frameless: false}]
+              InjectionPoints: [{PC: "0x808a40", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3807,11 +3807,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1525 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x8088a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8089b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1526 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x808930", Frameless: false}]
+              InjectionPoints: [{PC: "0x808a40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3833,11 +3833,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x808028", Frameless: false}]
+              InjectionPoints: [{PC: "0x808138", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1482 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x808068", Frameless: false}]
+              InjectionPoints: [{PC: "0x808178", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3860,18 +3860,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1497 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x808418", Frameless: false}]
+              InjectionPoints: [{PC: "0x808528", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1498 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x8084a0"
+                - PC: "0x8085b0"
                   Frameless: false
-                - PC: "0x8084f4"
+                - PC: "0x808604"
                   Frameless: false
-                - PC: "0x8085ac"
+                - PC: "0x8086bc"
                   Frameless: false
-                - PC: "0x8085c0"
+                - PC: "0x8086d0"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3899,18 +3899,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1495 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x808298", Frameless: false}]
+              InjectionPoints: [{PC: "0x8083a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1496 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x8082ec"
+                - PC: "0x8083fc"
                   Frameless: false
-                - PC: "0x808348"
+                - PC: "0x808458"
                   Frameless: false
-                - PC: "0x808390"
+                - PC: "0x8084a0"
                   Frameless: false
-                - PC: "0x8083d4"
+                - PC: "0x8084e4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3937,11 +3937,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1540 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x808f1c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80902c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1541 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x808f6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80907c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3958,11 +3958,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1542 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x808fa8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8090b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1543 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x808fe0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8090f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3979,11 +3979,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1544 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x809018", Frameless: false}]
+              InjectionPoints: [{PC: "0x809128", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1545 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x80904c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80915c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4000,11 +4000,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x809108", Frameless: false}]
+              InjectionPoints: [{PC: "0x809218", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1549 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x809168", Frameless: false}]
+              InjectionPoints: [{PC: "0x809278", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4021,11 +4021,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x809468", Frameless: false}]
+              InjectionPoints: [{PC: "0x809578", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1561 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x8094a4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8095b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4042,11 +4042,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x808dd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x808ee8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x808e20", Frameless: false}]
+              InjectionPoints: [{PC: "0x808f30", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4064,14 +4064,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x808218", Frameless: false}]
+              InjectionPoints: [{PC: "0x808328", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1494 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x80824c"
+                - PC: "0x80835c"
                   Frameless: false
-                - PC: "0x808260"
+                - PC: "0x808370"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4093,11 +4093,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x808028", Frameless: false}]
+              InjectionPoints: [{PC: "0x808138", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1484 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x808068", Frameless: false}]
+              InjectionPoints: [{PC: "0x808178", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4118,11 +4118,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1491 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x808148", Frameless: false}]
+              InjectionPoints: [{PC: "0x808258", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1492 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x8081d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8082e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4143,11 +4143,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1485 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x8080a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8081b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1486 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x808104", Frameless: false}]
+              InjectionPoints: [{PC: "0x808214", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4169,14 +4169,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1499 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x8085f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x808708", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1500 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x8086b0"
+                - PC: "0x8087c0"
                   Frameless: false
-                - PC: "0x8086c4"
+                - PC: "0x8087d4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4198,11 +4198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x808e60", Frameless: false}]
+              InjectionPoints: [{PC: "0x808f70", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1539 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x808ee0", Frameless: false}]
+              InjectionPoints: [{PC: "0x808ff0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4219,11 +4219,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x808d28", Frameless: false}]
+              InjectionPoints: [{PC: "0x808e38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x808da8", Frameless: false}]
+              InjectionPoints: [{PC: "0x808eb8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4240,11 +4240,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1552 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x809268", Frameless: false}]
+              InjectionPoints: [{PC: "0x809378", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1553 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x8092bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8093cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4261,11 +4261,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x809088", Frameless: false}]
+              InjectionPoints: [{PC: "0x809198", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1547 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x8090cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8091dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4282,11 +4282,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x8093f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x809508", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1559 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x809438", Frameless: false}]
+              InjectionPoints: [{PC: "0x809548", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4306,7 +4306,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1531 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x808af4", Frameless: false}]
+              InjectionPoints: [{PC: "0x808c04", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x809388", Frameless: false}]
+              InjectionPoints: [{PC: "0x809498", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1557 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x8093c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8094d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x808c98", Frameless: false}]
+              InjectionPoints: [{PC: "0x808da8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x808cec", Frameless: false}]
+              InjectionPoints: [{PC: "0x808dfc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4369,11 +4369,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x8092fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80940c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1555 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x80934c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80945c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4390,11 +4390,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1550 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x8091a0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8092b0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1551 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x809230", Frameless: false}]
+              InjectionPoints: [{PC: "0x809340", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4412,7 +4412,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0x8035e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8036f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4447,11 +4447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1513 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80897c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4497,7 +4497,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x803a70", Frameless: true}]
+              InjectionPoints: [{PC: "0x803b80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4519,7 +4519,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x803a50", Frameless: true}]
+              InjectionPoints: [{PC: "0x803b60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4541,7 +4541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x803b20", Frameless: true}]
+              InjectionPoints: [{PC: "0x803c30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4559,7 +4559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x803b30", Frameless: true}]
+              InjectionPoints: [{PC: "0x803c40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4577,7 +4577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x803a80", Frameless: true}]
+              InjectionPoints: [{PC: "0x803b90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4599,7 +4599,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x803aa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803bb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4622,7 +4622,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x803ab0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803bc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4644,7 +4644,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x803ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803bd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4673,7 +4673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x803a90", Frameless: true}]
+              InjectionPoints: [{PC: "0x803ba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4704,7 +4704,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x803a60", Frameless: true}]
+              InjectionPoints: [{PC: "0x803b70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4726,7 +4726,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x80a7c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a8d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4748,7 +4748,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x803ad0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4770,7 +4770,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x803af0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x803b00", Frameless: true}]
+              InjectionPoints: [{PC: "0x803c10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4814,7 +4814,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x803b10", Frameless: true}]
+              InjectionPoints: [{PC: "0x803c20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4836,7 +4836,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x803ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803bf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4858,7 +4858,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x80a480", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4880,7 +4880,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1582 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x80a400", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4902,7 +4902,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x806350", Frameless: true}]
+              InjectionPoints: [{PC: "0x806460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4923,11 +4923,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1527 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x8088a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8089b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x808930", Frameless: false}]
+              InjectionPoints: [{PC: "0x808a40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4948,11 +4948,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1572 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x809ce8", Frameless: false}]
+              InjectionPoints: [{PC: "0x809df8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1573 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x809d44", Frameless: false}]
+              InjectionPoints: [{PC: "0x809e54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4974,7 +4974,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0x8035f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4996,7 +4996,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1474 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x807cd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5018,7 +5018,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1586 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x80a440", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5040,7 +5040,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x8040c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8041d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x8040d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8041e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80aa40", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ab50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5111,7 +5111,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x80a410", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5138,7 +5138,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x805d60", Frameless: true}]
+              InjectionPoints: [{PC: "0x805e70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5159,11 +5159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1576 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x809e4c", Frameless: false}]
+              InjectionPoints: [{PC: "0x809f5c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1577 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x809ed4", Frameless: false}]
+              InjectionPoints: [{PC: "0x809fe4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5185,7 +5185,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x80a9a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80aab0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5206,7 +5206,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x80a990", Frameless: true}]
+              InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5233,7 +5233,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x806300", Frameless: true}]
+              InjectionPoints: [{PC: "0x806410", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5265,7 +5265,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x80a490", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5305,7 +5305,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x80a840", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a950", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5338,11 +5338,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80897c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5363,11 +5363,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80897c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5390,11 +5390,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8087e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8088f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80886c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80897c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5423,7 +5423,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x80a7d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5455,7 +5455,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80a7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a8f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5485,7 +5485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80a7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a8f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5517,7 +5517,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80a7f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5547,7 +5547,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80a7f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5579,7 +5579,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x803b40", Frameless: true}]
+              InjectionPoints: [{PC: "0x803c50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5601,7 +5601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0x803680", Frameless: true}]
+              InjectionPoints: [{PC: "0x803790", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5623,7 +5623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0x803690", Frameless: true}]
+              InjectionPoints: [{PC: "0x8037a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5645,7 +5645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0x8036a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8037b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5667,7 +5667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0x803670", Frameless: true}]
+              InjectionPoints: [{PC: "0x803780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5689,7 +5689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0x803660", Frameless: true}]
+              InjectionPoints: [{PC: "0x803770", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5711,7 +5711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x807c60", Frameless: true}]
+              InjectionPoints: [{PC: "0x807d70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5733,7 +5733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1580 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x80a3e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a4f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5755,7 +5755,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x80a820", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a930", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5777,7 +5777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x807c40", Frameless: true}]
+              InjectionPoints: [{PC: "0x807d50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5799,7 +5799,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0x803710", Frameless: true}]
+              InjectionPoints: [{PC: "0x803820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5821,7 +5821,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80a470", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5843,7 +5843,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80a470", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5866,14 +5866,14 @@ Probes:
             - Kind: Entry
               Type: 1682 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x805bc8"
+                - PC: "0x805cd8"
                   Frameless: false
-                - PC: "0x80cb70"
+                - PC: "0x80cc80"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1683 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x805bf0", Frameless: false}]
+              InjectionPoints: [{PC: "0x805d00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5895,11 +5895,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x809f08", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a018", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1579 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x809f6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a07c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5916,481 +5916,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x8035d0..0x8035e0]
+      OutOfLinePCRanges: [0x8036e0..0x8036f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 ArrayType [2]uint8
           Locations:
-            - Range: 0x8035d0..0x8035e0
+            - Range: 0x8036e0..0x8036f0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x8035e0..0x8035f0]
+      OutOfLinePCRanges: [0x8036f0..0x803700]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]int32
           Locations:
-            - Range: 0x8035e0..0x8035f0
+            - Range: 0x8036f0..0x803700
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x8035f0..0x803600]
+      OutOfLinePCRanges: [0x803700..0x803710]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]string
           Locations:
-            - Range: 0x8035f0..0x803600
+            - Range: 0x803700..0x803710
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x803600..0x803610]
+      OutOfLinePCRanges: [0x803710..0x803720]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 ArrayType [2]bool
           Locations:
-            - Range: 0x803600..0x803610
+            - Range: 0x803710..0x803720
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x803610..0x803620]
+      OutOfLinePCRanges: [0x803720..0x803730]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x803610..0x803620
+            - Range: 0x803720..0x803730
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x803620..0x803630]
+      OutOfLinePCRanges: [0x803730..0x803740]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 120 ArrayType [2]int8
           Locations:
-            - Range: 0x803620..0x803630
+            - Range: 0x803730..0x803740
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x803630..0x803640]
+      OutOfLinePCRanges: [0x803740..0x803750]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 ArrayType [2]int16
           Locations:
-            - Range: 0x803630..0x803640
+            - Range: 0x803740..0x803750
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x803640..0x803650]
+      OutOfLinePCRanges: [0x803750..0x803760]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]int32
           Locations:
-            - Range: 0x803640..0x803650
+            - Range: 0x803750..0x803760
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x803650..0x803660]
+      OutOfLinePCRanges: [0x803760..0x803770]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 122 ArrayType [2]int64
           Locations:
-            - Range: 0x803650..0x803660
+            - Range: 0x803760..0x803770
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x803660..0x803670]
+      OutOfLinePCRanges: [0x803770..0x803780]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 123 ArrayType [2]uint
           Locations:
-            - Range: 0x803660..0x803670
+            - Range: 0x803770..0x803780
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x803670..0x803680]
+      OutOfLinePCRanges: [0x803780..0x803790]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 ArrayType [2]uint8
           Locations:
-            - Range: 0x803670..0x803680
+            - Range: 0x803780..0x803790
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x803680..0x803690]
+      OutOfLinePCRanges: [0x803790..0x8037a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 124 ArrayType [2]uint16
           Locations:
-            - Range: 0x803680..0x803690
+            - Range: 0x803790..0x8037a0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x803690..0x8036a0]
+      OutOfLinePCRanges: [0x8037a0..0x8037b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 125 ArrayType [2]uint32
           Locations:
-            - Range: 0x803690..0x8036a0
+            - Range: 0x8037a0..0x8037b0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x8036a0..0x8036b0]
+      OutOfLinePCRanges: [0x8037b0..0x8037c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 58 ArrayType [2]uint64
           Locations:
-            - Range: 0x8036a0..0x8036b0
+            - Range: 0x8037b0..0x8037c0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x8036b0..0x8036c0]
+      OutOfLinePCRanges: [0x8037c0..0x8037d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 126 ArrayType [2][2]int
           Locations:
-            - Range: 0x8036b0..0x8036c0
+            - Range: 0x8037c0..0x8037d0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x8036c0..0x8036d0]
+      OutOfLinePCRanges: [0x8037d0..0x8037e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 117 ArrayType [2]string
           Locations:
-            - Range: 0x8036c0..0x8036d0
+            - Range: 0x8037d0..0x8037e0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x8036d0..0x8036e0]
+      OutOfLinePCRanges: [0x8037e0..0x8037f0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 127 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x8036d0..0x8036e0
+            - Range: 0x8037e0..0x8037f0
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0x8036e0..0x8036f0]
+      OutOfLinePCRanges: [0x8037f0..0x803800]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 128 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0x8036e0..0x8036f0
+            - Range: 0x8037f0..0x803800
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0x8036f0..0x803700]
+      OutOfLinePCRanges: [0x803800..0x803810]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 130 ArrayType [2]struct {}
           Locations:
-            - Range: 0x8036f0..0x803700
+            - Range: 0x803800..0x803810
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x803710..0x803720]
+      OutOfLinePCRanges: [0x803820..0x803830]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 132 ArrayType [100]uint
           Locations:
-            - Range: 0x803710..0x803720
+            - Range: 0x803820..0x803830
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x803a50..0x803a60]
+      OutOfLinePCRanges: [0x803b60..0x803b70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x803a50..0x803a60
+            - Range: 0x803b60..0x803b70
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x803a60..0x803a70]
+      OutOfLinePCRanges: [0x803b70..0x803b80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x803a60..0x803a70
+            - Range: 0x803b70..0x803b80
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x803a70..0x803a80]
+      OutOfLinePCRanges: [0x803b80..0x803b90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x803a70..0x803a80
+            - Range: 0x803b80..0x803b90
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x803a80..0x803a90]
+      OutOfLinePCRanges: [0x803b90..0x803ba0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x803a80..0x803a90
+            - Range: 0x803b90..0x803ba0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x803a90..0x803aa0]
+      OutOfLinePCRanges: [0x803ba0..0x803bb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x803a90..0x803aa0
+            - Range: 0x803ba0..0x803bb0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x803aa0..0x803ab0]
+      OutOfLinePCRanges: [0x803bb0..0x803bc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 102 BaseType int16
           Locations:
-            - Range: 0x803aa0..0x803ab0
+            - Range: 0x803bb0..0x803bc0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x803ab0..0x803ac0]
+      OutOfLinePCRanges: [0x803bc0..0x803bd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x803ab0..0x803ac0
+            - Range: 0x803bc0..0x803bd0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x803ac0..0x803ad0]
+      OutOfLinePCRanges: [0x803bd0..0x803be0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x803ac0..0x803ad0
+            - Range: 0x803bd0..0x803be0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x803ad0..0x803ae0]
+      OutOfLinePCRanges: [0x803be0..0x803bf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x803ad0..0x803ae0
+            - Range: 0x803be0..0x803bf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x803ae0..0x803af0]
+      OutOfLinePCRanges: [0x803bf0..0x803c00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x803ae0..0x803af0
+            - Range: 0x803bf0..0x803c00
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x803af0..0x803b00]
+      OutOfLinePCRanges: [0x803c00..0x803c10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x803af0..0x803b00
+            - Range: 0x803c00..0x803c10
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x803b00..0x803b10]
+      OutOfLinePCRanges: [0x803c10..0x803c20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x803b00..0x803b10
+            - Range: 0x803c10..0x803c20
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x803b10..0x803b20]
+      OutOfLinePCRanges: [0x803c20..0x803c30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x803b10..0x803b20
+            - Range: 0x803c20..0x803c30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x803b20..0x803b30]
+      OutOfLinePCRanges: [0x803c30..0x803c40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x803b20..0x803b30
+            - Range: 0x803c30..0x803c40
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x803b30..0x803b40]
+      OutOfLinePCRanges: [0x803c40..0x803c50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType float64
           Locations:
-            - Range: 0x803b30..0x803b40
+            - Range: 0x803c40..0x803c50
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x803b40..0x803b50]
+      OutOfLinePCRanges: [0x803c50..0x803c60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 133 BaseType main.typeAlias
           Locations:
-            - Range: 0x803b40..0x803b50
+            - Range: 0x803c50..0x803c60
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x803c40..0x803c50]
+      OutOfLinePCRanges: [0x803d50..0x803d60]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 134 StructureType main.bigStruct
           Locations:
-            - Range: 0x803c40..0x803c50
+            - Range: 0x803d50..0x803d60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6409,42 +6409,42 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x803c70..0x803d80]
+      OutOfLinePCRanges: [0x803d80..0x803e90]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x803c70..0x803c90
+            - Range: 0x803d80..0x803da0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x803c70..0x803d80, Pieces: []}]
+          Locations: [{Range: 0x803d80..0x803e90, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
-          Locations: [{Range: 0x803c70..0x803d80, Pieces: []}]
+          Locations: [{Range: 0x803d80..0x803e90, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x803c88..0x803ccc
+            - Range: 0x803d98..0x803ddc
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x803ccc..0x803d2c
+            - Range: 0x803ddc..0x803e3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x803d2c..0x803d80
+            - Range: 0x803e3c..0x803e90
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
@@ -6455,39 +6455,39 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x803e10..0x803e20]
+      OutOfLinePCRanges: [0x803f20..0x803f30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 138 StructureType main.deepPtr1
           Locations:
-            - Range: 0x803e10..0x803e20
+            - Range: 0x803f20..0x803f30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x803e20..0x803e30]
+      OutOfLinePCRanges: [0x803f30..0x803f40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 141 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x803e20..0x803e30
+            - Range: 0x803f30..0x803f40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x803f40..0x803f50]
+      OutOfLinePCRanges: [0x804050..0x804060]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 143 StructureType main.deepSlice1
           Locations:
-            - Range: 0x803f40..0x803f50
+            - Range: 0x804050..0x804060
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6500,121 +6500,121 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x803f50..0x803f60]
+      OutOfLinePCRanges: [0x804060..0x804070]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 147 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x803f50..0x803f60
+            - Range: 0x804060..0x804070
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x8040a0..0x8040b0]
+      OutOfLinePCRanges: [0x8041b0..0x8041c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 StructureType main.deepMap1
           Locations:
-            - Range: 0x8040a0..0x8040b0
+            - Range: 0x8041b0..0x8041c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x8040b0..0x8040c0]
+      OutOfLinePCRanges: [0x8041c0..0x8041d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 155 PointerType *main.deepMap7
           Locations:
-            - Range: 0x8040b0..0x8040c0
+            - Range: 0x8041c0..0x8041d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x8040c0..0x8040d0]
+      OutOfLinePCRanges: [0x8041d0..0x8041e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 157 PointerType *main.stringType1
           Locations:
-            - Range: 0x8040c0..0x8040d0
+            - Range: 0x8041d0..0x8041e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x8040d0..0x8040e0]
+      OutOfLinePCRanges: [0x8041e0..0x8041f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 159 PointerType **main.stringType2
           Locations:
-            - Range: 0x8040d0..0x8040e0
+            - Range: 0x8041e0..0x8041f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x8040e0..0x8042c0]
+      OutOfLinePCRanges: [0x8041f0..0x8043d0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80419c..0x8041b0
+            - Range: 0x8042ac..0x8042c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x804240..0x804254
+            - Range: 0x804350..0x804364
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 7 BaseType int
           Locations:
-            - Range: 0x804100..0x8042c0
+            - Range: 0x804210..0x8043d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80417c..0x804188
+            - Range: 0x80428c..0x804298
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x804188..0x804188
+            - Range: 0x804298..0x804298
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x804188..0x80419c
+            - Range: 0x804298..0x8042ac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80419c..0x804234
+            - Range: 0x8042ac..0x804344
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x804234..0x804238
+            - Range: 0x804344..0x804348
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x804238..0x80423c
+            - Range: 0x804348..0x80434c
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x80423c..0x804254
+            - Range: 0x80434c..0x804364
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x804254..0x8042c0
+            - Range: 0x804364..0x8043d0
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x8045d0..0x804690]
+      OutOfLinePCRanges: [0x8046e0..0x8047a0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 161 StructureType main.esotericStack
           Locations:
-            - Range: 0x8045d0..0x804608
+            - Range: 0x8046e0..0x804718
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6634,7 +6634,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x804608..0x80460c
+            - Range: 0x804718..0x80471c
               Pieces:
                 - Size: 4
                   Op: null
@@ -6654,7 +6654,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x80460c..0x804610
+            - Range: 0x80471c..0x804720
               Pieces:
                 - Size: 4
                   Op: null
@@ -6679,153 +6679,153 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x804690..0x804700]
+      OutOfLinePCRanges: [0x8047a0..0x804810]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 165 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x804690..0x8046c4
+            - Range: 0x8047a0..0x8047d4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 50
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x805740..0x8057d0]
+      OutOfLinePCRanges: [0x805850..0x8058e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x805740..0x805770
+            - Range: 0x805850..0x805880
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 51
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x8057d0..0x805890]
+      OutOfLinePCRanges: [0x8058e0..0x8059a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8057d0..0x8057ec
+            - Range: 0x8058e0..0x8058fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8057d0..0x8057fc
+            - Range: 0x8058e0..0x80590c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8057ec..0x8057fc
+            - Range: 0x8058fc..0x80590c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8057fc..0x805890
+            - Range: 0x80590c..0x8059a0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x805890..0x805900]
+      OutOfLinePCRanges: [0x8059a0..0x805a10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x805890..0x8058b4
+            - Range: 0x8059a0..0x8059c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x805900..0x805a10]
+      OutOfLinePCRanges: [0x805a10..0x805b20]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80591c..0x805988
+            - Range: 0x805a2c..0x805a98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x805988..0x805990
+            - Range: 0x805a98..0x805aa0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80591c..0x805988
+            - Range: 0x805a2c..0x805a98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x805988..0x80598c
+            - Range: 0x805a98..0x805a9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x805a10..0x805a20]
+      OutOfLinePCRanges: [0x805b20..0x805b30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x805a10..0x805a18
+            - Range: 0x805b20..0x805b28
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x805a10..0x805a18
+            - Range: 0x805b20..0x805b28
               Pieces: []
-            - Range: 0x805a18..0x805a19
+            - Range: 0x805b28..0x805b29
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x805a19..0x805a20
+            - Range: 0x805b29..0x805b30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x805a20..0x805a70]
+      OutOfLinePCRanges: [0x805b30..0x805b80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0x805a20..0x805a70
+            - Range: 0x805b30..0x805b80
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x805a20..0x805a60
+            - Range: 0x805b30..0x805b70
               Pieces: []
-            - Range: 0x805a60..0x805a61
+            - Range: 0x805b70..0x805b71
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x805a61..0x805a70
+            - Range: 0x805b71..0x805b80
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testInterface
-      OutOfLinePCRanges: [0x805c80..0x805c90]
+      OutOfLinePCRanges: [0x805d90..0x805da0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x805c80..0x805c90
+            - Range: 0x805d90..0x805da0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6836,19 +6836,19 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testAny
-      OutOfLinePCRanges: [0x805c90..0x805cf0]
+      OutOfLinePCRanges: [0x805da0..0x805e00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x805c90..0x805cbc
+            - Range: 0x805da0..0x805dcc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x805cbc..0x805cc0
+            - Range: 0x805dcc..0x805dd0
               Pieces:
                 - Size: 8
                   Op: null
@@ -6859,28 +6859,28 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x805c90..0x805cd0
+            - Range: 0x805da0..0x805de0
               Pieces: []
-            - Range: 0x805cd0..0x805cd1
+            - Range: 0x805de0..0x805de1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x805cd1..0x805cf0
+            - Range: 0x805de1..0x805e00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testError
-      OutOfLinePCRanges: [0x805cf0..0x805d00]
+      OutOfLinePCRanges: [0x805e00..0x805e10]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x805cf0..0x805d00
+            - Range: 0x805e00..0x805e10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6891,41 +6891,41 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x805d00..0x805d60]
+      OutOfLinePCRanges: [0x805e10..0x805e70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 169 PointerType *interface {}
           Locations:
-            - Range: 0x805d00..0x805d2c
+            - Range: 0x805e10..0x805e3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x805d00..0x805d40
+            - Range: 0x805e10..0x805e50
               Pieces: []
-            - Range: 0x805d40..0x805d41
+            - Range: 0x805e50..0x805e51
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x805d41..0x805d60
+            - Range: 0x805e51..0x805e70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x805d60..0x805d70]
+      OutOfLinePCRanges: [0x805e70..0x805e80]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 170 StructureType main.structWithAny
           Locations:
-            - Range: 0x805d60..0x805d70
+            - Range: 0x805e70..0x805e80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6936,346 +6936,346 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x806300..0x806310]
+      OutOfLinePCRanges: [0x806410..0x806420]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 171 StructureType main.structWithMap
-          Locations:
-            - Range: 0x806300..0x806310
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x806310..0x806320]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 177 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x806310..0x806320
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 63
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x806320..0x806330]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 182 GoMapType map[string]int
-          Locations:
-            - Range: 0x806320..0x806330
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x806330..0x806340]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 187 GoMapType map[string][]string
-          Locations:
-            - Range: 0x806330..0x806340
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x806340..0x806350]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 192 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0x806340..0x806350
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 66
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0x806350..0x806360]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 182 GoMapType map[string]int
-          Locations:
-            - Range: 0x806350..0x806360
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x806360..0x806370]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 197 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0x806360..0x806370
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x806370..0x806380]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 198 PointerType *map[string]int
-          Locations:
-            - Range: 0x806370..0x806380
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x806380..0x806390]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 172 GoMapType map[int]int
-          Locations:
-            - Range: 0x806380..0x806390
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0x806390..0x8063a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 199 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x806390..0x8063a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 71
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x8063a0..0x8063b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 199 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x8063a0..0x8063b0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 72
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x8063b0..0x8063c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 204 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0x8063b0..0x8063c0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 73
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x8063c0..0x8063d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 209 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x8063c0..0x8063d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 74
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x8063d0..0x8063e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 209 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x8063d0..0x8063e0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x8063e0..0x8063f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 214 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x8063e0..0x8063f0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x8063f0..0x806400]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 214 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x8063f0..0x806400
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 77
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x806400..0x806410]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 214 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x806400..0x806410
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 78
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x806410..0x806420]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 219 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x806410..0x806420
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapLargeKeySmallValue
+    - ID: 62
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x806420..0x806430]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 224 GoMapType map[[4]int]uint8
+          Type: 177 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x806420..0x806430
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 63
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x806430..0x806440]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 229 GoMapType map[[4]int][4]int
+          Type: 182 GoMapType map[string]int
           Locations:
             - Range: 0x806430..0x806440
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapEmptyKey
+    - ID: 64
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x806440..0x806450]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 234 GoMapType map[struct {}]int
+          Type: 187 GoMapType map[string][]string
           Locations:
             - Range: 0x806440..0x806450
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapEmptyValue
+    - ID: 65
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x806450..0x806460]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 239 GoMapType map[int]struct {}
+          Type: 192 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x806450..0x806460
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 66
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0x806460..0x806470]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 244 GoMapType map[struct {}]struct {}
+          Type: 182 GoMapType map[string]int
           Locations:
             - Range: 0x806460..0x806470
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 67
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x806470..0x806480]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 197 ArrayType [2]map[string]int
+          Locations:
+            - Range: 0x806470..0x806480
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 68
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x806480..0x806490]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 198 PointerType *map[string]int
+          Locations:
+            - Range: 0x806480..0x806490
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 69
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x806490..0x8064a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 172 GoMapType map[int]int
+          Locations:
+            - Range: 0x806490..0x8064a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 70
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x8064a0..0x8064b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 199 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x8064a0..0x8064b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 71
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x8064b0..0x8064c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 199 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x8064b0..0x8064c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 72
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x8064c0..0x8064d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 204 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0x8064c0..0x8064d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x8064d0..0x8064e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 209 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x8064d0..0x8064e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x8064e0..0x8064f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 209 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x8064e0..0x8064f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 75
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x8064f0..0x806500]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 214 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x8064f0..0x806500
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 76
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x806500..0x806510]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 214 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x806500..0x806510
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 77
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x806510..0x806520]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 214 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x806510..0x806520
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 78
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x806520..0x806530]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 219 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x806520..0x806530
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 79
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x806530..0x806540]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 224 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x806530..0x806540
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 80
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x806540..0x806550]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 229 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x806540..0x806550
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 81
+      Name: main.testMapEmptyKey
+      OutOfLinePCRanges: [0x806550..0x806560]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 234 GoMapType map[struct {}]int
+          Locations:
+            - Range: 0x806550..0x806560
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 82
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0x806560..0x806570]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 239 GoMapType map[int]struct {}
+          Locations:
+            - Range: 0x806560..0x806570
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x806570..0x806580]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 244 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x806570..0x806580
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 84
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x8077d0..0x8077e0]
+      OutOfLinePCRanges: [0x8078e0..0x8078f0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8077d0..0x8077e0
+            - Range: 0x8078e0..0x8078f0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8077d0..0x8077e0
+            - Range: 0x8078e0..0x8078f0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x8077d0..0x8077e0
+            - Range: 0x8078e0..0x8078f0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x8077f0..0x807800]
+      OutOfLinePCRanges: [0x807900..0x807910]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8077f0..0x807800
+            - Range: 0x807900..0x807910
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8077f0..0x807800
+            - Range: 0x807900..0x807910
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7286,48 +7286,48 @@ Subprograms:
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x8077f0..0x807800
+            - Range: 0x807900..0x807910
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x8078b0..0x8078c0]
+      OutOfLinePCRanges: [0x8079c0..0x8079d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8078b0..0x8078c0
+            - Range: 0x8079c0..0x8079d0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8078b0..0x8078c0
+            - Range: 0x8079c0..0x8079d0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x8078b0..0x8078c0
+            - Range: 0x8079c0..0x8079d0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x8078b0..0x8078c0
+            - Range: 0x8079c0..0x8079d0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8078b0..0x8078c0
+            - Range: 0x8079c0..0x8079d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7338,63 +7338,63 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x807a50..0x807a90]
+      OutOfLinePCRanges: [0x807b60..0x807ba0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x807a50..0x807a8c
+            - Range: 0x807b60..0x807b9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x807a50..0x807a8c
+            - Range: 0x807b60..0x807b9c
               Pieces: []
-            - Range: 0x807a8c..0x807a8d
+            - Range: 0x807b9c..0x807b9d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807a8d..0x807a90
+            - Range: 0x807b9d..0x807ba0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testChannel
-      OutOfLinePCRanges: [0x807a90..0x807aa0]
+      OutOfLinePCRanges: [0x807ba0..0x807bb0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 249 GoChannelType chan bool
           Locations:
-            - Range: 0x807a90..0x807aa0
+            - Range: 0x807ba0..0x807bb0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x807c10..0x807c20]
+      OutOfLinePCRanges: [0x807d20..0x807d30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 250 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x807c10..0x807c20
+            - Range: 0x807d20..0x807d30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x807c20..0x807c30]
+      OutOfLinePCRanges: [0x807d30..0x807d40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 StructureType main.node
           Locations:
-            - Range: 0x807c20..0x807c30
+            - Range: 0x807d30..0x807d40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7405,267 +7405,267 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x807c30..0x807c40]
+      OutOfLinePCRanges: [0x807d40..0x807d50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 PointerType *main.node
           Locations:
-            - Range: 0x807c30..0x807c40
+            - Range: 0x807d40..0x807d50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x807c40..0x807c50]
+      OutOfLinePCRanges: [0x807d50..0x807d60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x807c40..0x807c50
+            - Range: 0x807d50..0x807d60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 93
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x807c60..0x807c70]
+      OutOfLinePCRanges: [0x807d70..0x807d80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 PointerType *uint
           Locations:
-            - Range: 0x807c60..0x807c70
+            - Range: 0x807d70..0x807d80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x807cd0..0x807ce0]
+      OutOfLinePCRanges: [0x807de0..0x807df0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 101 PointerType *string
           Locations:
-            - Range: 0x807cd0..0x807ce0
+            - Range: 0x807de0..0x807df0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 95
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x807cf0..0x807d00]
+      OutOfLinePCRanges: [0x807e00..0x807e10]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 10 PointerType *bool
           Locations:
-            - Range: 0x807cf0..0x807d00
+            - Range: 0x807e00..0x807e10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x807cf0..0x807d00
+            - Range: 0x807e00..0x807e10
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testCycle
-      OutOfLinePCRanges: [0x807d10..0x807d20]
+      OutOfLinePCRanges: [0x807e20..0x807e30]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 254 PointerType *main.t
           Locations:
-            - Range: 0x807d10..0x807d20
+            - Range: 0x807e20..0x807e30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x808010..0x808090]
+      OutOfLinePCRanges: [0x808120..0x8081a0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808010..0x80802c
+            - Range: 0x808120..0x80813c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808010..0x808068
+            - Range: 0x808120..0x808178
               Pieces: []
-            - Range: 0x808068..0x808069
+            - Range: 0x808178..0x808179
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808069..0x808090
+            - Range: 0x808179..0x8081a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80802c..0x808038
+            - Range: 0x80813c..0x808148
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808038..0x808090
+            - Range: 0x808148..0x8081a0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x808090..0x808130]
+      OutOfLinePCRanges: [0x8081a0..0x808240]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808090..0x8080b4
+            - Range: 0x8081a0..0x8081c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8080b4..0x808130
+            - Range: 0x8081c4..0x808240
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 105 PointerType *int
           Locations:
-            - Range: 0x808090..0x808104
+            - Range: 0x8081a0..0x808214
               Pieces: []
-            - Range: 0x808104..0x808105
+            - Range: 0x808214..0x808215
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808105..0x808130
+            - Range: 0x808215..0x808240
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 105 PointerType *int
           Locations:
-            - Range: 0x8080b8..0x8080d0
+            - Range: 0x8081c8..0x8081e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8080d0..0x808130
+            - Range: 0x8081e0..0x808240
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x808130..0x808200]
+      OutOfLinePCRanges: [0x808240..0x808310]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808130..0x808188
+            - Range: 0x808240..0x808298
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808130..0x8081d8
+            - Range: 0x808240..0x8082e8
               Pieces: []
-            - Range: 0x8081d8..0x8081d9
+            - Range: 0x8082e8..0x8082e9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8081d9..0x808200
+            - Range: 0x8082e9..0x808310
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808130..0x808200, Pieces: []}]
+          Locations: [{Range: 0x808240..0x808310, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80814c..0x80818c
+            - Range: 0x80825c..0x80829c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80818c..0x808200
+            - Range: 0x80829c..0x808310
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 14 BaseType float64
           Locations:
-            - Range: 0x80815c..0x80818c
+            - Range: 0x80826c..0x80829c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80818c..0x808200
+            - Range: 0x80829c..0x808310
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x808200..0x808280]
+      OutOfLinePCRanges: [0x808310..0x808390]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x808200..0x808220
+            - Range: 0x808310..0x808330
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x808200..0x80824c
+            - Range: 0x808310..0x80835c
               Pieces: []
-            - Range: 0x80824c..0x80824d
+            - Range: 0x80835c..0x80835d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80824d..0x808260
+            - Range: 0x80835d..0x808370
               Pieces: []
-            - Range: 0x808260..0x808261
+            - Range: 0x808370..0x808371
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x808261..0x808280
+            - Range: 0x808371..0x808390
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x808280..0x808400]
+      OutOfLinePCRanges: [0x808390..0x808510]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x808280..0x8082d0
+            - Range: 0x808390..0x8083e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8082d0..0x8082d4
+            - Range: 0x8083e0..0x8083e4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x808358..0x808360
+            - Range: 0x808468..0x808470
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8083a0..0x8083a8
+            - Range: 0x8084b0..0x8084b8
               Pieces:
                 - Size: 8
                   Op: null
@@ -7676,128 +7676,30 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x808280..0x8082d8
+            - Range: 0x808390..0x8083e8
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x808280..0x8082ec
+            - Range: 0x808390..0x8083fc
               Pieces: []
-            - Range: 0x8082ec..0x8082ed
+            - Range: 0x8083fc..0x8083fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8082ed..0x808348
+            - Range: 0x8083fd..0x808458
               Pieces: []
-            - Range: 0x808348..0x808349
+            - Range: 0x808458..0x808459
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x808349..0x808390
-              Pieces: []
-            - Range: 0x808390..0x808391
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x808391..0x8083d4
-              Pieces: []
-            - Range: 0x8083d4..0x8083d5
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8083d5..0x808400
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 15 GoInterfaceType error
-          Locations:
-            - Range: 0x808280..0x8082ec
-              Pieces: []
-            - Range: 0x8082ec..0x8082ed
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8082ed..0x808348
-              Pieces: []
-            - Range: 0x808348..0x808349
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x808349..0x808390
-              Pieces: []
-            - Range: 0x808390..0x808391
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x808391..0x8083d4
-              Pieces: []
-            - Range: 0x8083d4..0x8083d5
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8083d5..0x808400
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: val
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x8082d0..0x8082d8
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Local
-          DictIndex: -1
-      DictRegister: null
-    - ID: 102
-      Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x808400..0x8085e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: v
-          Type: 163 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0x808400..0x808440
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x808440..0x808448
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x808448..0x8085e0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 163 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0x808400..0x8084a0
+            - Range: 0x808459..0x8084a0
               Pieces: []
             - Range: 0x8084a0..0x8084a1
               Pieces:
@@ -7805,541 +7707,639 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8084a1..0x8084f4
+            - Range: 0x8084a1..0x8084e4
               Pieces: []
-            - Range: 0x8084f4..0x8084f5
+            - Range: 0x8084e4..0x8084e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8084f5..0x8085ac
+            - Range: 0x8084e5..0x808510
               Pieces: []
-            - Range: 0x8085ac..0x8085ad
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 15 GoInterfaceType error
+          Locations:
+            - Range: 0x808390..0x8083fc
+              Pieces: []
+            - Range: 0x8083fc..0x8083fd
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
+                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8085ad..0x8085c0
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x8083fd..0x808458
               Pieces: []
-            - Range: 0x8085c0..0x8085c1
+            - Range: 0x808458..0x808459
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
+                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8085c1..0x8085e0
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x808459..0x8084a0
+              Pieces: []
+            - Range: 0x8084a0..0x8084a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x8084a1..0x8084e4
+              Pieces: []
+            - Range: 0x8084e4..0x8084e5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x8084e5..0x808510
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80848c..0x808494
+            - Range: 0x8083e0..0x8083e8
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
+      DictRegister: null
+    - ID: 102
+      Name: main.testReturnsAny
+      OutOfLinePCRanges: [0x808510..0x8086f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: v
+          Type: 163 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0x808510..0x808550
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x808550..0x808558
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x808558..0x8086f0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 163 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0x808510..0x8085b0
+              Pieces: []
+            - Range: 0x8085b0..0x8085b1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8085b1..0x808604
+              Pieces: []
+            - Range: 0x808604..0x808605
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x808605..0x8086bc
+              Pieces: []
+            - Range: 0x8086bc..0x8086bd
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8086bd..0x8086d0
+              Pieces: []
+            - Range: 0x8086d0..0x8086d1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8086d1..0x8086f0
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: val
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80859c..0x8085a4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 105 PointerType *int
           Locations:
-            - Range: 0x8084d8..0x8084f4
+            - Range: 0x8085e8..0x808604
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x8085e0..0x808730]
+      OutOfLinePCRanges: [0x8086f0..0x808840]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8085e0..0x80861c
+            - Range: 0x8086f0..0x80872c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80861c..0x808660
+            - Range: 0x80872c..0x808770
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x808660..0x8086d0
+            - Range: 0x808770..0x8087e0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8086d0..0x8086f8
+            - Range: 0x8087e0..0x808808
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8086f8..0x8086fc
+            - Range: 0x808808..0x80880c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8086fc..0x808730
+            - Range: 0x80880c..0x808840
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8085e0..0x8086b0
+            - Range: 0x8086f0..0x8087c0
               Pieces: []
-            - Range: 0x8086b0..0x8086b1
+            - Range: 0x8087c0..0x8087c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8086b1..0x8086c4
+            - Range: 0x8087c1..0x8087d4
               Pieces: []
-            - Range: 0x8086c4..0x8086c5
+            - Range: 0x8087d4..0x8087d5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8086c5..0x808730
+            - Range: 0x8087d5..0x808840
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8085e0..0x80861c
+            - Range: 0x8086f0..0x80872c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80861c..0x808660
+            - Range: 0x80872c..0x808770
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x808660..0x808668
+            - Range: 0x808770..0x808778
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x808668..0x8086bc
+            - Range: 0x808778..0x8087cc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8086bc..0x8086c0
+            - Range: 0x8087cc..0x8087d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8086c0..0x8086c4
+            - Range: 0x8087d0..0x8087d4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8086c4..0x808730
+            - Range: 0x8087d4..0x808840
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x808730..0x8087d0]
+      OutOfLinePCRanges: [0x808840..0x8088e0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808730..0x80874c
+            - Range: 0x808840..0x80885c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808730..0x8087a4
+            - Range: 0x808840..0x8088b4
               Pieces: []
-            - Range: 0x8087a4..0x8087a5
+            - Range: 0x8088b4..0x8088b5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8087a5..0x8087d0
+            - Range: 0x8088b5..0x8088e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x8087d0..0x808890]
+      OutOfLinePCRanges: [0x8088e0..0x8089a0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8087d0..0x808820
+            - Range: 0x8088e0..0x808930
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8087d0..0x80886c
+            - Range: 0x8088e0..0x80897c
               Pieces: []
-            - Range: 0x80886c..0x80886d
+            - Range: 0x80897c..0x80897d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80886d..0x808890
+            - Range: 0x80897d..0x8089a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8087d0..0x80886c
+            - Range: 0x8088e0..0x80897c
               Pieces: []
-            - Range: 0x80886c..0x80886d
+            - Range: 0x80897c..0x80897d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80886d..0x808890
+            - Range: 0x80897d..0x8089a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x808890..0x808950]
+      OutOfLinePCRanges: [0x8089a0..0x808a60]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808890..0x8088d0
+            - Range: 0x8089a0..0x8089e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8088d0..0x808950
+            - Range: 0x8089e0..0x808a60
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808890..0x808930
+            - Range: 0x8089a0..0x808a40
               Pieces: []
-            - Range: 0x808930..0x808931
+            - Range: 0x808a40..0x808a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808931..0x808950
+            - Range: 0x808a41..0x808a60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808890..0x808930
+            - Range: 0x8089a0..0x808a40
               Pieces: []
-            - Range: 0x808930..0x808931
+            - Range: 0x808a40..0x808a41
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x808931..0x808950
+            - Range: 0x808a41..0x808a60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808890..0x808930
+            - Range: 0x8089a0..0x808a40
               Pieces: []
-            - Range: 0x808930..0x808931
+            - Range: 0x808a40..0x808a41
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x808931..0x808950
+            - Range: 0x808a41..0x808a60
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x808950..0x808a30]
+      OutOfLinePCRanges: [0x808a60..0x808b40]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808950..0x808990
+            - Range: 0x808a60..0x808aa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808990..0x808a30
+            - Range: 0x808aa0..0x808b40
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808950..0x808a0c
+            - Range: 0x808a60..0x808b1c
               Pieces: []
-            - Range: 0x808a0c..0x808a0d
+            - Range: 0x808b1c..0x808b1d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808a0d..0x808a30
+            - Range: 0x808b1d..0x808b40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808950..0x808a0c
+            - Range: 0x808a60..0x808b1c
               Pieces: []
-            - Range: 0x808a0c..0x808a0d
+            - Range: 0x808b1c..0x808b1d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x808a0d..0x808a30
+            - Range: 0x808b1d..0x808b40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x808a30..0x808bc0]
+      OutOfLinePCRanges: [0x808b40..0x808cd0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808a30..0x808a90
+            - Range: 0x808b40..0x808ba0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808a90..0x808bc0
+            - Range: 0x808ba0..0x808cd0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808a5c..0x808bc0
+            - Range: 0x808b6c..0x808cd0
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808a60..0x808bc0
+            - Range: 0x808b70..0x808cd0
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x808c80..0x808d10]
+      OutOfLinePCRanges: [0x808d90..0x808e20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x808c80..0x808cec
+            - Range: 0x808d90..0x808dfc
               Pieces: []
-            - Range: 0x808cec..0x808ced
+            - Range: 0x808dfc..0x808dfd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808ced..0x808d10
+            - Range: 0x808dfd..0x808e20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 102 BaseType int16
           Locations:
-            - Range: 0x808c80..0x808cec
+            - Range: 0x808d90..0x808dfc
               Pieces: []
-            - Range: 0x808cec..0x808ced
+            - Range: 0x808dfc..0x808dfd
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x808ced..0x808d10
+            - Range: 0x808dfd..0x808e20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x808c80..0x808cec
+            - Range: 0x808d90..0x808dfc
               Pieces: []
-            - Range: 0x808cec..0x808ced
+            - Range: 0x808dfc..0x808dfd
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x808ced..0x808d10
+            - Range: 0x808dfd..0x808e20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x808c80..0x808cec
+            - Range: 0x808d90..0x808dfc
               Pieces: []
-            - Range: 0x808cec..0x808ced
+            - Range: 0x808dfc..0x808dfd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x808ced..0x808d10
+            - Range: 0x808dfd..0x808e20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x808c80..0x808cec
+            - Range: 0x808d90..0x808dfc
               Pieces: []
-            - Range: 0x808cec..0x808ced
+            - Range: 0x808dfc..0x808dfd
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x808ced..0x808d10
+            - Range: 0x808dfd..0x808e20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x808c80..0x808cec
+            - Range: 0x808d90..0x808dfc
               Pieces: []
-            - Range: 0x808cec..0x808ced
+            - Range: 0x808dfc..0x808dfd
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x808ced..0x808d10
+            - Range: 0x808dfd..0x808e20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x808c80..0x808cec
+            - Range: 0x808d90..0x808dfc
               Pieces: []
-            - Range: 0x808cec..0x808ced
+            - Range: 0x808dfc..0x808dfd
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x808ced..0x808d10
+            - Range: 0x808dfd..0x808e20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x808c80..0x808cec
+            - Range: 0x808d90..0x808dfc
               Pieces: []
-            - Range: 0x808cec..0x808ced
+            - Range: 0x808dfc..0x808dfd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x808ced..0x808d10
+            - Range: 0x808dfd..0x808e20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x808d10..0x808dc0]
+      OutOfLinePCRanges: [0x808e20..0x808ed0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 14 BaseType float64
-          Locations: [{Range: 0x808d10..0x808dc0, Pieces: []}]
+          Locations: [{Range: 0x808e20..0x808ed0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 14 BaseType float64
           Locations:
-            - Range: 0x808d10..0x808da8
+            - Range: 0x808e20..0x808eb8
               Pieces: []
-            - Range: 0x808da8..0x808da9
+            - Range: 0x808eb8..0x808eb9
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x808da9..0x808dc0
+            - Range: 0x808eb9..0x808ed0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x808dc0..0x808e40]
+      OutOfLinePCRanges: [0x808ed0..0x808f50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 103 BaseType complex64
-          Locations: [{Range: 0x808dc0..0x808e40, Pieces: []}]
+          Locations: [{Range: 0x808ed0..0x808f50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType complex128
-          Locations: [{Range: 0x808dc0..0x808e40, Pieces: []}]
+          Locations: [{Range: 0x808ed0..0x808f50, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x808e40..0x808f00]
+      OutOfLinePCRanges: [0x808f50..0x809010]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x808e40..0x808ee0
+            - Range: 0x808f50..0x808ff0
               Pieces: []
-            - Range: 0x808ee0..0x808ee1
+            - Range: 0x808ff0..0x808ff1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8361,193 +8361,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x808ee1..0x808f00
+            - Range: 0x808ff1..0x809010
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x808f00..0x808f90]
+      OutOfLinePCRanges: [0x809010..0x8090a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x808f00..0x808f6c
+            - Range: 0x809010..0x80907c
               Pieces: []
-            - Range: 0x808f6c..0x808f6d
+            - Range: 0x80907c..0x80907d
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x808f6d..0x808f90
+            - Range: 0x80907d..0x8090a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x808f90..0x809000]
+      OutOfLinePCRanges: [0x8090a0..0x809110]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 ArrayType [1]int
           Locations:
-            - Range: 0x808f90..0x808fe0
+            - Range: 0x8090a0..0x8090f0
               Pieces: []
-            - Range: 0x808fe0..0x808fe1
+            - Range: 0x8090f0..0x8090f1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808fe1..0x809000
+            - Range: 0x8090f1..0x809110
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x809000..0x809070]
+      OutOfLinePCRanges: [0x809110..0x809180]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0x809000..0x80904c
+            - Range: 0x809110..0x80915c
               Pieces: []
-            - Range: 0x80904c..0x80904d
+            - Range: 0x80915c..0x80915d
               Pieces: []
-            - Range: 0x80904d..0x809070
+            - Range: 0x80915d..0x809180
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x809070..0x8090f0]
+      OutOfLinePCRanges: [0x809180..0x809200]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 260 StructureType main.mixedStruct
-          Locations: [{Range: 0x809070..0x8090f0, Pieces: []}]
+          Locations: [{Range: 0x809180..0x809200, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x8090f0..0x809180]
+      OutOfLinePCRanges: [0x809200..0x809290]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090f0..0x809168
+            - Range: 0x809200..0x809278
               Pieces: []
-            - Range: 0x809168..0x809169
+            - Range: 0x809278..0x809279
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809169..0x809180
+            - Range: 0x809279..0x809290
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090f0..0x809168
+            - Range: 0x809200..0x809278
               Pieces: []
-            - Range: 0x809168..0x809169
+            - Range: 0x809278..0x809279
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x809169..0x809180
+            - Range: 0x809279..0x809290
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090f0..0x809168
+            - Range: 0x809200..0x809278
               Pieces: []
-            - Range: 0x809168..0x809169
+            - Range: 0x809278..0x809279
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x809169..0x809180
+            - Range: 0x809279..0x809290
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090f0..0x809168
+            - Range: 0x809200..0x809278
               Pieces: []
-            - Range: 0x809168..0x809169
+            - Range: 0x809278..0x809279
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x809169..0x809180
+            - Range: 0x809279..0x809290
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090f0..0x809168
+            - Range: 0x809200..0x809278
               Pieces: []
-            - Range: 0x809168..0x809169
+            - Range: 0x809278..0x809279
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x809169..0x809180
+            - Range: 0x809279..0x809290
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090f0..0x809168
+            - Range: 0x809200..0x809278
               Pieces: []
-            - Range: 0x809168..0x809169
+            - Range: 0x809278..0x809279
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x809169..0x809180
+            - Range: 0x809279..0x809290
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090f0..0x809168
+            - Range: 0x809200..0x809278
               Pieces: []
-            - Range: 0x809168..0x809169
+            - Range: 0x809278..0x809279
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x809169..0x809180
+            - Range: 0x809279..0x809290
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8090f0..0x809168
+            - Range: 0x809200..0x809278
               Pieces: []
-            - Range: 0x809168..0x809169
+            - Range: 0x809278..0x809279
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x809169..0x809180
+            - Range: 0x809279..0x809290
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8090f0..0x809168
+            - Range: 0x809200..0x809278
               Pieces: []
-            - Range: 0x809168..0x809169
+            - Range: 0x809278..0x809279
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809169..0x809180
+            - Range: 0x809279..0x809290
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x809180..0x809250]
+      OutOfLinePCRanges: [0x809290..0x809360]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.wideStruct
           Locations:
-            - Range: 0x809180..0x809230
+            - Range: 0x809290..0x809340
               Pieces: []
-            - Range: 0x809230..0x809231
+            - Range: 0x809340..0x809341
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8571,145 +8571,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x809231..0x809250
+            - Range: 0x809341..0x809360
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x809250..0x8092e0]
+      OutOfLinePCRanges: [0x809360..0x8093f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809250..0x8092bc
+            - Range: 0x809360..0x8093cc
               Pieces: []
-            - Range: 0x8092bc..0x8092bd
+            - Range: 0x8093cc..0x8093cd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8092bd..0x8092e0
+            - Range: 0x8093cd..0x8093f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x809250..0x8092e0, Pieces: []}]
+          Locations: [{Range: 0x809360..0x8093f0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809250..0x8092bc
+            - Range: 0x809360..0x8093cc
               Pieces: []
-            - Range: 0x8092bc..0x8092bd
+            - Range: 0x8093cc..0x8093cd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8092bd..0x8092e0
+            - Range: 0x8093cd..0x8093f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType float64
-          Locations: [{Range: 0x809250..0x8092e0, Pieces: []}]
+          Locations: [{Range: 0x809360..0x8093f0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809250..0x8092bc
+            - Range: 0x809360..0x8093cc
               Pieces: []
-            - Range: 0x8092bc..0x8092bd
+            - Range: 0x8093cc..0x8093cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8092bd..0x8092e0
+            - Range: 0x8093cd..0x8093f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x8092e0..0x809370]
+      OutOfLinePCRanges: [0x8093f0..0x809480]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x8092e0..0x80934c
+            - Range: 0x8093f0..0x80945c
               Pieces: []
-            - Range: 0x80934c..0x80934d
+            - Range: 0x80945c..0x80945d
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80934d..0x809370
+            - Range: 0x80945d..0x809480
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x809370..0x8093e0]
+      OutOfLinePCRanges: [0x809480..0x8094f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType float64
-          Locations: [{Range: 0x809370..0x8093e0, Pieces: []}]
+          Locations: [{Range: 0x809480..0x8094f0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x8093e0..0x809450]
+      OutOfLinePCRanges: [0x8094f0..0x809560]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0x8093e0..0x809450, Pieces: []}]
+          Locations: [{Range: 0x8094f0..0x809560, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x8093e0..0x809450, Pieces: []}]
+          Locations: [{Range: 0x8094f0..0x809560, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x809450..0x8094c0]
+      OutOfLinePCRanges: [0x809560..0x8095d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x809450..0x8094a4
+            - Range: 0x809560..0x8095b4
               Pieces: []
-            - Range: 0x8094a4..0x8094a5
+            - Range: 0x8095b4..0x8095b5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8094a5..0x8094c0
+            - Range: 0x8095b5..0x8095d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x809450..0x8094a4
+            - Range: 0x809560..0x8095b4
               Pieces: []
-            - Range: 0x8094a4..0x8094a5
+            - Range: 0x8095b4..0x8095b5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8094a5..0x8094c0
+            - Range: 0x8095b5..0x8095d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x8094c0..0x809650]
+      OutOfLinePCRanges: [0x8095d0..0x809760]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x8094c0..0x8094f4
+            - Range: 0x8095d0..0x809604
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8731,7 +8731,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8094f4..0x809524
+            - Range: 0x809604..0x809634
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8753,7 +8753,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809524..0x80952c
+            - Range: 0x809634..0x80963c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8775,7 +8775,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80952c..0x809530
+            - Range: 0x80963c..0x809640
               Pieces:
                 - Size: 8
                   Op: null
@@ -8802,9 +8802,9 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x8094c0..0x809610
+            - Range: 0x8095d0..0x809720
               Pieces: []
-            - Range: 0x809610..0x809611
+            - Range: 0x809720..0x809721
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8826,44 +8826,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809611..0x809650
+            - Range: 0x809721..0x809760
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x809650..0x809720]
+      OutOfLinePCRanges: [0x809760..0x809830]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x809650..0x809720
+            - Range: 0x809760..0x809830
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x809650..0x809700
+            - Range: 0x809760..0x809810
               Pieces: []
-            - Range: 0x809700..0x809701
+            - Range: 0x809810..0x809811
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x809701..0x809720
+            - Range: 0x809811..0x809830
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x809720..0x809930]
+      OutOfLinePCRanges: [0x809830..0x809a40]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x809720..0x809754
+            - Range: 0x809830..0x809864
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8885,7 +8885,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809754..0x809788
+            - Range: 0x809864..0x809898
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8907,7 +8907,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809788..0x809790
+            - Range: 0x809898..0x8098a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8929,7 +8929,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809790..0x809794
+            - Range: 0x8098a0..0x8098a4
               Pieces:
                 - Size: 8
                   Op: null
@@ -8956,16 +8956,16 @@ Subprograms:
         - Name: s2
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x809720..0x809930
+            - Range: 0x809830..0x809a40
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x809720..0x8098e8
+            - Range: 0x809830..0x8099f8
               Pieces: []
-            - Range: 0x8098e8..0x8098e9
+            - Range: 0x8099f8..0x8099f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8987,196 +8987,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8098e9..0x809930
+            - Range: 0x8099f9..0x809a40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x809930..0x809ae0]
+      OutOfLinePCRanges: [0x809a40..0x809bf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809930..0x8099b8
+            - Range: 0x809a40..0x809ac8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8099b8..0x809ae0
+            - Range: 0x809ac8..0x809bf0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809930..0x809978
+            - Range: 0x809a40..0x809a88
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x809978..0x809ae0
+            - Range: 0x809a88..0x809bf0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809930..0x8099b0
+            - Range: 0x809a40..0x809ac0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8099b0..0x809ae0
+            - Range: 0x809ac0..0x809bf0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809930..0x8099b8
+            - Range: 0x809a40..0x809ac8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8099b8..0x809ae0
+            - Range: 0x809ac8..0x809bf0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809930..0x8099b8
+            - Range: 0x809a40..0x809ac8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8099b8..0x809ae0
+            - Range: 0x809ac8..0x809bf0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809930..0x8099b8
+            - Range: 0x809a40..0x809ac8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8099b8..0x809ae0
+            - Range: 0x809ac8..0x809bf0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809930..0x8099b8
+            - Range: 0x809a40..0x809ac8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8099b8..0x809ae0
+            - Range: 0x809ac8..0x809bf0
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809930..0x8099b8
+            - Range: 0x809a40..0x809ac8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8099b8..0x809ae0
+            - Range: 0x809ac8..0x809bf0
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809930..0x8099b8
+            - Range: 0x809a40..0x809ac8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x8099b8..0x809ae0
+            - Range: 0x809ac8..0x809bf0
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x809930..0x809aa0
+            - Range: 0x809a40..0x809bb0
               Pieces: []
-            - Range: 0x809aa0..0x809aa1
+            - Range: 0x809bb0..0x809bb1
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x809aa1..0x809ae0
+            - Range: 0x809bb1..0x809bf0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x809ae0..0x809cd0]
+      OutOfLinePCRanges: [0x809bf0..0x809de0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ae0..0x809b68
+            - Range: 0x809bf0..0x809c78
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809b68..0x809cd0
+            - Range: 0x809c78..0x809de0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ae0..0x809b2c
+            - Range: 0x809bf0..0x809c3c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x809b2c..0x809cd0
+            - Range: 0x809c3c..0x809de0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ae0..0x809b60
+            - Range: 0x809bf0..0x809c70
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x809b60..0x809cd0
+            - Range: 0x809c70..0x809de0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ae0..0x809b68
+            - Range: 0x809bf0..0x809c78
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x809b68..0x809cd0
+            - Range: 0x809c78..0x809de0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ae0..0x809b68
+            - Range: 0x809bf0..0x809c78
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x809b68..0x809cd0
+            - Range: 0x809c78..0x809de0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ae0..0x809b68
+            - Range: 0x809bf0..0x809c78
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x809b68..0x809cd0
+            - Range: 0x809c78..0x809de0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ae0..0x809b68
+            - Range: 0x809bf0..0x809c78
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x809b68..0x809cd0
+            - Range: 0x809c78..0x809de0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ae0..0x809b68
+            - Range: 0x809bf0..0x809c78
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x809b68..0x809cd0
+            - Range: 0x809c78..0x809de0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809ae0..0x809b68
+            - Range: 0x809bf0..0x809c78
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809b68..0x809cd0
+            - Range: 0x809c78..0x809de0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9187,9 +9187,9 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x809ae0..0x809c8c
+            - Range: 0x809bf0..0x809d9c
               Pieces: []
-            - Range: 0x809c8c..0x809c8d
+            - Range: 0x809d9c..0x809d9d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9211,196 +9211,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809c8d..0x809cd0
+            - Range: 0x809d9d..0x809de0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x809cd0..0x809d60]
+      OutOfLinePCRanges: [0x809de0..0x809e70]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0x809cd0..0x809d60
+            - Range: 0x809de0..0x809e70
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809cd0..0x809d44
+            - Range: 0x809de0..0x809e54
               Pieces: []
-            - Range: 0x809d44..0x809d45
+            - Range: 0x809e54..0x809e55
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809d45..0x809d60
+            - Range: 0x809e55..0x809e70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809cd0..0x809d44
+            - Range: 0x809de0..0x809e54
               Pieces: []
-            - Range: 0x809d44..0x809d45
+            - Range: 0x809e54..0x809e55
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x809d45..0x809d60
+            - Range: 0x809e55..0x809e70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809cd0..0x809d44
+            - Range: 0x809de0..0x809e54
               Pieces: []
-            - Range: 0x809d44..0x809d45
+            - Range: 0x809e54..0x809e55
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x809d45..0x809d60
+            - Range: 0x809e55..0x809e70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x809d60..0x809e30]
+      OutOfLinePCRanges: [0x809e70..0x809f40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x809d60..0x809e30
+            - Range: 0x809e70..0x809f40
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x809d60..0x809e30
+            - Range: 0x809e70..0x809f40
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809d60..0x809e18
+            - Range: 0x809e70..0x809f28
               Pieces: []
-            - Range: 0x809e18..0x809e19
+            - Range: 0x809f28..0x809f29
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809e19..0x809e30
+            - Range: 0x809f29..0x809f40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x809d60..0x809e18
+            - Range: 0x809e70..0x809f28
               Pieces: []
-            - Range: 0x809e18..0x809e19
+            - Range: 0x809f28..0x809f29
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x809e19..0x809e30
+            - Range: 0x809f29..0x809f40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x809e30..0x809ef0]
+      OutOfLinePCRanges: [0x809f40..0x80a000]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x809e30..0x809ef0
+            - Range: 0x809f40..0x80a000
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809e30..0x809ed4
+            - Range: 0x809f40..0x809fe4
               Pieces: []
-            - Range: 0x809ed4..0x809ed5
+            - Range: 0x809fe4..0x809fe5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809ed5..0x809ef0
+            - Range: 0x809fe5..0x80a000
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x809e30..0x809ed4
+            - Range: 0x809f40..0x809fe4
               Pieces: []
-            - Range: 0x809ed4..0x809ed5
+            - Range: 0x809fe4..0x809fe5
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x809ed5..0x809ef0
+            - Range: 0x809fe5..0x80a000
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809eb0..0x809ef0
+            - Range: 0x809fc0..0x80a000
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x809ef0..0x809f90]
+      OutOfLinePCRanges: [0x80a000..0x80a0a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 259 ArrayType [0]int
-          Locations: [{Range: 0x809ef0..0x809f90, Pieces: []}]
+          Locations: [{Range: 0x80a000..0x80a0a0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ef0..0x809f30
+            - Range: 0x80a000..0x80a040
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809f30..0x809f48
+            - Range: 0x80a040..0x80a058
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x809f48..0x809f50
+            - Range: 0x80a058..0x80a060
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x809f50..0x809f90
+            - Range: 0x80a060..0x80a0a0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ef0..0x809f6c
+            - Range: 0x80a000..0x80a07c
               Pieces: []
-            - Range: 0x809f6c..0x809f6d
+            - Range: 0x80a07c..0x80a07d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809f6d..0x809f90
+            - Range: 0x80a07d..0x80a0a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0x809ef0..0x809f6c
+            - Range: 0x80a000..0x80a07c
               Pieces: []
-            - Range: 0x809f6c..0x809f6d
+            - Range: 0x80a07c..0x80a07d
               Pieces: []
-            - Range: 0x809f6d..0x809f90
+            - Range: 0x80a07d..0x80a0a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80a3e0..0x80a3f0]
+      OutOfLinePCRanges: [0x80a4f0..0x80a500]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a3e0..0x80a3f0
+            - Range: 0x80a4f0..0x80a500
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9413,13 +9413,13 @@ Subprograms:
       DictRegister: null
     - ID: 134
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x80a3f0..0x80a400]
+      OutOfLinePCRanges: [0x80a500..0x80a510]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a3f0..0x80a400
+            - Range: 0x80a500..0x80a510
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9432,13 +9432,13 @@ Subprograms:
       DictRegister: null
     - ID: 135
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x80a400..0x80a410]
+      OutOfLinePCRanges: [0x80a510..0x80a520]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 264 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x80a400..0x80a410
+            - Range: 0x80a510..0x80a520
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9451,13 +9451,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x80a410..0x80a420]
+      OutOfLinePCRanges: [0x80a520..0x80a530]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 266 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80a410..0x80a420
+            - Range: 0x80a520..0x80a530
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9470,20 +9470,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a410..0x80a420
+            - Range: 0x80a520..0x80a530
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 137
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x80a420..0x80a430]
+      OutOfLinePCRanges: [0x80a530..0x80a540]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 266 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80a420..0x80a430
+            - Range: 0x80a530..0x80a540
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9496,20 +9496,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a420..0x80a430
+            - Range: 0x80a530..0x80a540
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 138
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x80a430..0x80a440]
+      OutOfLinePCRanges: [0x80a540..0x80a550]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 266 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80a430..0x80a440
+            - Range: 0x80a540..0x80a550
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9522,20 +9522,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a430..0x80a440
+            - Range: 0x80a540..0x80a550
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x80a440..0x80a450]
+      OutOfLinePCRanges: [0x80a550..0x80a560]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 269 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80a440..0x80a450
+            - Range: 0x80a550..0x80a560
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9548,20 +9548,20 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x80a450..0x80a460]
+      OutOfLinePCRanges: [0x80a560..0x80a570]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x80a450..0x80a460
+            - Range: 0x80a560..0x80a570
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 270 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80a450..0x80a460
+            - Range: 0x80a560..0x80a570
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9574,20 +9574,20 @@ Subprograms:
         - Name: x
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x80a450..0x80a460
+            - Range: 0x80a560..0x80a570
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80a460..0x80a470]
+      OutOfLinePCRanges: [0x80a570..0x80a580]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x80a460..0x80a470
+            - Range: 0x80a570..0x80a580
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9600,13 +9600,13 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x80a470..0x80a480]
+      OutOfLinePCRanges: [0x80a580..0x80a590]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a470..0x80a480
+            - Range: 0x80a580..0x80a590
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9619,13 +9619,13 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x80a480..0x80a490]
+      OutOfLinePCRanges: [0x80a590..0x80a5a0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 272 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x80a480..0x80a490
+            - Range: 0x80a590..0x80a5a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9638,13 +9638,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80a490..0x80a4a0]
+      OutOfLinePCRanges: [0x80a5a0..0x80a5b0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a490..0x80a4a0
+            - Range: 0x80a5a0..0x80a5b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9657,7 +9657,7 @@ Subprograms:
         - Name: bs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a490..0x80a4a0
+            - Range: 0x80a5a0..0x80a5b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9670,7 +9670,7 @@ Subprograms:
         - Name: cs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a490..0x80a4a0
+            - Range: 0x80a5a0..0x80a5b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9683,34 +9683,34 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0x80a760..0x80a7c0]
+      OutOfLinePCRanges: [0x80a870..0x80a8d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a760..0x80a7a8
+            - Range: 0x80a870..0x80a8b8
               Pieces: []
-            - Range: 0x80a7a8..0x80a7a9
+            - Range: 0x80a8b8..0x80a8b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a7a9..0x80a7c0
+            - Range: 0x80a8b9..0x80a8d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80a7c0..0x80a7d0]
+      OutOfLinePCRanges: [0x80a8d0..0x80a8e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a7c0..0x80a7d0
+            - Range: 0x80a8d0..0x80a8e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9721,13 +9721,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x80a7d0..0x80a7e0]
+      OutOfLinePCRanges: [0x80a8e0..0x80a8f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a7d0..0x80a7e0
+            - Range: 0x80a8e0..0x80a8f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9738,7 +9738,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a7d0..0x80a7e0
+            - Range: 0x80a8e0..0x80a8f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9749,7 +9749,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a7d0..0x80a7e0
+            - Range: 0x80a8e0..0x80a8f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9760,13 +9760,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80a7e0..0x80a7f0]
+      OutOfLinePCRanges: [0x80a8f0..0x80a900]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80a7e0..0x80a7f0
+            - Range: 0x80a8f0..0x80a900
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9785,39 +9785,39 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80a7f0..0x80a800]
+      OutOfLinePCRanges: [0x80a900..0x80a910]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 275 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x80a7f0..0x80a800
+            - Range: 0x80a900..0x80a910
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x80a800..0x80a810]
+      OutOfLinePCRanges: [0x80a910..0x80a920]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 276 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x80a800..0x80a810
+            - Range: 0x80a910..0x80a920
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x80a810..0x80a820]
+      OutOfLinePCRanges: [0x80a920..0x80a930]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a810..0x80a820
+            - Range: 0x80a920..0x80a930
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9828,13 +9828,13 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x80a820..0x80a830]
+      OutOfLinePCRanges: [0x80a930..0x80a940]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a820..0x80a830
+            - Range: 0x80a930..0x80a940
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9845,13 +9845,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x80a830..0x80a840]
+      OutOfLinePCRanges: [0x80a940..0x80a950]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a830..0x80a840
+            - Range: 0x80a940..0x80a950
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9862,13 +9862,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x80a840..0x80a850]
+      OutOfLinePCRanges: [0x80a950..0x80a960]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a840..0x80a850
+            - Range: 0x80a950..0x80a960
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9879,7 +9879,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a840..0x80a850
+            - Range: 0x80a950..0x80a960
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9890,7 +9890,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a840..0x80a850
+            - Range: 0x80a950..0x80a960
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9901,26 +9901,26 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80a990..0x80a9a0]
+      OutOfLinePCRanges: [0x80aaa0..0x80aab0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80a990..0x80a9a0
+            - Range: 0x80aaa0..0x80aab0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80a9a0..0x80a9b0]
+      OutOfLinePCRanges: [0x80aab0..0x80aac0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 291 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80a9a0..0x80a9b0
+            - Range: 0x80aab0..0x80aac0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9939,13 +9939,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80aa40..0x80aa50]
+      OutOfLinePCRanges: [0x80ab50..0x80ab60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 322 StructureType main.aStruct
           Locations:
-            - Range: 0x80aa40..0x80aa50
+            - Range: 0x80ab50..0x80ab60
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9966,93 +9966,93 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x80aaa0..0x80aab0]
+      OutOfLinePCRanges: [0x80abb0..0x80abc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x80aaa0..0x80aab0
+            - Range: 0x80abb0..0x80abc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x80aab0..0x80aac0]
+      OutOfLinePCRanges: [0x80abc0..0x80abd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 325 StructureType main.tenStrings
           Locations:
-            - Range: 0x80aab0..0x80aac0
+            - Range: 0x80abc0..0x80abd0
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80aae0..0x80aaf0]
+      OutOfLinePCRanges: [0x80abf0..0x80ac00]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 326 StructureType main.emptyStruct
-          Locations: [{Range: 0x80aae0..0x80aaf0, Pieces: []}]
+          Locations: [{Range: 0x80abf0..0x80ac00, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80aaf0..0x80ab00]
+      OutOfLinePCRanges: [0x80ac00..0x80ac10]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 327 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80aaf0..0x80ab00
+            - Range: 0x80ac00..0x80ac10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x80c0f0..0x80c100]
+      OutOfLinePCRanges: [0x80c200..0x80c210]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c0f0..0x80c100
+            - Range: 0x80c200..0x80c210
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80c0f0..0x80c0f4
+            - Range: 0x80c200..0x80c204
               Pieces: []
-            - Range: 0x80c0f4..0x80c0f5
+            - Range: 0x80c204..0x80c205
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c0f5..0x80c100
+            - Range: 0x80c205..0x80c210
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x80c100..0x80c110]
+      OutOfLinePCRanges: [0x80c210..0x80c220]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c100..0x80c10c
+            - Range: 0x80c210..0x80c21c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c10c..0x80c110
+            - Range: 0x80c21c..0x80c220
               Pieces:
                 - Size: 8
                   Op: null
@@ -10063,58 +10063,58 @@ Subprograms:
         - Name: ~r0
           Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80c100..0x80c10c
+            - Range: 0x80c210..0x80c21c
               Pieces: []
-            - Range: 0x80c10c..0x80c10d
+            - Range: 0x80c21c..0x80c21d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c10d..0x80c110
+            - Range: 0x80c21d..0x80c220
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x80c110..0x80c120]
+      OutOfLinePCRanges: [0x80c220..0x80c230]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80c110..0x80c120
+            - Range: 0x80c220..0x80c230
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c110..0x80c114
+            - Range: 0x80c220..0x80c224
               Pieces: []
-            - Range: 0x80c114..0x80c115
+            - Range: 0x80c224..0x80c225
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c115..0x80c120
+            - Range: 0x80c225..0x80c230
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x80c120..0x80c130]
+      OutOfLinePCRanges: [0x80c230..0x80c240]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80c120..0x80c12c
+            - Range: 0x80c230..0x80c23c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c12c..0x80c130
+            - Range: 0x80c23c..0x80c240
               Pieces:
                 - Size: 8
                   Op: null
@@ -10125,28 +10125,28 @@ Subprograms:
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c120..0x80c12c
+            - Range: 0x80c230..0x80c23c
               Pieces: []
-            - Range: 0x80c12c..0x80c12d
+            - Range: 0x80c23c..0x80c23d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c12d..0x80c130
+            - Range: 0x80c23d..0x80c240
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x80c190..0x80c330]
+      OutOfLinePCRanges: [0x80c2a0..0x80c440]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80c190..0x80c1c0
+            - Range: 0x80c2a0..0x80c2d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10154,7 +10154,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80c1c0..0x80c1d4
+            - Range: 0x80c2d0..0x80c2e4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10162,7 +10162,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x80c1d4..0x80c330
+            - Range: 0x80c2e4..0x80c440
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10175,18 +10175,18 @@ Subprograms:
         - Name: pred
           Type: 334 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x80c190..0x80c1d4
+            - Range: 0x80c2a0..0x80c2e4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80c1d4..0x80c330
+            - Range: 0x80c2e4..0x80c440
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80c190..0x80c2f8
+            - Range: 0x80c2a0..0x80c408
               Pieces: []
-            - Range: 0x80c2f8..0x80c2f9
+            - Range: 0x80c408..0x80c409
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10194,14 +10194,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c2f9..0x80c330
+            - Range: 0x80c409..0x80c440
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80c1c0..0x80c1d4
+            - Range: 0x80c2d0..0x80c2e4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10209,7 +10209,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80c1d4..0x80c1f4
+            - Range: 0x80c2e4..0x80c304
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10217,7 +10217,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80c1f4..0x80c1f8
+            - Range: 0x80c304..0x80c308
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10225,7 +10225,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80c1f8..0x80c1f8
+            - Range: 0x80c308..0x80c308
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10233,7 +10233,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80c1f8..0x80c228
+            - Range: 0x80c308..0x80c338
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10241,7 +10241,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80c228..0x80c2b8
+            - Range: 0x80c338..0x80c3c8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10249,7 +10249,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80c2b8..0x80c2cc
+            - Range: 0x80c3c8..0x80c3dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10257,7 +10257,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80c2cc..0x80c2e0
+            - Range: 0x80c3dc..0x80c3f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10265,7 +10265,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80c2e0..0x80c2ec
+            - Range: 0x80c3f0..0x80c3fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10273,7 +10273,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80c2ec..0x80c330
+            - Range: 0x80c3fc..0x80c440
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10286,215 +10286,215 @@ Subprograms:
         - Name: item
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c218..0x80c228
+            - Range: 0x80c328..0x80c338
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c228..0x80c2b8
+            - Range: 0x80c338..0x80c3c8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80c330..0x80c380]
+      OutOfLinePCRanges: [0x80c440..0x80c490]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80c330..0x80c358
+            - Range: 0x80c440..0x80c468
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 335 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x80c330..0x80c358
+            - Range: 0x80c440..0x80c468
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80c330..0x80c358
+            - Range: 0x80c440..0x80c468
               Pieces: []
-            - Range: 0x80c358..0x80c359
+            - Range: 0x80c468..0x80c469
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c359..0x80c380
+            - Range: 0x80c469..0x80c490
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 168
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x80c570..0x80c580]
+      OutOfLinePCRanges: [0x80c680..0x80c690]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 333 PointerType *go.shape.int
           Locations:
-            - Range: 0x80c570..0x80c580
+            - Range: 0x80c680..0x80c690
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 333 PointerType *go.shape.int
           Locations:
-            - Range: 0x80c570..0x80c574
+            - Range: 0x80c680..0x80c684
               Pieces: []
-            - Range: 0x80c574..0x80c575
+            - Range: 0x80c684..0x80c685
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c575..0x80c580
+            - Range: 0x80c685..0x80c690
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x80c580..0x80c590]
+      OutOfLinePCRanges: [0x80c690..0x80c6a0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 336 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x80c580..0x80c590
+            - Range: 0x80c690..0x80c6a0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 336 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x80c580..0x80c584
+            - Range: 0x80c690..0x80c694
               Pieces: []
-            - Range: 0x80c584..0x80c585
+            - Range: 0x80c694..0x80c695
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c585..0x80c590
+            - Range: 0x80c695..0x80c6a0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x80c590..0x80c5a0]
+      OutOfLinePCRanges: [0x80c6a0..0x80c6b0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 338 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x80c590..0x80c5a0
+            - Range: 0x80c6a0..0x80c6b0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 338 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x80c590..0x80c594
+            - Range: 0x80c6a0..0x80c6a4
               Pieces: []
-            - Range: 0x80c594..0x80c595
+            - Range: 0x80c6a4..0x80c6a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c595..0x80c5a0
+            - Range: 0x80c6a5..0x80c6b0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x80c5a0..0x80c5b0]
+      OutOfLinePCRanges: [0x80c6b0..0x80c6c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x80c5a0..0x80c5b0
+            - Range: 0x80c6b0..0x80c6c0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c5a0..0x80c5a4
+            - Range: 0x80c6b0..0x80c6b4
               Pieces: []
-            - Range: 0x80c5a4..0x80c5a5
+            - Range: 0x80c6b4..0x80c6b5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c5a5..0x80c5b0
+            - Range: 0x80c6b5..0x80c6c0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x80c620..0x80c630]
+      OutOfLinePCRanges: [0x80c730..0x80c740]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 342 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x80c620..0x80c630
+            - Range: 0x80c730..0x80c740
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c620..0x80c624
+            - Range: 0x80c730..0x80c734
               Pieces: []
-            - Range: 0x80c624..0x80c625
+            - Range: 0x80c734..0x80c735
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c625..0x80c630
+            - Range: 0x80c735..0x80c740
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x80c6a0..0x80c6b0]
+      OutOfLinePCRanges: [0x80c7b0..0x80c7c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 343 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x80c6a0..0x80c6b0
+            - Range: 0x80c7b0..0x80c7c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c6a0..0x80c6b0
+            - Range: 0x80c7b0..0x80c7c0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0x80c6a0..0x80c6b0
+            - Range: 0x80c7b0..0x80c7c0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x80c710..0x80c780]
+      OutOfLinePCRanges: [0x80c820..0x80c890]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x80c710..0x80c780
+            - Range: 0x80c820..0x80c890
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c710..0x80c780
+            - Range: 0x80c820..0x80c890
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10505,20 +10505,20 @@ Subprograms:
         - Name: v
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c710..0x80c780
+            - Range: 0x80c820..0x80c890
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x80c7e0..0x80c7f0]
+      OutOfLinePCRanges: [0x80c8f0..0x80c900]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c7e0..0x80c7f0
+            - Range: 0x80c8f0..0x80c900
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10529,59 +10529,59 @@ Subprograms:
         - Name: b
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0x80c7e0..0x80c7f0
+            - Range: 0x80c8f0..0x80c900
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0x80c7e0..0x80c7e8
+            - Range: 0x80c8f0..0x80c8f8
               Pieces: []
-            - Range: 0x80c7e8..0x80c7e9
+            - Range: 0x80c8f8..0x80c8f9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c7e9..0x80c7f0
+            - Range: 0x80c8f9..0x80c900
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c7e0..0x80c7e8
+            - Range: 0x80c8f0..0x80c8f8
               Pieces: []
-            - Range: 0x80c7e8..0x80c7e9
+            - Range: 0x80c8f8..0x80c8f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c7e9..0x80c7f0
+            - Range: 0x80c8f9..0x80c900
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80c7f0..0x80c810]
+      OutOfLinePCRanges: [0x80c900..0x80c920]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c7f0..0x80c800
+            - Range: 0x80c900..0x80c910
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c7f0..0x80c7fc
+            - Range: 0x80c900..0x80c90c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80c7fc..0x80c810
+            - Range: 0x80c90c..0x80c920
               Pieces:
                 - Size: 8
                   Op: null
@@ -10592,73 +10592,73 @@ Subprograms:
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c7f0..0x80c800
+            - Range: 0x80c900..0x80c910
               Pieces: []
-            - Range: 0x80c800..0x80c801
+            - Range: 0x80c910..0x80c911
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c801..0x80c810
+            - Range: 0x80c911..0x80c920
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c7f0..0x80c800
+            - Range: 0x80c900..0x80c910
               Pieces: []
-            - Range: 0x80c800..0x80c801
+            - Range: 0x80c910..0x80c911
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80c801..0x80c810
+            - Range: 0x80c911..0x80c920
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x80c810..0x80c860]
+      OutOfLinePCRanges: [0x80c920..0x80c970]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 348 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x80c810..0x80c838
+            - Range: 0x80c920..0x80c948
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c810..0x80c838
+            - Range: 0x80c920..0x80c948
               Pieces: []
-            - Range: 0x80c838..0x80c839
+            - Range: 0x80c948..0x80c949
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c839..0x80c860
+            - Range: 0x80c949..0x80c970
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x80c860..0x80c8c0]
+      OutOfLinePCRanges: [0x80c970..0x80c9d0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 349 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x80c860..0x80c88c
+            - Range: 0x80c970..0x80c99c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c88c..0x80c890
+            - Range: 0x80c99c..0x80c9a0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10669,65 +10669,65 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c860..0x80c890
+            - Range: 0x80c970..0x80c9a0
               Pieces: []
-            - Range: 0x80c890..0x80c891
+            - Range: 0x80c9a0..0x80c9a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c891..0x80c8c0
+            - Range: 0x80c9a1..0x80c9d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x80c8c0..0x80c8d0]
+      OutOfLinePCRanges: [0x80c9d0..0x80c9e0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 350 PointerType *go.shape.string
           Locations:
-            - Range: 0x80c8c0..0x80c8c4
+            - Range: 0x80c9d0..0x80c9d4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c8c0..0x80c8c4
+            - Range: 0x80c9d0..0x80c9d4
               Pieces: []
-            - Range: 0x80c8c4..0x80c8c5
+            - Range: 0x80c9d4..0x80c9d5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c8c5..0x80c8d0
+            - Range: 0x80c9d5..0x80c9e0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x80c8d0..0x80c920]
+      OutOfLinePCRanges: [0x80c9e0..0x80ca30]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x80c8d0..0x80c910
+            - Range: 0x80c9e0..0x80ca20
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 352 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x80c8d0..0x80c914
+            - Range: 0x80c9e0..0x80ca24
               Pieces: []
-            - Range: 0x80c914..0x80c915
+            - Range: 0x80ca24..0x80ca25
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10741,20 +10741,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80c915..0x80c920
+            - Range: 0x80ca25..0x80ca30
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x80c920..0x80c960]
+      OutOfLinePCRanges: [0x80ca30..0x80ca70]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80c920..0x80c92c
+            - Range: 0x80ca30..0x80ca3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10762,7 +10762,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80c92c..0x80c960
+            - Range: 0x80ca3c..0x80ca70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10775,42 +10775,42 @@ Subprograms:
         - Name: needle
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c920..0x80c960
+            - Range: 0x80ca30..0x80ca70
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80c920..0x80c948
+            - Range: 0x80ca30..0x80ca58
               Pieces: []
-            - Range: 0x80c948..0x80c949
+            - Range: 0x80ca58..0x80ca59
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c949..0x80c950
+            - Range: 0x80ca59..0x80ca60
               Pieces: []
-            - Range: 0x80c950..0x80c951
+            - Range: 0x80ca60..0x80ca61
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c951..0x80c960
+            - Range: 0x80ca61..0x80ca70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c93c..0x80c94c
+            - Range: 0x80ca4c..0x80ca5c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x80c960..0x80ca20]
+      OutOfLinePCRanges: [0x80ca70..0x80cb30]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 353 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x80c960..0x80c984
+            - Range: 0x80ca70..0x80ca94
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10818,7 +10818,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80c984..0x80c988
+            - Range: 0x80ca94..0x80ca98
               Pieces:
                 - Size: 8
                   Op: null
@@ -10831,13 +10831,13 @@ Subprograms:
         - Name: needle
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c960..0x80c9bc
+            - Range: 0x80ca70..0x80cacc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80c9bc..0x80ca20
+            - Range: 0x80cacc..0x80cb30
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10848,22 +10848,22 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80c960..0x80c9d8
+            - Range: 0x80ca70..0x80cae8
               Pieces: []
-            - Range: 0x80c9d8..0x80c9d9
+            - Range: 0x80cae8..0x80cae9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c9d9..0x80c9e8
+            - Range: 0x80cae9..0x80caf8
               Pieces: []
-            - Range: 0x80c9e8..0x80c9e9
+            - Range: 0x80caf8..0x80caf9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c9e9..0x80ca20
+            - Range: 0x80caf9..0x80cb30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c9a4..0x80c9bc
+            - Range: 0x80cab4..0x80cacc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10874,56 +10874,56 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x80ca20..0x80ca30]
+      OutOfLinePCRanges: [0x80cb30..0x80cb40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 354 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x80ca20..0x80ca28
+            - Range: 0x80cb30..0x80cb38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80ca20..0x80ca30
+            - Range: 0x80cb30..0x80cb40
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80ca20..0x80ca28
+            - Range: 0x80cb30..0x80cb38
               Pieces: []
-            - Range: 0x80ca28..0x80ca29
+            - Range: 0x80cb38..0x80cb39
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ca29..0x80ca30
+            - Range: 0x80cb39..0x80cb40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x80ca80..0x80caf0]
+      OutOfLinePCRanges: [0x80cb90..0x80cc00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 355 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x80ca80..0x80caac
+            - Range: 0x80cb90..0x80cbbc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80caac..0x80cab8
+            - Range: 0x80cbbc..0x80cbc8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80cab8..0x80cabc
+            - Range: 0x80cbc8..0x80cbcc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10934,7 +10934,7 @@ Subprograms:
         - Name: value
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80ca80..0x80cabc
+            - Range: 0x80cb90..0x80cbcc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10945,11 +10945,11 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80ca80..0x80cabc
+            - Range: 0x80cb90..0x80cbcc
               Pieces: []
-            - Range: 0x80cabc..0x80cabd
+            - Range: 0x80cbcc..0x80cbcd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cabd..0x80caf0
+            - Range: 0x80cbcd..0x80cc00
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11111,31 +11111,31 @@ Subprograms:
       DictRegister: 0
     - ID: 186
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x8055b0..0x805620]
+      OutOfLinePCRanges: [0x8056c0..0x805730]
       InlinePCRanges:
-        - Ranges: [0x80563c..0x805670]
-          RootRanges: [0x805620..0x805690]
-        - Ranges: [0x805770..0x8057a4]
-          RootRanges: [0x805740..0x8057d0]
-        - Ranges: [0x8057f4..0x805828]
-          RootRanges: [0x8057d0..0x805890]
-        - Ranges: [0x8058ac..0x8058e0]
-          RootRanges: [0x805890..0x805900]
+        - Ranges: [0x80574c..0x805780]
+          RootRanges: [0x805730..0x8057a0]
+        - Ranges: [0x805880..0x8058b4]
+          RootRanges: [0x805850..0x8058e0]
+        - Ranges: [0x805904..0x805938]
+          RootRanges: [0x8058e0..0x8059a0]
+        - Ranges: [0x8059bc..0x8059f0]
+          RootRanges: [0x8059a0..0x805a10]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8055b0..0x8055d0
+            - Range: 0x8056c0..0x8056e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80563c..0x805644
+            - Range: 0x80574c..0x805754
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x805770..0x805778
+            - Range: 0x805880..0x805888
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8057ec..0x8057fc
+            - Range: 0x8058fc..0x80590c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8057fc..0x805890
+            - Range: 0x80590c..0x8059a0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x805890..0x8058b4
+            - Range: 0x8059a0..0x8059c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11144,37 +11144,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x805834..0x805868]
-          RootRanges: [0x8057d0..0x805890]
+        - Ranges: [0x805944..0x805978]
+          RootRanges: [0x8058e0..0x8059a0]
       Variables: []
       DictRegister: null
     - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80591c..0x805950, 0x805958..0x80595c]
-          RootRanges: [0x805900..0x805a10]
+        - Ranges: [0x805a2c..0x805a60, 0x805a68..0x805a6c]
+          RootRanges: [0x805a10..0x805b20]
       Variables: []
       DictRegister: null
     - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8059c0..0x8059f4]
-          RootRanges: [0x805900..0x805a10]
+        - Ranges: [0x805ad0..0x805b04]
+          RootRanges: [0x805a10..0x805b20]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x805a14..0x805a18]
-          RootRanges: [0x805a10..0x805a20]
+        - Ranges: [0x805b24..0x805b28]
+          RootRanges: [0x805b20..0x805b30]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x805a10..0x805a18
+            - Range: 0x805b20..0x805b28
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11183,32 +11183,32 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x805a44..0x805a60]
-          RootRanges: [0x805a20..0x805a70]
-        - Ranges: [0x805acc..0x805aec]
-          RootRanges: [0x805a70..0x805bb0]
+        - Ranges: [0x805b54..0x805b70]
+          RootRanges: [0x805b30..0x805b80]
+        - Ranges: [0x805bdc..0x805bfc]
+          RootRanges: [0x805b80..0x805cc0]
       Variables:
         - Name: a
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0x805a30..0x805a70
+            - Range: 0x805b40..0x805b80
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x805ab8..0x805bb0
+            - Range: 0x805bc8..0x805cc0
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 192
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x805bb0..0x805c10]
+      OutOfLinePCRanges: [0x805cc0..0x805d20]
       InlinePCRanges:
-        - Ranges: [0x80cb70..0x80cb94]
-          RootRanges: [0x80cb50..0x80cbc0]
+        - Ranges: [0x80cc80..0x80cca4]
+          RootRanges: [0x80cc60..0x80ccd0]
       Variables:
         - Name: b
           Type: 360 StructureType main.firstBehavior
           Locations:
-            - Range: 0x805bb0..0x805bd4
+            - Range: 0x805cc0..0x805ce4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11219,15 +11219,15 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x805bb0..0x805bf0
+            - Range: 0x805cc0..0x805d00
               Pieces: []
-            - Range: 0x805bf0..0x805bf1
+            - Range: 0x805d00..0x805d01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x805bf1..0x805c10
+            - Range: 0x805d01..0x805d20
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11236,8 +11236,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x806230..0x80623c, 0x806240..0x806248]
-          RootRanges: [0x806110..0x806290]
+        - Ranges: [0x806344..0x806350, 0x806354..0x80635c]
+          RootRanges: [0x806220..0x8063a0]
         - Ranges: [0x139638..0x13963c, 0x139640..0x139648]
           RootRanges: [0x139630..0x139650]
       Variables: []
@@ -11284,7 +11284,7 @@ Types:
       ID: 136
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 538528
+      GoRuntimeType: 538560
       GoKind: 22
       Pointee: 101 PointerType *string
     - __kind: PointerType
@@ -11556,7 +11556,7 @@ Types:
       ID: 40
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 496736
+      GoRuntimeType: 496768
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11598,14 +11598,14 @@ Types:
       ID: 1192
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.01648e+06
+      GoRuntimeType: 2.016768e+06
       GoKind: 22
       Pointee: 1193 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
       ID: 826
       Name: '*archive/tar.headerError'
       ByteSize: 8
-      GoRuntimeType: 943840
+      GoRuntimeType: 943872
       GoKind: 22
       Pointee: 827 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
@@ -11617,91 +11617,91 @@ Types:
       ID: 1126
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.453376e+06
+      GoRuntimeType: 1.453504e+06
       GoKind: 22
       Pointee: 1127 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
       ID: 1074
       Name: '*archive/zip.countWriter'
       ByteSize: 8
-      GoRuntimeType: 944032
+      GoRuntimeType: 944064
       GoKind: 22
       Pointee: 1075 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
       ID: 1076
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
-      GoRuntimeType: 944128
+      GoRuntimeType: 944160
       GoKind: 22
       Pointee: 1077 StructureType archive/zip.dirWriter
     - __kind: PointerType
       ID: 1169
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.932512e+06
+      GoRuntimeType: 1.9328e+06
       GoKind: 22
       Pointee: 1170 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 1102
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.070624e+06
+      GoRuntimeType: 1.070752e+06
       GoKind: 22
       Pointee: 1103 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 1104
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.07088e+06
+      GoRuntimeType: 1.071008e+06
       GoKind: 22
       Pointee: 1105 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 10
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 400416
+      GoRuntimeType: 400448
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 1150
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.20656e+06
+      GoRuntimeType: 2.206848e+06
       GoKind: 22
       Pointee: 1151 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1181
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.97904e+06
+      GoRuntimeType: 1.979328e+06
       GoKind: 22
       Pointee: 1182 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1228
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.308544e+06
+      GoRuntimeType: 2.308832e+06
       GoKind: 22
       Pointee: 1229 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
       ID: 114
       Name: '*complex128'
       ByteSize: 8
-      GoRuntimeType: 400224
+      GoRuntimeType: 400256
       GoKind: 22
       Pointee: 18 BaseType complex128
     - __kind: PointerType
       ID: 741
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 926080
+      GoRuntimeType: 926112
       GoKind: 22
       Pointee: 630 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
       ID: 742
       Name: '*compress/flate.InternalError'
       ByteSize: 8
-      GoRuntimeType: 926176
+      GoRuntimeType: 926208
       GoKind: 22
       Pointee: 631 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
@@ -11713,469 +11713,469 @@ Types:
       ID: 1124
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.442176e+06
+      GoRuntimeType: 1.442304e+06
       GoKind: 22
       Pointee: 1125 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
       ID: 1070
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
-      GoRuntimeType: 926272
+      GoRuntimeType: 926304
       GoKind: 22
       Pointee: 1071 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
       ID: 1146
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.751872e+06
+      GoRuntimeType: 1.75216e+06
       GoKind: 22
       Pointee: 1147 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 974
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.21744e+06
+      GoRuntimeType: 1.217568e+06
       GoKind: 22
       Pointee: 975 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 818
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 938464
+      GoRuntimeType: 938496
       GoKind: 22
       Pointee: 641 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
       ID: 819
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 938656
+      GoRuntimeType: 938688
       GoKind: 22
       Pointee: 642 BaseType crypto/des.KeySizeError
     - __kind: PointerType
       ID: 820
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 938944
+      GoRuntimeType: 938976
       GoKind: 22
       Pointee: 643 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
       ID: 1141
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
-      GoRuntimeType: 1.692416e+06
+      GoRuntimeType: 1.692704e+06
       GoKind: 22
       Pointee: 1142 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
       ID: 923
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
-      GoRuntimeType: 1.078432e+06
+      GoRuntimeType: 1.07856e+06
       GoKind: 22
       Pointee: 924 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
       ID: 1171
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.933024e+06
+      GoRuntimeType: 1.933312e+06
       GoKind: 22
       Pointee: 1172 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
       ID: 1203
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
-      GoRuntimeType: 2.15056e+06
+      GoRuntimeType: 2.150848e+06
       GoKind: 22
       Pointee: 1204 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
       ID: 1177
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.933792e+06
+      GoRuntimeType: 1.93408e+06
       GoKind: 22
       Pointee: 1178 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
       ID: 1173
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.93328e+06
+      GoRuntimeType: 1.933568e+06
       GoKind: 22
       Pointee: 1174 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
       ID: 1167
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.930464e+06
+      GoRuntimeType: 1.930752e+06
       GoKind: 22
       Pointee: 1168 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
       ID: 821
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
-      GoRuntimeType: 939232
+      GoRuntimeType: 939264
       GoKind: 22
       Pointee: 644 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
       ID: 1190
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 2.014176e+06
+      GoRuntimeType: 2.014464e+06
       GoKind: 22
       Pointee: 1191 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1175
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
-      GoRuntimeType: 1.933536e+06
+      GoRuntimeType: 1.933824e+06
       GoKind: 22
       Pointee: 1176 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
       ID: 1159
       Name: '*crypto/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.835424e+06
+      GoRuntimeType: 1.835712e+06
       GoKind: 22
       Pointee: 1160 UnresolvedPointeeType crypto/sha3.SHAKE
     - __kind: PointerType
       ID: 745
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
-      GoRuntimeType: 927520
+      GoRuntimeType: 927552
       GoKind: 22
       Pointee: 634 BaseType crypto/tls.AlertError
     - __kind: PointerType
       ID: 912
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.059872e+06
+      GoRuntimeType: 1.06e+06
       GoKind: 22
       Pointee: 913 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1254
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.411072e+06
+      GoRuntimeType: 2.41136e+06
       GoKind: 22
       Pointee: 1255 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
       ID: 746
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
-      GoRuntimeType: 927616
+      GoRuntimeType: 927648
       GoKind: 22
       Pointee: 747 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
       ID: 743
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
-      GoRuntimeType: 927424
+      GoRuntimeType: 927456
       GoKind: 22
       Pointee: 744 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
       ID: 911
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.058208e+06
+      GoRuntimeType: 1.058336e+06
       GoKind: 22
       Pointee: 866 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 1134
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.581248e+06
+      GoRuntimeType: 1.581536e+06
       GoKind: 22
       Pointee: 1135 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
       ID: 748
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
-      GoRuntimeType: 927712
+      GoRuntimeType: 927744
       GoKind: 22
       Pointee: 749 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
       ID: 1139
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.666496e+06
+      GoRuntimeType: 1.666784e+06
       GoKind: 22
       Pointee: 1140 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 1009
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.442656e+06
+      GoRuntimeType: 1.442784e+06
       GoKind: 22
       Pointee: 1010 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 1026
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.042816e+06
+      GoRuntimeType: 2.043104e+06
       GoKind: 22
       Pointee: 1027 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
       ID: 814
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
-      GoRuntimeType: 937312
+      GoRuntimeType: 937344
       GoKind: 22
       Pointee: 815 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
       ID: 808
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
-      GoRuntimeType: 936352
+      GoRuntimeType: 936384
       GoKind: 22
       Pointee: 809 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
       ID: 810
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
-      GoRuntimeType: 936832
+      GoRuntimeType: 936864
       GoKind: 22
       Pointee: 811 StructureType crypto/x509.HostnameError
     - __kind: PointerType
       ID: 807
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
-      GoRuntimeType: 936256
+      GoRuntimeType: 936288
       GoKind: 22
       Pointee: 640 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
       ID: 917
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.06512e+06
+      GoRuntimeType: 1.065248e+06
       GoKind: 22
       Pointee: 918 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
       ID: 816
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
-      GoRuntimeType: 937408
+      GoRuntimeType: 937440
       GoKind: 22
       Pointee: 817 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
       ID: 812
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
-      GoRuntimeType: 937216
+      GoRuntimeType: 937248
       GoKind: 22
       Pointee: 813 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
       ID: 830
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
-      GoRuntimeType: 944320
+      GoRuntimeType: 944352
       GoKind: 22
       Pointee: 831 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
       ID: 834
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 944512
+      GoRuntimeType: 944544
       GoKind: 22
       Pointee: 835 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
       ID: 832
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 944416
+      GoRuntimeType: 944448
       GoKind: 22
       Pointee: 833 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
       ID: 730
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 924352
+      GoRuntimeType: 924384
       GoKind: 22
       Pointee: 625 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 1092
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.055648e+06
+      GoRuntimeType: 1.055776e+06
       GoKind: 22
       Pointee: 1093 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
       ID: 733
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
-      GoRuntimeType: 925216
+      GoRuntimeType: 925248
       GoKind: 22
       Pointee: 626 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
       ID: 701
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 919168
+      GoRuntimeType: 919200
       GoKind: 22
       Pointee: 702 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 901
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.051808e+06
+      GoRuntimeType: 1.051936e+06
       GoKind: 22
       Pointee: 902 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 693
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 918784
+      GoRuntimeType: 918816
       GoKind: 22
       Pointee: 694 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 699
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 919072
+      GoRuntimeType: 919104
       GoKind: 22
       Pointee: 700 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 697
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
-      GoRuntimeType: 918976
+      GoRuntimeType: 919008
       GoKind: 22
       Pointee: 698 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
       ID: 695
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 918880
+      GoRuntimeType: 918912
       GoKind: 22
       Pointee: 696 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1234
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.329664e+06
+      GoRuntimeType: 2.329952e+06
       GoKind: 22
       Pointee: 1235 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
       ID: 703
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 919552
+      GoRuntimeType: 919584
       GoKind: 22
       Pointee: 704 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 1100
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.067424e+06
+      GoRuntimeType: 1.067552e+06
       GoKind: 22
       Pointee: 1101 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
       ID: 805
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 935488
+      GoRuntimeType: 935520
       GoKind: 22
       Pointee: 806 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 111
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 399328
+      GoRuntimeType: 399360
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
       ID: 666
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 908512
+      GoRuntimeType: 908544
       GoKind: 22
       Pointee: 667 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 868
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1.036064e+06
+      GoRuntimeType: 1.036192e+06
       GoKind: 22
       Pointee: 869 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 113
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 400288
+      GoRuntimeType: 400320
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 104
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 400352
+      GoRuntimeType: 400384
       GoKind: 22
       Pointee: 14 BaseType float64
     - __kind: PointerType
       ID: 1222
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.291104e+06
+      GoRuntimeType: 2.291392e+06
       GoKind: 22
       Pointee: 1223 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 870
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.036192e+06
+      GoRuntimeType: 1.03632e+06
       GoKind: 22
       Pointee: 871 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 872
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.03632e+06
+      GoRuntimeType: 1.036448e+06
       GoKind: 22
       Pointee: 873 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
       ID: 731
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 924736
+      GoRuntimeType: 924768
       GoKind: 22
       Pointee: 732 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 712
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 921952
+      GoRuntimeType: 921984
       GoKind: 22
       Pointee: 713 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
       ID: 714
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 922048
+      GoRuntimeType: 922080
       GoKind: 22
       Pointee: 715 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 1038
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 921760
+      GoRuntimeType: 921792
       GoKind: 22
       Pointee: 1039 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
       ID: 718
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 922336
+      GoRuntimeType: 922368
       GoKind: 22
       Pointee: 719 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 1040
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 921856
+      GoRuntimeType: 921888
       GoKind: 22
       Pointee: 1041 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
       ID: 716
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 922144
+      GoRuntimeType: 922176
       GoKind: 22
       Pointee: 619 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -12187,7 +12187,7 @@ Types:
       ID: 711
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 921664
+      GoRuntimeType: 921696
       GoKind: 22
       Pointee: 616 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -12199,7 +12199,7 @@ Types:
       ID: 717
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 922240
+      GoRuntimeType: 922272
       GoKind: 22
       Pointee: 622 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -12211,98 +12211,98 @@ Types:
       ID: 1112
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.222944e+06
+      GoRuntimeType: 1.223072e+06
       GoKind: 22
       Pointee: 1113 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1200
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 2.088288e+06
+      GoRuntimeType: 2.088576e+06
       GoKind: 22
       Pointee: 1201 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
       ID: 824
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
-      GoRuntimeType: 942784
+      GoRuntimeType: 942816
       GoKind: 22
       Pointee: 825 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 983
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.2264e+06
+      GoRuntimeType: 1.226528e+06
       GoKind: 22
       Pointee: 984 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1230
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.309632e+06
+      GoRuntimeType: 2.30992e+06
       GoKind: 22
       Pointee: 1231 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
       ID: 756
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
-      GoRuntimeType: 931168
+      GoRuntimeType: 931200
       GoKind: 22
       Pointee: 757 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
       ID: 763
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
-      GoRuntimeType: 932224
+      GoRuntimeType: 932256
       GoKind: 22
       Pointee: 764 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
       ID: 758
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
-      GoRuntimeType: 931936
+      GoRuntimeType: 931968
       GoKind: 22
       Pointee: 639 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
       ID: 761
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
-      GoRuntimeType: 932128
+      GoRuntimeType: 932160
       GoKind: 22
       Pointee: 762 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
       ID: 759
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
-      GoRuntimeType: 932032
+      GoRuntimeType: 932064
       GoKind: 22
       Pointee: 760 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
       ID: 779
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
-      GoRuntimeType: 934144
+      GoRuntimeType: 934176
       GoKind: 22
       Pointee: 780 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
       ID: 783
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
-      GoRuntimeType: 934336
+      GoRuntimeType: 934368
       GoKind: 22
       Pointee: 784 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
       ID: 781
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
-      GoRuntimeType: 934240
+      GoRuntimeType: 934272
       GoKind: 22
       Pointee: 782 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
       ID: 777
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
-      GoRuntimeType: 934048
+      GoRuntimeType: 934080
       GoKind: 22
       Pointee: 778 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
@@ -12314,357 +12314,357 @@ Types:
       ID: 791
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
-      GoRuntimeType: 934720
+      GoRuntimeType: 934752
       GoKind: 22
       Pointee: 792 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
       ID: 785
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
-      GoRuntimeType: 934432
+      GoRuntimeType: 934464
       GoKind: 22
       Pointee: 786 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
       ID: 789
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
-      GoRuntimeType: 934624
+      GoRuntimeType: 934656
       GoKind: 22
       Pointee: 790 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
       ID: 787
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
-      GoRuntimeType: 934528
+      GoRuntimeType: 934560
       GoKind: 22
       Pointee: 788 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
       ID: 793
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
-      GoRuntimeType: 934816
+      GoRuntimeType: 934848
       GoKind: 22
       Pointee: 794 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
       ID: 799
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
-      GoRuntimeType: 935104
+      GoRuntimeType: 935136
       GoKind: 22
       Pointee: 800 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
       ID: 801
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
-      GoRuntimeType: 935200
+      GoRuntimeType: 935232
       GoKind: 22
       Pointee: 802 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
       ID: 797
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
-      GoRuntimeType: 935008
+      GoRuntimeType: 935040
       GoKind: 22
       Pointee: 798 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
       ID: 795
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
-      GoRuntimeType: 934912
+      GoRuntimeType: 934944
       GoKind: 22
       Pointee: 796 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
       ID: 803
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
-      GoRuntimeType: 935392
+      GoRuntimeType: 935424
       GoKind: 22
       Pointee: 804 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 720
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 923488
+      GoRuntimeType: 923520
       GoKind: 22
       Pointee: 721 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 1153
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.830048e+06
+      GoRuntimeType: 1.830336e+06
       GoKind: 22
       Pointee: 1154 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
       ID: 722
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 923584
+      GoRuntimeType: 923616
       GoKind: 22
       Pointee: 723 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 1132
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.579968e+06
+      GoRuntimeType: 1.580256e+06
       GoKind: 22
       Pointee: 1133 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 1088
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.054496e+06
+      GoRuntimeType: 1.054624e+06
       GoKind: 22
       Pointee: 1089 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1122
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.440256e+06
+      GoRuntimeType: 1.440384e+06
       GoKind: 22
       Pointee: 1123 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 726
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 923776
+      GoRuntimeType: 923808
       GoKind: 22
       Pointee: 727 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1188
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 2.0064e+06
+      GoRuntimeType: 2.006688e+06
       GoKind: 22
       Pointee: 1189 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1207
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.164736e+06
+      GoRuntimeType: 2.165024e+06
       GoKind: 22
       Pointee: 1202 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1206
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.164352e+06
+      GoRuntimeType: 2.16464e+06
       GoKind: 22
       Pointee: 1205 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 1090
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.054624e+06
+      GoRuntimeType: 1.054752e+06
       GoKind: 22
       Pointee: 1091 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 724
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 923680
+      GoRuntimeType: 923712
       GoKind: 22
       Pointee: 725 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
       ID: 728
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 923872
+      GoRuntimeType: 923904
       GoKind: 22
       Pointee: 729 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 1155
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.83184e+06
+      GoRuntimeType: 1.832128e+06
       GoKind: 22
       Pointee: 1156 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1196
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.042528e+06
+      GoRuntimeType: 2.042816e+06
       GoKind: 22
       Pointee: 1197 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1198
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.0736e+06
+      GoRuntimeType: 2.073888e+06
       GoKind: 22
       Pointee: 1199 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 1014
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.455776e+06
+      GoRuntimeType: 1.455904e+06
       GoKind: 22
       Pointee: 1015 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 927
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.0792e+06
+      GoRuntimeType: 1.079328e+06
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 925
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.079072e+06
+      GoRuntimeType: 1.0792e+06
       GoKind: 22
       Pointee: 926 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 929
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.083168e+06
+      GoRuntimeType: 1.083296e+06
       GoKind: 22
       Pointee: 930 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 931
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.083296e+06
+      GoRuntimeType: 1.083424e+06
       GoKind: 22
       Pointee: 932 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 1143
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.695296e+06
+      GoRuntimeType: 1.695584e+06
       GoKind: 22
       Pointee: 1144 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 919
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.065632e+06
+      GoRuntimeType: 1.06576e+06
       GoKind: 22
       Pointee: 920 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 734
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
-      GoRuntimeType: 925408
+      GoRuntimeType: 925440
       GoKind: 22
       Pointee: 735 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
       ID: 1246
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.384992e+06
+      GoRuntimeType: 2.38528e+06
       GoKind: 22
       Pointee: 1247 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 985
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.235488e+06
+      GoRuntimeType: 1.235616e+06
       GoKind: 22
       Pointee: 986 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 958
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.213984e+06
+      GoRuntimeType: 1.214112e+06
       GoKind: 22
       Pointee: 959 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 952
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.2136e+06
+      GoRuntimeType: 1.213728e+06
       GoKind: 22
       Pointee: 953 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 887
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.045664e+06
+      GoRuntimeType: 1.045792e+06
       GoKind: 22
       Pointee: 888 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 964
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.214368e+06
+      GoRuntimeType: 1.214496e+06
       GoKind: 22
       Pointee: 965 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 886
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1.045536e+06
+      GoRuntimeType: 1.045664e+06
       GoKind: 22
       Pointee: 865 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 956
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.213856e+06
+      GoRuntimeType: 1.213984e+06
       GoKind: 22
       Pointee: 957 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 954
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.213728e+06
+      GoRuntimeType: 1.213856e+06
       GoKind: 22
       Pointee: 955 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 962
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.21424e+06
+      GoRuntimeType: 1.214368e+06
       GoKind: 22
       Pointee: 963 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 960
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.214112e+06
+      GoRuntimeType: 1.21424e+06
       GoKind: 22
       Pointee: 961 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1250
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.400096e+06
+      GoRuntimeType: 2.400384e+06
       GoKind: 22
       Pointee: 1251 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 968
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.214752e+06
+      GoRuntimeType: 1.21488e+06
       GoKind: 22
       Pointee: 969 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 891
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1.04592e+06
+      GoRuntimeType: 1.046048e+06
       GoKind: 22
       Pointee: 892 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 889
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1.045792e+06
+      GoRuntimeType: 1.04592e+06
       GoKind: 22
       Pointee: 890 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 966
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.214624e+06
+      GoRuntimeType: 1.214752e+06
       GoKind: 22
       Pointee: 967 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
       ID: 846
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
-      GoRuntimeType: 957568
+      GoRuntimeType: 957600
       GoKind: 22
       Pointee: 649 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
@@ -12676,21 +12676,21 @@ Types:
       ID: 357
       Name: '*go.shape.float64'
       ByteSize: 8
-      GoRuntimeType: 487648
+      GoRuntimeType: 487680
       GoKind: 22
       Pointee: 358 BaseType go.shape.float64
     - __kind: PointerType
       ID: 333
       Name: '*go.shape.int'
       ByteSize: 8
-      GoRuntimeType: 487072
+      GoRuntimeType: 487104
       GoKind: 22
       Pointee: 328 BaseType go.shape.int
     - __kind: PointerType
       ID: 350
       Name: '*go.shape.string'
       ByteSize: 8
-      GoRuntimeType: 487136
+      GoRuntimeType: 487168
       GoKind: 22
       Pointee: 330 GoStringHeaderType go.shape.string
     - __kind: PointerType
@@ -12720,63 +12720,63 @@ Types:
       ID: 1029
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.69376e+06
+      GoRuntimeType: 1.694048e+06
       GoKind: 22
       Pointee: 1030 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 935
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.098016e+06
+      GoRuntimeType: 1.098144e+06
       GoKind: 22
       Pointee: 936 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 1118
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.27632e+06
+      GoRuntimeType: 1.276448e+06
       GoKind: 22
       Pointee: 1119 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1212
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.179328e+06
+      GoRuntimeType: 2.179616e+06
       GoKind: 22
       Pointee: 1213 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 1106
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.10032e+06
+      GoRuntimeType: 1.100448e+06
       GoKind: 22
       Pointee: 1107 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
       ID: 847
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 958816
+      GoRuntimeType: 958848
       GoKind: 22
       Pointee: 652 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
       ID: 993
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.277984e+06
+      GoRuntimeType: 1.278112e+06
       GoKind: 22
       Pointee: 994 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
       ID: 850
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
-      GoRuntimeType: 959104
+      GoRuntimeType: 959136
       GoKind: 22
       Pointee: 851 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
       ID: 849
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 959008
+      GoRuntimeType: 959040
       GoKind: 22
       Pointee: 656 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
@@ -12788,7 +12788,7 @@ Types:
       ID: 853
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 959296
+      GoRuntimeType: 959328
       GoKind: 22
       Pointee: 662 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
@@ -12800,7 +12800,7 @@ Types:
       ID: 852
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 959200
+      GoRuntimeType: 959232
       GoKind: 22
       Pointee: 659 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
@@ -12812,7 +12812,7 @@ Types:
       ID: 848
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 958912
+      GoRuntimeType: 958944
       GoKind: 22
       Pointee: 653 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
@@ -12824,252 +12824,252 @@ Types:
       ID: 1210
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.177408e+06
+      GoRuntimeType: 2.177696e+06
       GoKind: 22
       Pointee: 1211 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
       ID: 854
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
-      GoRuntimeType: 959392
+      GoRuntimeType: 959424
       GoKind: 22
       Pointee: 855 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
       ID: 856
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
-      GoRuntimeType: 959488
+      GoRuntimeType: 959520
       GoKind: 22
       Pointee: 665 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
       ID: 842
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
-      GoRuntimeType: 952768
+      GoRuntimeType: 952800
       GoKind: 22
       Pointee: 843 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
       ID: 991
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.27504e+06
+      GoRuntimeType: 1.275168e+06
       GoKind: 22
       Pointee: 992 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 1016
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.463136e+06
+      GoRuntimeType: 1.463264e+06
       GoKind: 22
       Pointee: 1017 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
       ID: 844
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
-      GoRuntimeType: 955840
+      GoRuntimeType: 955872
       GoKind: 22
       Pointee: 845 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 1161
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.837664e+06
+      GoRuntimeType: 1.837952e+06
       GoKind: 22
       Pointee: 1162 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 1116
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.271584e+06
+      GoRuntimeType: 1.271712e+06
       GoKind: 22
       Pointee: 1117 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 933
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.092256e+06
+      GoRuntimeType: 1.092384e+06
       GoKind: 22
       Pointee: 934 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 1078
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
-      GoRuntimeType: 955936
+      GoRuntimeType: 955968
       GoKind: 22
       Pointee: 1079 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
       ID: 822
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
-      GoRuntimeType: 940672
+      GoRuntimeType: 940704
       GoKind: 22
       Pointee: 823 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
       ID: 921
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.06896e+06
+      GoRuntimeType: 1.069088e+06
       GoKind: 22
       Pointee: 922 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 989
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.242272e+06
+      GoRuntimeType: 1.2424e+06
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 987
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.242016e+06
+      GoRuntimeType: 1.242144e+06
       GoKind: 22
       Pointee: 988 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
       ID: 836
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
-      GoRuntimeType: 945376
+      GoRuntimeType: 945408
       GoKind: 22
       Pointee: 837 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
       ID: 838
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
-      GoRuntimeType: 945472
+      GoRuntimeType: 945504
       GoKind: 22
       Pointee: 839 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
       ID: 771
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
-      GoRuntimeType: 932608
+      GoRuntimeType: 932640
       GoKind: 22
       Pointee: 772 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
       ID: 1165
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.928416e+06
+      GoRuntimeType: 1.928704e+06
       GoKind: 22
       Pointee: 1166 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 857
       Name: '*html/template.Error'
       ByteSize: 8
-      GoRuntimeType: 960256
+      GoRuntimeType: 960288
       GoKind: 22
       Pointee: 858 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 105
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 399968
+      GoRuntimeType: 400000
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 109
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 399584
+      GoRuntimeType: 399616
       GoKind: 22
       Pointee: 102 BaseType int16
     - __kind: PointerType
       ID: 21
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 399712
+      GoRuntimeType: 399744
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 107
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 399840
+      GoRuntimeType: 399872
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 110
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 399456
+      GoRuntimeType: 399488
       GoKind: 22
       Pointee: 19 BaseType int8
     - __kind: PointerType
       ID: 169
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 400544
+      GoRuntimeType: 400576
       GoKind: 22
       Pointee: 163 GoEmptyInterfaceType interface {}
     - __kind: PointerType
       ID: 1018
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 2.226496e+06
+      GoRuntimeType: 2.226784e+06
       GoKind: 22
       Pointee: 1019 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
       ID: 739
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 925792
+      GoRuntimeType: 925824
       GoKind: 22
       Pointee: 740 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 737
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
-      GoRuntimeType: 925696
+      GoRuntimeType: 925728
       GoKind: 22
       Pointee: 738 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
       ID: 1064
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 913888
+      GoRuntimeType: 913920
       GoKind: 22
       Pointee: 1065 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
       ID: 950
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.212832e+06
+      GoRuntimeType: 1.21296e+06
       GoKind: 22
       Pointee: 951 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1252
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.40576e+06
+      GoRuntimeType: 2.406048e+06
       GoKind: 22
       Pointee: 1253 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 948
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.212704e+06
+      GoRuntimeType: 1.212832e+06
       GoKind: 22
       Pointee: 949 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 670
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 912736
+      GoRuntimeType: 912768
       GoKind: 22
       Pointee: 671 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
       ByteSize: 8
-      GoRuntimeType: 1.595648e+06
+      GoRuntimeType: 1.595936e+06
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
       ID: 736
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
-      GoRuntimeType: 925504
+      GoRuntimeType: 925536
       GoKind: 22
       Pointee: 627 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
@@ -13081,49 +13081,49 @@ Types:
       ID: 905
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.056544e+06
+      GoRuntimeType: 1.056672e+06
       GoKind: 22
       Pointee: 906 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
       ID: 674
       Name: '*internal/strconv.Error'
       ByteSize: 8
-      GoRuntimeType: 913504
+      GoRuntimeType: 913536
       GoKind: 22
       Pointee: 593 BaseType internal/strconv.Error
     - __kind: PointerType
       ID: 1110
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.204e+06
+      GoRuntimeType: 1.204128e+06
       GoKind: 22
       Pointee: 1111 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1108
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.203616e+06
+      GoRuntimeType: 1.203744e+06
       GoKind: 22
       Pointee: 1109 StructureType io.discard
     - __kind: PointerType
       ID: 1082
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.037088e+06
+      GoRuntimeType: 1.037216e+06
       GoKind: 22
       Pointee: 1083 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 946
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.212192e+06
+      GoRuntimeType: 1.21232e+06
       GoKind: 22
       Pointee: 947 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 1157
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.832064e+06
+      GoRuntimeType: 1.832352e+06
       GoKind: 22
       Pointee: 1158 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13148,105 +13148,105 @@ Types:
       ID: 381
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 392928
+      GoRuntimeType: 392960
       GoKind: 22
       Pointee: 382 StructureType main.deepMap2
     - __kind: PointerType
       ID: 1296
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 392864
+      GoRuntimeType: 392896
       GoKind: 22
       Pointee: 1297 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 155
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 392608
+      GoRuntimeType: 392640
       GoKind: 22
       Pointee: 156 StructureType main.deepMap7
     - __kind: PointerType
       ID: 1330
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 392544
+      GoRuntimeType: 392576
       GoKind: 22
       Pointee: 1331 StructureType main.deepMap8
     - __kind: PointerType
       ID: 1345
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 392480
+      GoRuntimeType: 392512
       GoKind: 22
       Pointee: 1346 StructureType main.deepMap9
     - __kind: PointerType
       ID: 139
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 393504
+      GoRuntimeType: 393536
       GoKind: 22
       Pointee: 140 StructureType main.deepPtr2
     - __kind: PointerType
       ID: 1256
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 393440
+      GoRuntimeType: 393472
       GoKind: 22
       Pointee: 1257 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 141
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 393184
+      GoRuntimeType: 393216
       GoKind: 22
       Pointee: 142 StructureType main.deepPtr7
     - __kind: PointerType
       ID: 1300
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 393120
+      GoRuntimeType: 393152
       GoKind: 22
       Pointee: 1301 StructureType main.deepPtr8
     - __kind: PointerType
       ID: 1302
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 393056
+      GoRuntimeType: 393088
       GoKind: 22
       Pointee: 1303 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 146
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 394080
+      GoRuntimeType: 394112
       GoKind: 22
       Pointee: 372 StructureType main.deepSlice2
     - __kind: PointerType
       ID: 1281
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 394016
+      GoRuntimeType: 394048
       GoKind: 22
       Pointee: 1282 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 147
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 393760
+      GoRuntimeType: 393792
       GoKind: 22
       Pointee: 148 StructureType main.deepSlice7
     - __kind: PointerType
       ID: 1306
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 393696
+      GoRuntimeType: 393728
       GoKind: 22
       Pointee: 1307 StructureType main.deepSlice8
     - __kind: PointerType
       ID: 1312
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 393632
+      GoRuntimeType: 393664
       GoKind: 22
       Pointee: 1313 StructureType main.deepSlice9
     - __kind: PointerType
@@ -13259,28 +13259,28 @@ Types:
       ID: 165
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 394208
+      GoRuntimeType: 394240
       GoKind: 22
       Pointee: 166 StructureType main.esotericHeap
     - __kind: PointerType
       ID: 1273
       Name: '*main.firstBehavior'
       ByteSize: 8
-      GoRuntimeType: 908224
+      GoRuntimeType: 908256
       GoKind: 22
       Pointee: 360 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 1362
       Name: '*main.nestedStruct'
       ByteSize: 8
-      GoRuntimeType: 394464
+      GoRuntimeType: 394496
       GoKind: 22
       Pointee: 129 StructureType main.nestedStruct
     - __kind: PointerType
       ID: 253
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 394272
+      GoRuntimeType: 394304
       GoKind: 22
       Pointee: 252 StructureType main.node
     - __kind: PointerType
@@ -13293,14 +13293,14 @@ Types:
       ID: 1274
       Name: '*main.secondBehavior'
       ByteSize: 8
-      GoRuntimeType: 908320
+      GoRuntimeType: 908352
       GoKind: 22
       Pointee: 1275 StructureType main.secondBehavior
     - __kind: PointerType
       ID: 1261
       Name: '*main.somethingImpl'
       ByteSize: 8
-      GoRuntimeType: 908416
+      GoRuntimeType: 908448
       GoKind: 22
       Pointee: 1262 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
@@ -13334,7 +13334,7 @@ Types:
       ID: 433
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 392416
+      GoRuntimeType: 392448
       GoKind: 22
       Pointee: 171 StructureType main.structWithMap
     - __kind: PointerType
@@ -13510,77 +13510,77 @@ Types:
       ID: 775
       Name: '*math/big.ErrNaN'
       ByteSize: 8
-      GoRuntimeType: 933472
+      GoRuntimeType: 933504
       GoKind: 22
       Pointee: 776 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 1072
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
-      GoRuntimeType: 928288
+      GoRuntimeType: 928320
       GoKind: 22
       Pointee: 1073 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
       ID: 977
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.220768e+06
+      GoRuntimeType: 1.220896e+06
       GoKind: 22
       Pointee: 978 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1003
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.438496e+06
+      GoRuntimeType: 1.438624e+06
       GoKind: 22
       Pointee: 1004 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1216
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.264736e+06
+      GoRuntimeType: 2.265024e+06
       GoKind: 22
       Pointee: 1217 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 1001
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.438176e+06
+      GoRuntimeType: 1.438304e+06
       GoKind: 22
       Pointee: 1002 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 979
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.220896e+06
+      GoRuntimeType: 1.221024e+06
       GoKind: 22
       Pointee: 980 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1226
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.292128e+06
+      GoRuntimeType: 2.292416e+06
       GoKind: 22
       Pointee: 1227 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1236
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.337248e+06
+      GoRuntimeType: 2.337536e+06
       GoKind: 22
       Pointee: 1237 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1224
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.291616e+06
+      GoRuntimeType: 2.291904e+06
       GoKind: 22
       Pointee: 1225 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 976
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.22e+06
+      GoRuntimeType: 1.220128e+06
       GoKind: 22
       Pointee: 939 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13592,126 +13592,126 @@ Types:
       ID: 903
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.052704e+06
+      GoRuntimeType: 1.052832e+06
       GoKind: 22
       Pointee: 904 StructureType net.canceledError
     - __kind: PointerType
       ID: 1194
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2.039648e+06
+      GoRuntimeType: 2.039936e+06
       GoKind: 22
       Pointee: 1195 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1047
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.875744e+06
+      GoRuntimeType: 1.876032e+06
       GoKind: 22
       Pointee: 1048 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1238
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.341504e+06
+      GoRuntimeType: 2.341792e+06
       GoKind: 22
       Pointee: 1239 UnresolvedPointeeType net.netFD
     - __kind: PointerType
       ID: 705
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 920512
+      GoRuntimeType: 920544
       GoKind: 22
       Pointee: 706 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 707
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 921184
+      GoRuntimeType: 921216
       GoKind: 22
       Pointee: 708 StructureType net.result·2
     - __kind: PointerType
       ID: 1220
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.277664e+06
+      GoRuntimeType: 2.277952e+06
       GoKind: 22
       Pointee: 1221 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1218
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.277184e+06
+      GoRuntimeType: 2.277472e+06
       GoKind: 22
       Pointee: 1219 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 981
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.221536e+06
+      GoRuntimeType: 1.221664e+06
       GoKind: 22
       Pointee: 982 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1005
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.438656e+06
+      GoRuntimeType: 1.438784e+06
       GoKind: 22
       Pointee: 1006 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 893
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1.04848e+06
+      GoRuntimeType: 1.048608e+06
       GoKind: 22
       Pointee: 894 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 1066
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 916288
+      GoRuntimeType: 916320
       GoKind: 22
       Pointee: 1067 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 682
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 916960
+      GoRuntimeType: 916992
       GoKind: 22
       Pointee: 597 BaseType net/http.http2ConnectionError
     - __kind: PointerType
       ID: 683
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 917056
+      GoRuntimeType: 917088
       GoKind: 22
       Pointee: 684 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 997
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.434176e+06
+      GoRuntimeType: 1.434304e+06
       GoKind: 22
       Pointee: 998 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 687
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 917632
+      GoRuntimeType: 917664
       GoKind: 22
       Pointee: 688 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 1128
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.576128e+06
+      GoRuntimeType: 1.576416e+06
       GoKind: 22
       Pointee: 1129 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
       ID: 686
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 917536
+      GoRuntimeType: 917568
       GoKind: 22
       Pointee: 601 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -13723,7 +13723,7 @@ Types:
       ID: 690
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 917824
+      GoRuntimeType: 917856
       GoKind: 22
       Pointee: 607 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -13735,7 +13735,7 @@ Types:
       ID: 689
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 917728
+      GoRuntimeType: 917760
       GoKind: 22
       Pointee: 604 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -13747,28 +13747,28 @@ Types:
       ID: 972
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.216672e+06
+      GoRuntimeType: 1.2168e+06
       GoKind: 22
       Pointee: 973 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 899
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1.048992e+06
+      GoRuntimeType: 1.04912e+06
       GoKind: 22
       Pointee: 900 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1183
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.980832e+06
+      GoRuntimeType: 1.98112e+06
       GoKind: 22
       Pointee: 1184 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
       ID: 685
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 917440
+      GoRuntimeType: 917472
       GoKind: 22
       Pointee: 598 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -13780,133 +13780,133 @@ Types:
       ID: 1068
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 917920
+      GoRuntimeType: 917952
       GoKind: 22
       Pointee: 1069 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 895
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1.048736e+06
+      GoRuntimeType: 1.048864e+06
       GoKind: 22
       Pointee: 896 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1130
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.227328e+06
+      GoRuntimeType: 2.227616e+06
       GoKind: 22
       Pointee: 1131 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1086
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1.048608e+06
+      GoRuntimeType: 1.048736e+06
       GoKind: 22
       Pointee: 1087 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 1120
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.434336e+06
+      GoRuntimeType: 1.434464e+06
       GoKind: 22
       Pointee: 1121 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
       ID: 691
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 918016
+      GoRuntimeType: 918048
       GoKind: 22
       Pointee: 692 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 999
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.435456e+06
+      GoRuntimeType: 1.435584e+06
       GoKind: 22
       Pointee: 1000 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 970
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.216544e+06
+      GoRuntimeType: 1.216672e+06
       GoKind: 22
       Pointee: 971 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 897
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1.048864e+06
+      GoRuntimeType: 1.048992e+06
       GoKind: 22
       Pointee: 898 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1163
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1.871936e+06
+      GoRuntimeType: 1.872224e+06
       GoKind: 22
       Pointee: 1164 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
       ID: 680
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 916192
+      GoRuntimeType: 916224
       GoKind: 22
       Pointee: 681 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 1185
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.982624e+06
+      GoRuntimeType: 1.982912e+06
       GoKind: 22
       Pointee: 1186 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 1096
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.060896e+06
+      GoRuntimeType: 1.061024e+06
       GoKind: 22
       Pointee: 1097 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
       ID: 767
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
-      GoRuntimeType: 932416
+      GoRuntimeType: 932448
       GoKind: 22
       Pointee: 768 StructureType net/netip.parseAddrError
     - __kind: PointerType
       ID: 765
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
-      GoRuntimeType: 932320
+      GoRuntimeType: 932352
       GoKind: 22
       Pointee: 766 StructureType net/netip.parsePrefixError
     - __kind: PointerType
       ID: 1136
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 2.149152e+06
+      GoRuntimeType: 2.14944e+06
       GoKind: 22
       Pointee: 1137 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 1098
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.065248e+06
+      GoRuntimeType: 1.065376e+06
       GoKind: 22
       Pointee: 1099 StructureType net/smtp.dataCloser
     - __kind: PointerType
       ID: 751
       Name: '*net/textproto.Error'
       ByteSize: 8
-      GoRuntimeType: 928480
+      GoRuntimeType: 928512
       GoKind: 22
       Pointee: 752 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
       ID: 750
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 928384
+      GoRuntimeType: 928416
       GoKind: 22
       Pointee: 635 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
@@ -13918,21 +13918,21 @@ Types:
       ID: 1094
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.060384e+06
+      GoRuntimeType: 1.060512e+06
       GoKind: 22
       Pointee: 1095 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 1007
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.438976e+06
+      GoRuntimeType: 1.439104e+06
       GoKind: 22
       Pointee: 1008 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
       ID: 709
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 921280
+      GoRuntimeType: 921312
       GoKind: 22
       Pointee: 610 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -13944,7 +13944,7 @@ Types:
       ID: 710
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 921376
+      GoRuntimeType: 921408
       GoKind: 22
       Pointee: 613 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -14091,70 +14091,70 @@ Types:
       ID: 1244
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.379616e+06
+      GoRuntimeType: 2.379904e+06
       GoKind: 22
       Pointee: 1245 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 876
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 1.039776e+06
+      GoRuntimeType: 1.039904e+06
       GoKind: 22
       Pointee: 877 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 942
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.20528e+06
+      GoRuntimeType: 1.205408e+06
       GoKind: 22
       Pointee: 943 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1242
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.37888e+06
+      GoRuntimeType: 2.379168e+06
       GoKind: 22
       Pointee: 1243 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1240
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.378144e+06
+      GoRuntimeType: 2.378432e+06
       GoKind: 22
       Pointee: 1241 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 907
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.056928e+06
+      GoRuntimeType: 1.057056e+06
       GoKind: 22
       Pointee: 908 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 1050
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 2.120064e+06
+      GoRuntimeType: 2.120352e+06
       GoKind: 22
       Pointee: 1051 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 1114
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.227808e+06
+      GoRuntimeType: 1.227936e+06
       GoKind: 22
       Pointee: 1115 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 909
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.057056e+06
+      GoRuntimeType: 1.057184e+06
       GoKind: 22
       Pointee: 910 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 841
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
-      GoRuntimeType: 950848
+      GoRuntimeType: 950880
       GoKind: 22
       Pointee: 646 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
@@ -14166,84 +14166,84 @@ Types:
       ID: 840
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
-      GoRuntimeType: 950752
+      GoRuntimeType: 950784
       GoKind: 22
       Pointee: 645 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
       ID: 672
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 913408
+      GoRuntimeType: 913440
       GoKind: 22
       Pointee: 673 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 773
       Name: '*regexp/syntax.Error'
       ByteSize: 8
-      GoRuntimeType: 933088
+      GoRuntimeType: 933120
       GoKind: 22
       Pointee: 774 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
       ID: 880
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1.042592e+06
+      GoRuntimeType: 1.04272e+06
       GoKind: 22
       Pointee: 881 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 884
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1.043232e+06
+      GoRuntimeType: 1.04336e+06
       GoKind: 22
       Pointee: 885 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 27
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 400608
+      GoRuntimeType: 400640
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 25
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.432096e+06
+      GoRuntimeType: 1.432224e+06
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 882
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1.04272e+06
+      GoRuntimeType: 1.042848e+06
       GoKind: 22
       Pointee: 883 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 69
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 402784
+      GoRuntimeType: 402816
       GoKind: 22
       Pointee: 70 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 48
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 401504
+      GoRuntimeType: 401536
       GoKind: 22
       Pointee: 49 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 944
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.211168e+06
+      GoRuntimeType: 1.211296e+06
       GoKind: 22
       Pointee: 945 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 878
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1.040928e+06
+      GoRuntimeType: 1.041056e+06
       GoKind: 22
       Pointee: 859 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14255,28 +14255,28 @@ Types:
       ID: 59
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 1.209888e+06
+      GoRuntimeType: 1.210016e+06
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.432736e+06
+      GoRuntimeType: 1.432864e+06
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 68
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.042336e+06
+      GoRuntimeType: 1.042464e+06
       GoKind: 22
       Pointee: 367 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 879
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1.041056e+06
+      GoRuntimeType: 1.041184e+06
       GoKind: 22
       Pointee: 862 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14288,56 +14288,56 @@ Types:
       ID: 42
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 401376
+      GoRuntimeType: 401408
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 50
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.573408e+06
+      GoRuntimeType: 1.573696e+06
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 668
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
-      GoRuntimeType: 912448
+      GoRuntimeType: 912480
       GoKind: 22
       Pointee: 669 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 45
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.085088e+06
+      GoRuntimeType: 2.085376e+06
       GoKind: 22
       Pointee: 46 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 83
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.644608e+06
+      GoRuntimeType: 1.644896e+06
       GoKind: 22
       Pointee: 84 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 53
       Name: '*runtime.xRegState'
       ByteSize: 8
-      GoRuntimeType: 401696
+      GoRuntimeType: 401728
       GoKind: 22
       Pointee: 54 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
       ID: 874
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 1.039136e+06
+      GoRuntimeType: 1.039264e+06
       GoKind: 22
       Pointee: 875 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 101
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 399392
+      GoRuntimeType: 399424
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -14349,35 +14349,35 @@ Types:
       ID: 1179
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.978528e+06
+      GoRuntimeType: 1.978816e+06
       GoKind: 22
       Pointee: 1180 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 1084
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 1.039264e+06
+      GoRuntimeType: 1.039392e+06
       GoKind: 22
       Pointee: 1085 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
       ID: 1080
       Name: '*struct { io.Writer }'
       ByteSize: 8
-      GoRuntimeType: 985184
+      GoRuntimeType: 985312
       GoKind: 22
       Pointee: 1081 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 273
       Name: '*struct {}'
       ByteSize: 8
-      GoRuntimeType: 483936
+      GoRuntimeType: 483968
       GoKind: 22
       Pointee: 131 StructureType struct {}
     - __kind: PointerType
       ID: 996
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.433696e+06
+      GoRuntimeType: 1.433824e+06
       GoKind: 22
       Pointee: 995 BaseType syscall.Errno
     - __kind: PointerType
@@ -14519,35 +14519,35 @@ Types:
       ID: 1214
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.191552e+06
+      GoRuntimeType: 2.19184e+06
       GoKind: 22
       Pointee: 1215 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 937
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.101856e+06
+      GoRuntimeType: 1.101984e+06
       GoKind: 22
       Pointee: 938 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 1012
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.649216e+06
+      GoRuntimeType: 1.649504e+06
       GoKind: 22
       Pointee: 1013 UnresolvedPointeeType time.Location
     - __kind: PointerType
       ID: 678
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 914752
+      GoRuntimeType: 914784
       GoKind: 22
       Pointee: 679 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 675
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 914560
+      GoRuntimeType: 914592
       GoKind: 22
       Pointee: 594 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -14559,91 +14559,91 @@ Types:
       ID: 676
       Name: '*time.parseDurationError'
       ByteSize: 8
-      GoRuntimeType: 914656
+      GoRuntimeType: 914688
       GoKind: 22
       Pointee: 677 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
       ID: 112
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 400032
+      GoRuntimeType: 400064
       GoKind: 22
       Pointee: 11 BaseType uint
     - __kind: PointerType
       ID: 108
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 399648
+      GoRuntimeType: 399680
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 22
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 399776
+      GoRuntimeType: 399808
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 106
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 399904
+      GoRuntimeType: 399936
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 399520
+      GoRuntimeType: 399552
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 20
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 400096
+      GoRuntimeType: 400128
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
       ID: 769
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
-      GoRuntimeType: 932512
+      GoRuntimeType: 932544
       GoKind: 22
       Pointee: 770 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
       ID: 1208
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.16704e+06
+      GoRuntimeType: 2.167328e+06
       GoKind: 22
       Pointee: 1209 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
       ID: 753
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
-      GoRuntimeType: 928672
+      GoRuntimeType: 928704
       GoKind: 22
       Pointee: 754 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
       ID: 755
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
-      GoRuntimeType: 928768
+      GoRuntimeType: 928800
       GoKind: 22
       Pointee: 638 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
       ID: 914
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.06064e+06
+      GoRuntimeType: 1.060768e+06
       GoKind: 22
       Pointee: 915 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 916
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.060768e+06
+      GoRuntimeType: 1.060896e+06
       GoKind: 22
       Pointee: 867 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -23657,7 +23657,7 @@ Types:
       ID: 95
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 704928
+      GoRuntimeType: 704960
       GoKind: 17
       Count: 10
       HasCount: true
@@ -23666,7 +23666,7 @@ Types:
       ID: 341
       Name: '[16]uint8'
       ByteSize: 16
-      GoRuntimeType: 690048
+      GoRuntimeType: 690080
       GoKind: 17
       Count: 16
       HasCount: true
@@ -23675,7 +23675,7 @@ Types:
       ID: 258
       Name: '[1]int'
       ByteSize: 8
-      GoRuntimeType: 697344
+      GoRuntimeType: 697376
       GoKind: 17
       Count: 1
       HasCount: true
@@ -23684,7 +23684,7 @@ Types:
       ID: 82
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 712096
+      GoRuntimeType: 712128
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23693,7 +23693,7 @@ Types:
       ID: 81
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 712192
+      GoRuntimeType: 712224
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23718,7 +23718,7 @@ Types:
       ID: 87
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 712384
+      GoRuntimeType: 712416
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23735,7 +23735,7 @@ Types:
       ID: 119
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 693120
+      GoRuntimeType: 693152
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23752,7 +23752,7 @@ Types:
       ID: 116
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 694752
+      GoRuntimeType: 694784
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23793,7 +23793,7 @@ Types:
       ID: 117
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 694848
+      GoRuntimeType: 694880
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23833,7 +23833,7 @@ Types:
       ID: 58
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 694944
+      GoRuntimeType: 694976
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23842,7 +23842,7 @@ Types:
       ID: 115
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 694656
+      GoRuntimeType: 694688
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23851,7 +23851,7 @@ Types:
       ID: 93
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 745536
+      GoRuntimeType: 745568
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23860,7 +23860,7 @@ Types:
       ID: 73
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 704832
+      GoRuntimeType: 704864
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23869,7 +23869,7 @@ Types:
       ID: 257
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 695040
+      GoRuntimeType: 695072
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23878,7 +23878,7 @@ Types:
       ID: 57
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 710464
+      GoRuntimeType: 710496
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23887,7 +23887,7 @@ Types:
       ID: 466
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 692736
+      GoRuntimeType: 692768
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23896,7 +23896,7 @@ Types:
       ID: 423
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 693024
+      GoRuntimeType: 693056
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23905,7 +23905,7 @@ Types:
       ID: 94
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 703104
+      GoRuntimeType: 703136
       GoKind: 17
       Count: 4
       HasCount: true
@@ -23922,7 +23922,7 @@ Types:
       ID: 1042
       Name: '[5]uint8'
       ByteSize: 5
-      GoRuntimeType: 694560
+      GoRuntimeType: 694592
       GoKind: 17
       Count: 5
       HasCount: true
@@ -23931,7 +23931,7 @@ Types:
       ID: 62
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 696960
+      GoRuntimeType: 696992
       GoKind: 17
       Count: 6
       HasCount: true
@@ -23940,7 +23940,7 @@ Types:
       ID: 88
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 712288
+      GoRuntimeType: 712320
       GoKind: 17
       Count: 8
       HasCount: true
@@ -23949,7 +23949,7 @@ Types:
       ID: 144
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 485536
+      GoRuntimeType: 485568
       GoKind: 23
       RawFields:
         - Name: array
@@ -23972,7 +23972,7 @@ Types:
       ID: 1279
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 485472
+      GoRuntimeType: 485504
       GoKind: 23
       RawFields:
         - Name: array
@@ -23995,7 +23995,7 @@ Types:
       ID: 1304
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 485152
+      GoRuntimeType: 485184
       GoKind: 23
       RawFields:
         - Name: array
@@ -24018,7 +24018,7 @@ Types:
       ID: 1310
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 485088
+      GoRuntimeType: 485120
       GoKind: 23
       RawFields:
         - Name: array
@@ -24041,7 +24041,7 @@ Types:
       ID: 66
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 491552
+      GoRuntimeType: 491584
       GoKind: 23
       RawFields:
         - Name: array
@@ -24064,7 +24064,7 @@ Types:
       ID: 135
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 483808
+      GoRuntimeType: 483840
       GoKind: 23
       RawFields:
         - Name: array
@@ -24381,7 +24381,7 @@ Types:
       ID: 270
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 495776
+      GoRuntimeType: 495808
       GoKind: 23
       RawFields:
         - Name: array
@@ -24404,7 +24404,7 @@ Types:
       ID: 1037
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 495648
+      GoRuntimeType: 495680
       GoKind: 23
       RawFields:
         - Name: array
@@ -24427,7 +24427,7 @@ Types:
       ID: 356
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 490656
+      GoRuntimeType: 490688
       GoKind: 23
       RawFields:
         - Name: array
@@ -24494,7 +24494,7 @@ Types:
       ID: 1316
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 496096
+      GoRuntimeType: 496128
       GoKind: 23
       RawFields:
         - Name: array
@@ -24539,7 +24539,7 @@ Types:
       ID: 432
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 486112
+      GoRuntimeType: 486144
       GoKind: 23
       RawFields:
         - Name: array
@@ -24750,7 +24750,7 @@ Types:
       ID: 269
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 495904
+      GoRuntimeType: 495936
       GoKind: 23
       RawFields:
         - Name: array
@@ -24794,7 +24794,7 @@ Types:
       ID: 263
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 495392
+      GoRuntimeType: 495424
       GoKind: 23
       RawFields:
         - Name: array
@@ -24817,7 +24817,7 @@ Types:
       ID: 271
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 494752
+      GoRuntimeType: 494784
       GoKind: 23
       RawFields:
         - Name: array
@@ -24840,7 +24840,7 @@ Types:
       ID: 39
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 494624
+      GoRuntimeType: 494656
       GoKind: 23
       RawFields:
         - Name: array
@@ -24863,7 +24863,7 @@ Types:
       ID: 44
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 495456
+      GoRuntimeType: 495488
       GoKind: 23
       RawFields:
         - Name: array
@@ -24890,7 +24890,7 @@ Types:
       ID: 827
       Name: archive/tar.headerError
       ByteSize: 24
-      GoRuntimeType: 943936
+      GoRuntimeType: 943968
       GoKind: 23
       RawFields:
         - Name: array
@@ -24920,7 +24920,7 @@ Types:
     - __kind: StructureType
       ID: 1077
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.133984e+06
+      GoRuntimeType: 1.134112e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24931,7 +24931,7 @@ Types:
       ID: 1103
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.587328e+06
+      GoRuntimeType: 1.587616e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -24945,7 +24945,7 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 593664
+      GoRuntimeType: 593696
       GoKind: 1
     - __kind: UnresolvedPointeeType
       ID: 1151
@@ -24962,36 +24962,36 @@ Types:
     - __kind: GoChannelType
       ID: 249
       Name: chan bool
-      GoRuntimeType: 605184
+      GoRuntimeType: 605216
       GoKind: 18
     - __kind: GoChannelType
       ID: 162
       Name: chan struct {}
-      GoRuntimeType: 604224
+      GoRuntimeType: 604256
       GoKind: 18
     - __kind: BaseType
       ID: 18
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 593472
+      GoRuntimeType: 593504
       GoKind: 16
     - __kind: BaseType
       ID: 103
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 593408
+      GoRuntimeType: 593440
       GoKind: 15
     - __kind: BaseType
       ID: 630
       Name: compress/flate.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 844896
+      GoRuntimeType: 844928
       GoKind: 6
     - __kind: GoStringHeaderType
       ID: 631
       Name: compress/flate.InternalError
       ByteSize: 16
-      GoRuntimeType: 844992
+      GoRuntimeType: 845024
       GoKind: 24
       RawFields:
         - Name: str
@@ -25021,26 +25021,26 @@ Types:
     - __kind: StructureType
       ID: 975
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.499648e+06
+      GoRuntimeType: 1.499936e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 641
       Name: crypto/aes.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 847488
+      GoRuntimeType: 847520
       GoKind: 2
     - __kind: BaseType
       ID: 642
       Name: crypto/des.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 847584
+      GoRuntimeType: 847616
       GoKind: 2
     - __kind: BaseType
       ID: 643
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 847680
+      GoRuntimeType: 847712
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1142
@@ -25049,7 +25049,7 @@ Types:
     - __kind: StructureType
       ID: 924
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
-      GoRuntimeType: 1.305952e+06
+      GoRuntimeType: 1.30608e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25076,7 +25076,7 @@ Types:
       ID: 644
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
-      GoRuntimeType: 847776
+      GoRuntimeType: 847808
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1191
@@ -25094,7 +25094,7 @@ Types:
       ID: 634
       Name: crypto/tls.AlertError
       ByteSize: 1
-      GoRuntimeType: 845472
+      GoRuntimeType: 845504
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 913
@@ -25112,7 +25112,7 @@ Types:
       ID: 744
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.757248e+06
+      GoRuntimeType: 1.757536e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25128,7 +25128,7 @@ Types:
       ID: 866
       Name: crypto/tls.alert
       ByteSize: 1
-      GoRuntimeType: 1.00688e+06
+      GoRuntimeType: 1.007008e+06
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1135
@@ -25154,7 +25154,7 @@ Types:
       ID: 815
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.760128e+06
+      GoRuntimeType: 1.760416e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25169,14 +25169,14 @@ Types:
     - __kind: StructureType
       ID: 809
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.131424e+06
+      GoRuntimeType: 1.131552e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 811
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.62256e+06
+      GoRuntimeType: 1.622848e+06
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -25189,19 +25189,19 @@ Types:
       ID: 640
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
-      GoRuntimeType: 847008
+      GoRuntimeType: 847040
       GoKind: 2
     - __kind: BaseType
       ID: 1045
       Name: crypto/x509.InvalidReason
       ByteSize: 8
-      GoRuntimeType: 598720
+      GoRuntimeType: 598752
       GoKind: 2
     - __kind: StructureType
       ID: 918
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.583168e+06
+      GoRuntimeType: 1.583456e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -25210,14 +25210,14 @@ Types:
     - __kind: StructureType
       ID: 817
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.13168e+06
+      GoRuntimeType: 1.131808e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 813
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.759936e+06
+      GoRuntimeType: 1.760224e+06
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25233,7 +25233,7 @@ Types:
       ID: 831
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.454016e+06
+      GoRuntimeType: 1.454144e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25243,7 +25243,7 @@ Types:
       ID: 835
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.454176e+06
+      GoRuntimeType: 1.454304e+06
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25257,7 +25257,7 @@ Types:
       ID: 625
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 844512
+      GoRuntimeType: 844544
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1093
@@ -25267,7 +25267,7 @@ Types:
       ID: 626
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
-      GoRuntimeType: 844704
+      GoRuntimeType: 844736
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 702
@@ -25301,7 +25301,7 @@ Types:
       ID: 704
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.437216e+06
+      GoRuntimeType: 1.437344e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -25319,7 +25319,7 @@ Types:
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.0408e+06
+      GoRuntimeType: 1.040928e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25340,13 +25340,13 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 593536
+      GoRuntimeType: 593568
       GoKind: 13
     - __kind: BaseType
       ID: 14
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 593600
+      GoRuntimeType: 593632
       GoKind: 14
     - __kind: UnresolvedPointeeType
       ID: 1223
@@ -25364,13 +25364,13 @@ Types:
       ID: 63
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 483552
+      GoRuntimeType: 483584
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 78
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 858624
+      GoRuntimeType: 858656
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 359
@@ -25413,7 +25413,7 @@ Types:
       ID: 713
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.756096e+06
+      GoRuntimeType: 1.756384e+06
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25436,7 +25436,7 @@ Types:
     - __kind: StructureType
       ID: 719
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.127712e+06
+      GoRuntimeType: 1.12784e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25447,7 +25447,7 @@ Types:
       ID: 619
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 843936
+      GoRuntimeType: 843968
       GoKind: 24
       RawFields:
         - Name: str
@@ -25466,7 +25466,7 @@ Types:
       ID: 1035
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.251584e+06
+      GoRuntimeType: 2.251872e+06
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25515,13 +25515,13 @@ Types:
       ID: 1036
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 595968
+      GoRuntimeType: 596000
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 616
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 843840
+      GoRuntimeType: 843872
       GoKind: 24
       RawFields:
         - Name: str
@@ -25540,7 +25540,7 @@ Types:
       ID: 622
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 844032
+      GoRuntimeType: 844064
       GoKind: 24
       RawFields:
         - Name: str
@@ -25582,26 +25582,26 @@ Types:
     - __kind: StructureType
       ID: 764
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.130656e+06
+      GoRuntimeType: 1.130784e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 639
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
-      GoRuntimeType: 846144
+      GoRuntimeType: 846176
       GoKind: 2
     - __kind: StructureType
       ID: 762
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.130528e+06
+      GoRuntimeType: 1.130656e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 760
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.62048e+06
+      GoRuntimeType: 1.620768e+06
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25614,7 +25614,7 @@ Types:
       ID: 780
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.62128e+06
+      GoRuntimeType: 1.621568e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25627,7 +25627,7 @@ Types:
       ID: 784
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.75936e+06
+      GoRuntimeType: 1.759648e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25643,7 +25643,7 @@ Types:
       ID: 782
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.446976e+06
+      GoRuntimeType: 1.447104e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25653,7 +25653,7 @@ Types:
       ID: 778
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.446656e+06
+      GoRuntimeType: 1.446784e+06
       GoKind: 25
       RawFields:
         - Name: File
@@ -25663,14 +25663,14 @@ Types:
       ID: 1021
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.520608e+06
+      GoRuntimeType: 1.520896e+06
       GoKind: 21
       HeaderType: 1023 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 1044
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.064224e+06
+      GoRuntimeType: 1.064352e+06
       GoKind: 23
       RawFields:
         - Name: array
@@ -25693,7 +25693,7 @@ Types:
       ID: 792
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.6216e+06
+      GoRuntimeType: 1.621888e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25706,7 +25706,7 @@ Types:
       ID: 786
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.447136e+06
+      GoRuntimeType: 1.447264e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25716,7 +25716,7 @@ Types:
       ID: 790
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.759552e+06
+      GoRuntimeType: 1.75984e+06
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25732,7 +25732,7 @@ Types:
       ID: 788
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.62144e+06
+      GoRuntimeType: 1.621728e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25745,7 +25745,7 @@ Types:
       ID: 794
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.447296e+06
+      GoRuntimeType: 1.447424e+06
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25755,7 +25755,7 @@ Types:
       ID: 800
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.62192e+06
+      GoRuntimeType: 1.622208e+06
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25768,7 +25768,7 @@ Types:
       ID: 802
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.447616e+06
+      GoRuntimeType: 1.447744e+06
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25778,7 +25778,7 @@ Types:
       ID: 798
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.62176e+06
+      GoRuntimeType: 1.622048e+06
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25791,7 +25791,7 @@ Types:
       ID: 796
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.447456e+06
+      GoRuntimeType: 1.447584e+06
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25801,7 +25801,7 @@ Types:
       ID: 804
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.62208e+06
+      GoRuntimeType: 1.622368e+06
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25814,7 +25814,7 @@ Types:
       ID: 721
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.439456e+06
+      GoRuntimeType: 1.439584e+06
       GoKind: 25
       RawFields:
         - Name: message
@@ -25828,7 +25828,7 @@ Types:
       ID: 723
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.439616e+06
+      GoRuntimeType: 1.439744e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25850,7 +25850,7 @@ Types:
       ID: 727
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.439936e+06
+      GoRuntimeType: 1.440064e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25864,7 +25864,7 @@ Types:
       ID: 1202
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 2.13792e+06
+      GoRuntimeType: 2.138208e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25877,7 +25877,7 @@ Types:
       ID: 1205
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.163968e+06
+      GoRuntimeType: 2.164256e+06
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25897,7 +25897,7 @@ Types:
       ID: 725
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.439776e+06
+      GoRuntimeType: 1.439904e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25907,7 +25907,7 @@ Types:
       ID: 729
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.440096e+06
+      GoRuntimeType: 1.440224e+06
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25957,7 +25957,7 @@ Types:
       ID: 735
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.441056e+06
+      GoRuntimeType: 1.441184e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -25972,7 +25972,7 @@ Types:
       ID: 959
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.870144e+06
+      GoRuntimeType: 1.870432e+06
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -25992,7 +25992,7 @@ Types:
       ID: 888
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.7288e+06
+      GoRuntimeType: 1.729088e+06
       GoKind: 25
       RawFields:
         - Name: Got
@@ -26005,7 +26005,7 @@ Types:
       ID: 965
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.870592e+06
+      GoRuntimeType: 1.87088e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26021,13 +26021,13 @@ Types:
       ID: 865
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 1.004192e+06
+      GoRuntimeType: 1.00432e+06
       GoKind: 8
     - __kind: StructureType
       ID: 957
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.86992e+06
+      GoRuntimeType: 1.870208e+06
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -26043,13 +26043,13 @@ Types:
       ID: 1046
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 842112
+      GoRuntimeType: 842144
       GoKind: 8
     - __kind: StructureType
       ID: 955
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.869696e+06
+      GoRuntimeType: 1.869984e+06
       GoKind: 25
       RawFields:
         - Name: Method
@@ -26065,7 +26065,7 @@ Types:
       ID: 963
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.784256e+06
+      GoRuntimeType: 1.784544e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26078,7 +26078,7 @@ Types:
       ID: 961
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.870368e+06
+      GoRuntimeType: 1.870656e+06
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26098,7 +26098,7 @@ Types:
       ID: 969
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.650176e+06
+      GoRuntimeType: 1.650464e+06
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -26107,20 +26107,20 @@ Types:
     - __kind: StructureType
       ID: 892
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.299424e+06
+      GoRuntimeType: 1.299552e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 890
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.299296e+06
+      GoRuntimeType: 1.299424e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 967
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.784448e+06
+      GoRuntimeType: 1.784736e+06
       GoKind: 25
       RawFields:
         - Name: cause
@@ -26133,7 +26133,7 @@ Types:
       ID: 649
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
-      GoRuntimeType: 849600
+      GoRuntimeType: 849632
       GoKind: 24
       RawFields:
         - Name: str
@@ -26152,25 +26152,25 @@ Types:
       ID: 345
       Name: go.shape.bool
       ByteSize: 1
-      GoRuntimeType: 605376
+      GoRuntimeType: 605408
       GoKind: 1
     - __kind: BaseType
       ID: 358
       Name: go.shape.float64
       ByteSize: 8
-      GoRuntimeType: 606016
+      GoRuntimeType: 606048
       GoKind: 14
     - __kind: BaseType
       ID: 328
       Name: go.shape.int
       ByteSize: 8
-      GoRuntimeType: 605248
+      GoRuntimeType: 605280
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 330
       Name: go.shape.string
       ByteSize: 16
-      GoRuntimeType: 605312
+      GoRuntimeType: 605344
       GoKind: 24
       RawFields:
         - Name: str
@@ -26244,7 +26244,7 @@ Types:
       ID: 936
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.465856e+06
+      GoRuntimeType: 1.465984e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26254,7 +26254,7 @@ Types:
       ID: 1119
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.704128e+06
+      GoRuntimeType: 1.704416e+06
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -26268,7 +26268,7 @@ Types:
       ID: 1145
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.141536e+06
+      GoRuntimeType: 1.141664e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26281,7 +26281,7 @@ Types:
       ID: 1107
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.592448e+06
+      GoRuntimeType: 1.592736e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -26291,19 +26291,19 @@ Types:
       ID: 652
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
-      GoRuntimeType: 850176
+      GoRuntimeType: 850208
       GoKind: 10
     - __kind: BaseType
       ID: 1028
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.01744e+06
+      GoRuntimeType: 1.017568e+06
       GoKind: 10
     - __kind: StructureType
       ID: 994
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.908e+06
+      GoRuntimeType: 1.908288e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26319,7 +26319,7 @@ Types:
       ID: 851
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.6296e+06
+      GoRuntimeType: 1.629888e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26332,7 +26332,7 @@ Types:
       ID: 656
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 850368
+      GoRuntimeType: 850400
       GoKind: 24
       RawFields:
         - Name: str
@@ -26351,7 +26351,7 @@ Types:
       ID: 662
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 850560
+      GoRuntimeType: 850592
       GoKind: 24
       RawFields:
         - Name: str
@@ -26370,7 +26370,7 @@ Types:
       ID: 659
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 850464
+      GoRuntimeType: 850496
       GoKind: 24
       RawFields:
         - Name: str
@@ -26389,7 +26389,7 @@ Types:
       ID: 653
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 850272
+      GoRuntimeType: 850304
       GoKind: 24
       RawFields:
         - Name: str
@@ -26412,7 +26412,7 @@ Types:
       ID: 855
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.466496e+06
+      GoRuntimeType: 1.466624e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26422,13 +26422,13 @@ Types:
       ID: 665
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
-      GoRuntimeType: 850656
+      GoRuntimeType: 850688
       GoKind: 2
     - __kind: StructureType
       ID: 843
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.461536e+06
+      GoRuntimeType: 1.461664e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26442,7 +26442,7 @@ Types:
       ID: 1017
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.936864e+06
+      GoRuntimeType: 1.937152e+06
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26458,7 +26458,7 @@ Types:
       ID: 845
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.62912e+06
+      GoRuntimeType: 1.629408e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26471,7 +26471,7 @@ Types:
       ID: 1162
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.996192e+06
+      GoRuntimeType: 1.99648e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26488,7 +26488,7 @@ Types:
       ID: 934
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.590048e+06
+      GoRuntimeType: 1.590336e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -26513,14 +26513,14 @@ Types:
     - __kind: StructureType
       ID: 988
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.532128e+06
+      GoRuntimeType: 1.532416e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 837
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.454816e+06
+      GoRuntimeType: 1.454944e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26530,7 +26530,7 @@ Types:
       ID: 839
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.454976e+06
+      GoRuntimeType: 1.455104e+06
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26930,37 +26930,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 593216
+      GoRuntimeType: 593248
       GoKind: 2
     - __kind: BaseType
       ID: 102
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 592832
+      GoRuntimeType: 592864
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 592960
+      GoRuntimeType: 592992
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 593088
+      GoRuntimeType: 593120
       GoKind: 6
     - __kind: BaseType
       ID: 19
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 592704
+      GoRuntimeType: 592736
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 163
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 859680
+      GoRuntimeType: 859712
       GoKind: 20
       RawFields:
         - Name: _type
@@ -26973,7 +26973,7 @@ Types:
       ID: 1049
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
-      GoRuntimeType: 594496
+      GoRuntimeType: 594528
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1019
@@ -26987,7 +26987,7 @@ Types:
       ID: 92
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.878656e+06
+      GoRuntimeType: 1.878944e+06
       GoKind: 25
       RawFields:
         - Name: buf
@@ -27024,7 +27024,7 @@ Types:
     - __kind: StructureType
       ID: 949
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.496448e+06
+      GoRuntimeType: 1.496736e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27035,7 +27035,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.227168e+06
+      GoRuntimeType: 1.227296e+06
       GoKind: 25
       RawFields:
         - Name: u
@@ -27045,7 +27045,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.664576e+06
+      GoRuntimeType: 1.664864e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27065,7 +27065,7 @@ Types:
       ID: 33
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.510208e+06
+      GoRuntimeType: 1.510496e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27078,7 +27078,7 @@ Types:
       ID: 37
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.510048e+06
+      GoRuntimeType: 1.510336e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27090,20 +27090,20 @@ Types:
     - __kind: StructureType
       ID: 77
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 1.006592e+06
+      GoRuntimeType: 1.00672e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 34
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 1.006496e+06
+      GoRuntimeType: 1.006624e+06
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 627
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
-      GoRuntimeType: 844800
+      GoRuntimeType: 844832
       GoKind: 24
       RawFields:
         - Name: str
@@ -27122,7 +27122,7 @@ Types:
       ID: 906
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
-      GoRuntimeType: 1.580928e+06
+      GoRuntimeType: 1.581216e+06
       GoKind: 25
       RawFields:
         - Name: typ
@@ -27132,13 +27132,13 @@ Types:
       ID: 593
       Name: internal/strconv.Error
       ByteSize: 8
-      GoRuntimeType: 841536
+      GoRuntimeType: 841568
       GoKind: 2
     - __kind: StructureType
       ID: 1265
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.493408e+06
+      GoRuntimeType: 1.493696e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -27155,7 +27155,7 @@ Types:
       ID: 1152
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.203744e+06
+      GoRuntimeType: 1.203872e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27168,7 +27168,7 @@ Types:
       ID: 1187
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.037216e+06
+      GoRuntimeType: 1.037344e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27181,7 +27181,7 @@ Types:
       ID: 1138
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.124e+06
+      GoRuntimeType: 1.124128e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27194,7 +27194,7 @@ Types:
       ID: 137
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.03696e+06
+      GoRuntimeType: 1.037088e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27206,7 +27206,7 @@ Types:
     - __kind: StructureType
       ID: 1109
       Name: io.discard
-      GoRuntimeType: 1.482208e+06
+      GoRuntimeType: 1.482496e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27276,7 +27276,7 @@ Types:
       ID: 168
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.035808e+06
+      GoRuntimeType: 1.035936e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27289,7 +27289,7 @@ Types:
       ID: 134
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.636736e+06
+      GoRuntimeType: 1.637024e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -27305,7 +27305,7 @@ Types:
       ID: 149
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.200032e+06
+      GoRuntimeType: 1.20016e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27315,7 +27315,7 @@ Types:
       ID: 382
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.199904e+06
+      GoRuntimeType: 1.200032e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27329,7 +27329,7 @@ Types:
       ID: 156
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.199264e+06
+      GoRuntimeType: 1.199392e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27339,7 +27339,7 @@ Types:
       ID: 1331
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.199136e+06
+      GoRuntimeType: 1.199264e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27349,7 +27349,7 @@ Types:
       ID: 1346
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.199008e+06
+      GoRuntimeType: 1.199136e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27359,7 +27359,7 @@ Types:
       ID: 138
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.201184e+06
+      GoRuntimeType: 1.201312e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27369,7 +27369,7 @@ Types:
       ID: 140
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.201056e+06
+      GoRuntimeType: 1.201184e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27383,7 +27383,7 @@ Types:
       ID: 142
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.200416e+06
+      GoRuntimeType: 1.200544e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27393,7 +27393,7 @@ Types:
       ID: 1301
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.200288e+06
+      GoRuntimeType: 1.200416e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27403,7 +27403,7 @@ Types:
       ID: 1303
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.20016e+06
+      GoRuntimeType: 1.200288e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27413,7 +27413,7 @@ Types:
       ID: 143
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.202336e+06
+      GoRuntimeType: 1.202464e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27423,7 +27423,7 @@ Types:
       ID: 372
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.202208e+06
+      GoRuntimeType: 1.202336e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27437,7 +27437,7 @@ Types:
       ID: 148
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.201568e+06
+      GoRuntimeType: 1.201696e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27447,7 +27447,7 @@ Types:
       ID: 1307
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.20144e+06
+      GoRuntimeType: 1.201568e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27457,7 +27457,7 @@ Types:
       ID: 1313
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.201312e+06
+      GoRuntimeType: 1.20144e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27472,7 +27472,7 @@ Types:
       ID: 166
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.862304e+06
+      GoRuntimeType: 1.862592e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27494,7 +27494,7 @@ Types:
       ID: 161
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.99776e+06
+      GoRuntimeType: 1.998048e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -27522,7 +27522,7 @@ Types:
       ID: 360
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.430016e+06
+      GoRuntimeType: 1.430144e+06
       GoKind: 25
       RawFields:
         - Name: s
@@ -27649,7 +27649,7 @@ Types:
       ID: 129
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.481248e+06
+      GoRuntimeType: 1.481536e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -27662,7 +27662,7 @@ Types:
       ID: 252
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.480928e+06
+      GoRuntimeType: 1.481216e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -27684,14 +27684,14 @@ Types:
       ID: 1275
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.430176e+06
+      GoRuntimeType: 1.430304e+06
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 164
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.035936e+06
+      GoRuntimeType: 1.036064e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27744,7 +27744,7 @@ Types:
       ID: 170
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.198752e+06
+      GoRuntimeType: 1.19888e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -27814,7 +27814,7 @@ Types:
       ID: 171
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.19888e+06
+      GoRuntimeType: 1.199008e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -28928,119 +28928,119 @@ Types:
       ID: 229
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.143584e+06
+      GoRuntimeType: 1.143712e+06
       GoKind: 21
       HeaderType: 231 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 224
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.143712e+06
+      GoRuntimeType: 1.14384e+06
       GoKind: 21
       HeaderType: 226 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 192
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.14384e+06
+      GoRuntimeType: 1.143968e+06
       GoKind: 21
       HeaderType: 194 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 204
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.143968e+06
+      GoRuntimeType: 1.144096e+06
       GoKind: 21
       HeaderType: 206 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 150
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.143456e+06
+      GoRuntimeType: 1.143584e+06
       GoKind: 21
       HeaderType: 152 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1285
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.143328e+06
+      GoRuntimeType: 1.143456e+06
       GoKind: 21
       HeaderType: 1287 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1319
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.142688e+06
+      GoRuntimeType: 1.142816e+06
       GoKind: 21
       HeaderType: 1321 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1334
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.14256e+06
+      GoRuntimeType: 1.142688e+06
       GoKind: 21
       HeaderType: 1336 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 172
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.14192e+06
+      GoRuntimeType: 1.142048e+06
       GoKind: 21
       HeaderType: 174 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 1349
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.142432e+06
+      GoRuntimeType: 1.14256e+06
       GoKind: 21
       HeaderType: 1351 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 239
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.144096e+06
+      GoRuntimeType: 1.144224e+06
       GoKind: 21
       HeaderType: 241 GoSwissMapHeaderType map<int,struct {}>
     - __kind: GoMapType
       ID: 209
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.144224e+06
+      GoRuntimeType: 1.144352e+06
       GoKind: 21
       HeaderType: 211 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 199
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.144352e+06
+      GoRuntimeType: 1.14448e+06
       GoKind: 21
       HeaderType: 201 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 187
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.14448e+06
+      GoRuntimeType: 1.144608e+06
       GoKind: 21
       HeaderType: 189 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 182
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.144608e+06
+      GoRuntimeType: 1.144736e+06
       GoKind: 21
       HeaderType: 184 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 177
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.144736e+06
+      GoRuntimeType: 1.144864e+06
       GoKind: 21
       HeaderType: 179 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 234
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 1.144864e+06
+      GoRuntimeType: 1.144992e+06
       GoKind: 21
       HeaderType: 236 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
@@ -29083,28 +29083,28 @@ Types:
       ID: 244
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.144992e+06
+      GoRuntimeType: 1.14512e+06
       GoKind: 21
       HeaderType: 246 GoSwissMapHeaderType map<struct {},struct {}>
     - __kind: GoMapType
       ID: 219
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.14512e+06
+      GoRuntimeType: 1.145248e+06
       GoKind: 21
       HeaderType: 221 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 214
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.145248e+06
+      GoRuntimeType: 1.145376e+06
       GoKind: 21
       HeaderType: 216 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
       ID: 776
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.446176e+06
+      GoRuntimeType: 1.446304e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -29114,7 +29114,7 @@ Types:
       ID: 1073
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.443136e+06
+      GoRuntimeType: 1.443264e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29128,7 +29128,7 @@ Types:
       ID: 1043
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.6192e+06
+      GoRuntimeType: 1.619488e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29169,7 +29169,7 @@ Types:
       ID: 939
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.127328e+06
+      GoRuntimeType: 1.127456e+06
       GoKind: 24
       RawFields:
         - Name: str
@@ -29187,7 +29187,7 @@ Types:
     - __kind: StructureType
       ID: 904
       Name: net.canceledError
-      GoRuntimeType: 1.300704e+06
+      GoRuntimeType: 1.300832e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29198,7 +29198,7 @@ Types:
       ID: 1048
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 2.137216e+06
+      GoRuntimeType: 2.137504e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29220,13 +29220,13 @@ Types:
     - __kind: StructureType
       ID: 1233
       Name: net.noReadFrom
-      GoRuntimeType: 1.127584e+06
+      GoRuntimeType: 1.127712e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1232
       Name: net.noWriteTo
-      GoRuntimeType: 1.127456e+06
+      GoRuntimeType: 1.127584e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29237,7 +29237,7 @@ Types:
       ID: 708
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.755904e+06
+      GoRuntimeType: 1.756192e+06
       GoKind: 25
       RawFields:
         - Name: p
@@ -29253,7 +29253,7 @@ Types:
       ID: 1221
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.319392e+06
+      GoRuntimeType: 2.31968e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29266,7 +29266,7 @@ Types:
       ID: 1219
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.318848e+06
+      GoRuntimeType: 2.319136e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29291,7 +29291,7 @@ Types:
       ID: 1067
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.434656e+06
+      GoRuntimeType: 1.434784e+06
       GoKind: 25
       RawFields:
         - Name: w
@@ -29301,19 +29301,19 @@ Types:
       ID: 597
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 842592
+      GoRuntimeType: 842624
       GoKind: 10
     - __kind: BaseType
       ID: 1020
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.004288e+06
+      GoRuntimeType: 1.004416e+06
       GoKind: 10
     - __kind: StructureType
       ID: 684
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.753408e+06
+      GoRuntimeType: 1.753696e+06
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -29329,7 +29329,7 @@ Types:
       ID: 998
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.926112e+06
+      GoRuntimeType: 1.9264e+06
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -29345,7 +29345,7 @@ Types:
       ID: 688
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.61872e+06
+      GoRuntimeType: 1.619008e+06
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29362,7 +29362,7 @@ Types:
       ID: 601
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 842784
+      GoRuntimeType: 842816
       GoKind: 24
       RawFields:
         - Name: str
@@ -29381,7 +29381,7 @@ Types:
       ID: 607
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 842976
+      GoRuntimeType: 843008
       GoKind: 24
       RawFields:
         - Name: str
@@ -29400,7 +29400,7 @@ Types:
       ID: 604
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 842880
+      GoRuntimeType: 842912
       GoKind: 24
       RawFields:
         - Name: str
@@ -29422,7 +29422,7 @@ Types:
     - __kind: StructureType
       ID: 900
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.299936e+06
+      GoRuntimeType: 1.300064e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29433,7 +29433,7 @@ Types:
       ID: 598
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 842688
+      GoRuntimeType: 842720
       GoKind: 24
       RawFields:
         - Name: str
@@ -29452,7 +29452,7 @@ Types:
       ID: 1069
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
-      GoRuntimeType: 1.754176e+06
+      GoRuntimeType: 1.754464e+06
       GoKind: 25
       RawFields:
         - Name: conn
@@ -29467,7 +29467,7 @@ Types:
     - __kind: ArrayType
       ID: 1149
       Name: net/http.incomparable
-      GoRuntimeType: 916000
+      GoRuntimeType: 916032
       GoKind: 17
       HasCount: true
       Element: 63 GoSubroutineType func()
@@ -29475,7 +29475,7 @@ Types:
       ID: 896
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.576928e+06
+      GoRuntimeType: 1.577216e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -29489,7 +29489,7 @@ Types:
       ID: 1087
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.576768e+06
+      GoRuntimeType: 1.577056e+06
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29499,7 +29499,7 @@ Types:
       ID: 1121
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.827584e+06
+      GoRuntimeType: 1.827872e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -29515,7 +29515,7 @@ Types:
       ID: 692
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.435616e+06
+      GoRuntimeType: 1.435744e+06
       GoKind: 25
       RawFields:
         - Name: error
@@ -29528,14 +29528,14 @@ Types:
     - __kind: StructureType
       ID: 971
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.499328e+06
+      GoRuntimeType: 1.499616e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 898
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.577088e+06
+      GoRuntimeType: 1.577376e+06
       GoKind: 25
       RawFields:
         - Name: err
@@ -29545,7 +29545,7 @@ Types:
       ID: 1164
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2.056896e+06
+      GoRuntimeType: 2.057184e+06
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29562,7 +29562,7 @@ Types:
       ID: 1186
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 2.07264e+06
+      GoRuntimeType: 2.072928e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29576,7 +29576,7 @@ Types:
       ID: 768
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.758976e+06
+      GoRuntimeType: 1.759264e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29592,7 +29592,7 @@ Types:
       ID: 766
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.62064e+06
+      GoRuntimeType: 1.620928e+06
       GoKind: 25
       RawFields:
         - Name: in
@@ -29609,7 +29609,7 @@ Types:
       ID: 1099
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.62288e+06
+      GoRuntimeType: 1.623168e+06
       GoKind: 25
       RawFields:
         - Name: c
@@ -29626,7 +29626,7 @@ Types:
       ID: 635
       Name: net/textproto.ProtocolError
       ByteSize: 16
-      GoRuntimeType: 845568
+      GoRuntimeType: 845600
       GoKind: 24
       RawFields:
         - Name: str
@@ -29653,7 +29653,7 @@ Types:
       ID: 610
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 843552
+      GoRuntimeType: 843584
       GoKind: 24
       RawFields:
         - Name: str
@@ -29672,7 +29672,7 @@ Types:
       ID: 613
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 843648
+      GoRuntimeType: 843680
       GoKind: 24
       RawFields:
         - Name: str
@@ -29691,7 +29691,7 @@ Types:
       ID: 481
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 692832
+      GoRuntimeType: 692864
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29700,7 +29700,7 @@ Types:
       ID: 473
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 692928
+      GoRuntimeType: 692960
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29709,7 +29709,7 @@ Types:
       ID: 421
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 693216
+      GoRuntimeType: 693248
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29718,7 +29718,7 @@ Types:
       ID: 440
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 693312
+      GoRuntimeType: 693344
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29727,7 +29727,7 @@ Types:
       ID: 379
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
-      GoRuntimeType: 692064
+      GoRuntimeType: 692096
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29736,7 +29736,7 @@ Types:
       ID: 1294
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
-      GoRuntimeType: 691968
+      GoRuntimeType: 692000
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29745,7 +29745,7 @@ Types:
       ID: 1328
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
-      GoRuntimeType: 691488
+      GoRuntimeType: 691520
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29754,7 +29754,7 @@ Types:
       ID: 1343
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
-      GoRuntimeType: 691392
+      GoRuntimeType: 691424
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29763,7 +29763,7 @@ Types:
       ID: 389
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 690144
+      GoRuntimeType: 690176
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29772,7 +29772,7 @@ Types:
       ID: 1358
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
-      GoRuntimeType: 691296
+      GoRuntimeType: 691328
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29781,7 +29781,7 @@ Types:
       ID: 497
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
-      GoRuntimeType: 693408
+      GoRuntimeType: 693440
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29790,7 +29790,7 @@ Types:
       ID: 448
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 693504
+      GoRuntimeType: 693536
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29799,7 +29799,7 @@ Types:
       ID: 430
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 693600
+      GoRuntimeType: 693632
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29808,7 +29808,7 @@ Types:
       ID: 413
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 693696
+      GoRuntimeType: 693728
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29817,7 +29817,7 @@ Types:
       ID: 1056
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
-      GoRuntimeType: 769600
+      GoRuntimeType: 769632
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29826,7 +29826,7 @@ Types:
       ID: 405
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 693792
+      GoRuntimeType: 693824
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29835,7 +29835,7 @@ Types:
       ID: 397
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 693888
+      GoRuntimeType: 693920
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29844,7 +29844,7 @@ Types:
       ID: 489
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
-      GoRuntimeType: 693984
+      GoRuntimeType: 694016
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29900,7 +29900,7 @@ Types:
     - __kind: ArrayType
       ID: 505
       Name: noalg.[8]struct { key struct {}; elem struct {} }
-      GoRuntimeType: 694080
+      GoRuntimeType: 694112
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29909,7 +29909,7 @@ Types:
       ID: 464
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 694176
+      GoRuntimeType: 694208
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29918,7 +29918,7 @@ Types:
       ID: 456
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 694272
+      GoRuntimeType: 694304
       GoKind: 17
       Count: 8
       HasCount: true
@@ -29927,7 +29927,7 @@ Types:
       ID: 480
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.312224e+06
+      GoRuntimeType: 1.312352e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29940,7 +29940,7 @@ Types:
       ID: 472
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.31248e+06
+      GoRuntimeType: 1.312608e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29953,7 +29953,7 @@ Types:
       ID: 420
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.312736e+06
+      GoRuntimeType: 1.312864e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29966,7 +29966,7 @@ Types:
       ID: 439
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.312992e+06
+      GoRuntimeType: 1.31312e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29979,7 +29979,7 @@ Types:
       ID: 378
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.311968e+06
+      GoRuntimeType: 1.312096e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29992,7 +29992,7 @@ Types:
       ID: 1293
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.311712e+06
+      GoRuntimeType: 1.31184e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30005,7 +30005,7 @@ Types:
       ID: 1327
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.310432e+06
+      GoRuntimeType: 1.31056e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30018,7 +30018,7 @@ Types:
       ID: 1342
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.310176e+06
+      GoRuntimeType: 1.310304e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30031,7 +30031,7 @@ Types:
       ID: 388
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.308896e+06
+      GoRuntimeType: 1.309024e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30044,7 +30044,7 @@ Types:
       ID: 1357
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.30992e+06
+      GoRuntimeType: 1.310048e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30057,7 +30057,7 @@ Types:
       ID: 496
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
-      GoRuntimeType: 1.313248e+06
+      GoRuntimeType: 1.313376e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30070,7 +30070,7 @@ Types:
       ID: 447
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.313504e+06
+      GoRuntimeType: 1.313632e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30083,7 +30083,7 @@ Types:
       ID: 429
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.31376e+06
+      GoRuntimeType: 1.313888e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30096,7 +30096,7 @@ Types:
       ID: 412
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.314016e+06
+      GoRuntimeType: 1.314144e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30109,7 +30109,7 @@ Types:
       ID: 1055
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
-      GoRuntimeType: 1.375456e+06
+      GoRuntimeType: 1.375584e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30122,7 +30122,7 @@ Types:
       ID: 404
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.314272e+06
+      GoRuntimeType: 1.3144e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30135,7 +30135,7 @@ Types:
       ID: 396
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.314528e+06
+      GoRuntimeType: 1.314656e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30148,7 +30148,7 @@ Types:
       ID: 488
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
-      GoRuntimeType: 1.314784e+06
+      GoRuntimeType: 1.314912e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30233,7 +30233,7 @@ Types:
       ID: 504
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
-      GoRuntimeType: 1.31504e+06
+      GoRuntimeType: 1.315168e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30246,7 +30246,7 @@ Types:
       ID: 463
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.315296e+06
+      GoRuntimeType: 1.315424e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30259,7 +30259,7 @@ Types:
       ID: 455
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.315552e+06
+      GoRuntimeType: 1.31568e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30272,7 +30272,7 @@ Types:
       ID: 482
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.312096e+06
+      GoRuntimeType: 1.312224e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30285,7 +30285,7 @@ Types:
       ID: 474
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.312352e+06
+      GoRuntimeType: 1.31248e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30298,7 +30298,7 @@ Types:
       ID: 422
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.312608e+06
+      GoRuntimeType: 1.312736e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30311,7 +30311,7 @@ Types:
       ID: 441
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.312864e+06
+      GoRuntimeType: 1.312992e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30324,7 +30324,7 @@ Types:
       ID: 380
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.31184e+06
+      GoRuntimeType: 1.311968e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30337,7 +30337,7 @@ Types:
       ID: 1295
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.311584e+06
+      GoRuntimeType: 1.311712e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30350,7 +30350,7 @@ Types:
       ID: 1329
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.310304e+06
+      GoRuntimeType: 1.310432e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30363,7 +30363,7 @@ Types:
       ID: 1344
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.310048e+06
+      GoRuntimeType: 1.310176e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30376,7 +30376,7 @@ Types:
       ID: 390
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.308768e+06
+      GoRuntimeType: 1.308896e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30389,7 +30389,7 @@ Types:
       ID: 1359
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.309792e+06
+      GoRuntimeType: 1.30992e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30402,7 +30402,7 @@ Types:
       ID: 498
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
-      GoRuntimeType: 1.31312e+06
+      GoRuntimeType: 1.313248e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30415,7 +30415,7 @@ Types:
       ID: 449
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.313376e+06
+      GoRuntimeType: 1.313504e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30428,7 +30428,7 @@ Types:
       ID: 431
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.313632e+06
+      GoRuntimeType: 1.31376e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30441,7 +30441,7 @@ Types:
       ID: 414
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.313888e+06
+      GoRuntimeType: 1.314016e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30454,7 +30454,7 @@ Types:
       ID: 1057
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
-      GoRuntimeType: 1.375328e+06
+      GoRuntimeType: 1.375456e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30467,7 +30467,7 @@ Types:
       ID: 406
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.314144e+06
+      GoRuntimeType: 1.314272e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30480,7 +30480,7 @@ Types:
       ID: 398
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.3144e+06
+      GoRuntimeType: 1.314528e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30493,7 +30493,7 @@ Types:
       ID: 490
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
-      GoRuntimeType: 1.314656e+06
+      GoRuntimeType: 1.314784e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30577,7 +30577,7 @@ Types:
     - __kind: StructureType
       ID: 506
       Name: noalg.struct { key struct {}; elem struct {} }
-      GoRuntimeType: 1.314912e+06
+      GoRuntimeType: 1.31504e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30590,7 +30590,7 @@ Types:
       ID: 465
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.315168e+06
+      GoRuntimeType: 1.315296e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30603,7 +30603,7 @@ Types:
       ID: 457
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.315424e+06
+      GoRuntimeType: 1.315552e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -30628,7 +30628,7 @@ Types:
       ID: 1243
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.389792e+06
+      GoRuntimeType: 2.39008e+06
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -30641,7 +30641,7 @@ Types:
       ID: 1241
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.388992e+06
+      GoRuntimeType: 2.38928e+06
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -30653,13 +30653,13 @@ Types:
     - __kind: StructureType
       ID: 1249
       Name: os.noReadFrom
-      GoRuntimeType: 1.125024e+06
+      GoRuntimeType: 1.125152e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1248
       Name: os.noWriteTo
-      GoRuntimeType: 1.124896e+06
+      GoRuntimeType: 1.125024e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -30678,7 +30678,7 @@ Types:
       ID: 910
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.729376e+06
+      GoRuntimeType: 1.729664e+06
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -30691,7 +30691,7 @@ Types:
       ID: 646
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
-      GoRuntimeType: 848832
+      GoRuntimeType: 848864
       GoKind: 24
       RawFields:
         - Name: str
@@ -30710,7 +30710,7 @@ Types:
       ID: 645
       Name: os/user.UnknownUserIdError
       ByteSize: 8
-      GoRuntimeType: 848736
+      GoRuntimeType: 848768
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 673
@@ -30740,7 +30740,7 @@ Types:
       ID: 883
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.915168e+06
+      GoRuntimeType: 1.915456e+06
       GoKind: 25
       RawFields:
         - Name: x
@@ -30766,14 +30766,14 @@ Types:
     - __kind: StructureType
       ID: 90
       Name: runtime.dlogPerM
-      GoRuntimeType: 1.003424e+06
+      GoRuntimeType: 1.003552e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 945
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.780224e+06
+      GoRuntimeType: 1.780512e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30786,7 +30786,7 @@ Types:
       ID: 859
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 1.002848e+06
+      GoRuntimeType: 1.002976e+06
       GoKind: 24
       RawFields:
         - Name: str
@@ -30805,7 +30805,7 @@ Types:
       ID: 23
       Name: runtime.g
       ByteSize: 456
-      GoRuntimeType: 2.438528e+06
+      GoRuntimeType: 2.438816e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31007,7 +31007,7 @@ Types:
       ID: 55
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.20976e+06
+      GoRuntimeType: 1.209888e+06
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -31017,7 +31017,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.94192e+06
+      GoRuntimeType: 1.942208e+06
       GoKind: 25
       RawFields:
         - Name: sp
@@ -31042,7 +31042,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.488448e+06
+      GoRuntimeType: 1.488736e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31055,7 +31055,7 @@ Types:
       ID: 60
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.779072e+06
+      GoRuntimeType: 1.77936e+06
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31074,13 +31074,13 @@ Types:
       ID: 32
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 840864
+      GoRuntimeType: 840896
       GoKind: 12
     - __kind: StructureType
       ID: 96
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.490848e+06
+      GoRuntimeType: 1.491136e+06
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -31093,7 +31093,7 @@ Types:
       ID: 72
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 1.490048e+06
+      GoRuntimeType: 1.490336e+06
       GoKind: 25
       RawFields:
         - Name: prev
@@ -31106,13 +31106,13 @@ Types:
       ID: 97
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 841248
+      GoRuntimeType: 841280
       GoKind: 2
     - __kind: StructureType
       ID: 30
       Name: runtime.m
       ByteSize: 1824
-      GoRuntimeType: 2.443808e+06
+      GoRuntimeType: 2.444096e+06
       GoKind: 25
       RawFields:
         - Name: g0
@@ -31341,7 +31341,7 @@ Types:
       ID: 75
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.942432e+06
+      GoRuntimeType: 1.94272e+06
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31366,7 +31366,7 @@ Types:
       ID: 91
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.86768e+06
+      GoRuntimeType: 1.867968e+06
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31388,7 +31388,7 @@ Types:
       ID: 80
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 1.942688e+06
+      GoRuntimeType: 1.942976e+06
       GoKind: 25
       RawFields:
         - Name: writing
@@ -31413,7 +31413,7 @@ Types:
       ID: 74
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.490528e+06
+      GoRuntimeType: 1.490816e+06
       GoKind: 25
       RawFields:
         - Name: next
@@ -31426,7 +31426,7 @@ Types:
       ID: 98
       Name: runtime.mWeakPointer
       ByteSize: 8
-      GoRuntimeType: 1.573888e+06
+      GoRuntimeType: 1.574176e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -31436,13 +31436,13 @@ Types:
       ID: 38
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 840960
+      GoRuntimeType: 840992
       GoKind: 12
     - __kind: StructureType
       ID: 71
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.210784e+06
+      GoRuntimeType: 1.210912e+06
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -31453,7 +31453,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.490688e+06
+      GoRuntimeType: 1.490976e+06
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31466,7 +31466,7 @@ Types:
       ID: 89
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.780032e+06
+      GoRuntimeType: 1.78032e+06
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -31485,7 +31485,7 @@ Types:
       ID: 862
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 1.002944e+06
+      GoRuntimeType: 1.003072e+06
       GoKind: 24
       RawFields:
         - Name: str
@@ -31504,13 +31504,13 @@ Types:
       ID: 64
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 841152
+      GoRuntimeType: 841184
       GoKind: 12
     - __kind: ArrayType
       ID: 61
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 911008
+      GoRuntimeType: 911040
       GoKind: 17
       Count: 2
       HasCount: true
@@ -31519,7 +31519,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.487168e+06
+      GoRuntimeType: 1.487456e+06
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31540,7 +31540,7 @@ Types:
       ID: 669
       Name: runtime.synctestDeadlockError
       ByteSize: 24
-      GoRuntimeType: 1.6184e+06
+      GoRuntimeType: 1.618688e+06
       GoKind: 25
       RawFields:
         - Name: reason
@@ -31553,7 +31553,7 @@ Types:
       ID: 65
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 593920
+      GoRuntimeType: 593952
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 46
@@ -31563,7 +31563,7 @@ Types:
       ID: 79
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 593984
+      GoRuntimeType: 594016
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 84
@@ -31573,7 +31573,7 @@ Types:
       ID: 56
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.488768e+06
+      GoRuntimeType: 1.489056e+06
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -31586,19 +31586,19 @@ Types:
       ID: 35
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.61808e+06
+      GoRuntimeType: 1.618368e+06
       GoKind: 8
     - __kind: StructureType
       ID: 85
       Name: runtime.winlibcall
-      GoRuntimeType: 1.003328e+06
+      GoRuntimeType: 1.003456e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 52
       Name: runtime.xRegPerG
       ByteSize: 8
-      GoRuntimeType: 1.209632e+06
+      GoRuntimeType: 1.20976e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -31616,7 +31616,7 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 592640
+      GoRuntimeType: 592672
       GoKind: 24
       RawFields:
         - Name: str
@@ -31643,7 +31643,7 @@ Types:
       ID: 1081
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.473696e+06
+      GoRuntimeType: 1.473984e+06
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -31652,14 +31652,14 @@ Types:
     - __kind: StructureType
       ID: 131
       Name: struct {}
-      GoRuntimeType: 852480
+      GoRuntimeType: 852512
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1263
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.482528e+06
+      GoRuntimeType: 1.482816e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31672,7 +31672,7 @@ Types:
       ID: 1266
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.637696e+06
+      GoRuntimeType: 1.637984e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31688,7 +31688,7 @@ Types:
       ID: 1269
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.637504e+06
+      GoRuntimeType: 1.637792e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31703,14 +31703,14 @@ Types:
     - __kind: StructureType
       ID: 1264
       Name: sync.noCopy
-      GoRuntimeType: 1.001792e+06
+      GoRuntimeType: 1.00192e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1267
       Name: sync/atomic.Bool
       ByteSize: 4
-      GoRuntimeType: 1.483648e+06
+      GoRuntimeType: 1.483936e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31723,7 +31723,7 @@ Types:
       ID: 1272
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.483808e+06
+      GoRuntimeType: 1.484096e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31736,7 +31736,7 @@ Types:
       ID: 1270
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.63808e+06
+      GoRuntimeType: 1.638368e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -31751,20 +31751,20 @@ Types:
     - __kind: StructureType
       ID: 1271
       Name: sync/atomic.align64
-      GoRuntimeType: 1.001984e+06
+      GoRuntimeType: 1.002112e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1268
       Name: sync/atomic.noCopy
-      GoRuntimeType: 1.001888e+06
+      GoRuntimeType: 1.002016e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 995
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.29904e+06
+      GoRuntimeType: 1.299168e+06
       GoKind: 12
     - __kind: StructureType
       ID: 477
@@ -32422,7 +32422,7 @@ Types:
       ID: 938
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.733792e+06
+      GoRuntimeType: 1.73408e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -32435,7 +32435,7 @@ Types:
       ID: 1148
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.943456e+06
+      GoRuntimeType: 1.943744e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1013
@@ -32449,7 +32449,7 @@ Types:
       ID: 1011
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.4048e+06
+      GoRuntimeType: 2.405088e+06
       GoKind: 25
       RawFields:
         - Name: wall
@@ -32465,7 +32465,7 @@ Types:
       ID: 594
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 841728
+      GoRuntimeType: 841760
       GoKind: 24
       RawFields:
         - Name: str
@@ -32488,49 +32488,49 @@ Types:
       ID: 11
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 593280
+      GoRuntimeType: 593312
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 592896
+      GoRuntimeType: 592928
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 593024
+      GoRuntimeType: 593056
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 593152
+      GoRuntimeType: 593184
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 592768
+      GoRuntimeType: 592800
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 593344
+      GoRuntimeType: 593376
       GoKind: 12
     - __kind: VoidPointerType
       ID: 16
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 593728
+      GoRuntimeType: 593760
       GoKind: 26
     - __kind: StructureType
       ID: 1031
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 2.093408e+06
+      GoRuntimeType: 2.093696e+06
       GoKind: 25
       RawFields:
         - Name: msg
@@ -32564,13 +32564,13 @@ Types:
       ID: 1034
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
-      GoRuntimeType: 1.008512e+06
+      GoRuntimeType: 1.00864e+06
       GoKind: 9
     - __kind: StructureType
       ID: 1032
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.95472e+06
+      GoRuntimeType: 1.955008e+06
       GoKind: 25
       RawFields:
         - Name: id
@@ -32599,7 +32599,7 @@ Types:
       ID: 1033
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
-      GoRuntimeType: 597440
+      GoRuntimeType: 597472
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1209
@@ -32609,7 +32609,7 @@ Types:
       ID: 754
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.443296e+06
+      GoRuntimeType: 1.443424e+06
       GoKind: 25
       RawFields:
         - Name: Err
@@ -32619,13 +32619,13 @@ Types:
       ID: 638
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
-      GoRuntimeType: 845664
+      GoRuntimeType: 845696
       GoKind: 2
     - __kind: StructureType
       ID: 915
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.729568e+06
+      GoRuntimeType: 1.729856e+06
       GoKind: 25
       RawFields:
         - Name: label
@@ -32638,7 +32638,7 @@ Types:
       ID: 867
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
-      GoRuntimeType: 1.00736e+06
+      GoRuntimeType: 1.007488e+06
       GoKind: 5
 MaxTypeID: 1684
 Issues:

--- a/pkg/dyninst/symdb/func_index.go
+++ b/pkg/dyninst/symdb/func_index.go
@@ -24,73 +24,75 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 )
 
-// genericFuncIndex maps canonicalized qualified names to DWARF offsets for
-// generic shape functions found across all compile units. Used to find
-// displaced generics that belong to a package but appear in a different CU.
-type genericFuncIndex interface {
+// funcOffsetByNameIndex maps canonicalized qualified names to DWARF offsets.
+// The name keys are treated as package-prefixed identifiers; forPackage
+// returns entries whose name starts with pkgName + ".". Used to find
+// functions that belong to a package but appear in a different CU (e.g.
+// generic shape instantiations placed in a foreign CU by the compiler).
+type funcOffsetByNameIndex interface {
 	// forPackage returns an iterator over all (canonicalName, funcOffset)
 	// pairs where the function's qualified name starts with pkgName + ".".
 	forPackage(pkgName string) iter.Seq2[string, dwarf.Offset]
 	io.Closer
 }
 
-// genericFuncIndexBuilder accumulates generic shape function entries and
-// produces a sorted genericFuncIndex.
-type genericFuncIndexBuilder interface {
-	// add records a generic shape function. name is the full canonicalized
-	// qualified name (e.g. "lib.Filter[...]").
+// funcOffsetByNameIndexBuilder accumulates name → offset entries and
+// produces a sorted funcOffsetByNameIndex.
+type funcOffsetByNameIndexBuilder interface {
+	// add records an entry. name is the full canonicalized qualified name
+	// (e.g. "lib.Filter[...]").
 	add(name string, funcOffset dwarf.Offset) error
-	build() (genericFuncIndex, error)
+	build() (funcOffsetByNameIndex, error)
 	io.Closer
 }
 
-// inMemGenericFuncEntry is a single entry in the in-memory generic function index.
-type inMemGenericFuncEntry struct {
+// inMemFuncOffsetByNameEntry is a single entry in the in-memory index.
+type inMemFuncOffsetByNameEntry struct {
 	name       string
 	funcOffset dwarf.Offset
 }
 
-// inMemGenericFuncIndexBuilder builds an in-memory generic function index.
-type inMemGenericFuncIndexBuilder struct {
-	entries []inMemGenericFuncEntry
+// inMemFuncOffsetByNameIndexBuilder builds an in-memory name-keyed index.
+type inMemFuncOffsetByNameIndexBuilder struct {
+	entries []inMemFuncOffsetByNameEntry
 }
 
-var _ genericFuncIndexBuilder = (*inMemGenericFuncIndexBuilder)(nil)
+var _ funcOffsetByNameIndexBuilder = (*inMemFuncOffsetByNameIndexBuilder)(nil)
 
-func (b *inMemGenericFuncIndexBuilder) add(name string, funcOffset dwarf.Offset) error {
-	b.entries = append(b.entries, inMemGenericFuncEntry{
+func (b *inMemFuncOffsetByNameIndexBuilder) add(name string, funcOffset dwarf.Offset) error {
+	b.entries = append(b.entries, inMemFuncOffsetByNameEntry{
 		name:       name,
 		funcOffset: funcOffset,
 	})
 	return nil
 }
 
-func (b *inMemGenericFuncIndexBuilder) build() (genericFuncIndex, error) {
-	slices.SortFunc(b.entries, func(a, c inMemGenericFuncEntry) int {
+func (b *inMemFuncOffsetByNameIndexBuilder) build() (funcOffsetByNameIndex, error) {
+	slices.SortFunc(b.entries, func(a, c inMemFuncOffsetByNameEntry) int {
 		return cmp.Or(
 			cmp.Compare(a.name, c.name),
 			cmp.Compare(a.funcOffset, c.funcOffset),
 		)
 	})
-	idx := &inMemGenericFuncIndex{entries: b.entries}
+	idx := &inMemFuncOffsetByNameIndex{entries: b.entries}
 	b.entries = nil
 	return idx, nil
 }
 
-func (b *inMemGenericFuncIndexBuilder) Close() error { return nil }
+func (b *inMemFuncOffsetByNameIndexBuilder) Close() error { return nil }
 
-// inMemGenericFuncIndex is the in-memory implementation of genericFuncIndex.
-type inMemGenericFuncIndex struct {
-	entries []inMemGenericFuncEntry // sorted by name
+// inMemFuncOffsetByNameIndex is the in-memory implementation.
+type inMemFuncOffsetByNameIndex struct {
+	entries []inMemFuncOffsetByNameEntry // sorted by name
 }
 
-var _ genericFuncIndex = (*inMemGenericFuncIndex)(nil)
+var _ funcOffsetByNameIndex = (*inMemFuncOffsetByNameIndex)(nil)
 
-func (idx *inMemGenericFuncIndex) forPackage(pkgName string) iter.Seq2[string, dwarf.Offset] {
+func (idx *inMemFuncOffsetByNameIndex) forPackage(pkgName string) iter.Seq2[string, dwarf.Offset] {
 	prefix := pkgName + "."
 	return func(yield func(string, dwarf.Offset) bool) {
 		// Binary search for the first entry whose name >= prefix.
-		i, _ := slices.BinarySearchFunc(idx.entries, prefix, func(e inMemGenericFuncEntry, target string) int {
+		i, _ := slices.BinarySearchFunc(idx.entries, prefix, func(e inMemFuncOffsetByNameEntry, target string) int {
 			return strings.Compare(e.name, target)
 		})
 		for ; i < len(idx.entries); i++ {
@@ -105,64 +107,64 @@ func (idx *inMemGenericFuncIndex) forPackage(pkgName string) iter.Seq2[string, d
 	}
 }
 
-func (idx *inMemGenericFuncIndex) Close() error { return nil }
+func (idx *inMemFuncOffsetByNameIndex) Close() error { return nil }
 
-// emptyGenericFuncIndex is a no-op index that returns no results.
-type emptyGenericFuncIndex struct{}
+// emptyFuncOffsetByNameIndex is a no-op index that returns no results.
+type emptyFuncOffsetByNameIndex struct{}
 
-var _ genericFuncIndex = emptyGenericFuncIndex{}
+var _ funcOffsetByNameIndex = emptyFuncOffsetByNameIndex{}
 
-func (emptyGenericFuncIndex) forPackage(string) iter.Seq2[string, dwarf.Offset] {
+func (emptyFuncOffsetByNameIndex) forPackage(string) iter.Seq2[string, dwarf.Offset] {
 	return func(func(string, dwarf.Offset) bool) {}
 }
 
-func (emptyGenericFuncIndex) Close() error { return nil }
+func (emptyFuncOffsetByNameIndex) Close() error { return nil }
 
 // ─── On-disk implementation ────────────────────────────────────────────────
 
-// onDiskGenericFuncIndexEntry is the fixed-size entry stored in the index file.
+// onDiskFuncOffsetByNameEntry is the fixed-size entry stored in the index file.
 // The strOffset field points into the string table file.
-type onDiskGenericFuncIndexEntry struct {
+type onDiskFuncOffsetByNameEntry struct {
 	strOffset  uint32
 	funcOffset uint32
 }
 
-// onDiskGenericFuncIndexBuilder writes entries to two disk files (string table
-// + index) and produces a sorted, mmap-backed index on build().
-type onDiskGenericFuncIndexBuilder struct {
+// onDiskFuncOffsetByNameIndexBuilder writes entries to two disk files (string
+// table + index) and produces a sorted, mmap-backed index on build().
+type onDiskFuncOffsetByNameIndexBuilder struct {
 	strFile  *object.DiskFile
 	strW     *bufio.Writer
 	idxFile  *object.DiskFile
 	idxW     *bufio.Writer
 	strPos   uint32 // current write position in string table
-	entryBuf onDiskGenericFuncIndexEntry
+	entryBuf onDiskFuncOffsetByNameEntry
 	lenBuf   [4]byte
 }
 
-var _ genericFuncIndexBuilder = (*onDiskGenericFuncIndexBuilder)(nil)
+var _ funcOffsetByNameIndexBuilder = (*onDiskFuncOffsetByNameIndexBuilder)(nil)
 
-const onDiskGenericIndexMaxSize = 256 << 20 // 256 MiB per file
-const onDiskGenericIndexInitialSize = 1 << 20
+const onDiskFuncOffsetByNameIndexMaxSize = 256 << 20 // 256 MiB per file
+const onDiskFuncOffsetByNameIndexInitialSize = 1 << 20
 
-func newOnDiskGenericFuncIndexBuilder(dc *object.DiskCache, suffix string) (*onDiskGenericFuncIndexBuilder, error) {
+func newOnDiskFuncOffsetByNameIndexBuilder(dc *object.DiskCache, suffix string) (*onDiskFuncOffsetByNameIndexBuilder, error) {
 	strFile, err := dc.NewFile(
-		"genericIndex."+suffix+".strings",
-		onDiskGenericIndexMaxSize,
-		onDiskGenericIndexInitialSize,
+		"funcOffsetByNameIndex."+suffix+".strings",
+		onDiskFuncOffsetByNameIndexMaxSize,
+		onDiskFuncOffsetByNameIndexInitialSize,
 	)
 	if err != nil {
 		return nil, err
 	}
 	idxFile, err := dc.NewFile(
-		"genericIndex."+suffix+".entries",
-		onDiskGenericIndexMaxSize,
-		onDiskGenericIndexInitialSize,
+		"funcOffsetByNameIndex."+suffix+".entries",
+		onDiskFuncOffsetByNameIndexMaxSize,
+		onDiskFuncOffsetByNameIndexInitialSize,
 	)
 	if err != nil {
 		_ = strFile.Close()
 		return nil, err
 	}
-	return &onDiskGenericFuncIndexBuilder{
+	return &onDiskFuncOffsetByNameIndexBuilder{
 		strFile: strFile,
 		strW:    bufio.NewWriter(strFile),
 		idxFile: idxFile,
@@ -170,7 +172,7 @@ func newOnDiskGenericFuncIndexBuilder(dc *object.DiskCache, suffix string) (*onD
 	}, nil
 }
 
-func (b *onDiskGenericFuncIndexBuilder) add(name string, funcOffset dwarf.Offset) error {
+func (b *onDiskFuncOffsetByNameIndexBuilder) add(name string, funcOffset dwarf.Offset) error {
 	if b.strW == nil {
 		return errors.New("builder is closed")
 	}
@@ -187,7 +189,7 @@ func (b *onDiskGenericFuncIndexBuilder) add(name string, funcOffset dwarf.Offset
 	b.strPos += 4 + uint32(len(name))
 
 	// Write index entry.
-	b.entryBuf = onDiskGenericFuncIndexEntry{
+	b.entryBuf = onDiskFuncOffsetByNameEntry{
 		strOffset:  nameOffset,
 		funcOffset: uint32(funcOffset),
 	}
@@ -198,7 +200,7 @@ func (b *onDiskGenericFuncIndexBuilder) add(name string, funcOffset dwarf.Offset
 	return nil
 }
 
-func (b *onDiskGenericFuncIndexBuilder) build() (_ genericFuncIndex, retErr error) {
+func (b *onDiskFuncOffsetByNameIndexBuilder) build() (_ funcOffsetByNameIndex, retErr error) {
 	if b.strW == nil {
 		return nil, errors.New("builder is closed")
 	}
@@ -217,7 +219,7 @@ func (b *onDiskGenericFuncIndexBuilder) build() (_ genericFuncIndex, retErr erro
 	// Handle empty index.
 	if b.strPos == 0 {
 		b.cleanup()
-		return emptyGenericFuncIndex{}, nil
+		return emptyFuncOffsetByNameIndex{}, nil
 	}
 
 	strMM, err := b.strFile.IntoMMap(syscall.PROT_READ)
@@ -250,8 +252,8 @@ func (b *onDiskGenericFuncIndexBuilder) build() (_ genericFuncIndex, retErr erro
 	idxData := idxMM.Data()
 
 	entries := unsafe.Slice(
-		(*onDiskGenericFuncIndexEntry)(unsafe.Pointer(unsafe.SliceData(idxData))),
-		uintptr(len(idxData))/unsafe.Sizeof(onDiskGenericFuncIndexEntry{}),
+		(*onDiskFuncOffsetByNameEntry)(unsafe.Pointer(unsafe.SliceData(idxData))),
+		uintptr(len(idxData))/unsafe.Sizeof(onDiskFuncOffsetByNameEntry{}),
 	)
 
 	// readName extracts the string from the string table at the given offset.
@@ -261,14 +263,14 @@ func (b *onDiskGenericFuncIndexBuilder) build() (_ genericFuncIndex, retErr erro
 	}
 
 	// Sort index entries by their string table names, then by funcOffset.
-	slices.SortFunc(entries, func(a, c onDiskGenericFuncIndexEntry) int {
+	slices.SortFunc(entries, func(a, c onDiskFuncOffsetByNameEntry) int {
 		return cmp.Or(
 			strings.Compare(readName(a.strOffset), readName(c.strOffset)),
 			cmp.Compare(a.funcOffset, c.funcOffset),
 		)
 	})
 
-	return &onDiskGenericFuncIndex{
+	return &onDiskFuncOffsetByNameIndex{
 		strMM:   strMM,
 		idxMM:   idxMM,
 		strData: strData,
@@ -276,7 +278,7 @@ func (b *onDiskGenericFuncIndexBuilder) build() (_ genericFuncIndex, retErr erro
 	}, nil
 }
 
-func (b *onDiskGenericFuncIndexBuilder) cleanup() {
+func (b *onDiskFuncOffsetByNameIndexBuilder) cleanup() {
 	if b.strFile != nil {
 		_ = b.strFile.Close()
 		b.strFile = nil
@@ -289,31 +291,31 @@ func (b *onDiskGenericFuncIndexBuilder) cleanup() {
 	b.idxW = nil
 }
 
-func (b *onDiskGenericFuncIndexBuilder) Close() error {
+func (b *onDiskFuncOffsetByNameIndexBuilder) Close() error {
 	b.cleanup()
 	return nil
 }
 
-// onDiskGenericFuncIndex is the mmap-backed implementation of genericFuncIndex.
-type onDiskGenericFuncIndex struct {
+// onDiskFuncOffsetByNameIndex is the mmap-backed implementation.
+type onDiskFuncOffsetByNameIndex struct {
 	strMM   object.SectionData
 	idxMM   object.SectionData
 	strData []byte
-	entries []onDiskGenericFuncIndexEntry // sorted by name
+	entries []onDiskFuncOffsetByNameEntry // sorted by name
 }
 
-var _ genericFuncIndex = (*onDiskGenericFuncIndex)(nil)
+var _ funcOffsetByNameIndex = (*onDiskFuncOffsetByNameIndex)(nil)
 
-func (idx *onDiskGenericFuncIndex) readName(offset uint32) string {
+func (idx *onDiskFuncOffsetByNameIndex) readName(offset uint32) string {
 	nameLen := binary.NativeEndian.Uint32(idx.strData[offset:])
 	return string(idx.strData[offset+4 : offset+4+nameLen])
 }
 
-func (idx *onDiskGenericFuncIndex) forPackage(pkgName string) iter.Seq2[string, dwarf.Offset] {
+func (idx *onDiskFuncOffsetByNameIndex) forPackage(pkgName string) iter.Seq2[string, dwarf.Offset] {
 	prefix := pkgName + "."
 	return func(yield func(string, dwarf.Offset) bool) {
 		// Binary search for the first entry whose name >= prefix.
-		i, _ := slices.BinarySearchFunc(idx.entries, prefix, func(e onDiskGenericFuncIndexEntry, target string) int {
+		i, _ := slices.BinarySearchFunc(idx.entries, prefix, func(e onDiskFuncOffsetByNameEntry, target string) int {
 			return strings.Compare(idx.readName(e.strOffset), target)
 		})
 		for ; i < len(idx.entries); i++ {
@@ -330,10 +332,10 @@ func (idx *onDiskGenericFuncIndex) forPackage(pkgName string) iter.Seq2[string, 
 	}
 }
 
-func (idx *onDiskGenericFuncIndex) Close() error {
+func (idx *onDiskFuncOffsetByNameIndex) Close() error {
 	if idx.strMM == nil {
 		return nil
 	}
-	defer func() { *idx = onDiskGenericFuncIndex{} }()
+	defer func() { *idx = onDiskFuncOffsetByNameIndex{} }()
 	return errors.Join(idx.strMM.Close(), idx.idxMM.Close())
 }

--- a/pkg/dyninst/symdb/func_index.go
+++ b/pkg/dyninst/symdb/func_index.go
@@ -120,8 +120,6 @@ func (emptyFuncOffsetByNameIndex) forPackage(string) iter.Seq2[string, dwarf.Off
 
 func (emptyFuncOffsetByNameIndex) Close() error { return nil }
 
-// ─── On-disk implementation ────────────────────────────────────────────────
-
 // onDiskFuncOffsetByNameEntry is the fixed-size entry stored in the index file.
 // The strOffset field points into the string table file.
 type onDiskFuncOffsetByNameEntry struct {
@@ -216,7 +214,6 @@ func (b *onDiskFuncOffsetByNameIndexBuilder) build() (_ funcOffsetByNameIndex, r
 	}
 	b.strW = nil
 
-	// Handle empty index.
 	if b.strPos == 0 {
 		b.cleanup()
 		return emptyFuncOffsetByNameIndex{}, nil
@@ -338,4 +335,236 @@ func (idx *onDiskFuncOffsetByNameIndex) Close() error {
 	}
 	defer func() { *idx = onDiskFuncOffsetByNameIndex{} }()
 	return errors.Join(idx.strMM.Close(), idx.idxMM.Close())
+}
+
+// funcOffsetByOriginIndex maps a DWARF offset (the "origin") to zero or more
+// other DWARF offsets. Used to look up every inlined instance of an abstract
+// function definition across all compile units: key = abstract-origin offset,
+// value = instance offset. Multiple entries for the same origin are
+// permitted and all yielded by forOrigin.
+type funcOffsetByOriginIndex interface {
+	// forOrigin returns an iterator over all instance offsets whose origin
+	// matches the given origin offset.
+	forOrigin(origin dwarf.Offset) iter.Seq[dwarf.Offset]
+	io.Closer
+}
+
+// funcOffsetByOriginIndexBuilder accumulates (origin, instance) pairs and
+// produces a sorted funcOffsetByOriginIndex.
+type funcOffsetByOriginIndexBuilder interface {
+	add(origin, instance dwarf.Offset) error
+	build() (funcOffsetByOriginIndex, error)
+	io.Closer
+}
+
+// funcOffsetByOriginEntry is the fixed-size entry shared by both in-memory
+// and on-disk implementations.
+type funcOffsetByOriginEntry struct {
+	origin   uint32
+	instance uint32
+}
+
+// inMemFuncOffsetByOriginIndexBuilder builds an in-memory origin-keyed index.
+type inMemFuncOffsetByOriginIndexBuilder struct {
+	entries []funcOffsetByOriginEntry
+}
+
+var _ funcOffsetByOriginIndexBuilder = (*inMemFuncOffsetByOriginIndexBuilder)(nil)
+
+func (b *inMemFuncOffsetByOriginIndexBuilder) add(origin, instance dwarf.Offset) error {
+	b.entries = append(b.entries, funcOffsetByOriginEntry{
+		origin:   uint32(origin),
+		instance: uint32(instance),
+	})
+	return nil
+}
+
+func (b *inMemFuncOffsetByOriginIndexBuilder) build() (funcOffsetByOriginIndex, error) {
+	sortFuncOffsetByOriginEntries(b.entries)
+	idx := &inMemFuncOffsetByOriginIndex{entries: b.entries}
+	b.entries = nil
+	return idx, nil
+}
+
+func (b *inMemFuncOffsetByOriginIndexBuilder) Close() error { return nil }
+
+// inMemFuncOffsetByOriginIndex is the in-memory implementation.
+type inMemFuncOffsetByOriginIndex struct {
+	entries []funcOffsetByOriginEntry // sorted by origin, then instance
+}
+
+var _ funcOffsetByOriginIndex = (*inMemFuncOffsetByOriginIndex)(nil)
+
+func (idx *inMemFuncOffsetByOriginIndex) forOrigin(origin dwarf.Offset) iter.Seq[dwarf.Offset] {
+	return forOriginFromEntries(idx.entries, origin, nil)
+}
+
+func (idx *inMemFuncOffsetByOriginIndex) Close() error { return nil }
+
+// emptyFuncOffsetByOriginIndex is a no-op index.
+type emptyFuncOffsetByOriginIndex struct{}
+
+var _ funcOffsetByOriginIndex = emptyFuncOffsetByOriginIndex{}
+
+func (emptyFuncOffsetByOriginIndex) forOrigin(dwarf.Offset) iter.Seq[dwarf.Offset] {
+	return func(func(dwarf.Offset) bool) {}
+}
+
+func (emptyFuncOffsetByOriginIndex) Close() error { return nil }
+
+// onDiskFuncOffsetByOriginIndexBuilder writes (origin, instance) pairs to a
+// single disk file and produces a sorted, mmap-backed index on build().
+type onDiskFuncOffsetByOriginIndexBuilder struct {
+	idxFile    *object.DiskFile
+	idxW       *bufio.Writer
+	numEntries uint32
+	entryBuf   funcOffsetByOriginEntry
+}
+
+var _ funcOffsetByOriginIndexBuilder = (*onDiskFuncOffsetByOriginIndexBuilder)(nil)
+
+const onDiskFuncOffsetByOriginIndexMaxSize = 256 << 20 // 256 MiB
+const onDiskFuncOffsetByOriginIndexInitialSize = 1 << 20
+
+func newOnDiskFuncOffsetByOriginIndexBuilder(dc *object.DiskCache, suffix string) (*onDiskFuncOffsetByOriginIndexBuilder, error) {
+	idxFile, err := dc.NewFile(
+		"funcOffsetByOriginIndex."+suffix+".entries",
+		onDiskFuncOffsetByOriginIndexMaxSize,
+		onDiskFuncOffsetByOriginIndexInitialSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &onDiskFuncOffsetByOriginIndexBuilder{
+		idxFile: idxFile,
+		idxW:    bufio.NewWriter(idxFile),
+	}, nil
+}
+
+func (b *onDiskFuncOffsetByOriginIndexBuilder) add(origin, instance dwarf.Offset) error {
+	if b.idxW == nil {
+		return errors.New("builder is closed")
+	}
+	b.entryBuf = funcOffsetByOriginEntry{
+		origin:   uint32(origin),
+		instance: uint32(instance),
+	}
+	buf := unsafe.Slice((*byte)(unsafe.Pointer(&b.entryBuf)), unsafe.Sizeof(b.entryBuf))
+	if _, err := b.idxW.Write(buf); err != nil {
+		return err
+	}
+	b.numEntries++
+	return nil
+}
+
+func (b *onDiskFuncOffsetByOriginIndexBuilder) build() (_ funcOffsetByOriginIndex, retErr error) {
+	if b.idxW == nil {
+		return nil, errors.New("builder is closed")
+	}
+	defer func() {
+		if retErr != nil {
+			b.cleanup()
+		}
+	}()
+
+	if err := b.idxW.Flush(); err != nil {
+		return nil, err
+	}
+	b.idxW = nil
+
+	if b.numEntries == 0 {
+		b.cleanup()
+		return emptyFuncOffsetByOriginIndex{}, nil
+	}
+
+	idxMM, err := b.idxFile.IntoMMap(syscall.PROT_READ | syscall.PROT_WRITE)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if retErr != nil {
+			_ = idxMM.Close()
+		}
+	}()
+	b.idxFile = nil
+	idxData := idxMM.Data()
+
+	entries := unsafe.Slice(
+		(*funcOffsetByOriginEntry)(unsafe.Pointer(unsafe.SliceData(idxData))),
+		uintptr(len(idxData))/unsafe.Sizeof(funcOffsetByOriginEntry{}),
+	)
+	sortFuncOffsetByOriginEntries(entries)
+
+	return &onDiskFuncOffsetByOriginIndex{
+		idxMM:   idxMM,
+		entries: entries,
+	}, nil
+}
+
+func (b *onDiskFuncOffsetByOriginIndexBuilder) cleanup() {
+	if b.idxFile != nil {
+		_ = b.idxFile.Close()
+		b.idxFile = nil
+	}
+	b.idxW = nil
+}
+
+func (b *onDiskFuncOffsetByOriginIndexBuilder) Close() error {
+	b.cleanup()
+	return nil
+}
+
+// onDiskFuncOffsetByOriginIndex is the mmap-backed implementation.
+type onDiskFuncOffsetByOriginIndex struct {
+	idxMM   object.SectionData
+	entries []funcOffsetByOriginEntry // sorted by origin, then instance
+}
+
+var _ funcOffsetByOriginIndex = (*onDiskFuncOffsetByOriginIndex)(nil)
+
+func (idx *onDiskFuncOffsetByOriginIndex) forOrigin(origin dwarf.Offset) iter.Seq[dwarf.Offset] {
+	return forOriginFromEntries(idx.entries, origin, idx)
+}
+
+func (idx *onDiskFuncOffsetByOriginIndex) Close() error {
+	if idx.idxMM == nil {
+		return nil
+	}
+	defer func() { *idx = onDiskFuncOffsetByOriginIndex{} }()
+	return idx.idxMM.Close()
+}
+
+// sortFuncOffsetByOriginEntries sorts entries by origin then instance.
+func sortFuncOffsetByOriginEntries(entries []funcOffsetByOriginEntry) {
+	slices.SortFunc(entries, func(a, b funcOffsetByOriginEntry) int {
+		return cmp.Or(
+			cmp.Compare(a.origin, b.origin),
+			cmp.Compare(a.instance, b.instance),
+		)
+	})
+}
+
+// forOriginFromEntries is shared by in-memory and on-disk implementations.
+// keepAlive is kept referenced for the lifetime of the iteration to prevent
+// the underlying mmap from being finalized while the caller iterates. Pass
+// nil for in-memory indexes.
+func forOriginFromEntries(entries []funcOffsetByOriginEntry, origin dwarf.Offset, keepAlive any) iter.Seq[dwarf.Offset] {
+	return func(yield func(dwarf.Offset) bool) {
+		target := uint32(origin)
+		i, _ := slices.BinarySearchFunc(entries, target, func(e funcOffsetByOriginEntry, t uint32) int {
+			return cmp.Compare(e.origin, t)
+		})
+		for ; i < len(entries); i++ {
+			e := &entries[i]
+			if e.origin != target {
+				break
+			}
+			if !yield(dwarf.Offset(e.instance)) {
+				return
+			}
+		}
+		if keepAlive != nil {
+			runtime.KeepAlive(keepAlive)
+		}
+	}
 }

--- a/pkg/dyninst/symdb/func_index.go
+++ b/pkg/dyninst/symdb/func_index.go
@@ -21,17 +21,28 @@ import (
 	"syscall"
 	"unsafe"
 
+	"github.com/DataDog/datadog-agent/pkg/dyninst/gosymname"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 )
 
-// funcOffsetByNameIndex maps canonicalized qualified names to DWARF offsets.
-// The name keys are treated as package-prefixed identifiers; forPackage
-// returns entries whose name starts with pkgName + ".". Used to find
-// functions that belong to a package but appear in a different CU (e.g.
-// generic shape instantiations placed in a foreign CU by the compiler).
+// funcOffsetByNameIndex maps DWARF-form qualified names to DWARF offsets.
+// The name keys are the linker-symbol form, where the package portion is
+// escaped per cmd/internal/objabi.PathToPrefix (dots inside the last
+// path segment become %2e, etc.). forPackage takes an *unescaped*
+// package import path (matching DW_AT_name on the compile unit) and
+// internally escapes it before searching, so callers don't deal with
+// the escaping themselves. Used to find functions that belong to a
+// package but appear in a different compile unit (e.g. generic shape
+// instantiations placed in a foreign compile unit by the compiler).
 type funcOffsetByNameIndex interface {
 	// forPackage returns an iterator over all (canonicalName, funcOffset)
-	// pairs where the function's qualified name starts with pkgName + ".".
+	// pairs whose owning package equals pkgName (compared in unescaped
+	// form). Internally the lookup escapes pkgName via gosymname.EscapePkg
+	// so that packages whose name contains a dot in a path segment (e.g.
+	// "lib.v2", "gopkg.in/ini.v1") match their own entries and only
+	// their own. Sibling packages that happen to share a dot-prefixed
+	// segment (e.g. "lib" and "lib.v2") are not yielded across each
+	// other.
 	forPackage(pkgName string) iter.Seq2[string, dwarf.Offset]
 	io.Closer
 }
@@ -89,9 +100,11 @@ type inMemFuncOffsetByNameIndex struct {
 var _ funcOffsetByNameIndex = (*inMemFuncOffsetByNameIndex)(nil)
 
 func (idx *inMemFuncOffsetByNameIndex) forPackage(pkgName string) iter.Seq2[string, dwarf.Offset] {
-	prefix := pkgName + "."
+	prefix := gosymname.EscapePkg(pkgName) + "."
 	return func(yield func(string, dwarf.Offset) bool) {
 		// Binary search for the first entry whose name >= prefix.
+		// Entries are stored in DWARF (escaped) form, so the prefix
+		// must be escaped too.
 		i, _ := slices.BinarySearchFunc(idx.entries, prefix, func(e inMemFuncOffsetByNameEntry, target string) int {
 			return strings.Compare(e.name, target)
 		})
@@ -309,9 +322,11 @@ func (idx *onDiskFuncOffsetByNameIndex) readName(offset uint32) string {
 }
 
 func (idx *onDiskFuncOffsetByNameIndex) forPackage(pkgName string) iter.Seq2[string, dwarf.Offset] {
-	prefix := pkgName + "."
+	prefix := gosymname.EscapePkg(pkgName) + "."
 	return func(yield func(string, dwarf.Offset) bool) {
 		// Binary search for the first entry whose name >= prefix.
+		// Entries are stored in DWARF (escaped) form, so the prefix
+		// must be escaped too.
 		i, _ := slices.BinarySearchFunc(idx.entries, prefix, func(e onDiskFuncOffsetByNameEntry, target string) int {
 			return strings.Compare(idx.readName(e.strOffset), target)
 		})

--- a/pkg/dyninst/symdb/func_index.go
+++ b/pkg/dyninst/symdb/func_index.go
@@ -472,6 +472,9 @@ func (b *onDiskFuncOffsetByOriginIndexBuilder) build() (_ funcOffsetByOriginInde
 	}
 	b.idxW = nil
 
+	// IntoMMap rejects empty files, so short-circuit before the mmap
+	// call. This handles binaries that have no inline-subroutine
+	// instances at all.
 	if b.numEntries == 0 {
 		b.cleanup()
 		return emptyFuncOffsetByOriginIndex{}, nil
@@ -516,8 +519,10 @@ func (b *onDiskFuncOffsetByOriginIndexBuilder) Close() error {
 
 // onDiskFuncOffsetByOriginIndex is the mmap-backed implementation.
 type onDiskFuncOffsetByOriginIndex struct {
-	idxMM   object.SectionData
-	entries []funcOffsetByOriginEntry // sorted by origin, then instance
+	idxMM object.SectionData
+	// entries is an unsafe view onto idxMM's mmap'ed data, sorted by
+	// origin, then instance. It must not be used after idxMM is closed.
+	entries []funcOffsetByOriginEntry
 }
 
 var _ funcOffsetByOriginIndex = (*onDiskFuncOffsetByOriginIndex)(nil)

--- a/pkg/dyninst/symdb/func_index_test.go
+++ b/pkg/dyninst/symdb/func_index_test.go
@@ -173,3 +173,114 @@ func TestFuncOffsetByNameIndex(t *testing.T) {
 		})
 	}
 }
+
+// originBuilderFactory creates a funcOffsetByOriginIndexBuilder for testing.
+type originBuilderFactory struct {
+	name   string
+	create func(t *testing.T) funcOffsetByOriginIndexBuilder
+}
+
+func getOriginBuilderFactories(t *testing.T) []originBuilderFactory {
+	t.Helper()
+	return []originBuilderFactory{
+		{
+			name:   "in_memory",
+			create: func(_ *testing.T) funcOffsetByOriginIndexBuilder { return &inMemFuncOffsetByOriginIndexBuilder{} },
+		},
+		{
+			name: "on_disk",
+			create: func(t *testing.T) funcOffsetByOriginIndexBuilder {
+				dc := newTestDiskCache(t)
+				b, err := newOnDiskFuncOffsetByOriginIndexBuilder(dc, "test")
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = b.Close() })
+				return b
+			},
+		},
+	}
+}
+
+func collectForOrigin(idx funcOffsetByOriginIndex, origin dwarf.Offset) []dwarf.Offset {
+	var out []dwarf.Offset
+	for instance := range idx.forOrigin(origin) {
+		out = append(out, instance)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func TestFuncOffsetByOriginIndex(t *testing.T) {
+	for _, factory := range getOriginBuilderFactories(t) {
+		t.Run(factory.name, func(t *testing.T) {
+			t.Run("empty", func(t *testing.T) {
+				builder := factory.create(t)
+				idx, err := builder.build()
+				require.NoError(t, err)
+				defer idx.Close()
+
+				assert.Empty(t, collectForOrigin(idx, 100))
+			})
+
+			t.Run("single_entry", func(t *testing.T) {
+				builder := factory.create(t)
+				require.NoError(t, builder.add(100, 500))
+				idx, err := builder.build()
+				require.NoError(t, err)
+				defer idx.Close()
+
+				assert.Equal(t, []dwarf.Offset{500}, collectForOrigin(idx, 100))
+				assert.Empty(t, collectForOrigin(idx, 200))
+			})
+
+			t.Run("multiple_origins", func(t *testing.T) {
+				builder := factory.create(t)
+				require.NoError(t, builder.add(100, 500))
+				require.NoError(t, builder.add(100, 600))
+				require.NoError(t, builder.add(200, 700))
+				require.NoError(t, builder.add(300, 800))
+				idx, err := builder.build()
+				require.NoError(t, err)
+				defer idx.Close()
+
+				assert.Equal(t, []dwarf.Offset{500, 600}, collectForOrigin(idx, 100))
+				assert.Equal(t, []dwarf.Offset{700}, collectForOrigin(idx, 200))
+				assert.Equal(t, []dwarf.Offset{800}, collectForOrigin(idx, 300))
+				assert.Empty(t, collectForOrigin(idx, 999))
+			})
+
+			t.Run("inserted_out_of_order", func(t *testing.T) {
+				builder := factory.create(t)
+				require.NoError(t, builder.add(300, 800))
+				require.NoError(t, builder.add(100, 600))
+				require.NoError(t, builder.add(100, 500))
+				require.NoError(t, builder.add(200, 700))
+				idx, err := builder.build()
+				require.NoError(t, err)
+				defer idx.Close()
+
+				assert.Equal(t, []dwarf.Offset{500, 600}, collectForOrigin(idx, 100))
+				assert.Equal(t, []dwarf.Offset{700}, collectForOrigin(idx, 200))
+				assert.Equal(t, []dwarf.Offset{800}, collectForOrigin(idx, 300))
+			})
+
+			t.Run("early_break_stops_iteration", func(t *testing.T) {
+				builder := factory.create(t)
+				require.NoError(t, builder.add(100, 500))
+				require.NoError(t, builder.add(100, 600))
+				require.NoError(t, builder.add(100, 700))
+				idx, err := builder.build()
+				require.NoError(t, err)
+				defer idx.Close()
+
+				var seen []dwarf.Offset
+				for inst := range idx.forOrigin(100) {
+					seen = append(seen, inst)
+					if len(seen) == 2 {
+						break
+					}
+				}
+				assert.Len(t, seen, 2)
+			})
+		})
+	}
+}

--- a/pkg/dyninst/symdb/func_index_test.go
+++ b/pkg/dyninst/symdb/func_index_test.go
@@ -24,10 +24,10 @@ type indexResult struct {
 	offset dwarf.Offset
 }
 
-// builderFactory creates a genericFuncIndexBuilder for testing.
+// builderFactory creates a funcOffsetByNameIndexBuilder for testing.
 type builderFactory struct {
 	name   string
-	create func(t *testing.T) genericFuncIndexBuilder
+	create func(t *testing.T) funcOffsetByNameIndexBuilder
 }
 
 func getBuilderFactories(t *testing.T) []builderFactory {
@@ -35,13 +35,13 @@ func getBuilderFactories(t *testing.T) []builderFactory {
 	return []builderFactory{
 		{
 			name:   "in_memory",
-			create: func(_ *testing.T) genericFuncIndexBuilder { return &inMemGenericFuncIndexBuilder{} },
+			create: func(_ *testing.T) funcOffsetByNameIndexBuilder { return &inMemFuncOffsetByNameIndexBuilder{} },
 		},
 		{
 			name: "on_disk",
-			create: func(t *testing.T) genericFuncIndexBuilder {
+			create: func(t *testing.T) funcOffsetByNameIndexBuilder {
 				dc := newTestDiskCache(t)
-				b, err := newOnDiskGenericFuncIndexBuilder(dc, "test")
+				b, err := newOnDiskFuncOffsetByNameIndexBuilder(dc, "test")
 				require.NoError(t, err)
 				t.Cleanup(func() { _ = b.Close() })
 				return b
@@ -60,7 +60,7 @@ func newTestDiskCache(t *testing.T) *object.DiskCache {
 	return dc
 }
 
-func collectForPackage(idx genericFuncIndex, pkgName string) []indexResult {
+func collectForPackage(idx funcOffsetByNameIndex, pkgName string) []indexResult {
 	var results []indexResult
 	for name, offset := range idx.forPackage(pkgName) {
 		results = append(results, indexResult{name, offset})
@@ -71,7 +71,7 @@ func collectForPackage(idx genericFuncIndex, pkgName string) []indexResult {
 	return results
 }
 
-func TestGenericFuncIndex(t *testing.T) {
+func TestFuncOffsetByNameIndex(t *testing.T) {
 	for _, factory := range getBuilderFactories(t) {
 		t.Run(factory.name, func(t *testing.T) {
 			t.Run("empty", func(t *testing.T) {

--- a/pkg/dyninst/symdb/index_integration_test.go
+++ b/pkg/dyninst/symdb/index_integration_test.go
@@ -1,0 +1,113 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package symdb
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+)
+
+// TestForPackageEscapeRoundTrip exercises funcOffsetByNameIndex.forPackage
+// against the indexes built from the sample testprog. The sample contains a
+// package "lib.v2" whose name has a dot in its last path segment — DWARF
+// emits the linker symbol with the segment-dot escaped as %2e, while the
+// compile unit's DW_AT_name keeps the unescaped form. forPackage takes the
+// unescaped form and must internally escape it before binary-searching.
+//
+// Concretely we assert:
+//  1. inlineDefs.forPackage("…/lib.v2") returns the inline definitions for
+//     lib.v2's symbols (otherwise cross-CU inline replay misses them).
+//  2. inlineDefs.forPackage("…/lib") yields no entries from lib.v2 — the
+//     escape boundary keeps sibling packages with shared dot-prefixed
+//     segments separate (the issue Andrei flagged).
+//  3. genericFuncs.forPackage works on unescaped names too.
+//  4. genericTypes.forPackage("…/lib.v2") returns lib.v2's generic types
+//     in DWARF (escaped) form — the index keys must match the lookup
+//     prefix's escape form, otherwise displaced generic types in
+//     dotted-segment packages are silently dropped.
+func TestForPackageEscapeRoundTrip(t *testing.T) {
+	cfgs, err := testprogs.GetCommonConfigs()
+	require.NoError(t, err)
+	for _, cfg := range cfgs {
+		t.Run(cfg.String(), func(t *testing.T) {
+			binaryPath, err := testprogs.GetBinary("sample", cfg)
+			require.NoError(t, err)
+
+			bin, err := openBinary(binaryPath, object.NewInMemoryLoader(), ExtractOptions{
+				Scope: ExtractScopeMainModuleOnly,
+			})
+			require.NoError(t, err)
+			b := newPackagesIterator(bin, ExtractOptions{
+				Scope: ExtractScopeMainModuleOnly,
+			})
+			t.Cleanup(b.close)
+
+			indexes, err := b.buildPrePassIndexes()
+			require.NoError(t, err)
+			b.indexes = indexes
+			t.Cleanup(b.indexes.close)
+
+			const (
+				libPkg   = "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib"
+				libV2Pkg = "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2"
+			)
+
+			// (1) lib.v2's inline definitions must be reachable.
+			var libV2Names []string
+			for name := range indexes.inlineDefs.forPackage(libV2Pkg) {
+				libV2Names = append(libV2Names, name)
+			}
+			require.NotEmpty(t, libV2Names,
+				"forPackage(%q) returned no inline-def entries — escape mismatch suspected", libV2Pkg)
+			for _, name := range libV2Names {
+				// Stored names are in DWARF (escaped) form.
+				require.Contains(t, name, "lib%2ev2.",
+					"expected entry %q to use the escaped package form", name)
+			}
+
+			// (2) forPackage("lib") must not yield lib.v2 entries.
+			for name := range indexes.inlineDefs.forPackage(libPkg) {
+				require.False(t, strings.Contains(name, "lib%2ev2."),
+					"forPackage(%q) leaked a lib.v2 entry: %s", libPkg, name)
+			}
+
+			// (3) genericFuncs uses the same forPackage mechanism. lib has
+			// generic functions (Filter, Map, Reduce, NewImmutableSet, …),
+			// so a lookup with the unescaped pkg name must yield entries.
+			var libGenericNames []string
+			for name := range indexes.genericFuncs.forPackage(libPkg) {
+				libGenericNames = append(libGenericNames, name)
+			}
+			require.NotEmpty(t, libGenericNames,
+				"forPackage(%q) returned no generic-func entries", libPkg)
+			for _, name := range libGenericNames {
+				require.True(t, strings.HasPrefix(name, libPkg+"."),
+					"genericFuncs entry %q does not belong to %q", name, libPkg)
+			}
+
+			// (4) genericTypes for a dotted-segment package. lib.v2
+			// defines V2GenericBox[T]; if its key were stored unescaped
+			// the escaped-prefix lookup would miss it.
+			var libV2GenericTypeNames []string
+			for name := range indexes.genericTypes.forPackage(libV2Pkg) {
+				libV2GenericTypeNames = append(libV2GenericTypeNames, name)
+			}
+			require.NotEmpty(t, libV2GenericTypeNames,
+				"forPackage(%q) returned no generic-type entries — escape mismatch in genericTypes keys?", libV2Pkg)
+			for _, name := range libV2GenericTypeNames {
+				require.Contains(t, name, "lib%2ev2.",
+					"expected genericTypes entry %q to use the escaped package form", name)
+			}
+		})
+	}
+}

--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -413,14 +413,14 @@ type packagesIterator struct {
 	// used for binary search to find which CU contains a given DWARF offset.
 	sortedCUOffsets []dwarf.Offset
 
-	// genericIndex maps canonicalized qualified names to DWARF offsets for
+	// genericFuncIndex maps canonicalized qualified names to DWARF offsets for
 	// generic shape functions found across all compile units. Built during a
-	// lightweight pre-pass in buildGenericIndex().
-	genericIndex genericFuncIndex
+	// lightweight pre-pass in buildGenericIndexes().
+	genericFuncIndex funcOffsetByNameIndex
 	// genericTypeIndex maps canonicalized qualified type names to DWARF offsets
 	// for generic struct type instantiations. Used to populate fields on
 	// displaced generic types.
-	genericTypeIndex genericFuncIndex
+	genericTypeIndex funcOffsetByNameIndex
 	// cuContextCache caches CU context (file table, etc.) for foreign compile
 	// units accessed when processing displaced generic functions.
 	cuContextCache map[dwarf.Offset]*cachedCUContext
@@ -476,7 +476,7 @@ func (b *packagesIterator) addFunctionToPackage(function Function) {
 	// Function belongs to a different package. If it's a canonicalized
 	// generic (contains "[...]"), the generic index will handle it via
 	// augmentWithDisplacedGenerics — skip accumulating it here.
-	if b.genericIndex != nil && strings.Contains(function.QualifiedName, "[...]") {
+	if b.genericFuncIndex != nil && strings.Contains(function.QualifiedName, "[...]") {
 		return
 	}
 
@@ -959,15 +959,15 @@ func (b *packagesIterator) innerIterator() iter.Seq2[Package, error] {
 		// Build generic indexes via a lightweight pre-scan of all DWARF
 		// compile units. These indexes let us find displaced generic shape
 		// functions and struct types regardless of CU ordering.
-		b.genericIndex, b.genericTypeIndex, err = b.buildGenericIndexes()
+		b.genericFuncIndex, b.genericTypeIndex, err = b.buildGenericIndexes()
 		if err != nil {
 			yield(Package{}, fmt.Errorf("failed to build generic indexes: %w", err))
 			return
 		}
 		defer func() {
-			if b.genericIndex != nil {
-				_ = b.genericIndex.Close()
-				b.genericIndex = nil
+			if b.genericFuncIndex != nil {
+				_ = b.genericFuncIndex.Close()
+				b.genericFuncIndex = nil
 			}
 			if b.genericTypeIndex != nil {
 				_ = b.genericTypeIndex.Close()
@@ -1140,12 +1140,12 @@ func (b *packagesIterator) getCUContext(cuOffset dwarf.Offset) (*cachedCUContext
 // units, recording the canonicalized qualified name and DWARF offset of every
 // generic shape function and struct type. Returns sorted indexes for
 // prefix-based package lookup.
-func (b *packagesIterator) buildGenericIndexes() (funcIdx genericFuncIndex, typeIdx genericFuncIndex, retErr error) {
-	newBuilder := func(suffix string) (genericFuncIndexBuilder, error) {
+func (b *packagesIterator) buildGenericIndexes() (funcIdx funcOffsetByNameIndex, typeIdx funcOffsetByNameIndex, retErr error) {
+	newBuilder := func(suffix string) (funcOffsetByNameIndexBuilder, error) {
 		if b.options.DiskCache != nil {
-			return newOnDiskGenericFuncIndexBuilder(b.options.DiskCache, suffix)
+			return newOnDiskFuncOffsetByNameIndexBuilder(b.options.DiskCache, suffix)
 		}
-		return &inMemGenericFuncIndexBuilder{}, nil
+		return &inMemFuncOffsetByNameIndexBuilder{}, nil
 	}
 
 	funcBuilder, err := newBuilder("funcs")
@@ -1256,13 +1256,13 @@ func (b *packagesIterator) buildGenericIndexes() (funcIdx genericFuncIndex, type
 // functions belonging to pkg and processes any that weren't already found in
 // the compile unit identified by cuOffset/cuLength.
 func (b *packagesIterator) augmentWithDisplacedGenerics(pkg *Package, cuOffset dwarf.Offset, cuLength uint64) error {
-	if b.genericIndex == nil {
+	if b.genericFuncIndex == nil {
 		return nil
 	}
 
 	cuEnd := uint64(cuOffset) + cuLength
 
-	for name, funcOffset := range b.genericIndex.forPackage(pkg.Name) {
+	for name, funcOffset := range b.genericFuncIndex.forPackage(pkg.Name) {
 		// Skip functions that are within the current CU — they were already
 		// processed during normal exploration.
 		if uint64(funcOffset) >= uint64(cuOffset) && uint64(funcOffset) < cuEnd {
@@ -1430,7 +1430,7 @@ func (b *packagesIterator) addAbstractFunctions(targetPackage *Package) {
 		} else if af.pkg != targetPackage.Name {
 			// Freestanding function from a different package. If it's a
 			// canonicalized generic, the generic index handles it — skip.
-			if b.genericIndex != nil && strings.Contains(f.QualifiedName, "[...]") {
+			if b.genericFuncIndex != nil && strings.Contains(f.QualifiedName, "[...]") {
 				continue
 			}
 			// Non-generic displaced function: route to displacedFunctions.
@@ -1781,7 +1781,7 @@ func (b *packagesIterator) exploreSubprogram(
 		// package and will be processed by augmentWithDisplacedGenerics
 		// when that package is yielded. This prevents creating a foreign
 		// type (e.g. lib.Box[...]) under the wrong package (e.g. main).
-		if b.genericIndex != nil &&
+		if b.genericFuncIndex != nil &&
 			funcName.Package != b.currentCompileUnit.outputPkg.Name &&
 			strings.Contains(typeQualifiedName, "[...]") {
 			return Function{}, nil

--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -385,14 +385,6 @@ type packagesIterator struct {
 	// The compile unit currently being processed by explore* functions.
 	currentCompileUnit compileUnitInfo
 
-	abstractFunctions map[dwarf.Offset]*abstractFunction
-
-	// displacedFunctions accumulates functions that were found in a compile
-	// unit different from where they are defined (e.g. generic shape functions
-	// instantiated in a different package). Keyed by the function's actual
-	// package name.
-	displacedFunctions map[string]*Package
-
 	// typesCache will accumulate types as we look them up to resolve variables
 	// and functions. The cache is indexed by DWARF offset.
 	typesCache *dwarfutils.TypeFinder
@@ -413,17 +405,63 @@ type packagesIterator struct {
 	// used for binary search to find which CU contains a given DWARF offset.
 	sortedCUOffsets []dwarf.Offset
 
-	// genericFuncIndex maps canonicalized qualified names to DWARF offsets for
-	// generic shape functions found across all compile units. Built during a
-	// lightweight pre-pass in buildGenericIndexes().
-	genericFuncIndex funcOffsetByNameIndex
-	// genericTypeIndex maps canonicalized qualified type names to DWARF offsets
-	// for generic struct type instantiations. Used to populate fields on
-	// displaced generic types.
-	genericTypeIndex funcOffsetByNameIndex
+	indexes prePassIndexes
 	// cuContextCache caches CU context (file table, etc.) for foreign compile
 	// units accessed when processing displaced generic functions.
 	cuContextCache map[dwarf.Offset]*cachedCUContext
+}
+
+// prePassIndexes bundles the four indexes built by buildPrePassIndexes
+// during a lightweight pre-scan of the DWARF, used at iteration time to
+// resolve functions and types that the compiler placed in a different CU
+// than their source package.
+//
+// The name-keyed indexes (genericFuncs, genericTypes, inlineDefs) filter
+// by interestingPackage at collection time since the qualified name
+// encodes the owning package. inlineInstances cannot filter at
+// collection time — its key is a raw DWARF offset — so it records every
+// inline instance; lookups only ever originate from abstract-origin
+// offsets that appear in inlineDefs, so uninteresting packages are
+// never reached.
+type prePassIndexes struct {
+	// genericFuncs maps canonicalized qualified names to DWARF offsets
+	// for generic shape Subprograms whose body is out-of-line (not
+	// DW_AT_inline). Used to find generic functions placed in a foreign
+	// CU by the compiler.
+	genericFuncs funcOffsetByNameIndex
+	// genericTypes maps canonicalized qualified type names to DWARF
+	// offsets for generic struct type instantiations. Used to populate
+	// fields on displaced generic types.
+	genericTypes funcOffsetByNameIndex
+	// inlineDefs maps canonicalized qualified names to DWARF offsets for
+	// every Subprogram with DW_AT_inline = DW_INL_inlined (both generic
+	// and non-generic). Used to find a package's abstract function
+	// definitions at emission time.
+	inlineDefs funcOffsetByNameIndex
+	// inlineInstances maps abstract-origin DWARF offsets to instance
+	// DWARF offsets for every DW_TAG_inlined_subroutine and every
+	// out-of-line Subprogram with DW_AT_abstract_origin. Used at emission
+	// time to replay every instance of an abstract function regardless of
+	// which CU it lives in.
+	inlineInstances funcOffsetByOriginIndex
+}
+
+// close releases any resources owned by the indexes (e.g. mmap regions
+// for on-disk variants). Safe to call multiple times.
+func (p *prePassIndexes) close() {
+	if p.genericFuncs != nil {
+		_ = p.genericFuncs.Close()
+	}
+	if p.genericTypes != nil {
+		_ = p.genericTypes.Close()
+	}
+	if p.inlineDefs != nil {
+		_ = p.inlineDefs.Close()
+	}
+	if p.inlineInstances != nil {
+		_ = p.inlineInstances.Close()
+	}
+	*p = prePassIndexes{}
 }
 
 type compileUnitInfo struct {
@@ -455,47 +493,18 @@ func (c *compileUnitInfo) hasFunctionQName(qname string) bool {
 	})
 }
 
-// addFunctionToPackage adds a function to the correct package. If the
-// function's package (extracted from its qualified name) matches the current
-// compile unit, it goes into the compile unit's output package. Otherwise it
-// is accumulated in displacedFunctions for later yielding under the correct
-// package name. This handles generic shape functions that the Go compiler
-// places in the instantiating package's compile unit rather than the defining
-// package's compile unit.
+// addFunctionToPackage adds a function to the current compile unit's output
+// package if the function's package matches. Functions belonging to a
+// different package are dropped; generic shape functions whose out-of-line
+// body lives in a foreign CU are picked up by augmentWithDisplacedGenerics.
 func (b *packagesIterator) addFunctionToPackage(function Function) {
-	// Extract the function's package from its qualified name.
 	sym := gosymname.Parse(function.QualifiedName, gosymname.SourceDWARF)
 	funcPkg := sym.Package()
-
-	if funcPkg == "" || funcPkg == b.currentCompileUnit.name {
-		b.currentCompileUnit.outputPkg.Functions = append(
-			b.currentCompileUnit.outputPkg.Functions, function)
+	if funcPkg != "" && funcPkg != b.currentCompileUnit.name {
 		return
 	}
-
-	// Function belongs to a different package. If it's a canonicalized
-	// generic (contains "[...]"), the generic index will handle it via
-	// augmentWithDisplacedGenerics — skip accumulating it here.
-	if b.genericFuncIndex != nil && strings.Contains(function.QualifiedName, "[...]") {
-		return
-	}
-
-	// Non-generic function from a different package — accumulate it in
-	// displacedFunctions for merging when that package's CU is processed.
-	pkg, ok := b.displacedFunctions[funcPkg]
-	if !ok {
-		pkg = &Package{
-			Name:  funcPkg,
-			Types: make(map[string]*Type),
-		}
-		b.displacedFunctions[funcPkg] = pkg
-	}
-	// Dedup by qualified name.
-	if !slices.ContainsFunc(pkg.Functions, func(f Function) bool {
-		return f.QualifiedName == function.QualifiedName
-	}) {
-		pkg.Functions = append(pkg.Functions, function)
-	}
+	b.currentCompileUnit.outputPkg.Functions = append(
+		b.currentCompileUnit.outputPkg.Functions, function)
 }
 
 // abstractFunction aggregates data for an inlined function.
@@ -508,14 +517,14 @@ type abstractFunction struct {
 	qualifiedName string
 	startLine     int
 
-	// Updated when inlined instances are encountered.
+	// Updated as inline instances are replayed.
 	file            string
 	endLine         uint32
 	injectibleLines []LineRange
 
-	// The variables map is generated by parsing abstract definition.
-	// The AvailableLineRanges field is updated when inlined instances are
-	// encountered.
+	// The variables map is generated by parsing the abstract definition.
+	// The AvailableLineRanges field is updated as inline instances are
+	// replayed.
 	variables map[dwarf.Offset]*abstractVariable
 }
 
@@ -791,8 +800,6 @@ func newPackagesIterator(bin binaryInfo, opt ExtractOptions) *packagesIterator {
 		mainModule:          bin.mainModule,
 		firstPartyPkgPrefix: bin.firstPartyPkgPrefix,
 		filesFilter:         bin.filesFilter,
-		abstractFunctions:   make(map[dwarf.Offset]*abstractFunction),
-		displacedFunctions:  make(map[string]*Package),
 		typesCache:          dwarfutils.NewTypeFinder(bin.obj.DwarfData()),
 		types: typesCollection{
 			scopeFilter:         opt.Scope,
@@ -956,24 +963,16 @@ func (b *packagesIterator) innerIterator() iter.Seq2[Package, error] {
 	return func(yield func(pkg Package, err error) bool) {
 		defer b.close()
 
-		// Build generic indexes via a lightweight pre-scan of all DWARF
+		// Build pre-pass indexes via a lightweight pre-scan of all DWARF
 		// compile units. These indexes let us find displaced generic shape
-		// functions and struct types regardless of CU ordering.
-		b.genericFuncIndex, b.genericTypeIndex, err = b.buildGenericIndexes()
+		// functions, struct types, and inline abstract definitions and
+		// their instances regardless of CU ordering.
+		b.indexes, err = b.buildPrePassIndexes()
 		if err != nil {
-			yield(Package{}, fmt.Errorf("failed to build generic indexes: %w", err))
+			yield(Package{}, fmt.Errorf("failed to build pre-pass indexes: %w", err))
 			return
 		}
-		defer func() {
-			if b.genericFuncIndex != nil {
-				_ = b.genericFuncIndex.Close()
-				b.genericFuncIndex = nil
-			}
-			if b.genericTypeIndex != nil {
-				_ = b.genericTypeIndex.Close()
-				b.genericTypeIndex = nil
-			}
-		}()
+		defer b.indexes.close()
 
 		entryReader := b.dwarfData.Reader()
 
@@ -1002,21 +1001,23 @@ func (b *packagesIterator) innerIterator() iter.Seq2[Package, error] {
 				continue
 			}
 
-			// Move all accumulated abstract functions to the output package.
-			b.addAbstractFunctions(pkg)
-
-			// Augment the package with displaced generic shape functions
-			// found in other compile units via the pre-built index.
 			unitHeader := b.offsetToUnit[entry.Offset]
-			if err = b.augmentWithDisplacedGenerics(pkg, entry.Offset, unitHeader.Length); err != nil {
+
+			// Emit every abstract (inline) function owned by this
+			// package by driving from inlineDefs and
+			// inlineInstances. Doing it here rather than as a
+			// side-effect of the per-CU walk makes emission order
+			// independent of where the compiler places the abstract
+			// definition and its inline instances.
+			if err = b.emitAbstractFunctionsForPackage(pkg); err != nil {
 				break
 			}
 
-			// Merge in any displaced functions that belong to this package.
-			// This handles non-generic abstract functions from other CUs.
-			if displaced, ok := b.displacedFunctions[pkg.Name]; ok {
-				pkg.Functions = append(pkg.Functions, displaced.Functions...)
-				delete(b.displacedFunctions, pkg.Name)
+			// Augment the package with displaced generic shape functions
+			// (the out-of-line subprogram variant) found in other compile
+			// units via the pre-built index.
+			if err = b.augmentWithDisplacedGenerics(pkg, entry.Offset, unitHeader.Length); err != nil {
+				break
 			}
 
 			// Yield the package if it's not empty.
@@ -1032,17 +1033,34 @@ func (b *packagesIterator) innerIterator() iter.Seq2[Package, error] {
 			yield(Package{}, err)
 			return
 		}
+	}
+}
 
-		// Yield packages for functions that were found in a compile unit
-		// different from their defining package (e.g. abstract inlined
-		// functions from other packages).
-		for _, pkg := range b.displacedFunctions {
-			if len(pkg.Functions) > 0 {
-				if !yield(*pkg, nil) {
-					return
-				}
-			}
-		}
+// buildFunctionFromAbstract converts an abstractFunction into a Function
+// with coalesced and sorted variable line ranges.
+func buildFunctionFromAbstract(af *abstractFunction) Function {
+	variables := make([]Variable, 0, len(af.variables))
+	for _, v := range af.variables {
+		v.Variable.AvailableLineRanges = coalesceLineRanges(v.AvailableLineRanges)
+		variables = append(variables, v.Variable)
+	}
+	slices.SortFunc(variables, func(a, b Variable) int {
+		return cmp.Or(
+			cmp.Compare(a.Name, b.Name),
+			cmp.Compare(a.DeclLine, b.DeclLine),
+		)
+	})
+	return Function{
+		Name:            af.name,
+		QualifiedName:   af.qualifiedName,
+		File:            af.file,
+		InjectibleLines: af.injectibleLines,
+		Scope: Scope{
+			StartLine: af.startLine,
+			EndLine:   int(af.endLine),
+			Scopes:    nil,
+			Variables: variables,
+		},
 	}
 }
 
@@ -1136,35 +1154,53 @@ func (b *packagesIterator) getCUContext(cuOffset dwarf.Offset) (*cachedCUContext
 	return ctx, nil
 }
 
-// buildGenericIndexes performs a lightweight pre-scan of all DWARF compile
-// units, recording the canonicalized qualified name and DWARF offset of every
-// generic shape function and struct type. Returns sorted indexes for
-// prefix-based package lookup.
-func (b *packagesIterator) buildGenericIndexes() (funcIdx funcOffsetByNameIndex, typeIdx funcOffsetByNameIndex, retErr error) {
-	newBuilder := func(suffix string) (funcOffsetByNameIndexBuilder, error) {
+// buildPrePassIndexes performs one top-to-bottom walk of the DWARF and
+// populates the four indexes bundled in prePassIndexes. The walk
+// recurses into subprograms and lexical blocks to find nested
+// DW_TAG_inlined_subroutine DIEs.
+func (b *packagesIterator) buildPrePassIndexes() (idx prePassIndexes, retErr error) {
+	newNameBuilder := func(suffix string) (funcOffsetByNameIndexBuilder, error) {
 		if b.options.DiskCache != nil {
 			return newOnDiskFuncOffsetByNameIndexBuilder(b.options.DiskCache, suffix)
 		}
 		return &inMemFuncOffsetByNameIndexBuilder{}, nil
 	}
-
-	funcBuilder, err := newBuilder("funcs")
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create generic func index builder: %w", err)
+	newOriginBuilder := func(suffix string) (funcOffsetByOriginIndexBuilder, error) {
+		if b.options.DiskCache != nil {
+			return newOnDiskFuncOffsetByOriginIndexBuilder(b.options.DiskCache, suffix)
+		}
+		return &inMemFuncOffsetByOriginIndexBuilder{}, nil
 	}
-	defer funcBuilder.Close()
 
-	typeBuilder, err := newBuilder("types")
+	genericFuncBuilder, err := newNameBuilder("genericFuncs")
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create generic type index builder: %w", err)
+		return prePassIndexes{}, fmt.Errorf("failed to create generic func index builder: %w", err)
 	}
-	defer typeBuilder.Close()
+	defer genericFuncBuilder.Close()
+
+	genericTypeBuilder, err := newNameBuilder("genericTypes")
+	if err != nil {
+		return prePassIndexes{}, fmt.Errorf("failed to create generic type index builder: %w", err)
+	}
+	defer genericTypeBuilder.Close()
+
+	inlineDefBuilder, err := newNameBuilder("inlineDefs")
+	if err != nil {
+		return prePassIndexes{}, fmt.Errorf("failed to create inline def index builder: %w", err)
+	}
+	defer inlineDefBuilder.Close()
+
+	inlineInstanceBuilder, err := newOriginBuilder("inlineInstances")
+	if err != nil {
+		return prePassIndexes{}, fmt.Errorf("failed to create inline instance index builder: %w", err)
+	}
+	defer inlineInstanceBuilder.Close()
 
 	reader := b.dwarfData.Reader()
 	for {
 		entry, err := reader.Next()
 		if err != nil {
-			return nil, nil, fmt.Errorf("generic index pre-scan: %w", err)
+			return prePassIndexes{}, fmt.Errorf("pre-pass scan: %w", err)
 		}
 		if entry == nil {
 			break
@@ -1176,36 +1212,9 @@ func (b *packagesIterator) buildGenericIndexes() (funcIdx funcOffsetByNameIndex,
 			continue
 
 		case dwarf.TagSubprogram:
-			// Skip trampolines.
-			if entry.AttrField(dwarf.AttrTrampoline) != nil {
-				reader.SkipChildren()
-				continue
+			if err := b.preScanSubprogram(reader, entry, genericFuncBuilder, inlineDefBuilder, inlineInstanceBuilder); err != nil {
+				return prePassIndexes{}, err
 			}
-
-			name, ok := entry.Val(dwarf.AttrName).(string)
-			if !ok || !strings.Contains(name, "[go.shape.") {
-				reader.SkipChildren()
-				continue
-			}
-
-			// Parse the function's package from its qualified name.
-			result, err := parseFuncName(name)
-			if err != nil || result.failureReason != parseFuncNameFailureReasonUndefined {
-				reader.SkipChildren()
-				continue
-			}
-
-			pkg := result.funcName.Package
-			if !interestingPackage(pkg, b.mainModule, b.firstPartyPkgPrefix, b.options.Scope) {
-				reader.SkipChildren()
-				continue
-			}
-
-			// parseFuncName already canonicalizes generics in QualifiedName.
-			if err := funcBuilder.add(result.funcName.QualifiedName, entry.Offset); err != nil {
-				return nil, nil, err
-			}
-			reader.SkipChildren()
 
 		case dwarf.TagStructType:
 			name, ok := entry.Val(dwarf.AttrName).(string)
@@ -1230,8 +1239,8 @@ func (b *packagesIterator) buildGenericIndexes() (funcIdx funcOffsetByNameIndex,
 			if unescaped, err := unescapeSymbol(canonicalName); err == nil {
 				canonicalName = unescaped
 			}
-			if err := typeBuilder.add(canonicalName, entry.Offset); err != nil {
-				return nil, nil, err
+			if err := genericTypeBuilder.add(canonicalName, entry.Offset); err != nil {
+				return prePassIndexes{}, err
 			}
 			reader.SkipChildren()
 
@@ -1240,29 +1249,177 @@ func (b *packagesIterator) buildGenericIndexes() (funcIdx funcOffsetByNameIndex,
 		}
 	}
 
-	funcIdx, err = funcBuilder.build()
-	if err != nil {
-		return nil, nil, err
+	defer func() {
+		if retErr != nil {
+			idx.close()
+		}
+	}()
+	if idx.genericFuncs, err = genericFuncBuilder.build(); err != nil {
+		return prePassIndexes{}, err
 	}
-	typeIdx, err = typeBuilder.build()
-	if err != nil {
-		_ = funcIdx.Close()
-		return nil, nil, err
+	if idx.genericTypes, err = genericTypeBuilder.build(); err != nil {
+		return prePassIndexes{}, err
 	}
-	return funcIdx, typeIdx, nil
+	if idx.inlineDefs, err = inlineDefBuilder.build(); err != nil {
+		return prePassIndexes{}, err
+	}
+	if idx.inlineInstances, err = inlineInstanceBuilder.build(); err != nil {
+		return prePassIndexes{}, err
+	}
+	return idx, nil
+}
+
+// preScanSubprogram processes a top-level Subprogram DIE during the pre-pass.
+// It indexes generic shape functions, abstract inline definitions, and
+// out-of-line instances, then recurses into the subprogram's children to
+// find inlined subroutines.
+func (b *packagesIterator) preScanSubprogram(
+	reader *dwarf.Reader,
+	entry *dwarf.Entry,
+	genericFuncBuilder funcOffsetByNameIndexBuilder,
+	inlineDefBuilder funcOffsetByNameIndexBuilder,
+	inlineInstanceBuilder funcOffsetByOriginIndexBuilder,
+) error {
+	// Skip trampolines entirely — they're compiler-generated and never
+	// contain inline instances we care about.
+	if entry.AttrField(dwarf.AttrTrampoline) != nil {
+		reader.SkipChildren()
+		return nil
+	}
+
+	// Out-of-line subprogram instances have DW_AT_abstract_origin pointing
+	// at the abstract definition.
+	if originOffset, ok := entry.Val(dwarf.AttrAbstractOrigin).(dwarf.Offset); ok {
+		if err := inlineInstanceBuilder.add(originOffset, entry.Offset); err != nil {
+			return err
+		}
+		// Out-of-line instances can still contain inlined subroutines
+		// nested inside them (e.g. calls that got further inlined).
+		if entry.Children {
+			if err := b.preScanChildrenForInlines(reader, inlineInstanceBuilder); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	name, _ := entry.Val(dwarf.AttrName).(string)
+	// Abstract inline definition: index in inlineDefs.
+	if inlineAttr, hasInline := entry.Val(dwarf.AttrInline).(int64); hasInline &&
+		inlineAttr == dwarf2.DW_INL_inlined {
+		if name != "" {
+			if err := indexIfInteresting(b, name, entry.Offset, inlineDefBuilder); err != nil {
+				return err
+			}
+		}
+		// An abstract definition never has PC ranges itself, but it may
+		// syntactically contain inlined subroutines in rare edge cases
+		// produced by Go toolchains. Recurse to be safe.
+		if entry.Children {
+			if err := b.preScanChildrenForInlines(reader, inlineInstanceBuilder); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Generic shape Subprogram: index in genericFuncs.
+	if name != "" && strings.Contains(name, "[go.shape.") {
+		if err := indexIfInteresting(b, name, entry.Offset, genericFuncBuilder); err != nil {
+			return err
+		}
+	}
+
+	// Recurse into children to pick up inlined subroutines.
+	if entry.Children {
+		if err := b.preScanChildrenForInlines(reader, inlineInstanceBuilder); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// preScanChildrenForInlines walks the children of a subprogram or lexical
+// block entry, recording inlined-subroutine instances and recursing through
+// nested lexical blocks and further inlined subroutines. The reader is
+// positioned immediately after the parent entry on entry and is advanced to
+// just past the parent's null terminator on exit.
+//
+// Children tags we skip without recursing: TagFormalParameter, TagVariable,
+// TagTypedef, and any unknown tag (we still consume their children via
+// SkipChildren). Only TagLexDwarfBlock and TagInlinedSubroutine can
+// transitively contain more inlined subroutines.
+func (b *packagesIterator) preScanChildrenForInlines(
+	reader *dwarf.Reader,
+	inlineInstanceBuilder funcOffsetByOriginIndexBuilder,
+) error {
+	for {
+		child, err := reader.Next()
+		if err != nil {
+			return err
+		}
+		if child == nil {
+			return nil
+		}
+		if dwarfutil.IsEntryNull(child) {
+			return nil
+		}
+		switch child.Tag {
+		case dwarf.TagInlinedSubroutine:
+			if originOffset, ok := child.Val(dwarf.AttrAbstractOrigin).(dwarf.Offset); ok {
+				if err := inlineInstanceBuilder.add(originOffset, child.Offset); err != nil {
+					return err
+				}
+			}
+			if child.Children {
+				if err := b.preScanChildrenForInlines(reader, inlineInstanceBuilder); err != nil {
+					return err
+				}
+			}
+		case dwarf.TagLexDwarfBlock:
+			if child.Children {
+				if err := b.preScanChildrenForInlines(reader, inlineInstanceBuilder); err != nil {
+					return err
+				}
+			}
+		default:
+			// TagFormalParameter, TagVariable, TagTypedef, and anything
+			// unexpected: never contains inlined subroutines. Skip.
+			reader.SkipChildren()
+		}
+	}
+}
+
+// indexIfInteresting parses name via parseFuncName, filters by interesting
+// package, and adds the canonical qualified name → offset entry to builder.
+func indexIfInteresting(
+	b *packagesIterator,
+	name string,
+	offset dwarf.Offset,
+	builder funcOffsetByNameIndexBuilder,
+) error {
+	result, err := parseFuncName(name)
+	if err != nil || result.failureReason != parseFuncNameFailureReasonUndefined {
+		return nil
+	}
+	pkg := result.funcName.Package
+	if !interestingPackage(pkg, b.mainModule, b.firstPartyPkgPrefix, b.options.Scope) {
+		return nil
+	}
+	return builder.add(result.funcName.QualifiedName, offset)
 }
 
 // augmentWithDisplacedGenerics queries the generic index for all shape
 // functions belonging to pkg and processes any that weren't already found in
 // the compile unit identified by cuOffset/cuLength.
 func (b *packagesIterator) augmentWithDisplacedGenerics(pkg *Package, cuOffset dwarf.Offset, cuLength uint64) error {
-	if b.genericFuncIndex == nil {
+	if b.indexes.genericFuncs == nil {
 		return nil
 	}
 
 	cuEnd := uint64(cuOffset) + cuLength
 
-	for name, funcOffset := range b.genericFuncIndex.forPackage(pkg.Name) {
+	for name, funcOffset := range b.indexes.genericFuncs.forPackage(pkg.Name) {
 		// Skip functions that are within the current CU — they were already
 		// processed during normal exploration.
 		if uint64(funcOffset) >= uint64(cuOffset) && uint64(funcOffset) < cuEnd {
@@ -1325,8 +1482,8 @@ func (b *packagesIterator) augmentWithDisplacedGenerics(pkg *Package, cuOffset d
 	// the same type (e.g. lib.Box[go.shape.int] and lib.Box[go.shape.float64])
 	// are compared field-by-field in maybeAddType to deduce which fields are
 	// type-parameter-dependent.
-	if b.genericTypeIndex != nil {
-		for _, typeOffset := range b.genericTypeIndex.forPackage(pkg.Name) {
+	if b.indexes.genericTypes != nil {
+		for _, typeOffset := range b.indexes.genericTypes.forPackage(pkg.Name) {
 			// Skip types within the current CU.
 			if uint64(typeOffset) >= uint64(cuOffset) && uint64(typeOffset) < cuEnd {
 				continue
@@ -1356,101 +1513,148 @@ func packageHasFunctionQName(pkg *Package, qname string) bool {
 	})
 }
 
-// addAbstractFunctions takes the aggregated data about inlined functions
-// accumulated in b.abstractFunctions and adds the functions to targetPackage
-// and methods to types in `b.types`. `b.abstractFunctions` is reset.
-//
-// targetPackage is the package in which all freestanding abstract functions
-// will go, regardless of the package they really belong to. Abstract *methods*
-// that don't belong to this single package are ignored: methods are added to
-// types, and we only ever report a type in the package that it belongs to -- we
-// don't move types to the a different package as we do with freestanding
-// functions. That's because types might not be complete yet (they might have
-// methods that can only be discovered when exploring other packages in which
-// they were inlined) and we don't want to report incomplete types or report a
-// type multiple times.
-func (b *packagesIterator) addAbstractFunctions(targetPackage *Package) {
-	// Sort abstract functions so that output is stable.
-	abstractFunctions := make([]*abstractFunction, 0, len(b.abstractFunctions))
-	for _, af := range b.abstractFunctions {
+// emitAbstractFunctionsForPackage emits every abstract (inlined) function
+// that inlineDefs attributes to pkg. Each abstract DIE is parsed
+// fresh, its inline instances are replayed from inlineInstances to
+// accumulate file/endLine/injectibleLines and per-variable availability,
+// and the resulting Function is attached to pkg (or the receiver type's
+// Methods). Because emission is driven from the pre-pass indexes rather
+// than from per-CU walk state, it is independent of CU iteration order.
+func (b *packagesIterator) emitAbstractFunctionsForPackage(pkg *Package) error {
+	if b.indexes.inlineDefs == nil || b.indexes.inlineInstances == nil {
+		return nil
+	}
+
+	for _, defOffset := range b.indexes.inlineDefs.forPackage(pkg.Name) {
+		defCUOffset, ok := b.findCUForOffset(defOffset)
+		if !ok {
+			continue
+		}
+		defCU, err := b.getCUContext(defCUOffset)
+		if err != nil {
+			return fmt.Errorf("emitAbstractFunctionsForPackage: get CU context for 0x%x: %w", defOffset, err)
+		}
+
+		// Swap the current CU to the abstract's CU so that resolveType's
+		// maybeAddType sees the right outputPkg and file table.
+		savedCU := b.currentCompileUnit
+		b.currentCompileUnit = compileUnitInfo{
+			entry:     defCU.entry,
+			name:      defCU.name,
+			length:    defCU.length,
+			files:     defCU.files,
+			outputPkg: pkg,
+		}
+		af, err := b.parseAbstractFunction(defOffset, b.dwarfData.Reader())
+		b.currentCompileUnit = savedCU
+		if err != nil {
+			return fmt.Errorf("emitAbstractFunctionsForPackage: parse abstract at 0x%x: %w", defOffset, err)
+		}
 		if !af.interesting {
 			continue
 		}
-		abstractFunctions = append(abstractFunctions, af)
-	}
-	// Reset the map.
-	clear(b.abstractFunctions)
-	sort.Slice(abstractFunctions, func(i, j int) bool {
-		return abstractFunctions[i].name < abstractFunctions[j].name
-	})
-	for _, af := range abstractFunctions {
-		// Ignore methods that don't belong to the target package; see function
-		// comment.
-		if af.pkg != targetPackage.Name && af.receiver != "" {
+		// forPackage is a prefix match on the qualified name, so it also
+		// returns entries for packages with the same prefix (e.g. "lib."
+		// matches "lib.v2.*"). Filter.
+		if af.pkg != pkg.Name {
 			continue
 		}
 
-		variables := make([]Variable, 0, len(af.variables))
-		for _, v := range af.variables {
-			v.Variable.AvailableLineRanges = coalesceLineRanges(v.AvailableLineRanges)
-			variables = append(variables, v.Variable)
-		}
-		// Sort variables so that output is stable.
-		sort.Slice(variables, func(i, j int) bool {
-			if variables[i].Name != variables[j].Name {
-				return variables[i].Name < variables[j].Name
+		for instanceOffset := range b.indexes.inlineInstances.forOrigin(defOffset) {
+			if err := b.replayInlineInstance(instanceOffset, pkg, af); err != nil {
+				return fmt.Errorf("emitAbstractFunctionsForPackage: instance 0x%x of 0x%x: %w",
+					instanceOffset, defOffset, err)
 			}
-			return variables[i].DeclLine < variables[j].DeclLine
-		})
-		f := Function{
-			Name:            af.name,
-			QualifiedName:   af.qualifiedName,
-			File:            af.file,
-			InjectibleLines: af.injectibleLines,
-			Scope: Scope{
-				StartLine: af.startLine,
-				EndLine:   int(af.endLine),
-				Scopes:    nil,
-				Variables: variables,
-			},
 		}
+
+		f := buildFunctionFromAbstract(af)
 		if af.receiver != "" {
-			t, ok := targetPackage.Types[af.receiver]
+			t, ok := pkg.Types[af.receiver]
 			if !ok {
-				// Some types are empty structures, and functions that
-				// use them as receivers don't actually have a parameter
-				// of the receiver type. Thus, we end up without a type.
-				// Just make one up.
-				t = &Type{
-					Name: af.receiver,
-				}
-				targetPackage.Types[af.receiver] = t
+				t = &Type{Name: af.receiver}
+				pkg.Types[af.receiver] = t
 			}
 			t.Methods = append(t.Methods, f)
-		} else if af.pkg != targetPackage.Name {
-			// Freestanding function from a different package. If it's a
-			// canonicalized generic, the generic index handles it — skip.
-			if b.genericFuncIndex != nil && strings.Contains(f.QualifiedName, "[...]") {
-				continue
-			}
-			// Non-generic displaced function: route to displacedFunctions.
-			pkg, ok := b.displacedFunctions[af.pkg]
-			if !ok {
-				pkg = &Package{
-					Name:  af.pkg,
-					Types: make(map[string]*Type),
-				}
-				b.displacedFunctions[af.pkg] = pkg
-			}
-			if !slices.ContainsFunc(pkg.Functions, func(existing Function) bool {
-				return existing.QualifiedName == f.QualifiedName
-			}) {
-				pkg.Functions = append(pkg.Functions, f)
-			}
 		} else {
-			targetPackage.Functions = append(targetPackage.Functions, f)
+			pkg.Functions = append(pkg.Functions, f)
 		}
 	}
+	return nil
+}
+
+// replayInlineInstance seeks to an inline-instance DIE and calls
+// exploreInlinedInstance with b.currentCompileUnit set to the instance's
+// CU. outputPkg is the owning package being emitted; types resolved
+// during replay are routed to it via maybeAddType.
+func (b *packagesIterator) replayInlineInstance(instanceOffset dwarf.Offset, outputPkg *Package, af *abstractFunction) error {
+	instanceCUOffset, ok := b.findCUForOffset(instanceOffset)
+	if !ok {
+		return nil
+	}
+	instanceCU, err := b.getCUContext(instanceCUOffset)
+	if err != nil {
+		return fmt.Errorf("get CU context for 0x%x: %w", instanceOffset, err)
+	}
+
+	savedCU := b.currentCompileUnit
+	savedBlockStack := b.blockStack
+	defer func() {
+		b.currentCompileUnit = savedCU
+		b.blockStack = savedBlockStack
+	}()
+
+	b.currentCompileUnit = compileUnitInfo{
+		entry:     instanceCU.entry,
+		name:      instanceCU.name,
+		length:    instanceCU.length,
+		files:     instanceCU.files,
+		outputPkg: outputPkg,
+	}
+	// exploreInlinedCode pushes a block derived from the instance DIE; start
+	// from a fresh block stack so the instance is treated as a top-level.
+	b.blockStack = nil
+
+	reader := b.dwarfData.Reader()
+	reader.Seek(instanceOffset)
+	entry, err := reader.Next()
+	if err != nil {
+		return err
+	}
+	if entry == nil {
+		return fmt.Errorf("no entry at 0x%x", instanceOffset)
+	}
+
+	// exploreInlinedInstance needs FunctionLines keyed by qualified name,
+	// which comes from the containing physical function's pclntab entry.
+	// Address into it via the instance's PC.
+	lowpc, ok := resolveInstanceLowPC(entry, b.dwarfData)
+	if !ok {
+		return nil
+	}
+	lines, err := b.sym.FunctionLines(lowpc)
+	if err != nil {
+		return nil
+	}
+	// Best-effort: a single bad instance shouldn't fail the whole
+	// extraction. DWARF and pclntab can disagree on inlining.
+	_ = b.exploreInlinedInstance(entry, reader, lines, af)
+	return nil
+}
+
+// resolveInstanceLowPC returns a representative PC for an inline instance
+// DIE, either from DW_AT_low_pc or the first PC of DW_AT_ranges.
+func resolveInstanceLowPC(entry *dwarf.Entry, dwarfData *dwarf.Data) (uint64, bool) {
+	if v, ok := entry.Val(dwarf.AttrLowpc).(uint64); ok {
+		return v, true
+	}
+	// TagInlinedSubroutine can use DW_AT_ranges instead of low_pc/high_pc.
+	if entry.AttrField(dwarf.AttrRanges) != nil {
+		pcRanges, err := dwarfData.Ranges(entry)
+		if err == nil && len(pcRanges) > 0 {
+			return pcRanges[0][0], true
+		}
+	}
+	return 0, false
 }
 
 func (b *packagesIterator) currentBlock() codeBlock {
@@ -1633,37 +1837,14 @@ func (b *packagesIterator) exploreSubprogram(
 		return earlyExit()
 	}
 
-	inlineAttr, ok := entry.Val(dwarf.AttrInline).(int64)
-	// The attribute DW_AT_inline with a value of DW_INL_inlined means that
-	// this is an "abstract definition" of the function, which is then
-	// referenced by inlined instances (and also possibly by an out-of-line
-	// instance) through their AttrAbstractOrigin attribute which will point
-	// to this entry.
-	if abstractFunc := ok && inlineAttr == dwarf2.DW_INL_inlined; abstractFunc {
-		if _, ok := b.abstractFunctions[entry.Offset]; !ok {
-			af, err := b.parseAbstractFunction(entry.Offset, reader)
-			if err != nil {
-				return Function{}, err
-			}
-			// Keep around information about this abstract function. It will be
-			// updated by every subsequent inlined instance of the function.
-			b.abstractFunctions[entry.Offset] = af
-		}
-
+	// Abstract inline definitions and out-of-line inline instances are
+	// both handled via inlineDefs / inlineInstances at emission
+	// time in emitAbstractFunctionsForPackage.
+	if inlineAttr, hasInline := entry.Val(dwarf.AttrInline).(int64); hasInline && inlineAttr == dwarf2.DW_INL_inlined {
 		return earlyExit()
 	}
-
 	if entry.AttrField(dwarf.AttrAbstractOrigin) != nil {
-		// "out-of-line" instance of an abstract subprogram.
-		lowpc, ok := entry.Val(dwarf.AttrLowpc).(uint64)
-		if !ok {
-			return Function{}, fmt.Errorf("subprogram without lowpc at 0x%x", entry.Offset)
-		}
-		lines, err := b.sym.FunctionLines(lowpc)
-		if err != nil {
-			return Function{}, fmt.Errorf("failed to resolve function lines for function pc 0x%x: %w", lowpc, err)
-		}
-		return Function{}, b.exploreInlinedInstance(entry, reader, lines)
+		return earlyExit()
 	}
 
 	funcQualifiedName, funcName, recognized, err := b.parseFunctionName(entry)
@@ -1781,7 +1962,7 @@ func (b *packagesIterator) exploreSubprogram(
 		// package and will be processed by augmentWithDisplacedGenerics
 		// when that package is yielded. This prevents creating a foreign
 		// type (e.g. lib.Box[...]) under the wrong package (e.g. main).
-		if b.genericFuncIndex != nil &&
+		if b.indexes.genericFuncs != nil &&
 			funcName.Package != b.currentCompileUnit.outputPkg.Name &&
 			strings.Contains(typeQualifiedName, "[...]") {
 			return Function{}, nil
@@ -1812,60 +1993,18 @@ func (b *packagesIterator) exploreSubprogram(
 	return res, nil
 }
 
-// Explores inlined instances of an abstract function (both InlinedSubroutines
-// and out-of-line Subprogram instances). Modify the data associated with the
-// abstract function definition based on the variable availability in this
-// instance.
+// exploreInlinedInstance updates af with per-instance data from an
+// inlined-subroutine (or out-of-line subprogram) DIE at the reader's
+// current position.
 func (b *packagesIterator) exploreInlinedInstance(
 	entry *dwarf.Entry,
 	reader *dwarf.Reader,
 	lines map[string]gosym.FunctionLines,
+	af *abstractFunction,
 ) error {
 	earlyExit := func() error {
 		reader.SkipChildren()
 		return nil
-	}
-	// resetReader repositions the reader back to entry after parseAbstractFunction
-	// has moved it.
-	resetReader := func() error {
-		reader.Seek(entry.Offset)
-		e, err := reader.Next()
-		if err != nil {
-			return err
-		}
-		if e.Tag != dwarf.TagSubprogram && e.Tag != dwarf.TagInlinedSubroutine {
-			return fmt.Errorf("unexpected tag %v at 0x%x, expected TagSubprogram or TagInlinedSubroutine", e.Tag, entry.Offset)
-		}
-		return nil
-	}
-
-	// Lookup the abstract function definition referenced by this inlined
-	// instance.
-	originOffset, ok := entry.Val(dwarf.AttrAbstractOrigin).(dwarf.Offset)
-	if !ok {
-		return fmt.Errorf("inlined instance without abstract origin at 0x%x", entry.Offset)
-	}
-
-	af, ok := b.abstractFunctions[originOffset]
-	if !ok {
-		// We only explore the abstract definition if it's in the current
-		// compilation unit; we don't accumulate data across compile units in
-		// b.abstractFunctions.
-		inCurrentUnit := originOffset >= b.currentCompileUnit.entry.Offset &&
-			uint64(originOffset) < uint64(b.currentCompileUnit.entry.Offset)+b.currentCompileUnit.length
-		if !inCurrentUnit {
-			return earlyExit()
-		}
-
-		var err error
-		af, err = b.parseAbstractFunction(originOffset, reader)
-		if err != nil {
-			return err
-		}
-		b.abstractFunctions[originOffset] = af
-		if err := resetReader(); err != nil {
-			return err
-		}
 	}
 	if !af.interesting {
 		return earlyExit()
@@ -1942,10 +2081,9 @@ func (b *packagesIterator) exploreInlinedCode(
 			}
 
 		case dwarf.TagInlinedSubroutine:
-			err := b.exploreInlinedInstance(child, reader, lines)
-			if err != nil {
-				return err
-			}
+			// Nested inline instances are handled by their own abstract
+			// function's emission in emitAbstractFunctionsForPackage.
+			reader.SkipChildren()
 		case dwarf.TagTypedef:
 			// Typedefs in generic shape functions for dictionary type
 			// parameters (.param0, .param1). Skip.
@@ -2386,10 +2524,9 @@ func (b *packagesIterator) exploreCode(
 			}
 			res.scopes = append(res.scopes, scopes...)
 		case dwarf.TagInlinedSubroutine:
-			err := b.exploreInlinedInstance(child, reader, lines)
-			if err != nil {
-				return exploreCodeResult{}, err
-			}
+			// Inline instances are processed at emission time in
+			// emitAbstractFunctionsForPackage via inlineInstances.
+			reader.SkipChildren()
 		}
 	}
 	return res, nil

--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -405,9 +405,19 @@ type packagesIterator struct {
 	// used for binary search to find which CU contains a given DWARF offset.
 	sortedCUOffsets []dwarf.Offset
 
+	// indexes are built during a lightweight pre-scan of all DWARF
+	// compile units. They let us find displaced generic shape functions,
+	// struct types, and inline abstract definitions and their instances
+	// regardless of compile-unit ordering. See prePassIndexes for the
+	// per-index details.
 	indexes prePassIndexes
-	// cuContextCache caches CU context (file table, etc.) for foreign compile
-	// units accessed when processing displaced generic functions.
+	// cuContextCache caches compile-unit context (file table, etc.) for
+	// compile units other than the one currently being walked. Populated
+	// lazily when a foreign compile unit is needed — to process a
+	// displaced generic function, to parse an abstract inline definition
+	// that lives in a different compile unit than its owning package, or
+	// to replay an inline instance whose compile unit has already been
+	// walked.
 	cuContextCache map[dwarf.Offset]*cachedCUContext
 }
 
@@ -475,8 +485,11 @@ type compileUnitInfo struct {
 	outputPkg *Package
 }
 
-// cachedCUContext stores a compile unit's context for processing displaced
-// generic functions that live in a foreign CU.
+// cachedCUContext stores a compile unit's context (file table, name,
+// length, header entry) so that we can swap b.currentCompileUnit to a
+// foreign compile unit when parsing displaced generic functions,
+// abstract inline definitions, or inline instances that live in a
+// different compile unit than the one currently being walked.
 type cachedCUContext struct {
 	entry  *dwarf.Entry
 	name   string
@@ -1004,11 +1017,7 @@ func (b *packagesIterator) innerIterator() iter.Seq2[Package, error] {
 			unitHeader := b.offsetToUnit[entry.Offset]
 
 			// Emit every abstract (inline) function owned by this
-			// package by driving from inlineDefs and
-			// inlineInstances. Doing it here rather than as a
-			// side-effect of the per-CU walk makes emission order
-			// independent of where the compiler places the abstract
-			// definition and its inline instances.
+			// package by driving from inlineDefs and inlineInstances.
 			if err = b.emitAbstractFunctionsForPackage(pkg); err != nil {
 				break
 			}
@@ -1484,7 +1493,7 @@ func (b *packagesIterator) augmentWithDisplacedGenerics(pkg *Package, cuOffset d
 	// type-parameter-dependent.
 	if b.indexes.genericTypes != nil {
 		for _, typeOffset := range b.indexes.genericTypes.forPackage(pkg.Name) {
-			// Skip types within the current CU.
+			// Skip types within the current compile unit.
 			if uint64(typeOffset) >= uint64(cuOffset) && uint64(typeOffset) < cuEnd {
 				continue
 			}

--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -1243,11 +1243,12 @@ func (b *packagesIterator) buildPrePassIndexes() (idx prePassIndexes, retErr err
 				continue
 			}
 
+			// Store the canonical name in DWARF (escaped) form,
+			// matching genericFuncs and inlineDefs. forPackage handles
+			// the escape on lookup; storing here in unescaped form
+			// would make lookups for packages whose last path segment
+			// contains a dot (e.g. "gopkg.in/foo.v2") miss this entry.
 			canonicalName := gosymname.CanonicalizeGenerics(name)
-			// Unescape the package path in the canonical name.
-			if unescaped, err := unescapeSymbol(canonicalName); err == nil {
-				canonicalName = unescaped
-			}
 			if err := genericTypeBuilder.add(canonicalName, entry.Offset); err != nil {
 				return prePassIndexes{}, err
 			}
@@ -1522,6 +1523,14 @@ func packageHasFunctionQName(pkg *Package, qname string) bool {
 	})
 }
 
+// typeHasMethodQName returns true if the type already has a method with the
+// given qualified name.
+func typeHasMethodQName(t *Type, qname string) bool {
+	return slices.ContainsFunc(t.Methods, func(f Function) bool {
+		return f.QualifiedName == qname
+	})
+}
+
 // emitAbstractFunctionsForPackage emits every abstract (inlined) function
 // that inlineDefs attributes to pkg. Each abstract DIE is parsed
 // fresh, its inline instances are replayed from inlineInstances to
@@ -1562,12 +1571,6 @@ func (b *packagesIterator) emitAbstractFunctionsForPackage(pkg *Package) error {
 		if !af.interesting {
 			continue
 		}
-		// forPackage is a prefix match on the qualified name, so it also
-		// returns entries for packages with the same prefix (e.g. "lib."
-		// matches "lib.v2.*"). Filter.
-		if af.pkg != pkg.Name {
-			continue
-		}
 
 		for instanceOffset := range b.indexes.inlineInstances.forOrigin(defOffset) {
 			if err := b.replayInlineInstance(instanceOffset, pkg, af); err != nil {
@@ -1577,14 +1580,22 @@ func (b *packagesIterator) emitAbstractFunctionsForPackage(pkg *Package) error {
 		}
 
 		f := buildFunctionFromAbstract(af)
+		// Dedup against entries the per-compile-unit walk already
+		// emitted: the Go compiler sometimes emits both an abstract
+		// inline DIE and an out-of-line Subprogram for the same
+		// function, in which case the out-of-line copy is processed
+		// first by the normal compile-unit walk and we'd otherwise
+		// emit the function a second time here.
 		if af.receiver != "" {
 			t, ok := pkg.Types[af.receiver]
 			if !ok {
 				t = &Type{Name: af.receiver}
 				pkg.Types[af.receiver] = t
 			}
-			t.Methods = append(t.Methods, f)
-		} else {
+			if !typeHasMethodQName(t, f.QualifiedName) {
+				t.Methods = append(t.Methods, f)
+			}
+		} else if !packageHasFunctionQName(pkg, f.QualifiedName) {
 			pkg.Functions = append(pkg.Functions, f)
 		}
 	}

--- a/pkg/dyninst/symdb/symdb_test.go
+++ b/pkg/dyninst/symdb/symdb_test.go
@@ -9,6 +9,7 @@ package symdb_test
 
 import (
 	"flag"
+	"fmt"
 	_ "net/http/pprof"
 	"os"
 	"path"
@@ -67,6 +68,11 @@ var rewrite = flag.Bool("rewrite", rewriteFromEnv, "rewrite the snapshot files")
 
 const snapshotDir = "testdata/snapshot"
 
+// TestSymDBSnapshot exercises the streaming PackagesIterator API — the
+// one used by the production uploader at pkg/dyninst/module/symdb.go —
+// and records every yield in the golden. Each yield is written as a
+// distinct "=== yield N [final=T/F] ===" section so that duplicate or
+// incomplete yields are visible in the golden.
 func TestSymDBSnapshot(t *testing.T) {
 	cfgs := testprogs.MustGetCommonConfigs(t)
 	progs := testprogs.MustGetPrograms(t)
@@ -80,19 +86,26 @@ func TestSymDBSnapshot(t *testing.T) {
 					defer sem.Acquire()()
 					binaryPath := testprogs.MustGetBinary(t, prog, cfg)
 					t.Logf("exploring binary: %s", binaryPath)
-					symbols, err := symdb.ExtractSymbols(
+					it, err := symdb.PackagesIterator(
 						binaryPath,
 						object.NewInMemoryLoader(),
 						symdb.ExtractOptions{
 							Scope: symdb.ExtractScopeMainModuleOnly,
 						})
-					require.NoError(t, err, "failed to extract symbols from %s", binaryPath)
-					require.NotEmpty(t, symbols.Packages)
+					require.NoError(t, err, "failed to open iterator on %s", binaryPath)
 
 					var sb strings.Builder
-					symbols.Serialize(symdbutil.MakePanickingWriter(&sb))
-					out := sb.String()
+					w := symdbutil.MakePanickingWriter(&sb)
+					yieldIdx := 0
+					for pkg, err := range it {
+						require.NoError(t, err)
+						yieldIdx++
+						w.WriteString(fmt.Sprintf("=== yield %d [final=%t] ===\n", yieldIdx, pkg.Final))
+						pkg.Package.Serialize(w)
+					}
+					require.NotZero(t, yieldIdx, "expected at least one package yield")
 
+					out := sb.String()
 					outputFile := path.Join(snapshotDir, prog+".streaming."+cfg.String()+".out")
 					if *rewrite {
 						tmpFile, err := os.CreateTemp(snapshotDir, ".out")

--- a/pkg/dyninst/symdb/symdb_test.go
+++ b/pkg/dyninst/symdb/symdb_test.go
@@ -71,8 +71,7 @@ const snapshotDir = "testdata/snapshot"
 // TestSymDBSnapshot exercises the streaming PackagesIterator API — the
 // one used by the production uploader at pkg/dyninst/module/symdb.go —
 // and records every yield in the golden. Each yield is written as a
-// distinct "=== yield N [final=T/F] ===" section so that duplicate or
-// incomplete yields are visible in the golden.
+// distinct "=== yield N [final=T/F] ===" section.
 func TestSymDBSnapshot(t *testing.T) {
 	cfgs := testprogs.MustGetCommonConfigs(t)
 	progs := testprogs.MustGetPrograms(t)

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [54:88] injectible: [54-54], [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [54-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [54:88] injectible: [54-54], [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [54-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [60:88] injectible: [60-60], [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [60-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1183,6 +1183,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1198,7 +1199,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1237,11 +1237,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-64])
@@ -1284,3 +1280,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1185,58 +1185,58 @@ Package: main
 		Field: k: int
 === yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
-		Arg: items: .param0 (declared at line 102, available: [102-104])
-		Arg: pred: .param1 (declared at line 102, available: [102-109])
-		Arg: ~r0: .param2 (declared at line 102, available: )
-		Var: result: .param3 (declared at line 103, available: [102-109])
-		Scope: 104-109
-			Var: item: .param4 (declared at line 104, available: [105-109])
+	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [113:120] injectible: [113-113], [115-117], [120-120]
+		Arg: items: .param0 (declared at line 113, available: [113-115])
+		Arg: pred: .param1 (declared at line 113, available: [113-120])
+		Arg: ~r0: .param2 (declared at line 113, available: )
+		Var: result: .param3 (declared at line 114, available: [113-120])
+		Scope: 115-120
+			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
-	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [94:95] injectible: [94-95]
-		Arg: box: .param0 (declared at line 94, available: [94-95])
-		Arg: f: .param1 (declared at line 94, available: [94-95])
-		Arg: ~r0: .param2 (declared at line 94, available: )
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
-		Arg: items: .param0 (declared at line 115, available: [115-117])
-		Arg: init: .param1 (declared at line 115, available: [115-117])
-		Arg: f: .param2 (declared at line 115, available: [115-120])
-		Arg: ~r0: .param1 (declared at line 115, available: )
-		Var: acc: .param1 (declared at line 116, available: [115-120])
-		Scope: 117-120
-			Var: item: .param3 (declared at line 117, available: [117-118])
+	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
+		Arg: box: .param0 (declared at line 105, available: [105-106])
+		Arg: f: .param1 (declared at line 105, available: [105-106])
+		Arg: ~r0: .param2 (declared at line 105, available: )
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [40:41] injectible: [41-41]
+	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [126:131] injectible: [126-126], [128-129], [131-131]
+		Arg: items: .param0 (declared at line 126, available: [126-128])
+		Arg: init: .param1 (declared at line 126, available: [126-128])
+		Arg: f: .param2 (declared at line 126, available: [126-131])
+		Arg: ~r0: .param1 (declared at line 126, available: )
+		Var: acc: .param1 (declared at line 127, available: [126-131])
+		Scope: 128-131
+			Var: item: .param3 (declared at line 128, available: [128-129])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...]
 		Field: Value: <T>
-		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [72:74] injectible: [72-74]
-			Arg: b: .param2 (declared at line 72, available: [72-74])
-			Arg: val: .param3 (declared at line 72, available: [72-74])
-		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [65:66] injectible: [65-66]
-			Arg: b: .param0 (declared at line 65, available: [65-66])
-			Arg: ~r0: .param1 (declared at line 65, available: )
+		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [83:85] injectible: [83-85]
+			Arg: b: .param2 (declared at line 83, available: [83-85])
+			Arg: val: .param3 (declared at line 83, available: [83-85])
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [76:77] injectible: [76-77]
+			Arg: b: .param0 (declared at line 76, available: [76-77])
+			Arg: ~r0: .param1 (declared at line 76, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[...]
 		Field: items: map[...]bool
-		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [51:52] injectible: [51-52]
-			Arg: s: .param5 (declared at line 51, available: [51-52])
-			Arg: item: .param6 (declared at line 51, available: [51-52])
-			Arg: ~r0: bool (declared at line 51, available: )
-		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [38:45] injectible: [38-42], [44-45]
-			Arg: s: .param0 (declared at line 38, available: [38-45])
-			Arg: item: .param1 (declared at line 38, available: [38-45])
-			Arg: ~r0: .param2 (declared at line 38, available: )
-			Arg: ~r1: bool (declared at line 38, available: )
-			Var: existed: bool (declared at line 39, available: [38-45])
-			Var: newItems: .param4 (declared at line 40, available: [38-45])
-			Scope: 41-44
-				Var: v: bool (declared at line 41, available: [41-41], [42-42])
-				Var: k: .param1 (declared at line 41, available: [42-42])
+		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [62:63] injectible: [62-63]
+			Arg: s: .param5 (declared at line 62, available: [62-63])
+			Arg: item: .param6 (declared at line 62, available: [62-63])
+			Arg: ~r0: bool (declared at line 62, available: )
+		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [49:56] injectible: [49-53], [55-56]
+			Arg: s: .param0 (declared at line 49, available: [49-56])
+			Arg: item: .param1 (declared at line 49, available: [49-56])
+			Arg: ~r0: .param2 (declared at line 49, available: )
+			Arg: ~r1: bool (declared at line 49, available: )
+			Var: existed: bool (declared at line 50, available: [49-56])
+			Var: newItems: .param4 (declared at line 51, available: [49-56])
+			Scope: 52-55
+				Var: v: bool (declared at line 52, available: [52-52], [53-53])
+				Var: k: .param1 (declared at line 52, available: [53-53])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...]
 		Field: First: <T>
 		Field: Second: <T>
-		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
-			Arg: p: .param0 (declared at line 86, available: [86-87])
-			Arg: ~r0: .param1 (declared at line 86, available: )
+		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [97:98] injectible: [97-98]
+			Arg: p: .param0 (declared at line 97, available: [97-98])
+			Arg: ~r0: .param1 (declared at line 97, available: )
 === yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
@@ -1282,10 +1282,11 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Arg: ~r0: .param3 (declared at line 30, available: )
 === yield 4 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
 === yield 5 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1194,6 +1194,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
 	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
 		Arg: box: .param0 (declared at line 105, available: [105-106])
 		Arg: f: .param1 (declared at line 105, available: [105-106])
@@ -1280,13 +1281,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -252,10 +252,10 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:54] injectible: [20-21], [24-25], [27-39], [41-41], [43-45], [48-54]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:55] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [49-55]
 		Var: scanner: *bufio.Scanner (declared at line 24, available: )
-		Var: it: main.iterExample (declared at line 42, available: [20-54])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-54])
+		Var: it: main.iterExample (declared at line 43, available: [20-55])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-55])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -1284,6 +1284,13 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 === yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
+	Function: UseV2GenericBox (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.UseV2GenericBox) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [54:57] injectible: [54-54], [56-57]
+		Var: b: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[int] (declared at line 55, available: )
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[...]
+		Field: Value: <T>
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2GenericBox[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [51:51] injectible: [51-51]
+			Arg: b: .param0 (declared at line 51, available: [51-51])
+			Arg: ~r0: .param1 (declared at line 51, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1182,6 +1182,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [13:14] injectible: [13-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
 	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
 		Arg: box: .param0 (declared at line 105, available: [105-106])
 		Arg: f: .param1 (declared at line 105, available: [105-106])
@@ -1268,13 +1269,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1171,6 +1171,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1186,7 +1187,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1225,11 +1225,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-64])
@@ -1272,3 +1268,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1173,58 +1173,58 @@ Package: main
 		Field: k: int
 === yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
-		Arg: items: .param0 (declared at line 102, available: [102-104])
-		Arg: pred: .param1 (declared at line 102, available: [102-109])
-		Arg: ~r0: .param2 (declared at line 102, available: )
-		Var: result: .param3 (declared at line 103, available: [102-109])
-		Scope: 104-109
-			Var: item: .param4 (declared at line 104, available: [105-109])
+	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [113:120] injectible: [113-113], [115-117], [120-120]
+		Arg: items: .param0 (declared at line 113, available: [113-115])
+		Arg: pred: .param1 (declared at line 113, available: [113-120])
+		Arg: ~r0: .param2 (declared at line 113, available: )
+		Var: result: .param3 (declared at line 114, available: [113-120])
+		Scope: 115-120
+			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [13:14] injectible: [13-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
-	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [94:95] injectible: [94-95]
-		Arg: box: .param0 (declared at line 94, available: [94-95])
-		Arg: f: .param1 (declared at line 94, available: [94-95])
-		Arg: ~r0: .param2 (declared at line 94, available: )
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
-		Arg: items: .param0 (declared at line 115, available: [115-117])
-		Arg: init: .param1 (declared at line 115, available: [115-117])
-		Arg: f: .param2 (declared at line 115, available: [115-120])
-		Arg: ~r0: .param1 (declared at line 115, available: )
-		Var: acc: .param1 (declared at line 116, available: [115-120])
-		Scope: 117-120
-			Var: item: .param3 (declared at line 117, available: [117-118])
+	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
+		Arg: box: .param0 (declared at line 105, available: [105-106])
+		Arg: f: .param1 (declared at line 105, available: [105-106])
+		Arg: ~r0: .param2 (declared at line 105, available: )
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [40:41] injectible: [41-41]
+	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [126:131] injectible: [126-126], [128-129], [131-131]
+		Arg: items: .param0 (declared at line 126, available: [126-128])
+		Arg: init: .param1 (declared at line 126, available: [126-128])
+		Arg: f: .param2 (declared at line 126, available: [126-131])
+		Arg: ~r0: .param1 (declared at line 126, available: )
+		Var: acc: .param1 (declared at line 127, available: [126-131])
+		Scope: 128-131
+			Var: item: .param3 (declared at line 128, available: [128-129])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...]
 		Field: Value: <T>
-		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [72:74] injectible: [72-74]
-			Arg: b: .param2 (declared at line 72, available: [72-74])
-			Arg: val: .param3 (declared at line 72, available: [72-74])
-		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [65:66] injectible: [65-66]
-			Arg: b: .param0 (declared at line 65, available: [65-66])
-			Arg: ~r0: .param1 (declared at line 65, available: )
+		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [83:85] injectible: [83-85]
+			Arg: b: .param2 (declared at line 83, available: [83-85])
+			Arg: val: .param3 (declared at line 83, available: [83-85])
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [76:77] injectible: [76-77]
+			Arg: b: .param0 (declared at line 76, available: [76-77])
+			Arg: ~r0: .param1 (declared at line 76, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[...]
 		Field: items: map[...]bool
-		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [51:52] injectible: [51-52]
-			Arg: s: .param5 (declared at line 51, available: [51-52])
-			Arg: item: .param6 (declared at line 51, available: [51-52])
-			Arg: ~r0: bool (declared at line 51, available: )
-		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [38:45] injectible: [38-42], [44-45]
-			Arg: s: .param0 (declared at line 38, available: [38-45])
-			Arg: item: .param1 (declared at line 38, available: [38-45])
-			Arg: ~r0: .param2 (declared at line 38, available: )
-			Arg: ~r1: bool (declared at line 38, available: )
-			Var: existed: bool (declared at line 39, available: [38-45])
-			Var: newItems: .param4 (declared at line 40, available: [38-45])
-			Scope: 41-44
-				Var: v: bool (declared at line 41, available: [41-41], [42-42])
-				Var: k: .param1 (declared at line 41, available: [42-42])
+		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [62:63] injectible: [62-63]
+			Arg: s: .param5 (declared at line 62, available: [62-63])
+			Arg: item: .param6 (declared at line 62, available: [62-63])
+			Arg: ~r0: bool (declared at line 62, available: )
+		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [49:56] injectible: [49-53], [55-56]
+			Arg: s: .param0 (declared at line 49, available: [49-56])
+			Arg: item: .param1 (declared at line 49, available: [49-56])
+			Arg: ~r0: .param2 (declared at line 49, available: )
+			Arg: ~r1: bool (declared at line 49, available: )
+			Var: existed: bool (declared at line 50, available: [49-56])
+			Var: newItems: .param4 (declared at line 51, available: [49-56])
+			Scope: 52-55
+				Var: v: bool (declared at line 52, available: [52-52], [53-53])
+				Var: k: .param1 (declared at line 52, available: [53-53])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...]
 		Field: First: <T>
 		Field: Second: <T>
-		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
-			Arg: p: .param0 (declared at line 86, available: [86-87])
-			Arg: ~r0: .param1 (declared at line 86, available: )
+		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [97:98] injectible: [97-98]
+			Arg: p: .param0 (declared at line 97, available: [97-98])
+			Arg: ~r0: .param1 (declared at line 97, available: )
 === yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
@@ -1270,10 +1270,11 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Arg: ~r0: .param3 (declared at line 30, available: )
 === yield 4 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
 === yield 5 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -242,9 +242,9 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:54] injectible: [20-21], [24-25], [27-39], [41-41], [43-45], [48-54]
-		Var: it: main.iterExample (declared at line 42, available: [20-54])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-54])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:55] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [49-55]
+		Var: it: main.iterExample (declared at line 43, available: [20-55])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-55])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -1272,6 +1272,13 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 === yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
+	Function: UseV2GenericBox (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.UseV2GenericBox) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [54:57] injectible: [54-54], [56-57]
+		Var: b: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[int] (declared at line 55, available: )
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[...]
+		Field: Value: <T>
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2GenericBox[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [51:51] injectible: [51-51]
+			Arg: b: .param0 (declared at line 51, available: [51-51])
+			Arg: ~r0: .param1 (declared at line 51, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1168,6 +1168,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1183,7 +1184,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1222,11 +1222,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-64])
@@ -1269,3 +1265,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1170,58 +1170,58 @@ Package: main
 		Field: k: int
 === yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
-		Arg: items: .param0 (declared at line 102, available: [102-104])
-		Arg: pred: .param1 (declared at line 102, available: [102-109])
-		Arg: ~r0: .param2 (declared at line 102, available: )
-		Var: result: .param3 (declared at line 103, available: [102-109])
-		Scope: 104-109
-			Var: item: .param4 (declared at line 104, available: [105-109])
+	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [113:120] injectible: [113-113], [115-117], [120-120]
+		Arg: items: .param0 (declared at line 113, available: [113-115])
+		Arg: pred: .param1 (declared at line 113, available: [113-120])
+		Arg: ~r0: .param2 (declared at line 113, available: )
+		Var: result: .param3 (declared at line 114, available: [113-120])
+		Scope: 115-120
+			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [13:14] injectible: [13-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
-	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [94:95] injectible: [94-95]
-		Arg: box: .param0 (declared at line 94, available: [94-95])
-		Arg: f: .param1 (declared at line 94, available: [94-95])
-		Arg: ~r0: .param2 (declared at line 94, available: )
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
-		Arg: items: .param0 (declared at line 115, available: [115-117])
-		Arg: init: .param1 (declared at line 115, available: [115-117])
-		Arg: f: .param2 (declared at line 115, available: [115-120])
-		Arg: ~r0: .param1 (declared at line 115, available: )
-		Var: acc: .param1 (declared at line 116, available: [115-120])
-		Scope: 117-120
-			Var: item: .param3 (declared at line 117, available: [117-118])
+	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
+		Arg: box: .param0 (declared at line 105, available: [105-106])
+		Arg: f: .param1 (declared at line 105, available: [105-106])
+		Arg: ~r0: .param2 (declared at line 105, available: )
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [40:41] injectible: [41-41]
+	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [126:131] injectible: [126-126], [128-129], [131-131]
+		Arg: items: .param0 (declared at line 126, available: [126-128])
+		Arg: init: .param1 (declared at line 126, available: [126-128])
+		Arg: f: .param2 (declared at line 126, available: [126-131])
+		Arg: ~r0: .param1 (declared at line 126, available: )
+		Var: acc: .param1 (declared at line 127, available: [126-131])
+		Scope: 128-131
+			Var: item: .param3 (declared at line 128, available: [128-129])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...]
 		Field: Value: <T>
-		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [72:74] injectible: [72-74]
-			Arg: b: .param2 (declared at line 72, available: [72-74])
-			Arg: val: .param3 (declared at line 72, available: [72-74])
-		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [65:66] injectible: [65-66]
-			Arg: b: .param0 (declared at line 65, available: [65-66])
-			Arg: ~r0: .param1 (declared at line 65, available: )
+		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [83:85] injectible: [83-85]
+			Arg: b: .param2 (declared at line 83, available: [83-85])
+			Arg: val: .param3 (declared at line 83, available: [83-85])
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [76:77] injectible: [76-77]
+			Arg: b: .param0 (declared at line 76, available: [76-77])
+			Arg: ~r0: .param1 (declared at line 76, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[...]
 		Field: items: map[...]bool
-		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [51:52] injectible: [51-52]
-			Arg: s: .param5 (declared at line 51, available: [51-52])
-			Arg: item: .param6 (declared at line 51, available: [51-52])
-			Arg: ~r0: bool (declared at line 51, available: )
-		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [38:45] injectible: [38-42], [44-45]
-			Arg: s: .param0 (declared at line 38, available: [38-45])
-			Arg: item: .param1 (declared at line 38, available: [38-45])
-			Arg: ~r0: .param2 (declared at line 38, available: )
-			Arg: ~r1: bool (declared at line 38, available: )
-			Var: existed: bool (declared at line 39, available: [38-45])
-			Var: newItems: .param4 (declared at line 40, available: [38-45])
-			Scope: 41-44
-				Var: v: bool (declared at line 41, available: [41-41], [42-42])
-				Var: k: .param1 (declared at line 41, available: [42-42])
+		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [62:63] injectible: [62-63]
+			Arg: s: .param5 (declared at line 62, available: [62-63])
+			Arg: item: .param6 (declared at line 62, available: [62-63])
+			Arg: ~r0: bool (declared at line 62, available: )
+		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [49:56] injectible: [49-53], [55-56]
+			Arg: s: .param0 (declared at line 49, available: [49-56])
+			Arg: item: .param1 (declared at line 49, available: [49-56])
+			Arg: ~r0: .param2 (declared at line 49, available: )
+			Arg: ~r1: bool (declared at line 49, available: )
+			Var: existed: bool (declared at line 50, available: [49-56])
+			Var: newItems: .param4 (declared at line 51, available: [49-56])
+			Scope: 52-55
+				Var: v: bool (declared at line 52, available: [52-52], [53-53])
+				Var: k: .param1 (declared at line 52, available: [53-53])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...]
 		Field: First: <T>
 		Field: Second: <T>
-		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
-			Arg: p: .param0 (declared at line 86, available: [86-87])
-			Arg: ~r0: .param1 (declared at line 86, available: )
+		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [97:98] injectible: [97-98]
+			Arg: p: .param0 (declared at line 97, available: [97-98])
+			Arg: ~r0: .param1 (declared at line 97, available: )
 === yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
@@ -1267,10 +1267,11 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Arg: ~r0: .param3 (declared at line 30, available: )
 === yield 4 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
 === yield 5 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1179,6 +1179,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [13:14] injectible: [13-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
 	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
 		Arg: box: .param0 (declared at line 105, available: [105-106])
 		Arg: f: .param1 (declared at line 105, available: [105-106])
@@ -1265,13 +1266,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -239,9 +239,9 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:54] injectible: [20-21], [24-25], [27-39], [41-41], [43-45], [48-54]
-		Var: it: main.iterExample (declared at line 42, available: [20-54])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-54])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:55] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [49-55]
+		Var: it: main.iterExample (declared at line 43, available: [20-55])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-55])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -1269,6 +1269,13 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 === yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
+	Function: UseV2GenericBox (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.UseV2GenericBox) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [54:57] injectible: [54-54], [56-57]
+		Var: b: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[int] (declared at line 55, available: )
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[...]
+		Field: Value: <T>
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2GenericBox[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [51:51] injectible: [51-51]
+			Arg: b: .param0 (declared at line 51, available: [51-51])
+			Arg: ~r0: .param1 (declared at line 51, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1170,58 +1170,58 @@ Package: main
 		Field: k: int
 === yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
-		Arg: items: .param0 (declared at line 102, available: [102-104])
-		Arg: pred: .param1 (declared at line 102, available: [102-109])
-		Arg: ~r0: .param2 (declared at line 102, available: )
-		Var: result: .param3 (declared at line 103, available: [104-109])
-		Scope: 104-109
-			Var: item: .param4 (declared at line 104, available: [104-109])
+	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [113:120] injectible: [113-113], [115-117], [120-120]
+		Arg: items: .param0 (declared at line 113, available: [113-115])
+		Arg: pred: .param1 (declared at line 113, available: [113-120])
+		Arg: ~r0: .param2 (declared at line 113, available: )
+		Var: result: .param3 (declared at line 114, available: [115-120])
+		Scope: 115-120
+			Var: item: .param4 (declared at line 115, available: [115-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [13:14] injectible: [13-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
-	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [94:95] injectible: [94-95]
-		Arg: box: .param0 (declared at line 94, available: [94-95])
-		Arg: f: .param1 (declared at line 94, available: [94-95])
-		Arg: ~r0: .param2 (declared at line 94, available: )
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
-		Arg: items: .param0 (declared at line 115, available: [115-117])
-		Arg: init: .param1 (declared at line 115, available: [115-117])
-		Arg: f: .param2 (declared at line 115, available: [115-120])
-		Arg: ~r0: .param1 (declared at line 115, available: )
-		Var: acc: .param1 (declared at line 116, available: [115-120])
-		Scope: 117-120
-			Var: item: .param3 (declared at line 117, available: [117-118])
+	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
+		Arg: box: .param0 (declared at line 105, available: [105-106])
+		Arg: f: .param1 (declared at line 105, available: [105-106])
+		Arg: ~r0: .param2 (declared at line 105, available: )
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [40:41] injectible: [41-41]
+	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [126:131] injectible: [126-126], [128-129], [131-131]
+		Arg: items: .param0 (declared at line 126, available: [126-128])
+		Arg: init: .param1 (declared at line 126, available: [126-128])
+		Arg: f: .param2 (declared at line 126, available: [126-131])
+		Arg: ~r0: .param1 (declared at line 126, available: )
+		Var: acc: .param1 (declared at line 127, available: [126-131])
+		Scope: 128-131
+			Var: item: .param3 (declared at line 128, available: [128-129])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...]
 		Field: Value: <T>
-		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [72:74] injectible: [72-74]
-			Arg: b: .param2 (declared at line 72, available: [72-74])
-			Arg: val: .param3 (declared at line 72, available: [72-74])
-		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [65:66] injectible: [65-66]
-			Arg: b: .param0 (declared at line 65, available: [65-66])
-			Arg: ~r0: .param1 (declared at line 65, available: )
+		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [83:85] injectible: [83-85]
+			Arg: b: .param2 (declared at line 83, available: [83-85])
+			Arg: val: .param3 (declared at line 83, available: [83-85])
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [76:77] injectible: [76-77]
+			Arg: b: .param0 (declared at line 76, available: [76-77])
+			Arg: ~r0: .param1 (declared at line 76, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[...]
 		Field: items: map[...]bool
-		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [51:52] injectible: [51-52]
-			Arg: s: .param5 (declared at line 51, available: [51-52])
-			Arg: item: .param6 (declared at line 51, available: [51-52])
-			Arg: ~r0: bool (declared at line 51, available: )
-		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [38:45] injectible: [38-42], [44-45]
-			Arg: s: .param0 (declared at line 38, available: [38-45])
-			Arg: item: .param1 (declared at line 38, available: [38-45])
-			Arg: ~r0: .param2 (declared at line 38, available: )
-			Arg: ~r1: bool (declared at line 38, available: )
-			Var: existed: bool (declared at line 39, available: [38-45])
-			Var: newItems: .param4 (declared at line 40, available: [38-45])
-			Scope: 41-44
-				Var: v: bool (declared at line 41, available: [41-41], [42-42])
-				Var: k: .param1 (declared at line 41, available: [42-42])
+		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [62:63] injectible: [62-63]
+			Arg: s: .param5 (declared at line 62, available: [62-63])
+			Arg: item: .param6 (declared at line 62, available: [62-63])
+			Arg: ~r0: bool (declared at line 62, available: )
+		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [49:56] injectible: [49-53], [55-56]
+			Arg: s: .param0 (declared at line 49, available: [49-56])
+			Arg: item: .param1 (declared at line 49, available: [49-56])
+			Arg: ~r0: .param2 (declared at line 49, available: )
+			Arg: ~r1: bool (declared at line 49, available: )
+			Var: existed: bool (declared at line 50, available: [49-56])
+			Var: newItems: .param4 (declared at line 51, available: [49-56])
+			Scope: 52-55
+				Var: v: bool (declared at line 52, available: [52-52], [53-53])
+				Var: k: .param1 (declared at line 52, available: [53-53])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...]
 		Field: First: <T>
 		Field: Second: <T>
-		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
-			Arg: p: .param0 (declared at line 86, available: [86-87])
-			Arg: ~r0: .param1 (declared at line 86, available: )
+		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [97:98] injectible: [97-98]
+			Arg: p: .param0 (declared at line 97, available: [97-98])
+			Arg: ~r0: .param1 (declared at line 97, available: )
 === yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
@@ -1267,10 +1267,11 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Arg: ~r0: .param3 (declared at line 30, available: )
 === yield 4 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
 === yield 5 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1168,6 +1168,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1183,7 +1184,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1222,11 +1222,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-59], [60-64])
@@ -1269,3 +1265,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1179,6 +1179,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Var: item: .param4 (declared at line 115, available: [115-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [13:14] injectible: [13-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
 	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
 		Arg: box: .param0 (declared at line 105, available: [105-106])
 		Arg: f: .param1 (declared at line 105, available: [105-106])
@@ -1265,13 +1266,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -239,9 +239,9 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:54] injectible: [20-21], [24-25], [27-39], [41-41], [43-45], [48-54]
-		Var: it: main.iterExample (declared at line 42, available: [20-54])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-54])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:55] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [49-55]
+		Var: it: main.iterExample (declared at line 43, available: [20-55])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-55])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -1269,6 +1269,13 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 === yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
+	Function: UseV2GenericBox (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.UseV2GenericBox) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [54:57] injectible: [54-54], [56-57]
+		Var: b: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[int] (declared at line 55, available: )
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[...]
+		Field: Value: <T>
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2GenericBox[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [51:51] injectible: [51-51]
+			Arg: b: .param0 (declared at line 51, available: [51-51])
+			Arg: ~r0: .param1 (declared at line 51, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1201,6 +1201,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
 	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
 		Arg: box: .param0 (declared at line 105, available: [105-106])
 		Arg: f: .param1 (declared at line 105, available: [105-106])
@@ -1287,13 +1288,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1190,6 +1190,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1205,7 +1206,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1244,11 +1244,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-64])
@@ -1291,3 +1287,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1192,58 +1192,58 @@ Package: main
 		Field: k: int
 === yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
-		Arg: items: .param0 (declared at line 102, available: [102-104])
-		Arg: pred: .param1 (declared at line 102, available: [102-109])
-		Arg: ~r0: .param2 (declared at line 102, available: )
-		Var: result: .param3 (declared at line 103, available: [102-109])
-		Scope: 104-109
-			Var: item: .param4 (declared at line 104, available: [105-109])
+	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [113:120] injectible: [113-113], [115-117], [120-120]
+		Arg: items: .param0 (declared at line 113, available: [113-115])
+		Arg: pred: .param1 (declared at line 113, available: [113-120])
+		Arg: ~r0: .param2 (declared at line 113, available: )
+		Var: result: .param3 (declared at line 114, available: [113-120])
+		Scope: 115-120
+			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
-	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [94:95] injectible: [94-95]
-		Arg: box: .param0 (declared at line 94, available: [94-95])
-		Arg: f: .param1 (declared at line 94, available: [94-95])
-		Arg: ~r0: .param2 (declared at line 94, available: )
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
-		Arg: items: .param0 (declared at line 115, available: [115-117])
-		Arg: init: .param1 (declared at line 115, available: [115-117])
-		Arg: f: .param2 (declared at line 115, available: [115-120])
-		Arg: ~r0: .param1 (declared at line 115, available: )
-		Var: acc: .param1 (declared at line 116, available: [115-120])
-		Scope: 117-120
-			Var: item: .param3 (declared at line 117, available: [117-118])
+	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
+		Arg: box: .param0 (declared at line 105, available: [105-106])
+		Arg: f: .param1 (declared at line 105, available: [105-106])
+		Arg: ~r0: .param2 (declared at line 105, available: )
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [40:41] injectible: [41-41]
+	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [126:131] injectible: [126-126], [128-129], [131-131]
+		Arg: items: .param0 (declared at line 126, available: [126-128])
+		Arg: init: .param1 (declared at line 126, available: [126-128])
+		Arg: f: .param2 (declared at line 126, available: [126-131])
+		Arg: ~r0: .param1 (declared at line 126, available: )
+		Var: acc: .param1 (declared at line 127, available: [126-131])
+		Scope: 128-131
+			Var: item: .param3 (declared at line 128, available: [128-129])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...]
 		Field: Value: <T>
-		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [72:74] injectible: [72-74]
-			Arg: b: .param2 (declared at line 72, available: [72-74])
-			Arg: val: .param3 (declared at line 72, available: [72-74])
-		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [65:66] injectible: [65-66]
-			Arg: b: .param0 (declared at line 65, available: [65-66])
-			Arg: ~r0: .param1 (declared at line 65, available: )
+		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [83:85] injectible: [83-85]
+			Arg: b: .param2 (declared at line 83, available: [83-85])
+			Arg: val: .param3 (declared at line 83, available: [83-85])
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [76:77] injectible: [76-77]
+			Arg: b: .param0 (declared at line 76, available: [76-77])
+			Arg: ~r0: .param1 (declared at line 76, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[...]
 		Field: items: map[...]bool
-		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [51:52] injectible: [51-52]
-			Arg: s: .param5 (declared at line 51, available: [51-52])
-			Arg: item: .param6 (declared at line 51, available: [51-52])
-			Arg: ~r0: bool (declared at line 51, available: )
-		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [38:45] injectible: [38-42], [44-45]
-			Arg: s: .param0 (declared at line 38, available: [38-45])
-			Arg: item: .param1 (declared at line 38, available: [38-45])
-			Arg: ~r0: .param2 (declared at line 38, available: )
-			Arg: ~r1: bool (declared at line 38, available: )
-			Var: existed: bool (declared at line 39, available: [38-45])
-			Var: newItems: .param4 (declared at line 40, available: [38-45])
-			Scope: 41-44
-				Var: v: bool (declared at line 41, available: [41-41], [42-42])
-				Var: k: .param1 (declared at line 41, available: [42-42])
+		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [62:63] injectible: [62-63]
+			Arg: s: .param5 (declared at line 62, available: [62-63])
+			Arg: item: .param6 (declared at line 62, available: [62-63])
+			Arg: ~r0: bool (declared at line 62, available: )
+		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [49:56] injectible: [49-53], [55-56]
+			Arg: s: .param0 (declared at line 49, available: [49-56])
+			Arg: item: .param1 (declared at line 49, available: [49-56])
+			Arg: ~r0: .param2 (declared at line 49, available: )
+			Arg: ~r1: bool (declared at line 49, available: )
+			Var: existed: bool (declared at line 50, available: [49-56])
+			Var: newItems: .param4 (declared at line 51, available: [49-56])
+			Scope: 52-55
+				Var: v: bool (declared at line 52, available: [52-52], [53-53])
+				Var: k: .param1 (declared at line 52, available: [53-53])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...]
 		Field: First: <T>
 		Field: Second: <T>
-		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
-			Arg: p: .param0 (declared at line 86, available: [86-87])
-			Arg: ~r0: .param1 (declared at line 86, available: )
+		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [97:98] injectible: [97-98]
+			Arg: p: .param0 (declared at line 97, available: [97-98])
+			Arg: ~r0: .param1 (declared at line 97, available: )
 === yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
@@ -1289,10 +1289,11 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Arg: ~r0: .param3 (declared at line 30, available: )
 === yield 4 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
 === yield 5 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -254,10 +254,10 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:54] injectible: [20-21], [24-25], [27-39], [41-41], [43-45], [48-54]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:55] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [49-55]
 		Var: scanner: *bufio.Scanner (declared at line 24, available: )
-		Var: it: main.iterExample (declared at line 42, available: [20-54])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-54])
+		Var: it: main.iterExample (declared at line 43, available: [20-55])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-55])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -1291,6 +1291,13 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 === yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
+	Function: UseV2GenericBox (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.UseV2GenericBox) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [54:57] injectible: [54-54], [56-57]
+		Var: b: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[int] (declared at line 55, available: )
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[...]
+		Field: Value: <T>
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2GenericBox[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [51:51] injectible: [51-51]
+			Arg: b: .param0 (declared at line 51, available: [51-51])
+			Arg: ~r0: .param1 (declared at line 51, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1180,58 +1180,58 @@ Package: main
 		Field: k: int
 === yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
-		Arg: items: .param0 (declared at line 102, available: [102-104])
-		Arg: pred: .param1 (declared at line 102, available: [102-109])
-		Arg: ~r0: .param2 (declared at line 102, available: )
-		Var: result: .param3 (declared at line 103, available: [102-109])
-		Scope: 104-109
-			Var: item: .param4 (declared at line 104, available: [105-109])
+	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [113:120] injectible: [113-113], [115-117], [120-120]
+		Arg: items: .param0 (declared at line 113, available: [113-115])
+		Arg: pred: .param1 (declared at line 113, available: [113-120])
+		Arg: ~r0: .param2 (declared at line 113, available: )
+		Var: result: .param3 (declared at line 114, available: [113-120])
+		Scope: 115-120
+			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
-	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [94:95] injectible: [94-95]
-		Arg: box: .param0 (declared at line 94, available: [94-95])
-		Arg: f: .param1 (declared at line 94, available: [94-95])
-		Arg: ~r0: .param2 (declared at line 94, available: )
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
-		Arg: items: .param0 (declared at line 115, available: [115-117])
-		Arg: init: .param1 (declared at line 115, available: [115-117])
-		Arg: f: .param2 (declared at line 115, available: [115-120])
-		Arg: ~r0: .param1 (declared at line 115, available: )
-		Var: acc: .param1 (declared at line 116, available: [115-120])
-		Scope: 117-120
-			Var: item: .param3 (declared at line 117, available: [117-118])
+	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
+		Arg: box: .param0 (declared at line 105, available: [105-106])
+		Arg: f: .param1 (declared at line 105, available: [105-106])
+		Arg: ~r0: .param2 (declared at line 105, available: )
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [40:41] injectible: [41-41]
+	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [126:131] injectible: [126-126], [128-129], [131-131]
+		Arg: items: .param0 (declared at line 126, available: [126-128])
+		Arg: init: .param1 (declared at line 126, available: [126-128])
+		Arg: f: .param2 (declared at line 126, available: [126-131])
+		Arg: ~r0: .param1 (declared at line 126, available: )
+		Var: acc: .param1 (declared at line 127, available: [126-131])
+		Scope: 128-131
+			Var: item: .param3 (declared at line 128, available: [128-129])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...]
 		Field: Value: <T>
-		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [72:74] injectible: [72-74]
-			Arg: b: .param2 (declared at line 72, available: [72-74])
-			Arg: val: .param3 (declared at line 72, available: [72-74])
-		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [65:66] injectible: [65-66]
-			Arg: b: .param0 (declared at line 65, available: [65-66])
-			Arg: ~r0: .param1 (declared at line 65, available: )
+		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [83:85] injectible: [83-85]
+			Arg: b: .param2 (declared at line 83, available: [83-85])
+			Arg: val: .param3 (declared at line 83, available: [83-85])
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [76:77] injectible: [76-77]
+			Arg: b: .param0 (declared at line 76, available: [76-77])
+			Arg: ~r0: .param1 (declared at line 76, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[...]
 		Field: items: map[...]bool
-		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [51:52] injectible: [51-52]
-			Arg: s: .param5 (declared at line 51, available: [51-52])
-			Arg: item: .param6 (declared at line 51, available: [51-52])
-			Arg: ~r0: bool (declared at line 51, available: )
-		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [38:45] injectible: [38-42], [44-45]
-			Arg: s: .param0 (declared at line 38, available: [38-45])
-			Arg: item: .param1 (declared at line 38, available: [38-45])
-			Arg: ~r0: .param2 (declared at line 38, available: )
-			Arg: ~r1: bool (declared at line 38, available: )
-			Var: existed: bool (declared at line 39, available: [38-45])
-			Var: newItems: .param4 (declared at line 40, available: [38-45])
-			Scope: 41-44
-				Var: v: bool (declared at line 41, available: [41-41], [42-42])
-				Var: k: .param1 (declared at line 41, available: [42-42])
+		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [62:63] injectible: [62-63]
+			Arg: s: .param5 (declared at line 62, available: [62-63])
+			Arg: item: .param6 (declared at line 62, available: [62-63])
+			Arg: ~r0: bool (declared at line 62, available: )
+		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [49:56] injectible: [49-53], [55-56]
+			Arg: s: .param0 (declared at line 49, available: [49-56])
+			Arg: item: .param1 (declared at line 49, available: [49-56])
+			Arg: ~r0: .param2 (declared at line 49, available: )
+			Arg: ~r1: bool (declared at line 49, available: )
+			Var: existed: bool (declared at line 50, available: [49-56])
+			Var: newItems: .param4 (declared at line 51, available: [49-56])
+			Scope: 52-55
+				Var: v: bool (declared at line 52, available: [52-52], [53-53])
+				Var: k: .param1 (declared at line 52, available: [53-53])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...]
 		Field: First: <T>
 		Field: Second: <T>
-		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
-			Arg: p: .param0 (declared at line 86, available: [86-87])
-			Arg: ~r0: .param1 (declared at line 86, available: )
+		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [97:98] injectible: [97-98]
+			Arg: p: .param0 (declared at line 97, available: [97-98])
+			Arg: ~r0: .param1 (declared at line 97, available: )
 === yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
@@ -1277,10 +1277,11 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Arg: ~r0: .param3 (declared at line 30, available: )
 === yield 4 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
 === yield 5 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1178,6 +1178,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1193,7 +1194,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1232,11 +1232,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-64])
@@ -1279,3 +1275,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1189,6 +1189,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
 	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
 		Arg: box: .param0 (declared at line 105, available: [105-106])
 		Arg: f: .param1 (declared at line 105, available: [105-106])
@@ -1275,13 +1276,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -244,9 +244,9 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:54] injectible: [20-21], [24-25], [27-39], [41-41], [43-45], [48-54]
-		Var: it: main.iterExample (declared at line 42, available: [20-54])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-54])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:55] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [49-55]
+		Var: it: main.iterExample (declared at line 43, available: [20-55])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-55])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -1279,6 +1279,13 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 === yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
+	Function: UseV2GenericBox (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.UseV2GenericBox) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [54:57] injectible: [54-54], [56-57]
+		Var: b: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[int] (declared at line 55, available: )
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[...]
+		Field: Value: <T>
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2GenericBox[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [51:51] injectible: [51-51]
+			Arg: b: .param0 (declared at line 51, available: [51-51])
+			Arg: ~r0: .param1 (declared at line 51, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1177,58 +1177,58 @@ Package: main
 		Field: k: int
 === yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
-		Arg: items: .param0 (declared at line 102, available: [102-106])
-		Arg: pred: .param1 (declared at line 102, available: [102-109])
-		Arg: ~r0: .param2 (declared at line 102, available: )
-		Var: result: .param3 (declared at line 103, available: [102-109])
-		Scope: 104-109
-			Var: item: .param4 (declared at line 104, available: [105-109])
+	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [113:120] injectible: [113-113], [115-117], [120-120]
+		Arg: items: .param0 (declared at line 113, available: [113-117])
+		Arg: pred: .param1 (declared at line 113, available: [113-120])
+		Arg: ~r0: .param2 (declared at line 113, available: )
+		Var: result: .param3 (declared at line 114, available: [113-120])
+		Scope: 115-120
+			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
-	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [94:95] injectible: [94-95]
-		Arg: box: .param0 (declared at line 94, available: [94-95])
-		Arg: f: .param1 (declared at line 94, available: [94-95])
-		Arg: ~r0: .param2 (declared at line 94, available: )
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
-		Arg: items: .param0 (declared at line 115, available: [115-117])
-		Arg: init: .param1 (declared at line 115, available: [115-117])
-		Arg: f: .param2 (declared at line 115, available: [115-120])
-		Arg: ~r0: .param1 (declared at line 115, available: )
-		Var: acc: .param1 (declared at line 116, available: [115-120])
-		Scope: 117-120
-			Var: item: .param3 (declared at line 117, available: [117-117])
+	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
+		Arg: box: .param0 (declared at line 105, available: [105-106])
+		Arg: f: .param1 (declared at line 105, available: [105-106])
+		Arg: ~r0: .param2 (declared at line 105, available: )
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [40:41] injectible: [41-41]
+	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [126:131] injectible: [126-126], [128-129], [131-131]
+		Arg: items: .param0 (declared at line 126, available: [126-128])
+		Arg: init: .param1 (declared at line 126, available: [126-128])
+		Arg: f: .param2 (declared at line 126, available: [126-131])
+		Arg: ~r0: .param1 (declared at line 126, available: )
+		Var: acc: .param1 (declared at line 127, available: [126-131])
+		Scope: 128-131
+			Var: item: .param3 (declared at line 128, available: [128-128])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...]
 		Field: Value: <T>
-		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [72:74] injectible: [72-74]
-			Arg: b: .param2 (declared at line 72, available: [72-74])
-			Arg: val: .param3 (declared at line 72, available: [72-74])
-		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [65:66] injectible: [65-66]
-			Arg: b: .param0 (declared at line 65, available: [65-66])
-			Arg: ~r0: .param1 (declared at line 65, available: )
+		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [83:85] injectible: [83-85]
+			Arg: b: .param2 (declared at line 83, available: [83-85])
+			Arg: val: .param3 (declared at line 83, available: [83-85])
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [76:77] injectible: [76-77]
+			Arg: b: .param0 (declared at line 76, available: [76-77])
+			Arg: ~r0: .param1 (declared at line 76, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[...]
 		Field: items: map[...]bool
-		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [51:52] injectible: [51-52]
-			Arg: s: .param5 (declared at line 51, available: [51-52])
-			Arg: item: .param6 (declared at line 51, available: [51-52])
-			Arg: ~r0: bool (declared at line 51, available: )
-		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [38:45] injectible: [38-42], [44-45]
-			Arg: s: .param0 (declared at line 38, available: [38-45])
-			Arg: item: .param1 (declared at line 38, available: [38-45])
-			Arg: ~r0: .param2 (declared at line 38, available: )
-			Arg: ~r1: bool (declared at line 38, available: )
-			Var: existed: bool (declared at line 39, available: [38-45])
-			Var: newItems: .param4 (declared at line 40, available: [38-45])
-			Scope: 41-44
-				Var: v: bool (declared at line 41, available: [41-41], [42-42])
-				Var: k: .param1 (declared at line 41, available: [42-42])
+		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [62:63] injectible: [62-63]
+			Arg: s: .param5 (declared at line 62, available: [62-63])
+			Arg: item: .param6 (declared at line 62, available: [62-63])
+			Arg: ~r0: bool (declared at line 62, available: )
+		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [49:56] injectible: [49-53], [55-56]
+			Arg: s: .param0 (declared at line 49, available: [49-56])
+			Arg: item: .param1 (declared at line 49, available: [49-56])
+			Arg: ~r0: .param2 (declared at line 49, available: )
+			Arg: ~r1: bool (declared at line 49, available: )
+			Var: existed: bool (declared at line 50, available: [49-56])
+			Var: newItems: .param4 (declared at line 51, available: [49-56])
+			Scope: 52-55
+				Var: v: bool (declared at line 52, available: [52-52], [53-53])
+				Var: k: .param1 (declared at line 52, available: [53-53])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...]
 		Field: First: <T>
 		Field: Second: <T>
-		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
-			Arg: p: .param0 (declared at line 86, available: [86-87])
-			Arg: ~r0: .param1 (declared at line 86, available: )
+		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [97:98] injectible: [97-98]
+			Arg: p: .param0 (declared at line 97, available: [97-98])
+			Arg: ~r0: .param1 (declared at line 97, available: )
 === yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
@@ -1274,10 +1274,11 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Arg: ~r0: .param3 (declared at line 30, available: )
 === yield 4 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
 === yield 5 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1186,6 +1186,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
 	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
 		Arg: box: .param0 (declared at line 105, available: [105-106])
 		Arg: f: .param1 (declared at line 105, available: [105-106])
@@ -1272,13 +1273,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1175,6 +1175,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-106])
@@ -1190,7 +1191,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1229,11 +1229,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-64])
@@ -1276,3 +1272,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -241,9 +241,9 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:54] injectible: [20-21], [24-25], [27-39], [41-41], [43-45], [48-54]
-		Var: it: main.iterExample (declared at line 42, available: [20-54])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-54])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:55] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [49-55]
+		Var: it: main.iterExample (declared at line 43, available: [20-55])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-55])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [988-989])
@@ -1276,6 +1276,13 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 === yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
+	Function: UseV2GenericBox (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.UseV2GenericBox) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [54:57] injectible: [54-54], [56-57]
+		Var: b: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[int] (declared at line 55, available: )
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[...]
+		Field: Value: <T>
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2GenericBox[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [51:51] injectible: [51-51]
+			Arg: b: .param0 (declared at line 51, available: [51-51])
+			Arg: ~r0: .param1 (declared at line 51, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1177,58 +1177,58 @@ Package: main
 		Field: k: int
 === yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
-		Arg: items: .param0 (declared at line 102, available: [102-104])
-		Arg: pred: .param1 (declared at line 102, available: [102-109])
-		Arg: ~r0: .param2 (declared at line 102, available: )
-		Var: result: .param3 (declared at line 103, available: [102-102], [104-109])
-		Scope: 104-109
-			Var: item: .param4 (declared at line 104, available: [105-109])
+	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [113:120] injectible: [113-113], [115-117], [120-120]
+		Arg: items: .param0 (declared at line 113, available: [113-115])
+		Arg: pred: .param1 (declared at line 113, available: [113-120])
+		Arg: ~r0: .param2 (declared at line 113, available: )
+		Var: result: .param3 (declared at line 114, available: [113-113], [115-120])
+		Scope: 115-120
+			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
-	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [94:95] injectible: [94-95]
-		Arg: box: .param0 (declared at line 94, available: [94-95])
-		Arg: f: .param1 (declared at line 94, available: [94-95])
-		Arg: ~r0: .param2 (declared at line 94, available: )
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
-		Arg: items: .param0 (declared at line 115, available: [115-117])
-		Arg: init: .param1 (declared at line 115, available: [115-117])
-		Arg: f: .param2 (declared at line 115, available: [115-120])
-		Arg: ~r0: .param1 (declared at line 115, available: )
-		Var: acc: .param1 (declared at line 116, available: [115-120])
-		Scope: 117-120
-			Var: item: .param3 (declared at line 117, available: [117-117])
+	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
+		Arg: box: .param0 (declared at line 105, available: [105-106])
+		Arg: f: .param1 (declared at line 105, available: [105-106])
+		Arg: ~r0: .param2 (declared at line 105, available: )
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [40:41] injectible: [41-41]
+	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [126:131] injectible: [126-126], [128-129], [131-131]
+		Arg: items: .param0 (declared at line 126, available: [126-128])
+		Arg: init: .param1 (declared at line 126, available: [126-128])
+		Arg: f: .param2 (declared at line 126, available: [126-131])
+		Arg: ~r0: .param1 (declared at line 126, available: )
+		Var: acc: .param1 (declared at line 127, available: [126-131])
+		Scope: 128-131
+			Var: item: .param3 (declared at line 128, available: [128-128])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...]
 		Field: Value: <T>
-		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [72:74] injectible: [72-74]
-			Arg: b: .param2 (declared at line 72, available: [72-74])
-			Arg: val: .param3 (declared at line 72, available: [72-74])
-		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [65:66] injectible: [65-66]
-			Arg: b: .param0 (declared at line 65, available: [65-66])
-			Arg: ~r0: .param1 (declared at line 65, available: )
+		Function: Set (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*Box[...]).Set) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [83:85] injectible: [83-85]
+			Arg: b: .param2 (declared at line 83, available: [83-85])
+			Arg: val: .param3 (declared at line 83, available: [83-85])
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [76:77] injectible: [76-77]
+			Arg: b: .param0 (declared at line 76, available: [76-77])
+			Arg: ~r0: .param1 (declared at line 76, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[...]
 		Field: items: map[...]bool
-		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [51:52] injectible: [51-52]
-			Arg: s: .param5 (declared at line 51, available: [51-52])
-			Arg: item: .param6 (declared at line 51, available: [51-52])
-			Arg: ~r0: bool (declared at line 51, available: )
-		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [38:45] injectible: [38-42], [44-45]
-			Arg: s: .param0 (declared at line 38, available: [38-45])
-			Arg: item: .param1 (declared at line 38, available: [38-45])
-			Arg: ~r0: .param2 (declared at line 38, available: )
-			Arg: ~r1: bool (declared at line 38, available: )
-			Var: existed: bool (declared at line 39, available: [38-45])
-			Var: newItems: .param4 (declared at line 40, available: [38-45])
-			Scope: 41-44
-				Var: v: bool (declared at line 41, available: [41-41], [42-42])
-				Var: k: .param1 (declared at line 41, available: [42-42])
+		Function: Contains (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Contains) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [62:63] injectible: [62-63]
+			Arg: s: .param5 (declared at line 62, available: [62-63])
+			Arg: item: .param6 (declared at line 62, available: [62-63])
+			Arg: ~r0: bool (declared at line 62, available: )
+		Function: Insert (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.(*ImmutableSet[...]).Insert) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [49:56] injectible: [49-53], [55-56]
+			Arg: s: .param0 (declared at line 49, available: [49-56])
+			Arg: item: .param1 (declared at line 49, available: [49-56])
+			Arg: ~r0: .param2 (declared at line 49, available: )
+			Arg: ~r1: bool (declared at line 49, available: )
+			Var: existed: bool (declared at line 50, available: [49-56])
+			Var: newItems: .param4 (declared at line 51, available: [49-56])
+			Scope: 52-55
+				Var: v: bool (declared at line 52, available: [52-52], [53-53])
+				Var: k: .param1 (declared at line 52, available: [53-53])
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...]
 		Field: First: <T>
 		Field: Second: <T>
-		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
-			Arg: p: .param0 (declared at line 86, available: [86-87])
-			Arg: ~r0: .param1 (declared at line 86, available: )
+		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [97:98] injectible: [97-98]
+			Arg: p: .param0 (declared at line 97, available: [97-98])
+			Arg: ~r0: .param1 (declared at line 97, available: )
 === yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
@@ -1274,10 +1274,11 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Arg: ~r0: .param3 (declared at line 30, available: )
 === yield 4 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
 === yield 5 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1175,6 +1175,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1190,7 +1191,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1229,11 +1229,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-59], [60-64])
@@ -1276,3 +1272,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1186,6 +1186,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 			Var: item: .param4 (declared at line 115, available: [116-120])
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
 	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
+	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
 	Function: Map[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [105:106] injectible: [105-106]
 		Arg: box: .param0 (declared at line 105, available: [105-106])
 		Arg: f: .param1 (declared at line 105, available: [105-106])
@@ -1272,13 +1273,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: InlinedInLaterCU (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedInLaterCU) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [27:28] injectible: [28-28]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [40:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -241,9 +241,9 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:54] injectible: [20-21], [24-25], [27-39], [41-41], [43-45], [48-54]
-		Var: it: main.iterExample (declared at line 42, available: [20-54])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-54])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:55] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [49-55]
+		Var: it: main.iterExample (declared at line 43, available: [20-55])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-55])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [988-989])
@@ -1276,6 +1276,13 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 === yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [21:30] injectible: [21-21], [29-30]
+	Function: UseV2GenericBox (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.UseV2GenericBox) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [54:57] injectible: [54-54], [56-57]
+		Var: b: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[int] (declared at line 55, available: )
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2GenericBox[...]
+		Field: Value: <T>
+		Function: Get (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2GenericBox[...].Get) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [51:51] injectible: [51-51]
+			Arg: b: .param0 (declared at line 51, available: [51-51])
+			Arg: ~r0: .param1 (declared at line 51, available: )
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [34:36] injectible: [34-36]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 34, available: [34-35])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [366:367] injectible: [367-367]
 		Arg: ptr: *****int (declared at line 0, available: [367-367])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [366:367] injectible: [367-367]
 		Arg: ptr: *****int (declared at line 0, available: [367-367])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [366:367] injectible: [367-367]
 		Arg: ptr: *****int (declared at line 0, available: [367-367])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [366:367] injectible: [367-367]
 		Arg: ptr: *****int (declared at line 0, available: [367-367])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [366:367] injectible: [367-367]
 		Arg: ptr: *****int (declared at line 0, available: [367-367])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [366:367] injectible: [367-367]
 		Arg: ptr: *****int (declared at line 0, available: [367-367])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [366:367] injectible: [367-367]
 		Arg: ptr: *****int (declared at line 0, available: [367-367])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [366:367] injectible: [367-367]
 		Arg: ptr: *****int (declared at line 0, available: [367-367])

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -107,7 +107,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -186,7 +186,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -265,7 +265,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -344,7 +344,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -423,7 +423,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -502,7 +502,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -576,7 +576,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -655,7 +655,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -735,7 +735,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -102,7 +102,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -177,7 +177,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -257,7 +257,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -337,7 +337,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -423,7 +423,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testConflictingReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testConflictingReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 48
+            "lineNumber": 49
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 48
+            "lineNumber": 49
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericDeref.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericDeref.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -129,7 +129,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericDo.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericDo.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -107,7 +107,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericFuncContains.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericFuncContains.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -120,7 +120,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -212,7 +212,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -304,7 +304,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -396,7 +396,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericFuncContainsLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericFuncContainsLine.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -97,7 +97,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -184,7 +184,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -271,7 +271,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -358,7 +358,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLargeGet.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLargeGet.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -667,7 +667,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLibFilter.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLibFilter.json
@@ -18,7 +18,7 @@
           {
             "function": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go",
-            "lineNumber": 109
+            "lineNumber": 120
           },
           {
             "function": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.UseGenericsWithFloat64",
@@ -120,7 +120,7 @@
           {
             "function": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go",
-            "lineNumber": 109
+            "lineNumber": 120
           },
           {
             "function": "main.outerFilter[go.shape.int]",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLibFilter.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLibFilter.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 46
           },
           {
             "function": "runtime.main",
@@ -135,7 +135,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLibMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLibMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLibMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLibMap.json
@@ -18,7 +18,7 @@
           {
             "function": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go",
-            "lineNumber": 95
+            "lineNumber": 106
           },
           {
             "function": "main.executeGenericFuncs",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericMethodGuess.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericMethodGuess.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -111,7 +111,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericNested.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericNested.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -107,7 +107,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericPairSetValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericPairSetValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -112,7 +112,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericPtrIdentity.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericPtrIdentity.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -122,7 +122,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -208,7 +208,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericSwap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericSwap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -114,7 +114,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericWrapBox.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericWrapBox.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -107,7 +107,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -109,7 +109,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -191,7 +191,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -272,7 +272,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -354,7 +354,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",
@@ -430,7 +430,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameCaptureExpr.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameMultiCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameMultiCaptureExpr.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameTemplate.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCaptureExpr.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondMulti.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondMulti.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondMultiFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondMultiFloat.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondSingle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondSingle.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnMultiCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnMultiCaptureExpr.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnMultiTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnMultiTemplate.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnTemplate.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",
@@ -102,7 +102,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",
@@ -186,7 +186,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",
@@ -130,7 +130,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",
@@ -113,7 +113,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",
@@ -107,7 +107,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",
@@ -201,7 +201,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsNamedDeferLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsNamedDeferLine.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 52
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 51
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -117,7 +117,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",
@@ -193,7 +193,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testprogs/progs/sample/lib.v2/BUILD.bazel
+++ b/pkg/dyninst/testprogs/progs/sample/lib.v2/BUILD.bazel
@@ -5,4 +5,7 @@ go_library(
     srcs = ["lib.go"],
     importpath = "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/dyninst/testprogs/progs/sample/lib",
+    ],
 )

--- a/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go
+++ b/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go
@@ -8,13 +8,25 @@
 // gets escaped in DWARF, making this useful for our tests.
 package lib_v2
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib"
+)
 
 var dummy int
 
 //go:noinline
 func FooV2() {
 	dummy++
+	// Call a function defined in lib from lib.v2. lib.v2's CU is
+	// emitted later in the DWARF than lib's own CU; when the Go
+	// compiler inlines this call, the abstract definition DIE for
+	// lib.InlinedInLaterCU lands in lib.v2's CU. That places the
+	// abstract after lib's CU has already been emitted by symdb —
+	// the scenario the new cross-CU inline-instance index is
+	// designed for.
+	lib.InlinedInLaterCU()
 }
 
 type V2Type struct{}

--- a/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go
+++ b/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go
@@ -34,3 +34,24 @@ type V2Type struct{}
 func (v *V2Type) MyMethod() {
 	fmt.Println("")
 }
+
+// V2GenericBox is a generic struct in a package whose last path segment
+// contains a dot. It exercises the index-key escape contract: the entry
+// stored in genericTypes uses the DWARF (escaped) package form, matching
+// forPackage's escaped-prefix lookup.
+type V2GenericBox[T any] struct {
+	Value T
+}
+
+// Get is a method so that the Go compiler emits a DW_TAG_structure_type
+// DIE for V2GenericBox. Without a method-using-the-receiver, no struct
+// DIE would be emitted and genericTypes would be empty for lib.v2.
+//
+//go:noinline
+func (b V2GenericBox[T]) Get() T { return b.Value }
+
+//go:noinline
+func UseV2GenericBox() {
+	b := V2GenericBox[int]{Value: 42}
+	dummy += b.Get()
+}

--- a/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go
+++ b/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go
@@ -19,13 +19,13 @@ var dummy int
 //go:noinline
 func FooV2() {
 	dummy++
-	// Call a function defined in lib from lib.v2. lib.v2's CU is
-	// emitted later in the DWARF than lib's own CU; when the Go
-	// compiler inlines this call, the abstract definition DIE for
-	// lib.InlinedInLaterCU lands in lib.v2's CU. That places the
-	// abstract after lib's CU has already been emitted by symdb —
-	// the scenario the new cross-CU inline-instance index is
-	// designed for.
+	// Call a function defined in lib from lib.v2. lib.v2's compile
+	// unit is emitted later in the DWARF than lib's own compile unit;
+	// when the Go compiler inlines this call, the abstract definition
+	// DIE for lib.InlinedInLaterCU lands in lib.v2's compile unit.
+	// That places the abstract after lib's compile unit has already
+	// been emitted by symdb — the scenario the cross-compile-unit
+	// inline-instance index is designed for.
 	lib.InlinedInLaterCU()
 }
 

--- a/pkg/dyninst/testprogs/progs/sample/lib/lib.go
+++ b/pkg/dyninst/testprogs/progs/sample/lib/lib.go
@@ -17,6 +17,17 @@ func InlinedFunc() {
 	dummy++
 }
 
+// InlinedInLaterCU is defined in lib but called only from lib.v2, which
+// is compiled into a CU that is emitted LATER in the binary than lib's
+// own CU. The Go compiler emits the abstract definition DIE for this
+// function into lib.v2's CU (the only CU that inlines it). symdb
+// processes lib's CU first and emits the lib package before it sees
+// lib.v2's CU — so without the cross-CU inline-instance index, this
+// function cannot be attached to lib at all.
+func InlinedInLaterCU() {
+	dummy++
+}
+
 // ImmutableSet is a generic immutable set. Calling Insert returns a new set,
 // mimicking the pattern from go-immutable-radix. When Insert is called in a
 // loop with reassignment (set, _ = set.Insert(k, v)), the Go compiler may

--- a/pkg/dyninst/testprogs/progs/sample/lib/lib.go
+++ b/pkg/dyninst/testprogs/progs/sample/lib/lib.go
@@ -17,13 +17,13 @@ func InlinedFunc() {
 	dummy++
 }
 
-// InlinedInLaterCU is defined in lib but called only from lib.v2, which
-// is compiled into a CU that is emitted LATER in the binary than lib's
-// own CU. The Go compiler emits the abstract definition DIE for this
-// function into lib.v2's CU (the only CU that inlines it). symdb
-// processes lib's CU first and emits the lib package before it sees
-// lib.v2's CU — so without the cross-CU inline-instance index, this
-// function cannot be attached to lib at all.
+// InlinedInLaterCU is defined in lib but called only from lib.v2,
+// whose compile unit is emitted LATER in the binary than lib's own.
+// The Go compiler places the abstract definition DIE for this function
+// into lib.v2's compile unit (the only one that inlines it). symdb
+// processes lib's compile unit first and emits the lib package before
+// it sees lib.v2's compile unit — so without the cross-compile-unit
+// inline-instance index, this function isn't attached to lib at all.
 func InlinedInLaterCU() {
 	dummy++
 }

--- a/pkg/dyninst/testprogs/progs/sample/main.go
+++ b/pkg/dyninst/testprogs/progs/sample/main.go
@@ -39,6 +39,7 @@ func main() {
 	lib_v2.FooV2()
 	var t lib_v2.V2Type
 	t.MyMethod()
+	lib_v2.UseV2GenericBox()
 	var it iterExample
 	it.rangeOverIterator()
 	lib.InlinedFunc()


### PR DESCRIPTION
### What does this PR do?

Extends the `symdb` cross-compile-unit indexing scheme introduced in #48822 to cover **non-generic** abstract inline functions and every inline instance regardless of which compile unit holds it. Along the way, fixes a streaming-iteration bug where a package could be yielded more than once, with the trailing yield containing only "leftover" functions that symdb couldn't attribute to the first yield in time.

The patch series is:

1. **`dyninst/symdb: drive TestSymDBSnapshot through streaming PackagesIterator`**
   Replace the existing `TestSymDBSnapshot` (which called `ExtractSymbols` and aggregated all yields into a single `Symbols` value before serialization) with a test that drives the streaming `PackagesIterator` API dire

2. **`dyninst/testprogs: add cross-CU inline test cases`**
   Add `lib.InlinedInLaterCU`, a function defined in `lib` but called only from `lib.v2.FooV2`. Because `lib.v2`'s compile unit is emitted *after* `lib`'s CU in the binary, the Go compiler places the abstract-definition DIE in `lib.v2`'s CU. Regenerate the snapshot goldens with the existing (pre-fix) `symdb` code — the new streaming goldens clearly capture the bug described below.

3. **`dyninst/symdb: rename genericFuncIndex to funcOffsetByNameIndex`**
   Pure rename of the sorted name-keyed index type to decouple it from its initial use for generic shape functions. No behaviour change.

4. **`dyninst/symdb: index inline instances across compile units`**
   The actual fix. Adds two pre-pass indexes:
   - `inlineDefIndex` — canonical qualified name → abstract-definition DWARF offset, for every `DW_TAG_subprogram` with `DW_AT_inline = DW_INL_inlined` (both generic and non-generic).
   - `inlineInstanceIndex` — abstract-origin DWARF offset → instance DWARF offset, for every inline instance (both `DW_TAG_inlined_subroutine` and out-of-line `DW_TAG_subprogram` with `DW_AT_abstract_origin`).

   At each package's CU emission, every instance of every abstract function owned by that package is replayed from `inlineInstanceIndex` so that `file`/`endLine`/`injectibleLines` and per-variable availability are populated regardless of which CU the abstract DIE or its instances live in. Emission is scoped to the defining CU: `b.abstractFunctions` is no longer cleared per CU, so instance data accumulates across CUs, and `addAbstractFunctions` only emits entries whose owning package matches. The `displacedFunctions` fallback is removed from the abstract-function path (and `addFunctionToPackage`) because the indexes cover that case by construction — verified with an empirical check that the fallback never fires on any of the sample programs.

### Motivation

A pre-existing bug in the streaming `PackagesIterator` API: a package can be yielded **more than once**, with the second yield containing only the "leftover" functions that `symdb` couldn't attribute to the first yield in time. The trailing yields are assembled from `displacedFunctions`, a side channel that accumulates functions parsed from non-owner CUs for later merging.

Two concrete cases in the sample binary:

- **Non-generic, cross-CU abstract.** `lib.InlinedInLaterCU` is defined in `lib` and inlined only from `lib.v2.FooV2`. The Go compiler emits the abstract-definition DIE in `lib.v2`'s CU, which comes *after* `lib`'s CU in the binary. When `symdb` iterates CUs:
  - `lib`'s CU is processed first and yields a `lib` package without `InlinedInLaterCU`.
  - `lib.v2`'s CU is processed later; its `exploreSubprogram` parses `InlinedInLaterCU`'s abstract DIE and, because it belongs to `lib` not `lib.v2`, routes it through `displacedFunctions["lib"]`.
  - At end-of-iteration, `displacedFunctions["lib"]` is yielded as a new `lib` package containing just this function.

  `ExtractSymbols` hid this by aggregating both yields into one `Symbols` value before serialization. `PackagesIterator` (used by the production uploader, `pkg/dyninst/module/symdb.go`) does not — it passes both yields through as two separate uploads, so the server sees the same package twice with disjoint contents. Switching the test to the streaming API (patch 1) makes this visible.

- **Generic shape, cross-CU abstract.** `lib.NewImmutableSet[go.shape.string]`'s abstract DIE lands in `main`'s CU (the compiler's generic-shape placement behaviour). The existing `augmentWithDisplacedGenerics` path re-parses the abstract DIE while processing `lib`'s CU, but never replays its inline instance, so it produces a broken stub entry with empty `file`/`endLine`/`injectibleLines` alongside the correctly-populated entry. Both entries end up in the output.

Both problems have the same shape: `symdb`'s abstract-function handling was scoped to the CU currently being walked, with a best-effort side channel for everything that didn't fit. The fix is to precompute the two indexes (abstract definitions, inline instances) in the existing pre-pass and replay instances at each package's emission point, so every abstract function is emitted exactly once, on its owning package's yield, with complete per-instance data — regardless of the compiler's DIE placement choices.

### Describe how you validated your changes

- New unit tests for the origin-keyed index (`TestFuncOffsetByOriginIndex`) covering empty / single / multi / duplicate origins / early-break iteration across both in-memory and on-disk (mmap-backed) variants.
- `TestSymDBSnapshot` goldens across 4 Go toolchains and 2 architectures. The golden diff across the commit chain visibly demonstrates:
  - pre-fix streaming output: 5 `lib` yields for `sample`, with a trailing duplicate yield containing `InlinedInLaterCU` + a broken `NewImmutableSet` stub.
  - post-fix: 4 yields, with `InlinedInLaterCU` attached to `lib`'s primary yield and the broken stub removed.
- `TestIRGenAndCompileSymDBProbes` passes across all toolchain/arch combinations.
- Dyninst E2E tests (`Dyn/sample/1.25`) pass.

### Additional Notes

https://datadoghq.atlassian.net/browse/DEBUG-5497