### PR TITLE
build(bazel): update remote cache endpoint to local cluster edge cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,16 +40,19 @@ common:lint --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=
 
 # Linux config ---------------------------------------------------------------------------------------------------------
 common:linux --credential_helper=*.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper
+common:linux --credential_helper=buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog=%workspace%/bazel/tools/credential-helper
 common:linux --strategy=sandboxed
 
 # macOS config ---------------------------------------------------------------------------------------------------------
 common:macos --credential_helper=*.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper
+common:macos --credential_helper=buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog=%workspace%/bazel/tools/credential-helper
 common:macos --features=-macos_default_link_flags # https://github.com/bazelbuild/bazel/issues/23312
 common:macos --macos_minimum_os=12.0 # Keep in sync with https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
 common:macos --strategy=sandboxed
 
 # Windows config -------------------------------------------------------------------------------------------------------
 common:windows --credential_helper=*.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper.bat
+common:windows --credential_helper=buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog=%workspace%/bazel/tools/credential-helper.bat
 common:windows --strategy=standalone # Valid values are: [dynamic_worker, standalone, dynamic, remote, worker, local]
 # rules_python 1.9.0 transitions enable_runfiles to `true` for every py_ target on Windows. Pre-setting it here makes
 # that transition a no-op, so Bazel deduplicates python_win and avoids 2 concurrent MSBuild racing on shared resources.

--- a/.bazelrc
+++ b/.bazelrc
@@ -68,7 +68,7 @@ common:windows --extra_toolchains=@rust_toolchains//:rw-2070622084
 # Remote cache config --------------------------------------------------------------------------------------------------
 # datadog-agent virtually isolates caching instance from its parent (which is remote-caching).
 # If entry isn't found in datadog-agent, it will be searched in remote-caching.
-common:cache --remote_cache=grpcs://buildbarn-frontend.us1.ddbuild.io:443
+common:cache --remote_cache=grpc://buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog:443
 common:cache --remote_instance_name=ci/datadog-agent
 common:cache --remote_local_fallback # best-effort on transient connection errors (no such host)
 common:cache --incompatible_remote_local_fallback_for_remote_cache # works only if --remote_local_fallback is also set

--- a/.bazelrc
+++ b/.bazelrc
@@ -39,19 +39,16 @@ common:lint --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect --output_gro
 common:lint --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=+rustfmt_checks
 
 # Linux config ---------------------------------------------------------------------------------------------------------
-common:linux --credential_helper=*.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper
 common:linux --credential_helper=buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog=%workspace%/bazel/tools/credential-helper
 common:linux --strategy=sandboxed
 
 # macOS config ---------------------------------------------------------------------------------------------------------
-common:macos --credential_helper=*.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper
 common:macos --credential_helper=buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog=%workspace%/bazel/tools/credential-helper
 common:macos --features=-macos_default_link_flags # https://github.com/bazelbuild/bazel/issues/23312
 common:macos --macos_minimum_os=12.0 # Keep in sync with https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
 common:macos --strategy=sandboxed
 
 # Windows config -------------------------------------------------------------------------------------------------------
-common:windows --credential_helper=*.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper.bat
 common:windows --credential_helper=buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog=%workspace%/bazel/tools/credential-helper.bat
 common:windows --strategy=standalone # Valid values are: [dynamic_worker, standalone, dynamic, remote, worker, local]
 # rules_python 1.9.0 transitions enable_runfiles to `true` for every py_ target on Windows. Pre-setting it here makes


### PR DESCRIPTION
## Summary

- Updates `.bazelrc` remote cache URL from `grpcs://buildbarn-frontend.us1.ddbuild.io:443` to `grpc://buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog:443`
- Switches to a local cluster edge cache for improved cache proximity

## Test plan

- [ ] Verify Bazel builds succeed with the new cache endpoint
- [ ] Confirm cache hits are working as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)