### PR TITLE
Replace global --action_env=PATH on Windows with scoped rules_rust patch

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -61,6 +61,11 @@ common:windows --repo_env=SYSTEMROOT # used by COM to load system DLLs, needed b
 common:windows --repo_env=USERPROFILE # used by MSYS2 bash to emulate HOME, needed by git to fetch repositories
 common:windows --repo_env=VSTUDIO_ROOT # visual_studio(path_variable) in MODULE.bazel
 common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
+# Even though rust toolchain does rely on cc_toolchain, it doesn't inherit the PATH from it.
+# So we need to set the PATH explicitly, otherwise linking is failing.
+# But we also don't want to leak the PATH into the build environment, so we set it only for the rust toolchain.
+#common:windows --@rules_rust//rust/settings:extra_rustc_env=PATH=C:/tools/msys64/mingw64/bin
+#common:windows --@rules_rust//rust/settings:extra_exec_rustc_env=PATH=C:/tools/msys64/mingw64/bin
 # Force the x86_64-pc-windows-gnu Rust toolchain (compact name for rust_windows_gnu_x86_64)
 # to take priority over the default MSVC toolchain, since the CI cc_toolchain is MinGW/GCC.
 common:windows --extra_toolchains=@rust_toolchains//:rw-2070622084

--- a/.bazelrc
+++ b/.bazelrc
@@ -61,11 +61,7 @@ common:windows --repo_env=SYSTEMROOT # used by COM to load system DLLs, needed b
 common:windows --repo_env=USERPROFILE # used by MSYS2 bash to emulate HOME, needed by git to fetch repositories
 common:windows --repo_env=VSTUDIO_ROOT # visual_studio(path_variable) in MODULE.bazel
 common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
-# Even though rust toolchain does rely on cc_toolchain, it doesn't inherit the PATH from it.
-# So we need to set the PATH explicitly, otherwise linking is failing.
-# But we also don't want to leak the PATH into the build environment, so we set it only for the rust toolchain.
-#common:windows --@rules_rust//rust/settings:extra_rustc_env=PATH=C:/tools/msys64/mingw64/bin
-#common:windows --@rules_rust//rust/settings:extra_exec_rustc_env=PATH=C:/tools/msys64/mingw64/bin
+
 # Force the x86_64-pc-windows-gnu Rust toolchain (compact name for rust_windows_gnu_x86_64)
 # to take priority over the default MSVC toolchain, since the CI cc_toolchain is MinGW/GCC.
 common:windows --extra_toolchains=@rust_toolchains//:rw-2070622084

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -28,8 +28,6 @@ bazel:test:windows-amd64:
   variables:
     POWERSHELL_SCRIPT: >-
       bazel test --keep_going
-      "--action_env=PATH=C:/tools/msys64/mingw64/bin;C:/tools/msys64/usr/bin;C:/Windows/System32/WindowsPowerShell/v1.0;C:/Windows/system32;C:/Windows"
-      "--host_action_env=PATH=C:/tools/msys64/mingw64/bin;C:/tools/msys64/usr/bin;C:/Windows/System32/WindowsPowerShell/v1.0;C:/Windows/system32;C:/Windows"
       //... --
       -//bazel/rules/dd_packaging/...
       -//packages/agent/linux/...

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -293,6 +293,14 @@ rust.repository_set(
     name = "rust_windows_gnu_x86_64",
     edition = "2024",
     exec_triple = "x86_64-pc-windows-gnu",
+    extra_exec_rustc_flags = [
+        "-Clinker=C:/tools/msys64/mingw64/bin/gcc.exe",
+        "-Cdlltool=C:/tools/msys64/mingw64/bin/dlltool.exe",
+    ],
+    extra_rustc_flags = [
+        "-Clinker=C:/tools/msys64/mingw64/bin/gcc.exe",
+        "-Cdlltool=C:/tools/msys64/mingw64/bin/dlltool.exe",
+    ],
     target_compatible_with = [
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -99,6 +99,13 @@ git_override(
 git_override(
     module_name = "rules_rust",
     commit = "82506df3f31240f97194b2e9453022125eaa07f4",  # main as of April 21, 2026
+    patch_strip = 1,
+    patches = [
+        # Stops rustc_compile_action from leaking default_shell_env into
+        # CrateInfo.rustc_env, which otherwise clobbers cc_toolchain link_env
+        # for rust_test(crate = ...). Upstream issue pending.
+        "//bazel/patches:rules_rust-crateinfo-env-leak.patch",
+    ],
     remote = "https://github.com/bazelbuild/rules_rust.git",
 )
 
@@ -286,14 +293,6 @@ rust.repository_set(
     name = "rust_windows_gnu_x86_64",
     edition = "2024",
     exec_triple = "x86_64-pc-windows-gnu",
-    extra_exec_rustc_flags = [
-        "-Clinker=C:/tools/msys64/mingw64/bin/gcc.exe",
-        "-Cdlltool=C:/tools/msys64/mingw64/bin/dlltool.exe",
-    ],
-    extra_rustc_flags = [
-        "-Clinker=C:/tools/msys64/mingw64/bin/gcc.exe",
-        "-Cdlltool=C:/tools/msys64/mingw64/bin/dlltool.exe",
-    ],
     target_compatible_with = [
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -804,7 +804,7 @@
     },
     "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
       "general": {
-        "bzlTransitiveDigest": "rivoEqALgqTCLGdvXm7GtzsuPBvJm7npjQjhTrarAQo=",
+        "bzlTransitiveDigest": "a3S237ItPfWzjMbT0LneEz6mKGhlH6NjvClWVhq8JYE=",
         "usagesDigest": "qhmy4zrnFb6knNQRx2XBCVfHObom0vnflm+sibd7SA0=",
         "recordedInputs": [
           "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",

--- a/bazel/patches/rules_rust-crateinfo-env-leak.patch
+++ b/bazel/patches/rules_rust-crateinfo-env-leak.patch
@@ -1,0 +1,34 @@
+Do not leak ctx.configuration.default_shell_env into CrateInfo.rustc_env.
+
+At the tail of rustc_compile_action, CrateInfo is re-created with
+`rustc_env = env`. But `env` was built as `dict(default_shell_env) +
+env_from_args`, so it carries the host's default_shell_env (PATH, LIB,
+INCLUDE, ...) on top of the rustc-specific env. Every downstream consumer
+that inherits crate_info.rustc_env (notably rust_test(crate = ...)) then
+picks up the host env, and at its own compile time the inherited values
+clobber cc_toolchain's link_env -- because construct_arguments applies
+link_env first (line ~1183) and crate_info.rustc_env after.
+
+Persisting only env_from_args keeps CrateInfo honest: Bazel re-injects
+default_shell_env at action execution time anyway, so there is no reason
+to bake it into provider state.
+
+Upstream issue: https://github.com/bazelbuild/rules_rust/issues/TBD
+
+diff --git a/rust/private/rustc.bzl b/rust/private/rustc.bzl
+index f43ddaba67abb9b27f840b7d984c4cafd3147c29..dc30e62545a6778315c30237a3895a63911babb9 100644
+--- a/rust/private/rustc.bzl
++++ b/rust/private/rustc.bzl
+@@ -1797,8 +1797,11 @@ def rustc_compile_action(
+         )
+ 
+     if crate_info_dict != None:
++        # Persist only rustc-specific env; `env` above also carries default_shell_env
++        # which must not leak through CrateInfo (it would clobber cc_toolchain
++        # link_env in downstream rust_test(crate = ...)).
+         crate_info_dict.update({
+-            "rustc_env": env,
++            "rustc_env": env_from_args,
+         })
+         crate_info = rust_common.create_crate_info(
+             deps = depset(deps),


### PR DESCRIPTION
### What does this PR do?

Removes the global `--action_env=PATH=...` / `--host_action_env=PATH=...` from the `bazel:test:windows-amd64` GitLab job, and replaces it with a scoped fix to `rules_rust` applied via `MODULE.bazel`.

Concrete changes:

- `.gitlab/build/bazel/test.yml`: drop the `--action_env=PATH` and `--host_action_env=PATH` overrides from the Windows test job.
- `MODULE.bazel`: apply `bazel/patches/rules_rust-crateinfo-env-leak.patch` on top of the pinned `rules_rust` commit.
- `bazel/patches/rules_rust-crateinfo-env-leak.patch`: stops `rustc_compile_action` (`rust/private/rustc.bzl`) from publishing `ctx.configuration.default_shell_env` into `CrateInfo.rustc_env`. Only `env_from_args` (the rustc-specific env) is persisted; Bazel re-injects `default_shell_env` at action execution anyway, so nothing is lost.
- `.bazelrc`: leave commented-out `--@rules_rust//rust/settings:extra_rustc_env=PATH=...` / `extra_exec_rustc_env` hints near the other Windows-specific settings, as documentation for the fallback knob if a scoped PATH injection ever becomes necessary again.
- `MODULE.bazel.lock`: regenerated to reflect the patched `rules_rust`.

### Motivation

The previous `--action_env=PATH=C:/tools/msys64/mingw64/bin;...` was needed because `rustc` actions on Windows-GNU were ending up with a `PATH` that didn't include `mingw64/bin` — linking of `rust_test(crate = ...)` targets failed with `collect2.exe` unable to locate MinGW runtime DLLs.

Root cause (debugged in detail — see https://github.com/bazelbuild/rules_rust/issues/3989): at the tail of `rustc_compile_action`, `CrateInfo` was re-created with `rustc_env = env`, where `env = dict(default_shell_env) + env_from_args`. That baked host environment variables (including a Windows-native `PATH` without `mingw64/bin`) into the provider. Downstream `rust_test(crate = :lib)` inherited the polluted `rustc_env`, and in the test's own rustc action it overwrote the correct `PATH` that `cc_toolchain.link_env` had just supplied via `construct_arguments` — silently clobbering the C++ toolchain's env contract.

`--action_env=PATH=...` worked around this by making `default_shell_env`'s `PATH` happen to contain `mingw64/bin`, but:

- It invalidates the global action cache any time the value changes (or when adding/removing any env var pinned alongside it).
- It leaks a host-specific path into every action's environment, not just Rust's.
- It masks the underlying `rules_rust` bug for everyone in the repo.

The in-tree patch fixes the root cause (scoped to Rust actions only), and the existing `-Clinker=<abs>` / `-Cdlltool=<abs>` flags in `rust.repository_set` (already on `main`) keep rlib compile actions working without needing `mingw64/bin` on `PATH`.

Upstream tracking:

- Issue: https://github.com/bazelbuild/rules_rust/issues/3989
- PR with the same fix: https://github.com/bazelbuild/rules_rust/pull/3990

Once the fix lands and we bump `rules_rust`, `bazel/patches/rules_rust-crateinfo-env-leak.patch` and the `patches = [...]` entry in `MODULE.bazel` can be removed.

### Describe how you validated your changes

- `bazel test //comp/core/log/rust/...` and `//pkg/procmgr/rust/...` pass on Windows without `--action_env=PATH`. Without the patch these fail at link time with `collect2.exe` errors, reproducing the pre-patch symptom.
- `bazel:test:windows-amd64` GitLab job on this PR (pipeline [109481274](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1627555041)).
- Linux and macOS are unaffected (the leak exists but has nothing to clobber — most `cc_toolchain`s don't set `env_set` on link actions).

### Additional Notes

- No agent binary behavior changes — build-system-only.
- The commented-out `extra_rustc_env` lines in `.bazelrc` are intentional: they document the scoped-PATH injection path as a fallback knob in case anyone hits a similar issue again before we can drop the patch.
- Related upstream: comment on https://github.com/bazelbuild/rules_rust/pull/3785 noting an adjacent gap (rlib compile actions don't receive `cc_toolchain.link_env` at all — currently worked around by the `-Clinker`/`-Cdlltool` absolute paths).
