### PR TITLE
CONTINT-4838 - increase test timeout for autoscalerController

### DIFF
--- a/pkg/util/kubernetes/apiserver/controllers/hpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/controllers/hpa_controller_test.go
@@ -336,7 +336,7 @@ func TestAutoscalerController(t *testing.T) {
 
 	timeoutDuration := 5 * time.Second
 	retryPeriod := 500 * time.Millisecond
-	timeout := time.NewTimer(10 * time.Second)
+	timeout := time.NewTimer(20 * time.Second)
 	defer timeout.Stop()
 
 	select {


### PR DESCRIPTION
The test `pkg/util/kubernetes/apiserver/controllers.TestAutoscalerController` is flaky, on very few occasions it takes 2 tries to complete.

1. try timeous out on the 10s timeout
2. try succeeds in a few ms.

Increase that timeout to a larger value if it fails now... it's real problem.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
