### PR TITLE
linter: remove dead exclusion rules from .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -357,34 +357,18 @@ linters:
       - staticcheck
       path: pkg/clusteragent/admission/mutate/cwsinstrumentation/
       text: "SA1019: slices"
-    # 'errcheck' errors in tools/dep_tree_resolver/go_deps.go
+    # io.WriteString to http.ResponseWriter - errors are not actionable
     - path: (.+)\.go$
       text: Error return value of `io.WriteString` is not checked
-    # 'errcheck' errors in test/integration/utils/certificates.go
-    - path: (.+)\.go$
-      text: Error return value of `pem.Encode` is not checked
     - linters:
       - revive
       path: (.+)\.go$
       text: 'var-naming: avoid meaningless package names'
-    # 'revive' errors in pkg/serverless/trace/inferredspan/constants.go
-    - path: (.+)\.go$
-      text: 'exported: exported const APIName should have comment \(or a comment on this block\) or be unexported'
     # 'unconvert' errors in test/integration/utils/certificates_test.go
     - path: (.+)\.go$
       text: unnecessary conversion
     - path: (.+)\.go$
       text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
-    - path: (.+)\.go$
-      text: '`eventContext` is unused'
-    - path: (.+)\.go$
-      text: '`\(\*DatadogLogger\).changeLogLevel` is unused'
-    # used by APM and Process
-    - path: (.+)\.go$
-      text: '`defaultRetryDuration` is unused'
-    # used by APM and Process
-    - path: (.+)\.go$
-      text: '`defaultRetries` is unused'
     # ignore warning about returning unexported field from CGO
     - path: (.+)\.go$
       text: python._Ctype_char, which can be annoying to use

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -393,9 +393,6 @@ linters:
       text: '`context` is unused'
     - path: (.+)\.go$
       text: '`id` is unused'
-    # 'unconvert' errors in test/integration/utils/certificates_test.go
-    - path: (.+)\.go$
-      text: unnecessary conversion
     # Exclude some linters from running on tests files.
     - path: _test\.go
       linters:


### PR DESCRIPTION
### What does this PR do?

Removes several dead or redundant exclusion rules from `.golangci.yml`:

**Duplicate rule (cosmetic):**
- Removed a duplicate `unnecessary conversion` exclusion that appeared twice.

**Dead `unused` suppressions (task #10):**
- `` `eventContext` is unused `` — symbol no longer exists in the codebase.
- `` `(*DatadogLogger).changeLogLevel` is unused `` — `changeLogLevel` moved to `*loggerPointer` during a refactor; the original type no longer has this method.
- `` `defaultRetryDuration` is unused `` — symbol no longer exists.
- `` `defaultRetries` is unused `` — symbol is used; the linter wouldn't fire on it regardless.

**Dead errcheck exclusion:**
- `pem.Encode` — the file that motivated this (`test/integration/utils/certificates.go`) was deleted in #39772. All remaining live `pem.Encode` call sites already check or explicitly ignore the error.

**Dead revive exclusion:**
- `exported const APIName` — the constant no longer exists in `pkg/serverless/trace/inferredspan/`; the file is also already globally excluded via the `paths` list.

**Stale comment fix:**
- Updated the comment on the `io.WriteString` errcheck exclusion — its originating file (`tools/dep_tree_resolver/go_deps.go`) was deleted in #22067. The rule itself is kept as it still covers unchecked writes to `http.ResponseWriter`.

### Motivation

Dead exclusions accumulate noise in the config and make it harder to reason about which rules are actively suppressing real violations.

### Describe how you validated your changes

Ran `dda inv linter.go` — 0 issues.

### Additional Notes

Part of a broader linter configuration cleanup pass.