### PR TITLE
[observer] Add observer.ingest_metrics.enabled to stop ingesting metrics

### DIFF
--- a/comp/observer/README.md
+++ b/comp/observer/README.md
@@ -283,6 +283,16 @@ observer:
   # Main switches
   analysis:
     enabled: true                    # Enable the anomaly detection pipeline
+  ingest_metrics:
+    enabled: true                    # When false, drops externally-ingested
+                                     # metrics (DogStatsD, check samplers,
+                                     # HF runners) at the handle factory.
+                                     # Logs and log-derived virtual metrics
+                                     # produced inside the engine by
+                                     # LogMetricsExtractors are unaffected,
+                                     # so the log -> metric detector path
+                                     # keeps working when external metric
+                                     # ingestion is disabled.
 
   # Agent internal log capture
   capture_agent_internal_logs:

--- a/comp/observer/impl/ingest_metrics_disabled_test.go
+++ b/comp/observer/impl/ingest_metrics_disabled_test.go
@@ -17,21 +17,9 @@ import (
 )
 
 // TestObserverDropsMetricsWhenIngestMetricsDisabled verifies that when
-// observer.ingest_metrics.enabled is false:
-//
-//   - the "all-metrics" handle is wrapped in metricDropHandle so
-//     ObserveMetric calls do not reach engine storage,
-//   - ObserveMetricAndReportDrop returns false (the call was dropped by
-//     configuration, not by a full channel),
-//   - ObserveLog still passes through to the engine and the
-//     LogMetricsExtractor's virtual metrics land in storage under the
-//     extractor's namespace.
-//
-// The third assertion is the structural regression guard: the gate must
-// only block externally-ingested metrics on the handle path. Virtual
-// metrics produced inside the engine by LogMetricsExtractors must keep
-// flowing because they are what enables log-only anomaly detection when
-// external metric ingestion is disabled.
+// observer.ingest_metrics.enabled is false, the handle drops external
+// ObserveMetric calls while logs and log-derived virtual metrics still
+// reach the engine.
 func TestObserverDropsMetricsWhenIngestMetricsDisabled(t *testing.T) {
 	storage := newTimeSeriesStorage()
 	extractor := NewLogMetricsExtractor(DefaultLogMetricsExtractorConfig())
@@ -50,39 +38,50 @@ func TestObserverDropsMetricsWhenIngestMetricsDisabled(t *testing.T) {
 	}
 	obs.handleFunc = obs.innerHandle
 
-	var wg sync.WaitGroup
+	var (
+		wg        sync.WaitGroup
+		closeOnce sync.Once
+	)
+	stopFn := func() {
+		// close is idempotent via Once; wg.Wait() is safe to call multiple times.
+		closeOnce.Do(func() { close(obs.obsCh) })
+		wg.Wait()
+	}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		obs.run()
 	}()
+	// Guarantee cleanup even if an assertion calls t.Fatal before stopFn().
+	t.Cleanup(stopFn)
 
 	h := obs.GetHandle("all-metrics")
 
-	dropHandle, ok := h.(*metricDropHandle)
-	require.Truef(t, ok, "expected metricDropHandle wrapper, got %T", h)
+	drop, ok := h.(*metricDropHandle)
+	require.Truef(t, ok, `GetHandle("all-metrics") returned %T, want *metricDropHandle`, h)
 
-	assert.False(t, dropHandle.ObserveMetricAndReportDrop(&metricObs{
+	assert.False(t, drop.ObserveMetricAndReportDrop(&metricObs{
 		name:      "system.cpu.user",
 		value:     50,
 		timestamp: 1000,
 	}), "ObserveMetricAndReportDrop should report false when dropped by configuration")
 
-	dropHandle.ObserveMetric(&metricObs{
+	drop.ObserveMetric(&metricObs{
 		name:      "system.mem.used",
 		value:     1024,
 		timestamp: 1000,
 	})
 
-	dropHandle.ObserveLog(&logObs{
+	drop.ObserveLog(&logObs{
 		content:     []byte("Request completed in 45ms"),
 		status:      "info",
 		tags:        []string{"service:web"},
 		timestampMs: 1_000_000,
 	})
 
-	close(obs.obsCh)
-	wg.Wait()
+	// Flush: close signals EOF; run() drains all buffered items before returning,
+	// so the ObserveLog above is guaranteed to be processed before we assert storage.
+	stopFn()
 
 	allMetricsSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: "all-metrics"})
 	assert.Empty(t, allMetricsSeries,
@@ -93,19 +92,25 @@ func TestObserverDropsMetricsWhenIngestMetricsDisabled(t *testing.T) {
 		"log-extractor virtual metrics must keep flowing into storage even when observer.ingest_metrics.enabled=false")
 }
 
-// TestMetricDropHandleUnit covers the wrapper in isolation, mirroring
+// TestMetricDropHandle covers the wrapper in isolation, mirroring
 // the pattern used in system_filter_test.go for hfFilteredHandle.
-func TestMetricDropHandleUnit(t *testing.T) {
+func TestMetricDropHandle(t *testing.T) {
 	inner := &countingHandle{}
 	wrap := &metricDropHandle{inner: inner}
 
 	wrap.ObserveMetric(&sampleNoSource{name: "any.metric"})
 	wrap.ObserveTrace(nil)
 	wrap.ObserveTraceStats(nil)
-	assert.Zero(t, inner.received, "ObserveMetric/Trace/TraceStats must not reach inner")
+	assert.Equal(t, 0, inner.received,
+		"metricDropHandle: inner.received = %d, want 0 (ObserveMetric/Trace/TraceStats must be dropped)", inner.received)
 	assert.False(t, wrap.ObserveMetricAndReportDrop(&sampleNoSource{name: "any.metric"}),
 		"ObserveMetricAndReportDrop reports false (config drop, not channel-full)")
 
 	wrap.ObserveLog(&logObs{content: []byte("hi"), timestampMs: 1})
+	assert.Equal(t, 1, inner.logReceived,
+		"metricDropHandle: inner.logReceived = %d, want 1 (ObserveLog must forward to inner)", inner.logReceived)
+
 	wrap.ObserveProfile(nil)
+	assert.Equal(t, 1, inner.profileReceived,
+		"metricDropHandle: inner.profileReceived = %d, want 1 (ObserveProfile must forward to inner)", inner.profileReceived)
 }

--- a/comp/observer/impl/ingest_metrics_disabled_test.go
+++ b/comp/observer/impl/ingest_metrics_disabled_test.go
@@ -1,0 +1,111 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// TestObserverDropsMetricsWhenIngestMetricsDisabled verifies that when
+// observer.ingest_metrics.enabled is false:
+//
+//   - the "all-metrics" handle is wrapped in metricDropHandle so
+//     ObserveMetric calls do not reach engine storage,
+//   - ObserveMetricAndReportDrop returns false (the call was dropped by
+//     configuration, not by a full channel),
+//   - ObserveLog still passes through to the engine and the
+//     LogMetricsExtractor's virtual metrics land in storage under the
+//     extractor's namespace.
+//
+// The third assertion is the structural regression guard: the gate must
+// only block externally-ingested metrics on the handle path. Virtual
+// metrics produced inside the engine by LogMetricsExtractors must keep
+// flowing because they are what enables log-only anomaly detection when
+// external metric ingestion is disabled.
+func TestObserverDropsMetricsWhenIngestMetricsDisabled(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	extractor := NewLogMetricsExtractor(DefaultLogMetricsExtractorConfig())
+	eng := newEngine(engineConfig{
+		storage:    storage,
+		extractors: []observerdef.LogMetricsExtractor{extractor},
+	})
+
+	th := newTelemetryHandler(noopsimpl.GetCompatComponent())
+	obs := &observerImpl{
+		engine:               eng,
+		obsCh:                make(chan observation, 16),
+		telemetryHandler:     th,
+		dropCounter:          th.telemetryCounters[telemetryObsChannelDropped],
+		ingestMetricsEnabled: false,
+	}
+	obs.handleFunc = obs.innerHandle
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		obs.run()
+	}()
+
+	h := obs.GetHandle("all-metrics")
+
+	dropHandle, ok := h.(*metricDropHandle)
+	require.Truef(t, ok, "expected metricDropHandle wrapper, got %T", h)
+
+	assert.False(t, dropHandle.ObserveMetricAndReportDrop(&metricObs{
+		name:      "system.cpu.user",
+		value:     50,
+		timestamp: 1000,
+	}), "ObserveMetricAndReportDrop should report false when dropped by configuration")
+
+	dropHandle.ObserveMetric(&metricObs{
+		name:      "system.mem.used",
+		value:     1024,
+		timestamp: 1000,
+	})
+
+	dropHandle.ObserveLog(&logObs{
+		content:     []byte("Request completed in 45ms"),
+		status:      "info",
+		tags:        []string{"service:web"},
+		timestampMs: 1_000_000,
+	})
+
+	close(obs.obsCh)
+	wg.Wait()
+
+	allMetricsSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: "all-metrics"})
+	assert.Empty(t, allMetricsSeries,
+		"external metrics must not be stored when observer.ingest_metrics.enabled=false")
+
+	extractorSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: extractor.Name()})
+	require.NotEmpty(t, extractorSeries,
+		"log-extractor virtual metrics must keep flowing into storage even when observer.ingest_metrics.enabled=false")
+}
+
+// TestMetricDropHandleUnit covers the wrapper in isolation, mirroring
+// the pattern used in system_filter_test.go for hfFilteredHandle.
+func TestMetricDropHandleUnit(t *testing.T) {
+	inner := &countingHandle{}
+	wrap := &metricDropHandle{inner: inner}
+
+	wrap.ObserveMetric(&sampleNoSource{name: "any.metric"})
+	wrap.ObserveTrace(nil)
+	wrap.ObserveTraceStats(nil)
+	assert.Zero(t, inner.received, "ObserveMetric/Trace/TraceStats must not reach inner")
+	assert.False(t, wrap.ObserveMetricAndReportDrop(&sampleNoSource{name: "any.metric"}),
+		"ObserveMetricAndReportDrop reports false (config drop, not channel-full)")
+
+	wrap.ObserveLog(&logObs{content: []byte("hi"), timestampMs: 1})
+	wrap.ObserveProfile(nil)
+}

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -244,6 +244,10 @@ func NewComponent(deps Requires) Provides {
 		ingestMetricsEnabled: cfg.GetBool("observer.ingest_metrics.enabled"),
 	}
 
+	if !obs.ingestMetricsEnabled {
+		pkglog.Warn("[observer] observer.ingest_metrics.enabled=false: externally-ingested metrics will be dropped at the handle factory")
+	}
+
 	// Set up handle function based on recording and analysis configuration.
 	// Recording (observer.recording.enabled) enables parquet writers and the fetcher.
 	// Analysis (observer.analysis.enabled) enables the anomaly detection pipeline.
@@ -775,6 +779,8 @@ func (f *hfFilteredHandle) ObserveProfile(p observerdef.ProfileView)       { f.i
 // during engine.IngestLog are unaffected because they bypass this handle
 // path entirely (they are written directly to storage from the engine).
 type metricDropHandle struct{ inner observerdef.Handle }
+
+var _ observerdef.Handle = (*metricDropHandle)(nil)
 
 func (m *metricDropHandle) ObserveMetric(_ observerdef.MetricView) {}
 func (m *metricDropHandle) ObserveMetricAndReportDrop(_ observerdef.MetricView) bool {

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -235,12 +235,13 @@ func NewComponent(deps Requires) Provides {
 	hfFilterSources := make(map[metrics.MetricSource]struct{})
 
 	obs := &observerImpl{
-		engine:             eng,
-		obsCh:              make(chan observation, 1000),
-		telemetryHandler:   th,
-		dropCounter:        th.telemetryCounters[telemetryObsChannelDropped],
-		hfContainerEnabled: hfContainerEnabled,
-		hfFilterSources:    hfFilterSources,
+		engine:               eng,
+		obsCh:                make(chan observation, 1000),
+		telemetryHandler:     th,
+		dropCounter:          th.telemetryCounters[telemetryObsChannelDropped],
+		hfContainerEnabled:   hfContainerEnabled,
+		hfFilterSources:      hfFilterSources,
+		ingestMetricsEnabled: cfg.GetBool("observer.ingest_metrics.enabled"),
 	}
 
 	// Set up handle function based on recording and analysis configuration.
@@ -510,6 +511,13 @@ type observerImpl struct {
 
 	// hfContainerEnabled is true when high-frequency container check collection is active.
 	hfContainerEnabled bool
+
+	// ingestMetricsEnabled gates externally-ingested metrics at the handle
+	// factory. When false, "all-metrics" and HF handles return a wrapper
+	// that drops ObserveMetric calls. Logs and profiles still pass through,
+	// and log-derived virtual metrics produced inside the engine by
+	// LogMetricsExtractors are unaffected because they bypass the handle.
+	ingestMetricsEnabled bool
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
@@ -677,13 +685,20 @@ func (o *observerImpl) GetHandle(name string) observerdef.Handle {
 // When any HF check collection is enabled, the "all-metrics" handle is wrapped
 // with hfFilteredHandle to suppress 15s samples for checks that have a 1s HF
 // counterpart active — the scorer should only see the higher-resolution stream.
+// When observer.ingest_metrics.enabled=false, the resulting handle is further
+// wrapped with metricDropHandle so external metrics are dropped at the edge,
+// while ObserveLog/ObserveProfile pass through.
 func (o *observerImpl) innerHandle(name string) observerdef.Handle {
 	h := &handle{ch: o.obsCh, source: name, dropCounter: o.dropCounter}
 	o.engine.registerHandle(h)
+	var out observerdef.Handle = h
 	if len(o.hfFilterSources) > 0 && name == "all-metrics" {
-		return &hfFilteredHandle{inner: h, sources: o.hfFilterSources}
+		out = &hfFilteredHandle{inner: h, sources: o.hfFilterSources}
 	}
-	return h
+	if !o.ingestMetricsEnabled {
+		out = &metricDropHandle{inner: out}
+	}
+	return out
 }
 
 // sourceProvider is a structural interface satisfied by *metrics.MetricSample,
@@ -752,6 +767,23 @@ func (f *hfFilteredHandle) ObserveLog(msg observerdef.LogView)             { f.i
 func (f *hfFilteredHandle) ObserveTrace(_ observerdef.TraceView)           {}
 func (f *hfFilteredHandle) ObserveTraceStats(_ observerdef.TraceStatsView) {}
 func (f *hfFilteredHandle) ObserveProfile(p observerdef.ProfileView)       { f.inner.ObserveProfile(p) }
+
+// metricDropHandle drops every ObserveMetric call but lets logs and
+// profiles through. Used when observer.ingest_metrics.enabled=false so
+// external metric sources (DogStatsD, check samplers, HF runners) do not
+// feed the engine. Virtual metrics produced by LogMetricsExtractors
+// during engine.IngestLog are unaffected because they bypass this handle
+// path entirely (they are written directly to storage from the engine).
+type metricDropHandle struct{ inner observerdef.Handle }
+
+func (m *metricDropHandle) ObserveMetric(_ observerdef.MetricView) {}
+func (m *metricDropHandle) ObserveMetricAndReportDrop(_ observerdef.MetricView) bool {
+	return false
+}
+func (m *metricDropHandle) ObserveLog(msg observerdef.LogView)             { m.inner.ObserveLog(msg) }
+func (m *metricDropHandle) ObserveTrace(_ observerdef.TraceView)           {}
+func (m *metricDropHandle) ObserveTraceStats(_ observerdef.TraceStatsView) {}
+func (m *metricDropHandle) ObserveProfile(p observerdef.ProfileView)       { m.inner.ObserveProfile(p) }
 
 // noopHandle returns a handle that discards all observations.
 // Used when analysis is disabled so the analysis pipeline is not started.

--- a/comp/observer/impl/system_filter_test.go
+++ b/comp/observer/impl/system_filter_test.go
@@ -34,16 +34,18 @@ func (s *sampleNoSource) GetRawTags() []string    { return nil }
 func (s *sampleNoSource) GetTimestampUnix() int64 { return 0 }
 func (s *sampleNoSource) GetSampleRate() float64  { return 1 }
 
-// countingHandle records how many MetricView observations it receives.
+// countingHandle records how many MetricView, LogView, and ProfileView observations it receives.
 type countingHandle struct {
-	received int
+	received        int
+	logReceived     int
+	profileReceived int
 }
 
 func (h *countingHandle) ObserveMetric(_ observerdef.MetricView)         { h.received++ }
-func (h *countingHandle) ObserveLog(_ observerdef.LogView)               {}
+func (h *countingHandle) ObserveLog(_ observerdef.LogView)               { h.logReceived++ }
 func (h *countingHandle) ObserveTrace(_ observerdef.TraceView)           {}
 func (h *countingHandle) ObserveTraceStats(_ observerdef.TraceStatsView) {}
-func (h *countingHandle) ObserveProfile(_ observerdef.ProfileView)       {}
+func (h *countingHandle) ObserveProfile(_ observerdef.ProfileView)       { h.profileReceived++ }
 
 func makeHFHandle(sources map[metrics.MetricSource]struct{}) *hfFilteredHandle {
 	return &hfFilteredHandle{inner: &countingHandle{}, sources: sources}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -361,9 +361,9 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("observer.analysis.enabled", true)
 	// When false, the observer drops externally-ingested metrics
 	// (DogStatsD, check samplers, HF runners) at the handle factory.
-	// Logs are unaffected, and log-derived virtual metrics produced
-	// inside the engine by LogMetricsExtractors continue to flow into
-	// storage, so log-only anomaly detection keeps working.
+	// Logs are unaffected. Log-derived virtual metrics produced inside
+	// the engine by LogMetricsExtractors continue to flow into storage,
+	// so log-only anomaly detection keeps working.
 	config.BindEnvAndSetDefault("observer.ingest_metrics.enabled", true)
 	config.BindEnvAndSetDefault("observer.traces.fetch_interval", 5*time.Second)
 	config.BindEnvAndSetDefault("observer.traces.max_fetch_batch", 100)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -359,6 +359,12 @@ func InitConfig(config pkgconfigmodel.Setup) {
 
 	// Observer component configuration for anomaly detection
 	config.BindEnvAndSetDefault("observer.analysis.enabled", true)
+	// When false, the observer drops externally-ingested metrics
+	// (DogStatsD, check samplers, HF runners) at the handle factory.
+	// Logs are unaffected, and log-derived virtual metrics produced
+	// inside the engine by LogMetricsExtractors continue to flow into
+	// storage, so log-only anomaly detection keeps working.
+	config.BindEnvAndSetDefault("observer.ingest_metrics.enabled", true)
 	config.BindEnvAndSetDefault("observer.traces.fetch_interval", 5*time.Second)
 	config.BindEnvAndSetDefault("observer.traces.max_fetch_batch", 100)
 	config.BindEnvAndSetDefault("observer.profiles.fetch_interval", 10*time.Second)


### PR DESCRIPTION
### What does this PR do?

Adds \`observer.ingest_metrics.enabled\` (default \`true\`) to drop externally-ingested metrics at the handle factory while keeping logs and log-derived virtual metrics flowing.

Wires the option into the gensim-eks runner via a \`--disable-metrics-ingestion\` flag on \`inv aws.eks.gensim.submit\`, setting both the env var and the Helm config field.

### Motivation

Enables log-only anomaly detection runs on gensim-eks without external metrics.

### Describe how you validated your changes

461 observer unit tests pass. New tests cover drop behavior, virtual metric passthrough, and template rendering for the new flag.

Manually tested on local build.

### Additional Notes