### PR TITLE
Run `datadog-agent status` via sudo in macOS install E2E

### DIFF
--- a/test/new-e2e/tests/agent-platform/tests/macos_install_test.go
+++ b/test/new-e2e/tests/agent-platform/tests/macos_install_test.go
@@ -48,7 +48,7 @@ func (m *macosInstallSuite) TestInstallAgent() {
 
 	// The agent should start at some point
 	m.EventuallyWithT(func(c *assert.CollectT) {
-		_, err := macosTestClient.Execute("/usr/local/bin/datadog-agent status")
+		_, err := macosTestClient.Execute("sudo /usr/local/bin/datadog-agent status")
 		assert.NoError(c, err)
 	}, 20*time.Second, 1*time.Second)
 


### PR DESCRIPTION
### What does this PR do?

Prefixes the `datadog-agent status` call in `TestMacosInstallScript/TestInstallAgent` with `sudo`, mirroring the Linux equivalent in `test/new-e2e/tests/agent-platform/common/agent_install.go`.

### Motivation

After #47801 switched macOS to a system-wide install running as `_dd-agent`, `/opt/datadog-agent/etc/auth_token` is created by the agent at runtime and owned by `_dd-agent:_dd-agent` with mode `0600` (the default from `os.CreateTemp` + the `Chown` in `pkg/util/filesystem.(*Permission).RestrictAccessToUser`). The E2E runs `datadog-agent status` over SSH as `ec2-user`, which cannot read that file, so the test fails with:

```
Error: unable to read artifact: open /opt/datadog-agent/etc/auth_token: permission denied
: Process exited with status 255
```

(example failure: [job 1626945019](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1626945019))

The Linux E2E already addresses this by invoking status through sudo (`common/agent_install.go:55`). This PR does the same for macOS.

### Additional context

This failure mode was previously masked because the published 1.6.0 install script at `install.datadoghq.com` couldn't install the current 7.79+ DMGs, so the test failed before ever reaching the status check. #49732 switched the E2E to the pipeline-built 2.0.0 script, which installs successfully — so the test now gets far enough to hit this issue.

### Describe how you validated your changes

- Confirmed with the Linux test that `sudo /usr/local/bin/datadog-agent status` is the intended invocation pattern for agent-platform install tests.
- Confirmed `ec2-user` on the macOS AMI has passwordless sudo (the next assertion in the same test, `sudo find /opt/datadog-agent …`, already runs successfully in the failing job).
- The E2E `new-e2e-install-script-agent7-deploy-macos` job will exercise this on the deploy pipeline once this merges.