### PR TITLE
feat(config): enable remote_agent.configstream by default

### DIFF
--- a/pkg/config/schema/core_schema.yaml
+++ b/pkg/config/schema/core_schema.yaml
@@ -13600,7 +13600,7 @@ properties:
           enabled:
             node_type: setting
             type: boolean
-            default: false
+            default: true
           sleep_interval:
             node_type: setting
             type: number

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1025,7 +1025,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("remote_agent.registry.idle_timeout", time.Duration(30*time.Second))
 	config.BindEnvAndSetDefault("remote_agent.registry.query_timeout", time.Duration(3*time.Second))
 	config.BindEnvAndSetDefault("remote_agent.registry.recommended_refresh_interval", time.Duration(10*time.Second))
-	config.BindEnvAndSetDefault("remote_agent.configstream.enabled", false)
+	config.BindEnvAndSetDefault("remote_agent.configstream.enabled", true)
 	config.BindEnvAndSetDefault("remote_agent.configstream.sleep_interval", 10*time.Second)
 
 	// Data Plane


### PR DESCRIPTION
## Summary

Flips the default for `remote_agent.configstream.enabled` from `false` to `true` so remote agents (notably the Agent Data Plane) receive streamed config updates from the Core Agent out of the box instead of having to opt in. This is a requirement of customers being able to opt into ADP with a single config option in the Agent. Prerequisite for landing the ADP/DogStatsD routing changes in #49891, where the Core Agent needs to push the resolved `data_plane.dogstatsd.enabled` value to ADP at runtime.

## Test plan

- [x] `go test -tags test ./pkg/config/setup/... ./pkg/config/schema/... ./comp/core/configstream/... -count=1` passes.
- [x] Manually verify on a dev agent with no explicit `remote_agent.configstream` block in `datadog.yaml` that the config-stream gRPC endpoint accepts subscribers.


Tracked by [DADP-38]