### PR TITLE
chore(renovate): restrict auto-runs to non-office hours

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:recommended", ":enablePreCommit"],
+    "extends": ["config:recommended", ":enablePreCommit", "schedule:nonOfficeHours"],
     "constraints": {
       "go": "1.25.9"
     },


### PR DESCRIPTION
### What does this PR do?
Adds the `schedule:nonOfficeHours` preset to the root `extends` array of `renovate.json`. The preset evaluates to:

- weekdays: before 5 AM and after 10 PM
- all of saturday and sunday

Per-package schedules already defined in `packageRules` (linux-images, windows-images, integrations-core, datadog-agent-dev) are not touched — they remain the authoritative filter for their respective deps.

### Motivation
Renovate currently opens, rebases, and closes dependency PRs at unpredictable times throughout the day, adding reviewer interruption during working hours. Constraining Renovate's update/branch activity to nights and weekends pushes that churn outside business hours.

**Scope clarification (after Codex review):** this preset only filters *what Renovate does once a run is already in progress* — it does **not** reduce how often Mend-hosted Renovate is invoked. Mend's scan cadence is platform-side and cannot be changed from `renovate.json` (see https://docs.renovatebot.com/key-concepts/scheduling/#default-behavior). So the *only* concrete effect of this PR is reducing mid-workday PR noise. Queue/rerun-latency complaints have to be handled at the Mend platform level, not here.

### Describe how you validated your changes
- `schedule:nonOfficeHours` is a Renovate built-in preset: https://docs.renovatebot.com/presets-schedule/#schedulenonofficehours — no custom regex to get wrong.
- No existing per-package `schedule` entries use office hours, so none are conflicted.
- Inspected the current Renovate job log (`2026-04-24T09:06Z`) to confirm there is no root `schedule` today.

No code change, no user-visible behavior change beyond *when* Renovate PRs appear.

### Additional Notes
- Companion to #48119 (silencing the bundler `git-refs` registry warning) — same review cycle but independent concerns.