### PR TITLE
chore(renovate): disable gomod digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -93,6 +93,11 @@
       },
       {
         "matchManagers": ["gomod"],
+        "matchUpdateTypes": ["digest"],
+        "enabled": false
+      },
+      {
+        "matchManagers": ["gomod"],
         "matchDepNames": ["github.com/twmb/franz-go{,/**}"],
         "groupName": "franz-go"
       },


### PR DESCRIPTION
## Summary

- Adds a `packageRules` entry that disables `digest`-type updates under the `gomod` manager.
- Only tagged (semver) gomod updates will be accepted from now on.

## Context

When a Go dependency does not publish semver tags, Renovate's `gomod` manager has nothing to do and falls back to the `digest` datasource, which tracks the HEAD of the upstream default branch. Two problems come out of this:

1. **Malformed `go.mod` entries.** The digest manager does not always round-trip a proper `v0.0.0-<timestamp>-<commit>` pseudo-version — it can leave a bare short hash in the root `go.mod`, breaking the build. Example: #49574 rewrote the root entry to `github.com/hectane/go-acl ca0b05cb1adb`.
2. **"Updates" that go backwards in time.** The digest datasource has no time or semver ordering. If the upstream default branch is reset, renamed, or never had the commit we currently pin, Renovate will happily "update" to an older commit. Example from the same PR: the subpackage `go.mod` was bumped from a Feb 2023 commit to a Jan 2023 commit.

Disabling digest updates for `gomod` is a guardrail so this class of regression cannot slip in again for any tag-less Go dependency.

## Test plan

- [ ] Renovate dashboard/dry-run confirms no new `gomod` digest PRs are opened.
- [ ] Existing tagged gomod update PRs continue to open normally.