### PR TITLE
Fix otel-agent coverage for secrets test

### DIFF
--- a/test/new-e2e/tests/otel/otel-agent/dogtel_secrets_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/dogtel_secrets_test.go
@@ -119,6 +119,10 @@ func TestOTelAgentDogtelSecretsStandalone(t *testing.T) {
 	t.Parallel()
 	e2e.Run(t, &dogtelSecretsTestSuite{},
 		e2e.WithProvisioner(dogtelSecretsStandaloneProvisioner()),
+		e2e.WithCoverageRequired(map[string]bool{
+			"agent":      false,
+			"otel-agent": true,
+		}),
 	)
 }
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d43d9e8e-c4fe-4864-a061-a4a82f90d38c","source":"chat","resourceId":"dd172110-f269-49f9-8282-595317308663","workflowId":"e30ad964-5c32-4585-ad14-09e19b8277c1","codeChangeId":"e30ad964-5c32-4585-ad14-09e19b8277c1","sourceType":"slack"} -->
### What does this PR do?

Adds `e2e.WithCoverageRequired` to `TestOTelAgentDogtelSecretsStandalone` so that only `otel-agent` coverage is required (not `agent`), matching the pattern used by `TestDogtelStandalone`.

### Motivation

The `new-e2e-otel` CI job is failing on `TestOTelAgentDogtelSecretsStandalone` because the test expects coverage from the `agent` container which is not present in standalone mode. This was already correctly handled in `TestDogtelStandalone` but missed for the secrets variant.

### Describe how you validated your changes

Verified the change mirrors the existing `TestDogtelStandalone` pattern in `test/new-e2e/tests/otel/otel-agent/dogtel_standalone_test.go` (lines 91-94).

### Additional Notes

Pipeline failure: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1630920158

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/dd172110-f269-49f9-8282-595317308663)

Comment @datadog to request changes