### PR TITLE
[AGENTRUN-1236] packaging/aix: compile rtloader with GCC 8 for AIX 7.2 TL2 compatibility

### DIFF
--- a/packaging/aix/lib/env.sh
+++ b/packaging/aix/lib/env.sh
@@ -98,8 +98,16 @@ GOPROXY=https://proxy.golang.org,direct
 # toolchain version (go.mod may require a newer patch than is installed).
 # Auto-download spawns extra processes and consumes significant memory on AIX.
 GOTOOLCHAIN=local
+# -p=1: one package compiled at a time; prevents multiple 3-4 GB Go compiler
+# processes from competing for RAM on the 4 GB AIX build host and causing
+# thrashing or OOM kills.
+GOFLAGS="-p=1"
+# Redirect the Go build cache off /tmp (which is only 12 GB) to the larger
+# build volume so that large packages like datadogV2 don't exhaust /tmp.
+GOCACHE=/opt/dd-build/gocache
+mkdir -p "$GOCACHE"
 
-export PATH GOPATH GOROOT CGO_ENABLED CGO_CFLAGS CGO_LDFLAGS GOPROXY GOTOOLCHAIN
+export PATH GOPATH GOROOT CGO_ENABLED CGO_CFLAGS CGO_LDFLAGS GOPROXY GOTOOLCHAIN GOFLAGS GOCACHE
 
 # ── Utility functions ─────────────────────────────────────────────────────────
 

--- a/packaging/aix/lib/env.sh
+++ b/packaging/aix/lib/env.sh
@@ -74,9 +74,13 @@ export CC CXX NM ARFLAGS OBJECT_MODE
 
 CFLAGS="-maix64"
 CXXFLAGS="-maix64"
-# -Wl,-bbigtoc: remove the 64KB TOC limit (required for large libs like OpenSSL and Python)
-# -Wl,-brtl:    enable runtime linking for dlopen support
-LDFLAGS="-maix64 -Wl,-brtl -Wl,-bbigtoc -L$EMBEDDED_DESTDIR/lib"
+# -Wl,-bbigtoc:     remove the 64KB TOC limit (required for large libs like OpenSSL and Python)
+# -Wl,-brtl:        enable runtime linking for dlopen support
+# -static-libstdc++: embed libstdc++ into each binary/shared library; eliminates the runtime
+#                    dependency on libstdc++.a[libstdc++.so.6], which differs between GCC
+#                    versions and AIX TL levels (e.g. GCC 13 needs strftime_l absent in TL2).
+# -static-libgcc:   embed libgcc_s for the same reason (version-specific GCC intrinsics).
+LDFLAGS="-maix64 -Wl,-brtl -Wl,-bbigtoc -static-libstdc++ -static-libgcc -L$EMBEDDED_DESTDIR/lib"
 CPPFLAGS="-I$EMBEDDED_DESTDIR/include"
 
 export CFLAGS CXXFLAGS LDFLAGS CPPFLAGS

--- a/packaging/aix/lib/env.sh
+++ b/packaging/aix/lib/env.sh
@@ -61,8 +61,18 @@ export AGENT_VERSION AGENT_BUILD AGENT_BRANCH AGENT_VRMF
 
 # ── Toolchain ─────────────────────────────────────────────────────────────────
 
-CC=/opt/freeware/bin/gcc
-CXX=/opt/freeware/bin/g++
+# GCC 8 is required for AIX 7.2 TL2 compatibility.
+# GCC 8's libstdc++ does not reference strftime_l (added to AIX libc only at
+# TL3+); GCC 10/13 do.  Code compiled by GCC 8 also calls ostringstream
+# constructors that GCC 8's libstdc++ actually exports, so the resulting
+# binaries run on AIX 7.2 without any compatibility stubs.
+# Install on the build host with: yum install -y gcc8 gcc8-c++
+if [ ! -x /opt/freeware/bin/gcc-8 ]; then
+    printf 'ERROR: gcc-8 not found. Install it with: yum install -y gcc8 gcc8-c++\n' >&2
+    exit 1
+fi
+CC=/opt/freeware/bin/gcc-8
+CXX=/opt/freeware/bin/g++-8
 NM="/usr/bin/nm -X64"
 ARFLAGS="-X64 -cru"
 OBJECT_MODE=64
@@ -74,13 +84,9 @@ export CC CXX NM ARFLAGS OBJECT_MODE
 
 CFLAGS="-maix64"
 CXXFLAGS="-maix64"
-# -Wl,-bbigtoc:     remove the 64KB TOC limit (required for large libs like OpenSSL and Python)
-# -Wl,-brtl:        enable runtime linking for dlopen support
-# -static-libstdc++: embed libstdc++ into each binary/shared library; eliminates the runtime
-#                    dependency on libstdc++.a[libstdc++.so.6], which differs between GCC
-#                    versions and AIX TL levels (e.g. GCC 13 needs strftime_l absent in TL2).
-# -static-libgcc:   embed libgcc_s for the same reason (version-specific GCC intrinsics).
-LDFLAGS="-maix64 -Wl,-brtl -Wl,-bbigtoc -static-libstdc++ -static-libgcc -L$EMBEDDED_DESTDIR/lib"
+# -Wl,-bbigtoc: remove the 64KB TOC limit (required for large libs like OpenSSL and Python)
+# -Wl,-brtl:    enable runtime linking for dlopen support
+LDFLAGS="-maix64 -Wl,-brtl -Wl,-bbigtoc -L$EMBEDDED_DESTDIR/lib"
 CPPFLAGS="-I$EMBEDDED_DESTDIR/include"
 
 export CFLAGS CXXFLAGS LDFLAGS CPPFLAGS

--- a/packaging/aix/stages/03-rtloader.sh
+++ b/packaging/aix/stages/03-rtloader.sh
@@ -151,64 +151,31 @@ if dump -X64 -Hv libdatadog-agent-three.so 2>/dev/null | grep "libpython${PYTHON
 fi
 log "Verified: libdatadog-agent-three.so depends on libpython${PYTHON_MAJ_MIN}.a(shr_64.o)"
 
-# ─── Step 3c: Embed strftime_l compatibility stub ─────────────────────────────
+# ─── Step 3c: Fix baked-in LIBPATH ────────────────────────────────────────────
 #
-# GCC 13's static libstdc++ (embedded via -static-libstdc++ in LDFLAGS) references
-# strftime_l from libc.  On AIX 7.2 TL2, libc does not export strftime_l (it was
-# added in a later Technology Level).  The mismatch causes exec() to fail with:
-#   Symbol strftime_l is not exported from dependent module /usr/lib/libc.a[shr_64.o]
-#
-# Fix: compile a tiny compatibility stub that implements strftime_l as a wrapper
-# around the universally available strftime(), then relink both rtloader .so files
-# with the stub object appended.  The IBM linker resolves strftime_l from the stub
-# and removes it from the external import table, so the installed .so no longer
-# requires strftime_l from libc.
-#
-# The relink also corrects -blibpath: cmake bakes the staging tree path into the
-# .so (e.g. /opt/dd-build/staging/...) which does not exist on a target host.
-# We replace it with the installed path so the loader resolves libraries correctly.
+# cmake bakes the staging tree path into the .so's loader section LIBPATH
+# (e.g. /opt/dd-build/staging/...) which does not exist on a target host.
+# Relink both .so files substituting the installed path so the AIX loader can
+# find the rtloader's dependencies (libpython, libgcc_s, libstdc++) on any host.
 
-log "Compiling strftime_l compatibility stub"
-cat > /tmp/strftime_compat.c << 'CEOF'
-#include <time.h>
-#include <locale.h>
-/* strftime_l is absent from AIX 7.2 TL2 libc; delegate to strftime. */
-size_t strftime_l(char *s, size_t maxsize, const char *format,
-                  const struct tm *timeptr, locale_t locale) {
-    return strftime(s, maxsize, format, timeptr);
-}
-CEOF
-"$CC" -maix64 -c /tmp/strftime_compat.c -o /tmp/strftime_compat.o
-log "strftime_l stub compiled"
-
-COMPAT=/tmp/strftime_compat.o
 INSTALLED_LIBPATH="/opt/datadog-agent/embedded/lib:/opt/datadog-agent/rtloader:/opt/freeware/lib:/usr/lib:/lib"
 
-log "Relinking libdatadog-agent-rtloader.so with strftime_l stub and installed LIBPATH"
+log "Relinking libdatadog-agent-rtloader.so with installed LIBPATH"
 cd /opt/datadog-agent/rtloader/build/rtloader
 eval "$(head -1 CMakeFiles/datadog-agent-rtloader.dir/link.txt)"
 LINK=$(tail -1 CMakeFiles/datadog-agent-rtloader.dir/link.txt)
 LINK_FIXED=$(printf '%s' "$LINK" | sed "s|-Wl,-blibpath:[^ ]*|-Wl,-blibpath:${INSTALLED_LIBPATH}|g")
-eval "$LINK_FIXED $COMPAT"
+eval "$LINK_FIXED"
 
-log "Relinking libdatadog-agent-three.so with strftime_l stub and installed LIBPATH"
+log "Relinking libdatadog-agent-three.so with installed LIBPATH"
 cd /opt/datadog-agent/rtloader/build/three
 eval "$(head -1 CMakeFiles/datadog-agent-three.dir/link.txt)"
 LINK=$(tail -1 CMakeFiles/datadog-agent-three.dir/link.txt)
 LINK_FIXED=$(printf '%s' "$LINK" | sed "s|libpython${PYTHON_MAJ_MIN}\\.so|libpython${PYTHON_MAJ_MIN}.a|g" \
                                   | sed "s|-Wl,-blibpath:[^ ]*|-Wl,-blibpath:${INSTALLED_LIBPATH}|g")
-eval "$LINK_FIXED $COMPAT"
+eval "$LINK_FIXED"
 
-log "strftime_l stub relink complete"
-
-# Verify: strftime_l should no longer appear as an unresolved import
-for so in \
-    /opt/datadog-agent/rtloader/build/rtloader/libdatadog-agent-rtloader.so \
-    /opt/datadog-agent/rtloader/build/three/libdatadog-agent-three.so; do
-    if /usr/bin/nm -X64 -u "$so" 2>/dev/null | grep "strftime_l"; then
-        log "WARNING: strftime_l still unresolved in $so — AIX 7.2 may not load this library"
-    fi
-done
+log "LIBPATH relink complete"
 
 # ─── Step 4: Copy outputs to staging ──────────────────────────────────────────
 #

--- a/packaging/aix/stages/03-rtloader.sh
+++ b/packaging/aix/stages/03-rtloader.sh
@@ -151,6 +151,65 @@ if dump -X64 -Hv libdatadog-agent-three.so 2>/dev/null | grep "libpython${PYTHON
 fi
 log "Verified: libdatadog-agent-three.so depends on libpython${PYTHON_MAJ_MIN}.a(shr_64.o)"
 
+# ─── Step 3c: Embed strftime_l compatibility stub ─────────────────────────────
+#
+# GCC 13's static libstdc++ (embedded via -static-libstdc++ in LDFLAGS) references
+# strftime_l from libc.  On AIX 7.2 TL2, libc does not export strftime_l (it was
+# added in a later Technology Level).  The mismatch causes exec() to fail with:
+#   Symbol strftime_l is not exported from dependent module /usr/lib/libc.a[shr_64.o]
+#
+# Fix: compile a tiny compatibility stub that implements strftime_l as a wrapper
+# around the universally available strftime(), then relink both rtloader .so files
+# with the stub object appended.  The IBM linker resolves strftime_l from the stub
+# and removes it from the external import table, so the installed .so no longer
+# requires strftime_l from libc.
+#
+# The relink also corrects -blibpath: cmake bakes the staging tree path into the
+# .so (e.g. /opt/dd-build/staging/...) which does not exist on a target host.
+# We replace it with the installed path so the loader resolves libraries correctly.
+
+log "Compiling strftime_l compatibility stub"
+cat > /tmp/strftime_compat.c << 'CEOF'
+#include <time.h>
+#include <locale.h>
+/* strftime_l is absent from AIX 7.2 TL2 libc; delegate to strftime. */
+size_t strftime_l(char *s, size_t maxsize, const char *format,
+                  const struct tm *timeptr, locale_t locale) {
+    return strftime(s, maxsize, format, timeptr);
+}
+CEOF
+"$CC" -maix64 -c /tmp/strftime_compat.c -o /tmp/strftime_compat.o
+log "strftime_l stub compiled"
+
+COMPAT=/tmp/strftime_compat.o
+INSTALLED_LIBPATH="/opt/datadog-agent/embedded/lib:/opt/datadog-agent/rtloader:/opt/freeware/lib:/usr/lib:/lib"
+
+log "Relinking libdatadog-agent-rtloader.so with strftime_l stub and installed LIBPATH"
+cd /opt/datadog-agent/rtloader/build/rtloader
+eval "$(head -1 CMakeFiles/datadog-agent-rtloader.dir/link.txt)"
+LINK=$(tail -1 CMakeFiles/datadog-agent-rtloader.dir/link.txt)
+LINK_FIXED=$(printf '%s' "$LINK" | sed "s|-Wl,-blibpath:[^ ]*|-Wl,-blibpath:${INSTALLED_LIBPATH}|g")
+eval "$LINK_FIXED $COMPAT"
+
+log "Relinking libdatadog-agent-three.so with strftime_l stub and installed LIBPATH"
+cd /opt/datadog-agent/rtloader/build/three
+eval "$(head -1 CMakeFiles/datadog-agent-three.dir/link.txt)"
+LINK=$(tail -1 CMakeFiles/datadog-agent-three.dir/link.txt)
+LINK_FIXED=$(printf '%s' "$LINK" | sed "s|libpython${PYTHON_MAJ_MIN}\\.so|libpython${PYTHON_MAJ_MIN}.a|g" \
+                                  | sed "s|-Wl,-blibpath:[^ ]*|-Wl,-blibpath:${INSTALLED_LIBPATH}|g")
+eval "$LINK_FIXED $COMPAT"
+
+log "strftime_l stub relink complete"
+
+# Verify: strftime_l should no longer appear as an unresolved import
+for so in \
+    /opt/datadog-agent/rtloader/build/rtloader/libdatadog-agent-rtloader.so \
+    /opt/datadog-agent/rtloader/build/three/libdatadog-agent-three.so; do
+    if /usr/bin/nm -X64 -u "$so" 2>/dev/null | grep "strftime_l"; then
+        log "WARNING: strftime_l still unresolved in $so — AIX 7.2 may not load this library"
+    fi
+done
+
 # ─── Step 4: Copy outputs to staging ──────────────────────────────────────────
 #
 # The two produced .so files must land in $STAGING/opt/datadog-agent/rtloader/

--- a/packaging/aix/stages/03-rtloader.sh
+++ b/packaging/aix/stages/03-rtloader.sh
@@ -87,6 +87,7 @@ _embedded_real=$(cd "$EMBEDDED" 2>/dev/null && pwd -P)
 _destdir_real=$(cd "$EMBEDDED_DESTDIR" 2>/dev/null && pwd -P)
 if [ "$_embedded_real" != "$_destdir_real" ]; then
     ln -sf "$EMBEDDED_DESTDIR/lib/libpython${PYTHON_MAJ_MIN}.so" "$EMBEDDED/lib/libpython${PYTHON_MAJ_MIN}.so" 2>/dev/null || true
+    ln -sf "$EMBEDDED_DESTDIR/lib/libpython${PYTHON_MAJ_MIN}.a"  "$EMBEDDED/lib/libpython${PYTHON_MAJ_MIN}.a"  2>/dev/null || true
 fi
 
 log "Running cmake for rtloader"
@@ -98,6 +99,8 @@ OBJECT_MODE=64 cmake \
     -DCMAKE_C_FLAGS="$CFLAGS" \
     -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
     -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS" \
+    -DCMAKE_INSTALL_RPATH="/opt/datadog-agent/embedded/lib:/opt/datadog-agent/rtloader:/opt/freeware/lib:/usr/lib:/lib" \
+    -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
     -DBUILD_DEMO=OFF \
     -DDISABLE_PYTHON2=ON \
     -DPython3_INCLUDE_DIR="$EMBEDDED_DESTDIR/include/python${PYTHON_MAJ_MIN}" \
@@ -150,32 +153,6 @@ if dump -X64 -Hv libdatadog-agent-three.so 2>/dev/null | grep "libpython${PYTHON
     exit 1
 fi
 log "Verified: libdatadog-agent-three.so depends on libpython${PYTHON_MAJ_MIN}.a(shr_64.o)"
-
-# ─── Step 3c: Fix baked-in LIBPATH ────────────────────────────────────────────
-#
-# cmake bakes the staging tree path into the .so's loader section LIBPATH
-# (e.g. /opt/dd-build/staging/...) which does not exist on a target host.
-# Relink both .so files substituting the installed path so the AIX loader can
-# find the rtloader's dependencies (libpython, libgcc_s, libstdc++) on any host.
-
-INSTALLED_LIBPATH="/opt/datadog-agent/embedded/lib:/opt/datadog-agent/rtloader:/opt/freeware/lib:/usr/lib:/lib"
-
-log "Relinking libdatadog-agent-rtloader.so with installed LIBPATH"
-cd /opt/datadog-agent/rtloader/build/rtloader
-eval "$(head -1 CMakeFiles/datadog-agent-rtloader.dir/link.txt)"
-LINK=$(tail -1 CMakeFiles/datadog-agent-rtloader.dir/link.txt)
-LINK_FIXED=$(printf '%s' "$LINK" | sed "s|-Wl,-blibpath:[^ ]*|-Wl,-blibpath:${INSTALLED_LIBPATH}|g")
-eval "$LINK_FIXED"
-
-log "Relinking libdatadog-agent-three.so with installed LIBPATH"
-cd /opt/datadog-agent/rtloader/build/three
-eval "$(head -1 CMakeFiles/datadog-agent-three.dir/link.txt)"
-LINK=$(tail -1 CMakeFiles/datadog-agent-three.dir/link.txt)
-LINK_FIXED=$(printf '%s' "$LINK" | sed "s|libpython${PYTHON_MAJ_MIN}\\.so|libpython${PYTHON_MAJ_MIN}.a|g" \
-                                  | sed "s|-Wl,-blibpath:[^ ]*|-Wl,-blibpath:${INSTALLED_LIBPATH}|g")
-eval "$LINK_FIXED"
-
-log "LIBPATH relink complete"
 
 # ─── Step 4: Copy outputs to staging ──────────────────────────────────────────
 #

--- a/packaging/aix/stages/04-agent.sh
+++ b/packaging/aix/stages/04-agent.sh
@@ -93,6 +93,7 @@ export CGO_LDFLAGS="$CGO_LDFLAGS \
   -L$EMBEDDED_DESTDIR/lib \
   -lpython3 \
   -Wl,-bE:$PYTHON_EXP \
+  -static-libstdc++ -static-libgcc \
   -Wl,-blibpath:/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/freeware/lib64:/opt/freeware/lib:/usr/lib:/lib"
 
 # ─── Step 3: Get commit hash ──────────────────────────────────────────────────

--- a/packaging/aix/stages/04-agent.sh
+++ b/packaging/aix/stages/04-agent.sh
@@ -93,7 +93,6 @@ export CGO_LDFLAGS="$CGO_LDFLAGS \
   -L$EMBEDDED_DESTDIR/lib \
   -lpython3 \
   -Wl,-bE:$PYTHON_EXP \
-  -static-libstdc++ -static-libgcc \
   -Wl,-blibpath:/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/freeware/lib64:/opt/freeware/lib:/usr/lib:/lib"
 
 # ─── Step 3: Get commit hash ──────────────────────────────────────────────────


### PR DESCRIPTION
### What does this PR do?

Uses `gcc-8`/`g++-8` instead of the default GCC 13 to compile the rtloader and all C/C++ code in the AIX packaging pipeline. Removes `-static-libstdc++`/`-static-libgcc` from `LDFLAGS` (no longer needed). Fixes the LIBPATH baked into the rtloader `.so` files using cmake's `CMAKE_INSTALL_RPATH` / `CMAKE_BUILD_WITH_INSTALL_RPATH` instead of a manual post-build relink. Also creates the `libpython.a` symlink alongside the `.so` symlink so that the step 3b python-archive relink finds it.

### Motivation

GCC 13's `libstdc++` references `strftime_l`, which was added to AIX libc only at TL3+. Running the GCC 13-compiled package on AIX 7.2 TL2 fails at `exec()` time with:

```
Symbol strftime_l is not exported from dependent module /usr/lib/libc.a[shr_64.o]
```

GCC 8's `libstdc++` does not reference `strftime_l` (the feature was added after GCC 8). Code compiled by GCC 8 also calls `ostringstream` constructors that GCC 8's `libstdc++` actually exports, so the resulting binaries are fully compatible with the GCC 8 `libstdc++` that is the only version available on AIX 7.2.

GCC 8 must be installed on the build host before running the pipeline (`yum install -y gcc8 gcc8-c++`). `env.sh` now exits with a clear error and the install command if `gcc-8` is not found.

cmake normally bakes the staging tree path into the LIBPATH of the `.so` files, which doesn't exist on the target host. Adding `-DCMAKE_INSTALL_RPATH=... -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON` to the cmake invocation places the installed paths first in the LIBPATH, so libraries are found correctly without a separate post-build relink step.

### Describe how you validated your changes

Built the package on an AIX 7.3 build host and installed on a clean AIX 7.2 TL2 host:
- `agent version` succeeds (no `strftime_l` / dynamic linking error)
- CPU check and lparstats check both collect metrics
- Python 3.13.12 loads correctly
- Verified LIBPATH in rtloader `.so` files has installed paths first (`dump -X64 -H`)

### Additional Notes

The GCC 8 compatibility is empirical rather than contractual: GCC 8's `libstdc++` happens not to reference `strftime_l` because that usage was added to libstdc++ after GCC 8 was released. The robust long-term solution is to raise the minimum supported AIX version to 7.2 TL3 where `strftime_l` exists in libc.

cmake also appends its own computed link directories (staging tree, GCC-version-specific paths) after the `CMAKE_INSTALL_RPATH` entries, but those are harmless — the AIX loader silently skips LIBPATH entries that do not exist on the target.