### PR TITLE
[procmgr] Cross-platform E2E tests and Windows install-test expectations

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,6 +111,7 @@
   - test/new-e2e/tests/windows/**/*
   - test/new-e2e/tests/sysprobe-functional/**/*
   - test/new-e2e/tests/process/**/*
+  - test/new-e2e/tests/agent-runtimes/**/*
 
 include:
   - local: .adms/**/*.yaml

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_common_test.go
@@ -1,0 +1,256 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package procmgr
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+)
+
+// platformConfig holds all platform-specific paths, commands, and config
+// snippets so that the shared test methods in baseProcmgrSuite work on both
+// Linux and Windows without branching.
+type platformConfig struct {
+	daemonBin    string // path to dd-procmgrd binary
+	cliBin       string // path to dd-procmgr CLI binary
+	configDir    string // processes.d directory for agent file provisioning
+	sleepCommand string // expected COMMAND column value in "list" output
+
+	testProcessYAML   string // YAML config that starts a long-running sleep process
+	missingBinaryYAML string // YAML config whose condition_path_exists prevents start
+
+	// checkBinCmd returns a shell command that succeeds (exit 0) when the
+	// given binary path exists on the remote host.
+	checkBinCmd func(path string) string
+
+	// checkSvcRunning is a shell command whose trimmed stdout indicates the
+	// service is running (compared against svcRunningOutput).
+	checkSvcRunning  string
+	svcRunningOutput string
+
+	// cliCmd returns the full shell command to invoke the procmgr CLI with
+	// the given arguments (handles quoting differences between bash and
+	// PowerShell).
+	cliCmd func(args string) string
+}
+
+type baseProcmgrSuite struct {
+	e2e.BaseSuite[environments.Host]
+	platform platformConfig
+	hasCLI   bool
+}
+
+func (s *baseProcmgrSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	defer s.CleanupOnSetupFailure()
+
+	_, err := s.Env().RemoteHost.Execute(s.platform.checkBinCmd(s.platform.daemonBin))
+	if err != nil {
+		s.T().Skip("procmgr daemon not included in this agent package; skipping process manager tests")
+	}
+
+	_, err = s.Env().RemoteHost.Execute(s.platform.checkBinCmd(s.platform.cliBin))
+	s.hasCLI = err == nil
+}
+
+func (s *baseProcmgrSuite) requireCLI() {
+	s.T().Helper()
+	if !s.hasCLI {
+		s.T().Skip("dd-procmgr CLI not included in this agent package")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Shared tests — run on both Linux and Windows
+// ---------------------------------------------------------------------------
+
+func (s *baseProcmgrSuite) TestBinariesExist() {
+	s.Env().RemoteHost.MustExecute(s.platform.checkBinCmd(s.platform.daemonBin))
+
+	if !s.hasCLI {
+		s.T().Skip("dd-procmgr CLI not included in this agent package")
+	}
+	s.Env().RemoteHost.MustExecute(s.platform.checkBinCmd(s.platform.cliBin))
+}
+
+func (s *baseProcmgrSuite) TestServiceRunning() {
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		out, err := s.Env().RemoteHost.Execute(s.platform.checkSvcRunning)
+		assert.NoError(t, err)
+		assert.Equal(t, s.platform.svcRunningOutput, strings.TrimSpace(out))
+	}, 30*time.Second, 2*time.Second)
+}
+
+func (s *baseProcmgrSuite) TestCLIStatus() {
+	s.requireCLI()
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		out := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("status"))
+		assertHasField(t, out, "Version")
+		assertHasField(t, out, "Uptime")
+	}, 30*time.Second, 2*time.Second)
+}
+
+func (s *baseProcmgrSuite) TestCLIListShowsConfiguredProcess() {
+	s.requireCLI()
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		out := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("list"))
+		assertTableRow(t, out, "test-sleep", map[string]string{
+			"STATE":   "Running",
+			"COMMAND": s.platform.sleepCommand,
+		})
+	}, 30*time.Second, 2*time.Second)
+}
+
+func (s *baseProcmgrSuite) TestCLIDescribe() {
+	s.requireCLI()
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		out := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("describe test-sleep"))
+		assertField(t, out, "Name", "test-sleep")
+		assertField(t, out, "State", "Running")
+		assertField(t, out, "Command", s.platform.sleepCommand)
+	}, 30*time.Second, 2*time.Second)
+}
+
+func (s *baseProcmgrSuite) TestConditionPathExistsSkipsMissingBinary() {
+	s.requireCLI()
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		out := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("list"))
+		assertTableRow(t, out, "missing-binary", map[string]string{
+			"STATE": "Created",
+			"PID":   "-",
+		})
+	}, 30*time.Second, 2*time.Second)
+}
+
+// ---------------------------------------------------------------------------
+// CLI output parsing helpers
+// ---------------------------------------------------------------------------
+
+func fieldValue(output, label string) string {
+	needle := label + ":"
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, needle) {
+			return strings.TrimSpace(trimmed[len(needle):])
+		}
+	}
+	return ""
+}
+
+func assertField(t assert.TestingT, output, label, expected string) {
+	needle := label + ":"
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, needle) {
+			actual := strings.TrimSpace(trimmed[len(needle):])
+			assert.Equal(t, expected, actual, "field %q", label)
+			return
+		}
+	}
+	assert.Fail(t, fmt.Sprintf("field %q not found in output:\n%s", label, output))
+}
+
+func assertHasField(t assert.TestingT, output, label string) {
+	needle := label + ":"
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), needle) {
+			return
+		}
+	}
+	assert.Fail(t, fmt.Sprintf("field %q not found in output:\n%s", label, output))
+}
+
+func assertTableRow(t assert.TestingT, output, rowName string, expected map[string]string) {
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	if !assert.GreaterOrEqual(t, len(lines), 2, "list output should have header + at least one row") {
+		return
+	}
+	header := lines[0]
+	columns := parseTableColumns(header)
+
+	for _, line := range lines[1:] {
+		name := extractColumn(line, 0, columns)
+		if name != rowName {
+			continue
+		}
+		for col, want := range expected {
+			idx := -1
+			for i, c := range columns {
+				if c.name == col {
+					idx = i
+					break
+				}
+			}
+			if !assert.NotEqual(t, -1, idx, "column %q not in header: %s", col, header) {
+				continue
+			}
+			got := extractColumn(line, idx, columns)
+			assert.Equal(t, want, got, "row %q column %q", rowName, col)
+		}
+		return
+	}
+	assert.Fail(t, fmt.Sprintf("row %q not found in table output:\n%s", rowName, output))
+}
+
+type tableColumn struct {
+	name  string
+	start int
+}
+
+func parseTableColumns(header string) []tableColumn {
+	var cols []tableColumn
+	i := 0
+	for i < len(header) {
+		for i < len(header) && header[i] == ' ' {
+			i++
+		}
+		if i >= len(header) {
+			break
+		}
+		start := i
+		for i < len(header) {
+			if header[i] == ' ' {
+				j := i
+				for j < len(header) && header[j] == ' ' {
+					j++
+				}
+				if j >= len(header) || (j-i >= 2) {
+					break
+				}
+				i = j
+			} else {
+				i++
+			}
+		}
+		cols = append(cols, tableColumn{name: header[start:i], start: start})
+	}
+	return cols
+}
+
+func extractColumn(line string, idx int, columns []tableColumn) string {
+	if idx >= len(columns) {
+		return ""
+	}
+	start := columns[idx].start
+	end := len(line)
+	if idx+1 < len(columns) {
+		end = columns[idx+1].start
+	}
+	if start >= len(line) {
+		return ""
+	}
+	if end > len(line) {
+		end = len(line)
+	}
+	return strings.TrimSpace(line[start:end])
+}

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
@@ -20,19 +20,19 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
 	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
 )
 
 const (
-	procmgrdBin   = "/opt/datadog-agent/embedded/bin/dd-procmgrd"
-	procmgrCLI    = "/opt/datadog-agent/embedded/bin/dd-procmgr"
-	procmgrSocket = "/var/run/datadog-procmgrd/dd-procmgrd.sock"
+	linuxDaemonBin = "/opt/datadog-agent/embedded/bin/dd-procmgrd"
+	linuxCLIBin    = "/opt/datadog-agent/embedded/bin/dd-procmgr"
+	linuxSocket    = "/var/run/datadog-procmgrd/dd-procmgrd.sock"
+	linuxConfigDir = "/opt/datadog-agent/processes.d"
 
 	ddotPkgBinaryPath = "/opt/datadog-agent/embedded/bin/otel-agent"
 	ddotExtBinaryPath = "/opt/datadog-agent/ext/ddot/embedded/bin/otel-agent"
 
-	testProcessConfig = `command: /bin/sleep
+	linuxTestProcessConfig = `command: /bin/sleep
 args:
   - "3600"
 auto_start: true
@@ -40,7 +40,7 @@ restart: always
 description: E2E test process
 `
 
-	missingBinaryConfig = `command: /nonexistent/binary
+	linuxMissingBinaryConfig = `command: /nonexistent/binary
 condition_path_exists: /nonexistent/binary
 auto_start: true
 restart: never
@@ -48,21 +48,35 @@ description: should not start
 `
 )
 
+var linuxPlatform = platformConfig{
+	daemonBin:         linuxDaemonBin,
+	cliBin:            linuxCLIBin,
+	configDir:         linuxConfigDir,
+	sleepCommand:      "/bin/sleep",
+	testProcessYAML:   linuxTestProcessConfig,
+	missingBinaryYAML: linuxMissingBinaryConfig,
+	checkBinCmd:       func(path string) string { return "test -f " + path },
+	checkSvcRunning:   "systemctl is-active datadog-agent-procmgrd",
+	svcRunningOutput:  "active",
+	cliCmd:            func(args string) string { return linuxCLIBin + " " + args },
+}
+
 type procmgrLinuxSuite struct {
-	e2e.BaseSuite[environments.Host]
-	hasCLI  bool
+	baseProcmgrSuite
 	hasDDOT bool
 }
 
 func TestProcmgrSmokeLinuxSuite(t *testing.T) {
 	t.Parallel()
-	e2e.Run(t, &procmgrLinuxSuite{}, e2e.WithProvisioner(
+	s := &procmgrLinuxSuite{}
+	s.platform = linuxPlatform
+	e2e.Run(t, s, e2e.WithProvisioner(
 		awshost.ProvisionerNoFakeIntake(
 			awshost.WithRunOptions(
 				scenec2.WithAgentOptions(
-					agentparams.WithFile("/opt/datadog-agent/processes.d/test-sleep.yaml", testProcessConfig, true),
-					agentparams.WithFile("/opt/datadog-agent/processes.d/datadog-agent-ddot.yaml", embedded.DDOTProcessConfig, true),
-					agentparams.WithFile("/opt/datadog-agent/processes.d/missing-binary.yaml", missingBinaryConfig, true),
+					agentparams.WithFile(linuxConfigDir+"/test-sleep.yaml", linuxTestProcessConfig, true),
+					agentparams.WithFile(linuxConfigDir+"/datadog-agent-ddot.yaml", embedded.DDOTProcessConfig, true),
+					agentparams.WithFile(linuxConfigDir+"/missing-binary.yaml", linuxMissingBinaryConfig, true),
 				),
 			),
 		),
@@ -70,26 +84,22 @@ func TestProcmgrSmokeLinuxSuite(t *testing.T) {
 }
 
 func (s *procmgrLinuxSuite) SetupSuite() {
-	s.BaseSuite.SetupSuite()
+	s.baseProcmgrSuite.SetupSuite()
 	defer s.CleanupOnSetupFailure()
-
-	_, err := s.Env().RemoteHost.Execute("test -f " + procmgrdBin)
-	if err != nil {
-		s.T().Skip("dd-procmgrd not included in this agent package; skipping process manager tests")
-	}
-
-	_, err = s.Env().RemoteHost.Execute("test -f " + procmgrCLI)
-	s.hasCLI = err == nil
 
 	s.hasDDOT = s.installRealDDOT()
 
 	if s.hasCLI {
 		require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-			_, err := s.Env().RemoteHost.Execute("sudo chmod 0777 " + procmgrSocket)
+			_, err := s.Env().RemoteHost.Execute("sudo chmod 0777 " + linuxSocket)
 			assert.NoError(t, err, "socket not yet available")
 		}, 30*time.Second, 2*time.Second)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Linux-only: DDOT tests
+// ---------------------------------------------------------------------------
 
 func ddotPackageName() string {
 	if os.Getenv("E2E_FIPS") != "" {
@@ -101,12 +111,9 @@ func ddotPackageName() string {
 func (s *procmgrLinuxSuite) installRealDDOT() bool {
 	pkg := ddotPackageName()
 
-	// Refresh repos first — this must succeed; a transient failure here
-	// should not silently skip DDOT tests.
 	s.Env().RemoteHost.MustExecute(
 		"(sudo apt-get update -qq) || (sudo yum makecache -q)")
 
-	// Check whether the package exists in repos. Only skip when genuinely absent.
 	_, err := s.Env().RemoteHost.Execute(
 		"(apt-cache show " + pkg + " >/dev/null 2>&1) || " +
 			"(yum info " + pkg + " >/dev/null 2>&1)")
@@ -115,7 +122,6 @@ func (s *procmgrLinuxSuite) installRealDDOT() bool {
 		return false
 	}
 
-	// Package is available — install must succeed or the suite fails.
 	s.Env().RemoteHost.MustExecute(
 		"(sudo apt-get install -y " + pkg + ") || " +
 			"(sudo yum install -y " + pkg + ")")
@@ -135,63 +141,6 @@ func (s *procmgrLinuxSuite) installRealDDOT() bool {
 	s.Env().RemoteHost.MustExecute("sudo systemctl restart datadog-agent-procmgrd")
 
 	return true
-}
-
-func (s *procmgrLinuxSuite) TestBinariesExist() {
-	s.Env().RemoteHost.MustExecute("test -f " + procmgrdBin)
-
-	if !s.hasCLI {
-		s.T().Skip("dd-procmgr CLI not included in this agent package")
-	}
-	s.Env().RemoteHost.MustExecute("test -f " + procmgrCLI)
-}
-
-func (s *procmgrLinuxSuite) TestServiceRunning() {
-	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out := s.Env().RemoteHost.MustExecute("systemctl is-active datadog-agent-procmgrd")
-		assert.Equal(t, "active", strings.TrimSpace(out))
-	}, 30*time.Second, 2*time.Second)
-}
-
-func (s *procmgrLinuxSuite) TestCLIStatus() {
-	s.requireCLI()
-	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " status")
-		assertHasField(t, out, "Version")
-		assertHasField(t, out, "Uptime")
-	}, 30*time.Second, 2*time.Second)
-}
-
-func (s *procmgrLinuxSuite) TestCLIListShowsConfiguredProcess() {
-	s.requireCLI()
-	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " list")
-		assertTableRow(t, out, "test-sleep", map[string]string{
-			"STATE":   "Running",
-			"COMMAND": "/bin/sleep",
-		})
-	}, 30*time.Second, 2*time.Second)
-}
-
-func (s *procmgrLinuxSuite) TestCLIDescribe() {
-	s.requireCLI()
-	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " describe test-sleep")
-		assertField(t, out, "Name", "test-sleep")
-		assertField(t, out, "State", "Running")
-		assertField(t, out, "Command", "/bin/sleep")
-	}, 30*time.Second, 2*time.Second)
-}
-
-func (s *procmgrLinuxSuite) TestConditionPathExistsSkipsMissingBinary() {
-	s.requireCLI()
-	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " list")
-		assertTableRow(t, out, "missing-binary", map[string]string{
-			"STATE": "Created",
-			"PID":   "-",
-		})
-	}, 30*time.Second, 2*time.Second)
 }
 
 func (s *procmgrLinuxSuite) TestDDOTProcessRunning() {
@@ -215,7 +164,6 @@ func (s *procmgrLinuxSuite) TestDDOTRestartAfterKill() {
 
 	baselineRestarts := s.getRestartCount("datadog-agent-ddot")
 
-	// Kill the DDOT process. Since restart policy is on-failure, procmgrd should restart it.
 	s.Env().RemoteHost.MustExecute("sudo kill -9 " + originalPID)
 
 	newPID := s.waitForRunningProcess("datadog-agent-ddot", ddotExtBinaryPath, 30*time.Second)
@@ -229,7 +177,7 @@ func (s *procmgrLinuxSuite) TestDDOTRestartAfterKill() {
 func (s *procmgrLinuxSuite) TestDDOTProcessDescribe() {
 	s.requireDDOT()
 	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " describe datadog-agent-ddot")
+		out := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("describe datadog-agent-ddot"))
 		assertField(t, out, "Name", "datadog-agent-ddot")
 		assertField(t, out, "State", "Running")
 		assertField(t, out, "Command", ddotExtBinaryPath)
@@ -239,133 +187,15 @@ func (s *procmgrLinuxSuite) TestDDOTProcessDescribe() {
 	}, 60*time.Second, 2*time.Second)
 }
 
-func fieldValue(output, label string) string {
-	needle := label + ":"
-	for _, line := range strings.Split(output, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, needle) {
-			return strings.TrimSpace(trimmed[len(needle):])
-		}
-	}
-	return ""
-}
+// ---------------------------------------------------------------------------
+// Linux-only helpers
+// ---------------------------------------------------------------------------
 
-func assertField(t assert.TestingT, output, label, expected string) {
-	needle := label + ":"
-	for _, line := range strings.Split(output, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, needle) {
-			actual := strings.TrimSpace(trimmed[len(needle):])
-			assert.Equal(t, expected, actual, "field %q", label)
-			return
-		}
-	}
-	assert.Fail(t, fmt.Sprintf("field %q not found in output:\n%s", label, output))
-}
-
-func assertHasField(t assert.TestingT, output, label string) {
-	needle := label + ":"
-	for _, line := range strings.Split(output, "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), needle) {
-			return
-		}
-	}
-	assert.Fail(t, fmt.Sprintf("field %q not found in output:\n%s", label, output))
-}
-
-func assertTableRow(t assert.TestingT, output, rowName string, expected map[string]string) {
-	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
-	if !assert.GreaterOrEqual(t, len(lines), 2, "list output should have header + at least one row") {
-		return
-	}
-	header := lines[0]
-	columns := parseTableColumns(header)
-
-	for _, line := range lines[1:] {
-		name := extractColumn(line, 0, columns)
-		if name != rowName {
-			continue
-		}
-		for col, want := range expected {
-			idx := -1
-			for i, c := range columns {
-				if c.name == col {
-					idx = i
-					break
-				}
-			}
-			if !assert.NotEqual(t, -1, idx, "column %q not in header: %s", col, header) {
-				continue
-			}
-			got := extractColumn(line, idx, columns)
-			assert.Equal(t, want, got, "row %q column %q", rowName, col)
-		}
-		return
-	}
-	assert.Fail(t, fmt.Sprintf("row %q not found in table output:\n%s", rowName, output))
-}
-
-type tableColumn struct {
-	name  string
-	start int
-}
-
-func parseTableColumns(header string) []tableColumn {
-	var cols []tableColumn
-	i := 0
-	for i < len(header) {
-		for i < len(header) && header[i] == ' ' {
-			i++
-		}
-		if i >= len(header) {
-			break
-		}
-		start := i
-		for i < len(header) {
-			if header[i] == ' ' {
-				j := i
-				for j < len(header) && header[j] == ' ' {
-					j++
-				}
-				if j >= len(header) || (j-i >= 2) {
-					break
-				}
-				i = j
-			} else {
-				i++
-			}
-		}
-		cols = append(cols, tableColumn{name: header[start:i], start: start})
-	}
-	return cols
-}
-
-func extractColumn(line string, idx int, columns []tableColumn) string {
-	if idx >= len(columns) {
-		return ""
-	}
-	start := columns[idx].start
-	end := len(line)
-	if idx+1 < len(columns) {
-		end = columns[idx+1].start
-	}
-	if start >= len(line) {
-		return ""
-	}
-	if end > len(line) {
-		end = len(line)
-	}
-	return strings.TrimSpace(line[start:end])
-}
-
-// waitForRunningProcess waits until procmgrd reports the named process as
-// Running with a valid PID, verifies the PID is alive and points to the
-// expected binary, then returns the PID.
 func (s *procmgrLinuxSuite) waitForRunningProcess(name, expectedBinary string, timeout time.Duration) string {
 	s.T().Helper()
 	var pid string
 	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " describe " + name)
+		out := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("describe " + name))
 		assertField(t, out, "State", "Running")
 		p := fieldValue(out, "PID")
 		if !assert.NotEmpty(t, p, "PID should be present for a Running process") ||
@@ -380,7 +210,7 @@ func (s *procmgrLinuxSuite) waitForRunningProcess(name, expectedBinary string, t
 
 func (s *procmgrLinuxSuite) getRestartCount(name string) int {
 	s.T().Helper()
-	out := s.Env().RemoteHost.MustExecute(procmgrCLI + " describe " + name)
+	out := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("describe " + name))
 	count, err := strconv.Atoi(fieldValue(out, "Restarts"))
 	require.NoError(s.T(), err, "Restarts field for %s should be a number", name)
 	return count
@@ -393,13 +223,6 @@ func (s *procmgrLinuxSuite) assertProcessBinary(t assert.TestingT, pid, expected
 	}
 	assert.Equal(t, expectedBinary, strings.TrimSpace(out),
 		"process %s should be running %s", pid, expectedBinary)
-}
-
-func (s *procmgrLinuxSuite) requireCLI() {
-	s.T().Helper()
-	if !s.hasCLI {
-		s.T().Skip("dd-procmgr CLI not included in this agent package")
-	}
 }
 
 func (s *procmgrLinuxSuite) requireDDOT() {

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_win_test.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package procmgr
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+)
+
+const (
+	winDaemonBin = `C:\Program Files\Datadog\Datadog Agent\bin\agent\dd-procmgrd.exe`
+	winCLIBin    = `C:\Program Files\Datadog\Datadog Agent\bin\agent\dd-procmgr.exe`
+	winConfigDir = `C:/ProgramData/Datadog/dd-procmgr/processes.d`
+
+	winSleepCommand = `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`
+
+	winTestProcessConfig = `command: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+args:
+  - "-NoProfile"
+  - "-NonInteractive"
+  - "-Command"
+  - "Start-Sleep -Seconds 3600"
+env:
+  SystemRoot: C:\Windows
+  PATH: C:\Windows\System32;C:\Windows
+auto_start: true
+restart: always
+description: E2E test process
+`
+
+	winMissingBinaryConfig = `command: C:\nonexistent\binary.exe
+condition_path_exists: C:\nonexistent\binary.exe
+auto_start: true
+restart: never
+description: should not start
+`
+)
+
+var winPlatform = platformConfig{
+	daemonBin:         winDaemonBin,
+	cliBin:            winCLIBin,
+	configDir:         winConfigDir,
+	sleepCommand:      winSleepCommand,
+	testProcessYAML:   winTestProcessConfig,
+	missingBinaryYAML: winMissingBinaryConfig,
+	checkBinCmd: func(path string) string {
+		return fmt.Sprintf(`powershell -Command "if (Test-Path '%s') { exit 0 } else { exit 1 }"`, path)
+	},
+	checkSvcRunning:  `powershell -Command "(Get-Service dd-procmgr-service).Status"`,
+	svcRunningOutput: "Running",
+	cliCmd: func(args string) string {
+		return fmt.Sprintf(`& "%s" %s`, winCLIBin, args)
+	},
+}
+
+type procmgrWindowsSuite struct {
+	baseProcmgrSuite
+}
+
+func TestProcmgrSmokeWindowsSuite(t *testing.T) {
+	t.Parallel()
+	s := &procmgrWindowsSuite{}
+	s.platform = winPlatform
+	e2e.Run(t, s, e2e.WithProvisioner(
+		awshost.ProvisionerNoFakeIntake(
+			awshost.WithRunOptions(
+				ec2.WithEC2InstanceOptions(ec2.WithOS(e2eos.WindowsServerDefault)),
+				ec2.WithAgentOptions(
+					agentparams.WithFile(winConfigDir+"/test-sleep.yaml", winTestProcessConfig, true),
+					agentparams.WithFile(winConfigDir+"/missing-binary.yaml", winMissingBinaryConfig, true),
+				),
+			),
+		),
+	))
+}
+
+func (s *procmgrWindowsSuite) SetupSuite() {
+	s.baseProcmgrSuite.SetupSuite()
+	defer s.CleanupOnSetupFailure()
+
+	// dd-procmgr-service is DEMAND_START; the agent starts it as a dependent
+	// service, but on a fresh install the timing is unpredictable. Ensure the
+	// service is running before the tests begin.
+	s.Env().RemoteHost.MustExecute(`powershell -Command "Start-Service dd-procmgr-service"`)
+
+	if s.hasCLI {
+		require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+			out, err := s.Env().RemoteHost.Execute(
+				`powershell -Command "(Get-Service dd-procmgr-service).Status"`)
+			assert.NoError(t, err)
+			assert.Equal(t, "Running", strings.TrimSpace(out))
+		}, 60*time.Second, 2*time.Second)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Extracts shared procmgr E2E test logic into a `baseProcmgrSuite` with a `platformConfig` abstraction, so the same 6 smoke tests (`TestBinariesExist`, `TestServiceRunning`, `TestCLIStatus`, `TestCLIListShowsConfiguredProcess`, `TestCLIDescribe`, `TestConditionPathExistsSkipsMissingBinary`) run on both Linux and Windows without code duplication.

Adds `procmgr_win_test.go` with a Windows-specific provisioner (`WindowsServerDefault` EC2) and PowerShell-based service/binary checks.

Adds `test/new-e2e/tests/agent-runtimes/**/*` to the `windows_path_3` change-detection list in `.gitlab-ci.yml` so that changes to agent-runtimes E2E tests trigger the Windows CI pipeline (MSI build + Windows E2E jobs).

### Motivation

`dd-procmgrd` was integrated into the Windows MSI installer (S23) but had no E2E test coverage for the Windows platform. The existing Linux procmgr E2E tests validated the CLI and service behavior but were not reusable across platforms. This PR closes that gap by making the tests cross-platform and ensuring the Windows E2E pipeline is triggered when agent-runtimes tests change.

### Describe how you validated your changes

- `go vet ./test/new-e2e/tests/agent-runtimes/procmgr/...` passes
- All pre-commit hooks pass (go-fmt, copyright, update-go, etc.)
- Manual verification on a Windows EC2 VM (S23 CI build) confirmed `dd-procmgrd` installs, starts via SCM, responds to CLI commands, and logs to `C:\ProgramData\Datadog\logs\dd-procmgr.log`
- Linux procmgr E2E suite passes in CI
- Windows procmgr E2E suite passes in CI

### Additional Notes