### PR TITLE
Have one and only one \n character at the end of the system-probe.yaml 

### DIFF
--- a/pkg/config/render_config/render_config.go
+++ b/pkg/config/render_config/render_config.go
@@ -113,20 +113,17 @@ func mkContext(buildType string, osName string) context {
 }
 
 func render(destFile string, tplFile string, component string, osName string) {
-	f, err := os.Create(destFile)
-	if err != nil {
-		panic(err)
-	}
-
 	tplFilename := filepath.Base(tplFile)
 
 	t := template.Must(template.New(tplFilename).ParseFiles(tplFile))
-	err = t.Execute(f, mkContext(component, osName))
-	if err != nil {
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, mkContext(component, osName)); err != nil {
 		panic(err)
 	}
 
-	if err := f.Close(); err != nil {
+	rendered := append(bytes.TrimRight(buf.Bytes(), "\n\r \t"), '\n')
+
+	if err := os.WriteFile(destFile, rendered, 0644); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/config/system-probe_template.yaml
+++ b/pkg/config/system-probe_template.yaml
@@ -236,9 +236,7 @@
 #     # Set to true to activate the CWS network detections.
 #
 #     enabled: true
-
-{{- if (eq .OS "windows") }}
-
+{{ if (eq .OS "windows") }}
 ##################################################
 ## Datadog Agent Windows Crash Detection module ##
 ##################################################

--- a/pkg/config/system-probe_template.yaml
+++ b/pkg/config/system-probe_template.yaml
@@ -236,7 +236,9 @@
 #     # Set to true to activate the CWS network detections.
 #
 #     enabled: true
-{{ if (eq .OS "windows") }}
+
+{{- if (eq .OS "windows") }}
+
 ##################################################
 ## Datadog Agent Windows Crash Detection module ##
 ##################################################

--- a/tasks/schema/template.py
+++ b/tasks/schema/template.py
@@ -413,7 +413,7 @@ def generate_template(schema_file, dest, build_type, os_target):
 
     final_render = [line.strip() for line in config_template.strip().split("\n")]
     with open(dest, "w") as f:
-        f.write("\n".join(final_render))
+        f.write("\n".join(final_render) + "\n")
 
 
 @task(


### PR DESCRIPTION
Recent change corrected the missing tailing \n in the system-probe.yaml and another removed it by mistake.

This missing \n shouldn't have execution impact since it doesn't prevent the yaml parsing.

However, this caused the agent_linux_install_script’s unit test to fail, as the script checks for the configuration by ensuring it is POSIX-compliant which expect a tailing \n