### PR TITLE
telemetry(installer): instrument OCI download and per-layer extract

### DIFF
--- a/pkg/fleet/installer/bootstrap/bootstrap_nix.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_nix.go
@@ -60,7 +60,7 @@ func downloadInstaller(ctx context.Context, env *env.Env, url string, tmpDir str
 	}
 
 	installerBinPath := filepath.Join(tmpDir, "installer")
-	err = downloadedPackage.ExtractLayers(oci.DatadogPackageInstallerLayerMediaType, installerBinPath) // Returns nil if the layer doesn't exist
+	err = downloadedPackage.ExtractLayers(ctx, oci.DatadogPackageInstallerLayerMediaType, installerBinPath) // Returns nil if the layer doesn't exist
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract layers: %w", err)
 	}

--- a/pkg/fleet/installer/bootstrap/bootstrap_windows.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_windows.go
@@ -81,7 +81,7 @@ func downloadInstaller(ctx context.Context, env *env.Env, url string, tmpDir str
 
 	// Production flow: try OCI layer, fallback to MSI extraction for older packages
 	installerBinPath := filepath.Join(tmpDir, "datadog-installer.exe")
-	err = downloadedPackage.ExtractLayers(oci.DatadogPackageInstallerLayerMediaType, installerBinPath) // Returns nil if the layer doesn't exist
+	err = downloadedPackage.ExtractLayers(ctx, oci.DatadogPackageInstallerLayerMediaType, installerBinPath) // Returns nil if the layer doesn't exist
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract layers: %w", err)
 	}
@@ -100,7 +100,7 @@ func downloadInstallerTestMode(ctx context.Context, env *env.Env, pkg *oci.Downl
 	case "OCI":
 		// Force OCI path - fail if installer layer is missing
 		installerBinPath := filepath.Join(tmpDir, "datadog-installer.exe")
-		err := pkg.ExtractLayers(oci.DatadogPackageInstallerLayerMediaType, installerBinPath)
+		err := pkg.ExtractLayers(ctx, oci.DatadogPackageInstallerLayerMediaType, installerBinPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract installer layer: %w", err)
 		}
@@ -163,7 +163,7 @@ func downloadInstallerOld(ctx context.Context, env *env.Env, url string, tmpDir 
 		return nil, fmt.Errorf("failed to write OCI layout: %w", err)
 	}
 
-	err = downloadedPackage.ExtractLayers(oci.DatadogPackageLayerMediaType, tmpDir)
+	err = downloadedPackage.ExtractLayers(ctx, oci.DatadogPackageLayerMediaType, tmpDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract layers: %w", err)
 	}

--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -341,11 +341,11 @@ func (i *installerImpl) doInstall(ctx context.Context, url string, args []string
 		return fmt.Errorf("could not remove package installation in db: %w", err)
 	}
 	configDir := filepath.Join(i.userConfigsDir, "datadog-agent")
-	err = pkg.ExtractLayers(oci.DatadogPackageLayerMediaType, tmpDir)
+	err = pkg.ExtractLayers(ctx, oci.DatadogPackageLayerMediaType, tmpDir)
 	if err != nil {
 		return fmt.Errorf("could not extract package layers: %w", err)
 	}
-	err = pkg.ExtractLayers(oci.DatadogPackageConfigLayerMediaType, configDir)
+	err = pkg.ExtractLayers(ctx, oci.DatadogPackageConfigLayerMediaType, configDir)
 	if err != nil {
 		return fmt.Errorf("could not extract package config layer: %w", err)
 	}
@@ -399,14 +399,14 @@ func (i *installerImpl) InstallExperiment(ctx context.Context, url string) error
 	}
 	defer os.RemoveAll(tmpDir)
 	configDir := filepath.Join(i.userConfigsDir, "datadog-agent")
-	err = pkg.ExtractLayers(oci.DatadogPackageLayerMediaType, tmpDir)
+	err = pkg.ExtractLayers(ctx, oci.DatadogPackageLayerMediaType, tmpDir)
 	if err != nil {
 		return installerErrors.Wrap(
 			installerErrors.ErrDownloadFailed,
 			fmt.Errorf("could not extract package layer: %w", err),
 		)
 	}
-	err = pkg.ExtractLayers(oci.DatadogPackageConfigLayerMediaType, configDir)
+	err = pkg.ExtractLayers(ctx, oci.DatadogPackageConfigLayerMediaType, configDir)
 	if err != nil {
 		return installerErrors.Wrap(
 			installerErrors.ErrDownloadFailed,

--- a/pkg/fleet/installer/oci/download.go
+++ b/pkg/fleet/installer/oci/download.go
@@ -138,12 +138,17 @@ func (d *Downloader) WithRegistryOverride(url, auth, username, password string) 
 }
 
 // Download downloads the Datadog Package referenced in the given Package struct.
-func (d *Downloader) Download(ctx context.Context, packageURL string) (*DownloadedPackage, error) {
+func (d *Downloader) Download(ctx context.Context, packageURL string) (_ *DownloadedPackage, err error) {
+	span, ctx := telemetry.StartSpanFromContext(ctx, "oci.download")
+	defer func() { span.Finish(err) }()
+	span.SetTag("package.url", packageURL)
+
 	log.Debugf("Downloading package from %s", packageURL)
 	url, err := url.Parse(packageURL)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse package URL: %w", err)
 	}
+	span.SetTag("url.scheme", url.Scheme)
 	var image oci.Image
 	switch url.Scheme {
 	case "oci":
@@ -176,6 +181,9 @@ func (d *Downloader) Download(ctx context.Context, packageURL string) (*Download
 			return nil, fmt.Errorf("could not parse package size: %w", err)
 		}
 	}
+	span.SetTag("package.name", name)
+	span.SetTag("package.version", version)
+	span.SetTag("package.size", size)
 	log.Debugf("Successfully downloaded package from %s", packageURL)
 	return &DownloadedPackage{
 		Image:   image,
@@ -351,7 +359,13 @@ func (d *Downloader) downloadIndex(index oci.ImageIndex) (oci.Image, error) {
 }
 
 // ExtractLayers extracts the layers of the downloaded package with the given media type to the given directory.
-func (d *DownloadedPackage) ExtractLayers(mediaType types.MediaType, dir string, annotationFilters ...LayerAnnotation) error {
+func (d *DownloadedPackage) ExtractLayers(ctx context.Context, mediaType types.MediaType, dir string, annotationFilters ...LayerAnnotation) (err error) {
+	span, ctx := telemetry.StartSpanFromContext(ctx, "oci.extract_layers")
+	defer func() { span.Finish(err) }()
+	span.SetTag("package.name", d.Name)
+	span.SetTag("package.version", d.Version)
+	span.SetTag("media_type", string(mediaType))
+
 	manifest, err := d.Image.Manifest()
 	if err != nil {
 		return fmt.Errorf("could not get image manifest: %w", err)
@@ -378,45 +392,59 @@ func (d *DownloadedPackage) ExtractLayers(mediaType types.MediaType, dir string,
 		if err != nil {
 			return fmt.Errorf("could not get layer: %w", err)
 		}
-		err = withNetworkRetries(
-			func() error {
-				var err error
-				defer func() {
-					if err != nil {
-						deferErr := tar.Clean(dir)
-						if deferErr != nil {
-							err = deferErr
-						}
-					}
-				}()
-				uncompressedLayer, err := layer.Uncompressed()
-				if err != nil {
-					return err
-				}
-
-				switch layerManifest.MediaType {
-				case DatadogPackageLayerMediaType, DatadogPackageConfigLayerMediaType, DatadogPackageExtensionLayerMediaType:
-					err = tar.Extract(uncompressedLayer, dir, layerMaxSize)
-				case DatadogPackageInstallerLayerMediaType:
-					err = writeBinary(uncompressedLayer, dir)
-				default:
-					return fmt.Errorf("unsupported layer media type: %s", layerManifest.MediaType)
-				}
-				uncompressedLayer.Close()
-				if err != nil {
-					return err
-				}
-				return nil
-			},
-		)
+		err = d.extractLayer(ctx, layer, layerManifest, dir)
 		if err != nil {
 			return fmt.Errorf("could not extract layer: %w", err)
 		}
 	}
+	span.SetTag("layers.matched", matchesAnnotationsCount)
 	if matchesAnnotationsCount == 0 && len(annotationFilters) > 0 {
 		return ErrNoLayerMatchesAnnotations
 	}
 	return nil
+}
+
+// extractLayer downloads + decompresses + extracts a single layer to the given
+// directory. A per-layer child span records compressed size and digest so the
+// dominant cost (network transfer vs tar extraction) can be isolated in APM.
+func (d *DownloadedPackage) extractLayer(ctx context.Context, layer oci.Layer, layerManifest oci.Descriptor, dir string) (err error) {
+	span, _ := telemetry.StartSpanFromContext(ctx, "oci.extract_layer")
+	defer func() { span.Finish(err) }()
+	span.SetTag("layer.digest", layerManifest.Digest.String())
+	span.SetTag("layer.media_type", string(layerManifest.MediaType))
+	span.SetTag("layer.size", layerManifest.Size)
+
+	return withNetworkRetries(
+		func() error {
+			var err error
+			defer func() {
+				if err != nil {
+					deferErr := tar.Clean(dir)
+					if deferErr != nil {
+						err = deferErr
+					}
+				}
+			}()
+			uncompressedLayer, err := layer.Uncompressed()
+			if err != nil {
+				return err
+			}
+
+			switch layerManifest.MediaType {
+			case DatadogPackageLayerMediaType, DatadogPackageConfigLayerMediaType, DatadogPackageExtensionLayerMediaType:
+				err = tar.Extract(uncompressedLayer, dir, layerMaxSize)
+			case DatadogPackageInstallerLayerMediaType:
+				err = writeBinary(uncompressedLayer, dir)
+			default:
+				return fmt.Errorf("unsupported layer media type: %s", layerManifest.MediaType)
+			}
+			uncompressedLayer.Close()
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	)
 }
 
 // WriteOCILayout writes the image as an OCI layout to the given directory.

--- a/pkg/fleet/installer/oci/download_test.go
+++ b/pkg/fleet/installer/oci/download_test.go
@@ -69,7 +69,7 @@ func TestDownload(t *testing.T) {
 	assert.Equal(t, fixtures.FixtureSimpleV1.Version, downloadedPackage.Version)
 	assert.NotZero(t, downloadedPackage.Size)
 	tmpDir := t.TempDir()
-	err = downloadedPackage.ExtractLayers(DatadogPackageLayerMediaType, tmpDir)
+	err = downloadedPackage.ExtractLayers(context.Background(), DatadogPackageLayerMediaType, tmpDir)
 	assert.NoError(t, err)
 	fixtures.AssertEqualFS(t, s.PackageFS(fixtures.FixtureSimpleV1), os.DirFS(tmpDir))
 }
@@ -85,7 +85,7 @@ func TestDownloadMirror(t *testing.T) {
 	assert.Equal(t, fixtures.FixtureSimpleV1.Version, downloadedPackage.Version)
 	assert.NotZero(t, downloadedPackage.Size)
 	tmpDir := t.TempDir()
-	err = downloadedPackage.ExtractLayers(DatadogPackageLayerMediaType, tmpDir)
+	err = downloadedPackage.ExtractLayers(context.Background(), DatadogPackageLayerMediaType, tmpDir)
 	assert.NoError(t, err)
 	fixtures.AssertEqualFS(t, s.PackageFS(fixtures.FixtureSimpleV1), os.DirFS(tmpDir))
 }
@@ -100,7 +100,7 @@ func TestDownloadLayout(t *testing.T) {
 	assert.Equal(t, fixtures.FixtureSimpleV1.Version, downloadedPackage.Version)
 	assert.NotZero(t, downloadedPackage.Size)
 	tmpDir := t.TempDir()
-	err = downloadedPackage.ExtractLayers(DatadogPackageLayerMediaType, tmpDir)
+	err = downloadedPackage.ExtractLayers(context.Background(), DatadogPackageLayerMediaType, tmpDir)
 	assert.NoError(t, err)
 	fixtures.AssertEqualFS(t, s.PackageFS(fixtures.FixtureSimpleV1), os.DirFS(tmpDir))
 }
@@ -115,7 +115,7 @@ func TestDownloadConfigLayer(t *testing.T) {
 	assert.Equal(t, fixtures.FixtureSimpleV1.Version, downloadedPackage.Version)
 	assert.NotZero(t, downloadedPackage.Size)
 	tmpDir := t.TempDir()
-	err = downloadedPackage.ExtractLayers(DatadogPackageExtensionLayerMediaType, tmpDir, LayerAnnotation{Key: "com.datadoghq.package.extension.name", Value: "simple-extension"})
+	err = downloadedPackage.ExtractLayers(context.Background(), DatadogPackageExtensionLayerMediaType, tmpDir, LayerAnnotation{Key: "com.datadoghq.package.extension.name", Value: "simple-extension"})
 	assert.NoError(t, err)
 
 	extensionsFS := s.ExtensionsFS(fixtures.FixtureSimpleV1WithExtension)

--- a/pkg/fleet/installer/packages/extensions/extensions.go
+++ b/pkg/fleet/installer/packages/extensions/extensions.go
@@ -221,7 +221,7 @@ func installSingle(ctx context.Context, pkg *oci.DownloadedPackage, extension st
 	}
 	defer os.RemoveAll(tmpDir)
 
-	err = pkg.ExtractLayers(oci.DatadogPackageExtensionLayerMediaType, tmpDir, oci.LayerAnnotation{Key: "com.datadoghq.package.extension.name", Value: extension})
+	err = pkg.ExtractLayers(ctx, oci.DatadogPackageExtensionLayerMediaType, tmpDir, oci.LayerAnnotation{Key: "com.datadoghq.package.extension.name", Value: extension})
 	if err != nil {
 		if errors.Is(err, oci.ErrNoLayerMatchesAnnotations) {
 			// The extension is not available in the package, skip it.


### PR DESCRIPTION
### What does this PR do?

Adds APM spans around `oci.Downloader.Download` and `oci.DownloadedPackage.ExtractLayers` in `pkg/fleet/installer/oci/download.go`. `ExtractLayers` also emits a child span per layer so the compressed layer size and digest are visible.

### Motivation

Today the installer daemon emits spans for its post-install scriptlets and hook execution (`postinst`, `restore_custom_integrations`, `installer.hooks`, `promote_experiment`, …) — typically 5–10 s of work per install. Measured per-test install on fleet E2E on main is 16–44 s on Linux and noticeably longer on Windows, so **10–35 s per install is uninstrumented**. Reading the code, that unmeasured time is spent in `Downloader.Download` (OCI manifest fetch) and `DownloadedPackage.ExtractLayers` (blob pull + tar extract for a ~100–500 MB agent package).

With one run after merging, we'll be able to see in APM:
- how long the OCI blob download actually takes,
- how long tar/zstd extraction takes,
- and whether the agent layer or a config/extension layer is the bottleneck.

That data decides whether a registry proxy / on-VM OCI cache is worth building to shorten fleet E2E jobs (fleet-upgrade is currently ~50 min, Windows-bound; install is estimated to be 40–50 % of the critical path).

### Describe how you validated your changes

- `go build ./pkg/fleet/installer/...` + `go vet ./pkg/fleet/installer/...` clean.
- `go test ./pkg/fleet/installer/oci/...` passes.
- Pre-push hooks (go-mod-tidy, go-mod-replace, go-test, go-linter) pass.

### Possible Drawbacks / Trade-offs

- `ExtractLayers` now takes a `context.Context` as its first argument. All non-test call sites in the repo are updated (`bootstrap_nix.go`, `bootstrap_windows.go`, `installer.go`, `packages/extensions/extensions.go`). This is an internal API of `pkg/fleet/installer/oci`; no external dependents.
- Two extra spans per extracted layer. Sampling is unchanged (existing installer telemetry sampling).

### Additional Notes

Spans added:
| Span | Tags |
|---|---|
| `oci.download` | `package.url`, `url.scheme`, `package.name`, `package.version`, `package.size` |
| `oci.extract_layers` | `package.name`, `package.version`, `media_type`, `layers.matched` |
| `oci.extract_layer` (child) | `layer.digest`, `layer.media_type`, `layer.size` |