### PR TITLE
feat: [SVLS-8975] restore deprecated config for serverless-init

### DIFF
--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"strings"
 	"sync"
@@ -56,6 +57,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/otlp"
 	serverlessTag "github.com/DataDog/datadog-agent/pkg/serverless/tags"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace"
+	traceconfig "github.com/DataDog/datadog-agent/pkg/trace/config"
 	tracelog "github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -261,6 +263,44 @@ var serverlessProfileTags = []string{
 	"_dd.origin",
 }
 
+// spanDerivedPrimaryTagsEnvVar is the environment variable consumed by
+// spanDerivedPrimaryTagsLoader below. See the type's doc comment for details.
+const spanDerivedPrimaryTagsEnvVar = "DD_APM_SPAN_DERIVED_PRIMARY_TAGS"
+
+// spanDerivedPrimaryTagsLoader wraps an inner trace.Load to layer the
+// DD_APM_SPAN_DERIVED_PRIMARY_TAGS env var onto AgentConfig.SpanDerivedPrimaryTagKeys.
+//
+// Deprecated: the agent-computed span_derived_primary_tags path is being
+// replaced by tracer-populated additional_metric_tags. This wrapper exists
+// solely to unblock serverless-init customers mid-transition and must be
+// removed once tracers emit additional_metric_tags. Do not generalize or
+// extend; do not reintroduce a customer-facing config key.
+type spanDerivedPrimaryTagsLoader struct {
+	inner trace.Load
+}
+
+// Load delegates to the inner loader, then parses DD_APM_SPAN_DERIVED_PRIMARY_TAGS
+// as a JSON array of strings and assigns it to AgentConfig.SpanDerivedPrimaryTagKeys.
+// Unset/empty env → no change. Invalid JSON → warn and continue.
+func (l *spanDerivedPrimaryTagsLoader) Load() (*traceconfig.AgentConfig, error) {
+	tc, err := l.inner.Load()
+	if err != nil {
+		return tc, err
+	}
+	raw := os.Getenv(spanDerivedPrimaryTagsEnvVar)
+	if raw == "" {
+		return tc, nil
+	}
+	var keys []string
+	if jsonErr := json.Unmarshal([]byte(raw), &keys); jsonErr != nil {
+		log.Warnf("%s could not be parsed as a JSON array of strings: %v", spanDerivedPrimaryTagsEnvVar, jsonErr)
+		return tc, nil
+	}
+	tc.SpanDerivedPrimaryTagKeys = keys
+	log.Debugf("%s set to %v; this is a deprecated serverless-init-only escape hatch and will be removed once tracers populate additional_metric_tags", spanDerivedPrimaryTagsEnvVar, keys)
+	return tc, nil
+}
+
 func setupTraceAgent(tags map[string]string, configuredTags []string, tagger tagger.Component, origin string) trace.ServerlessTraceAgent {
 	profileTags := make(map[string]string)
 	for _, serverlessProfileTag := range serverlessProfileTags {
@@ -282,7 +322,7 @@ func setupTraceAgent(tags map[string]string, configuredTags []string, tagger tag
 	functionTags := strings.Join(configuredTags, ",")
 	traceAgent := trace.StartServerlessTraceAgent(trace.StartServerlessTraceAgentArgs{
 		Enabled:               pkgconfigsetup.Datadog().GetBool("apm_config.enabled"),
-		LoadConfig:            &trace.LoadConfig{Path: datadogConfigPath, Tagger: tagger},
+		LoadConfig:            &spanDerivedPrimaryTagsLoader{inner: &trace.LoadConfig{Path: datadogConfigPath, Tagger: tagger}},
 		AdditionalProfileTags: profileTags,
 		FunctionTags:          functionTags,
 	})

--- a/cmd/serverless-init/span_derived_primary_tags_loader_test.go
+++ b/cmd/serverless-init/span_derived_primary_tags_loader_test.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	traceconfig "github.com/DataDog/datadog-agent/pkg/trace/config"
+)
+
+// fakeInnerLoad is a trace.Load stub that returns a caller-supplied
+// AgentConfig/error pair. It lets the wrapper tests exercise Load without
+// touching the real file-based loader.
+type fakeInnerLoad struct {
+	cfg *traceconfig.AgentConfig
+	err error
+}
+
+func (f *fakeInnerLoad) Load() (*traceconfig.AgentConfig, error) {
+	return f.cfg, f.err
+}
+
+func TestSpanDerivedPrimaryTagsLoader_ValidJSON(t *testing.T) {
+	t.Setenv(spanDerivedPrimaryTagsEnvVar, `["region","version","tier"]`)
+
+	inner := &fakeInnerLoad{cfg: &traceconfig.AgentConfig{}}
+	loader := &spanDerivedPrimaryTagsLoader{inner: inner}
+
+	tc, err := loader.Load()
+	require.NoError(t, err)
+	require.NotNil(t, tc)
+	assert.Equal(t, []string{"region", "version", "tier"}, tc.SpanDerivedPrimaryTagKeys)
+}
+
+func TestSpanDerivedPrimaryTagsLoader_EnvUnset(t *testing.T) {
+	// Explicitly clear the env var in case the test host has it set.
+	t.Setenv(spanDerivedPrimaryTagsEnvVar, "")
+
+	inner := &fakeInnerLoad{cfg: &traceconfig.AgentConfig{}}
+	loader := &spanDerivedPrimaryTagsLoader{inner: inner}
+
+	tc, err := loader.Load()
+	require.NoError(t, err)
+	require.NotNil(t, tc)
+	assert.Nil(t, tc.SpanDerivedPrimaryTagKeys)
+}
+
+func TestSpanDerivedPrimaryTagsLoader_MalformedJSON(t *testing.T) {
+	t.Setenv(spanDerivedPrimaryTagsEnvVar, `not a json array`)
+
+	inner := &fakeInnerLoad{cfg: &traceconfig.AgentConfig{}}
+	loader := &spanDerivedPrimaryTagsLoader{inner: inner}
+
+	tc, err := loader.Load()
+	// Malformed JSON must not turn into a Load error; the wrapper logs a
+	// warning and leaves the field untouched.
+	require.NoError(t, err)
+	require.NotNil(t, tc)
+	assert.Nil(t, tc.SpanDerivedPrimaryTagKeys)
+}
+
+func TestSpanDerivedPrimaryTagsLoader_InnerErrorPropagated(t *testing.T) {
+	// Even with a valid env var, an inner Load error must propagate and the
+	// wrapper must not mutate the returned config.
+	t.Setenv(spanDerivedPrimaryTagsEnvVar, `["region"]`)
+
+	innerErr := errors.New("inner load failed")
+	inner := &fakeInnerLoad{cfg: &traceconfig.AgentConfig{}, err: innerErr}
+	loader := &spanDerivedPrimaryTagsLoader{inner: inner}
+
+	tc, err := loader.Load()
+	require.ErrorIs(t, err, innerErr)
+	require.NotNil(t, tc)
+	assert.Nil(t, tc.SpanDerivedPrimaryTagKeys)
+}

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -372,7 +372,11 @@ type AgentConfig struct {
 	PeerTagsAggregation       bool          // enables/disables stats aggregation for peer entity tags, used by Concentrator and ClientStatsAggregator
 	ComputeStatsBySpanKind    bool          // enables/disables the computing of stats based on a span's `span.kind` field
 	PeerTags                  []string      // additional tags to use for peer entity stats aggregation
-	SpanDerivedPrimaryTagKeys []string      // tag keys to use for span-derived primary tag stats aggregation
+	// SpanDerivedPrimaryTagKeys holds the raw tag keys to use for span-derived primary tag stats aggregation.
+	// Do NOT read this field directly: callers must go through ConfiguredSpanDerivedPrimaryTagKeys(),
+	// which applies dedup/sort normalization via preparePeerTags (mirrors how ConfiguredPeerTags is the
+	// authoritative getter for PeerTags).
+	SpanDerivedPrimaryTagKeys []string
 
 	// Sampler configuration
 	ExtraSampleRate float64
@@ -813,6 +817,16 @@ func (c *AgentConfig) ConfiguredPeerTags() []string {
 		return nil
 	}
 	return preparePeerTags(append(basePeerTags, c.PeerTags...))
+}
+
+// ConfiguredSpanDerivedPrimaryTagKeys returns the set of span-derived primary tag keys that should be used
+// for stats aggregation. These tag keys will be used to extract tags from spans
+// for use in aggregation keys, similar to peer tags.
+func (c *AgentConfig) ConfiguredSpanDerivedPrimaryTagKeys() []string {
+	if len(c.SpanDerivedPrimaryTagKeys) == 0 {
+		return nil
+	}
+	return preparePeerTags(c.SpanDerivedPrimaryTagKeys)
 }
 
 func inAzureAppServices() bool {

--- a/pkg/trace/stats/concentrator.go
+++ b/pkg/trace/stats/concentrator.go
@@ -72,10 +72,12 @@ func NewConcentrator(conf *config.AgentConfig, writer Writer, now time.Time, sta
 		statsd:           statsd,
 		bsize:            bsize,
 		peerTagKeys:      conf.ConfiguredPeerTags(),
-		// additionalMetricTagKeys is intentionally nil on the agent side. This feature is only
-		// configurable through the Go tracer (dd-trace-go), which imports the SpanConcentrator
-		// directly and passes its own tag keys via NewStatSpanWithConfig's StatSpanConfig.AdditionalMetricTagKeys.
-		additionalMetricTagKeys: nil,
+		// additionalMetricTagKeys is populated from AgentConfig.SpanDerivedPrimaryTagKeys, which
+		// serverless-init sets from DD_APM_SPAN_DERIVED_PRIMARY_TAGS. In all other agent deployments
+		// this slice is empty, so the field stays nil. The Go tracer (dd-trace-go) also configures
+		// this via NewStatSpanWithConfig's StatSpanConfig.AdditionalMetricTagKeys when it imports
+		// the SpanConcentrator directly.
+		additionalMetricTagKeys: conf.ConfiguredSpanDerivedPrimaryTagKeys(),
 	}
 	return &c
 }


### PR DESCRIPTION
### What does this PR do?
Restore the deprecated config for span derived primary tags on agent computed stats. This config is deprecated in the main agent in favor of CSS (Client Side Stats, tracer-computed stats). But those don't currently support span derived primary tagging, so we enable this in the serverless-init code for now. This functionality *should not* be used in any other context.

### Describe how you validated your changes
Unit tests and e2e tests.