### PR TITLE
[OTAGENT-1020] Include service.instance.id in OTLP resource attribute to Datadog metric tag mapping

### DIFF
--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
@@ -209,6 +209,28 @@ func Test_ConsumeMetrics_Tags(t *testing.T) {
 			}, nil),
 			instrumentationScopeMetadataAsTags: true,
 		},
+		{
+			name: "service.instance.id resource attribute becomes tag",
+			genMetrics: func(_ *testing.T) pmetric.Metrics {
+				h := pmetric.NewHistogramDataPoint()
+				h.BucketCounts().FromRaw([]uint64{100})
+				h.SetCount(100)
+				h.SetSum(0)
+
+				n := pmetric.NewNumberDataPoint()
+				n.SetIntValue(777)
+				md := newMetrics(histogramMetricName, h, numberMetricName, n)
+				md.ResourceMetrics().At(0).Resource().Attributes().PutStr("service.instance.id", "my-instance-123")
+				return md
+			},
+			extraTags: []string{},
+			wantSketchTags: tagset.NewCompositeTags([]string{
+				"service.instance.id:my-instance-123",
+			}, nil),
+			wantSerieTags: tagset.NewCompositeTags([]string{
+				"service.instance.id:my-instance-123",
+			}, nil),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/opentelemetry-mapping-go/otlp/attributes/attributes.go
+++ b/pkg/opentelemetry-mapping-go/otlp/attributes/attributes.go
@@ -44,6 +44,8 @@ var (
 		string(semconv1_27.ServiceNameKey):               "service",
 		string(semconv1_27.ServiceVersionKey):            "version",
 		string(semconv1_27.DeploymentEnvironmentNameKey): "env",
+		// Required for OTel traffic metrics on Datadog Fleet Automation.
+		string(semconv1_27.ServiceInstanceIDKey): "service.instance.id",
 	}
 
 	// ContainerMappings defines the mapping between OpenTelemetry semantic conventions

--- a/pkg/opentelemetry-mapping-go/otlp/attributes/attributes_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/attributes/attributes_test.go
@@ -77,6 +77,13 @@ func TestTagsFromAttributesEmpty(t *testing.T) {
 	assert.Equal(t, []string{}, TagsFromAttributes(attrs))
 }
 
+func TestServiceInstanceIDMapping(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.PutStr(string(semconv127.ServiceInstanceIDKey), "my-instance-123")
+
+	assert.Equal(t, []string{"service.instance.id:my-instance-123"}, TagsFromAttributes(attrs))
+}
+
 func TestContainerTagFromResourceAttributes(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		attributes := pcommon.NewMap()

--- a/releasenotes/notes/otel-service-instance-id-tag-a3f2d891c74b6e05.yaml
+++ b/releasenotes/notes/otel-service-instance-id-tag-a3f2d891c74b6e05.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The ``service.instance.id`` OpenTelemetry resource attribute is now mapped to
+    the ``service.instance.id`` Datadog metric tag when converting OTLP metrics.
+    This attribute is required for OTel traffic metrics in Datadog Fleet Automation.


### PR DESCRIPTION
### What does this PR do?
Include `service.instance.id` in OTLP resource attribute to Datadog metric tag mapping so that it is sent as a metric tag by default.

### Motivation
`service.instance.id` is required to enable OTel traffic metrics on Datadog Fleet Automation. Add it to coreMapping so it is emitted as a Datadog metric tag when converting OTLP resource attributes.

### Describe how you validated your changes
new tests

### Additional Notes
This potentially increases the metric cardinality, but only OTel collector internal metrics should have this attribute, and OTel collector internal metrics are standard metrics, so in most cases this won't impact customers' CM billing.