### PR TITLE
[ABLD-387] Also `bazel`ify schema compression

### DIFF
--- a/.gitlab/build/binary_build/linux.yml
+++ b/.gitlab/build/binary_build/linux.yml
@@ -67,6 +67,7 @@ build_dogstatsd-binary_arm64:
 
 # IoT Agent builds to make sure the build is not broken because of build flags
 build_iot_agent-binary_x64:
+  extends: .bazel:defs:cache:progressive
   stage: binary_build
   timeout: 20m
   rules:

--- a/.gitlab/build/binary_build/schema_generation.yml
+++ b/.gitlab/build/binary_build/schema_generation.yml
@@ -15,7 +15,9 @@ include:
         compare_to: $COMPARE_TO_BRANCH
 
 generate_config_schema-linux:
-  extends: .generate_config_schema
+  extends:
+    - .generate_config_schema
+    - .bazel:defs:cache:progressive
   variables:
     KUBERNETES_CPU_REQUEST: 16
     KUBERNETES_MEMORY_REQUEST: 16Gi
@@ -74,6 +76,7 @@ lint_config_schema:
 generate_config_schema-windows:
   extends:
     - .generate_config_schema
+    - .bazel:defs:cache:windows
     - .windows_docker_default
   needs: ["go_deps", "go_tools_deps"]
   variables:
@@ -81,10 +84,9 @@ generate_config_schema-windows:
   script:
     - $ErrorActionPreference = "Stop"
     - >
-      docker run --rm
+      .\tools\ci\docker-run-with-bazel-cache.ps1
       -m 8192M
       -v "$(Get-Location):c:\mnt"
-      -e CI
       -e GITLAB_CI
       -e CI_JOB_ID
       -e CI_PIPELINE_ID

--- a/.gitlab/windows/build/source_test/windows.yml
+++ b/.gitlab/windows/build/source_test/windows.yml
@@ -8,6 +8,7 @@
   needs: ["go_deps", "go_tools_deps"]
   extends:
     - .windows_docker_default
+    - .bazel:defs:cache:windows
   script:
     - $ErrorActionPreference = "Stop"
     # we pass in CI_JOB_URL and CI_JOB_NAME so that they can be added to additional tags
@@ -16,12 +17,11 @@
     - $FAST_TESTS_FLAG=""
     - If ($FAST_TESTS -eq "true") { $FAST_TESTS_FLAG="--only-impacted-packages" }
     - >
-      docker run --rm
+      .\tools\ci\docker-run-with-bazel-cache.ps1
       -m 24576M
       --storage-opt "size=50GB"
       -v "$(Get-Location):c:\mnt"
       -e DD_ENV=prod
-      -e CI
       -e DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS
       -e GITLAB_CI
       -e CI_JOB_URL

--- a/pkg/config/schema/BUILD.bazel
+++ b/pkg/config/schema/BUILD.bazel
@@ -1,14 +1,49 @@
+load("@bazel_lib//lib:run_binary.bzl", "run_binary")
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+run_binary(
+    name = "compress",
+    srcs = [
+        "core_schema.yaml",
+        "system-probe_schema.yaml",
+    ],
+    outs = [
+        "compressed/core_schema.yaml.zstd",
+        "compressed/system-probe_schema.yaml.zstd",
+    ],
+    args = [
+        "$(location core_schema.yaml)",
+        "$(location compressed/core_schema.yaml.zstd)",
+        "$(location system-probe_schema.yaml)",
+        "$(location compressed/system-probe_schema.yaml.zstd)",
+    ],
+    tool = "//pkg/config/schema/compressor",
+)
+
+pkg_files(
+    name = "compressed",
+    srcs = [
+        "compressed/core_schema.yaml.zstd",
+        "compressed/system-probe_schema.yaml.zstd",
+    ],
+    prefix = "compressed",
+)
+
+pkg_install(
+    name = "install_compressed",
+    srcs = [":compressed"],
+)
 
 go_library(
     name = "schema",
     srcs = ["schema.go"],
     embedsrcs = [
         "compressed/.embed",
-    ] + glob(
-        ["compressed/*.zstd"],
-        allow_empty = True,
-    ),
+        "compressed/core_schema.yaml.zstd",
+        "compressed/system-probe_schema.yaml.zstd",
+    ],
     importpath = "github.com/DataDog/datadog-agent/pkg/config/schema",
     visibility = ["//visibility:public"],
     deps = [

--- a/tasks/schema/generate.py
+++ b/tasks/schema/generate.py
@@ -8,6 +8,7 @@ import yaml
 from invoke import task
 from invoke.exceptions import Exit
 
+from tasks.libs.build.bazel import bazel
 from tasks.schema.fixes import fix_schema
 from tasks.schema.template_parser import parse_template
 
@@ -29,30 +30,11 @@ yaml.add_representer(str, str_presenter)
 
 @task
 def compress(ctx, output_dir=SCHEMA_DIR):
-    compressed_dir = os.path.join(output_dir, "compressed")
-    if not os.path.exists(compressed_dir):
-        os.mkdir(compressed_dir)
-
-    core = os.path.join(output_dir, "core_schema.yaml")
-    sysprobe = os.path.join(output_dir, "system-probe_schema.yaml")
-    coreCompressed = os.path.join(output_dir, "compressed", "core_schema.yaml.zstd")
-    sysprobeCompressed = os.path.join(output_dir, "compressed", "system-probe_schema.yaml.zstd")
-    compressor = os.path.join(output_dir, "compressor", "compress_schema.go")
-
-    core_size_before = os.path.getsize(core)
-    sysprobe_size_before = os.path.getsize(sysprobe)
-
-    ctx.run(f"go run {compressor} {core} {coreCompressed} {sysprobe} {sysprobeCompressed}")
-
-    core_size_after = os.path.getsize(f"{coreCompressed}")
-    sysprobe_size_after = os.path.getsize(f"{sysprobeCompressed}")
-
-    print(
-        f"core_schema.yaml:        {core_size_before:>8,} B -> {core_size_after:>8,} B ({core_size_after / core_size_before * 100:.1f}%)"
-    )
-    print(
-        f"system-probe_schema.yaml:{sysprobe_size_before:>8,} B -> {sysprobe_size_after:>8,} B ({sysprobe_size_after / sysprobe_size_before * 100:.1f}%)"
-    )
+    bazel(ctx, "run", "//pkg/config/schema:install_compressed", "--", f"--destdir={os.path.abspath(output_dir)}")
+    for name in ("core_schema.yaml", "system-probe_schema.yaml"):
+        size_before = os.path.getsize(os.path.join(SCHEMA_DIR, name))
+        size_after = os.path.getsize(os.path.join(output_dir, "compressed", f"{name}.zstd"))
+        print(f"{name:<24}:{size_before:>8,} B -> {size_after:>8,} B ({size_after / size_before * 100:.1f}%)")
 
 
 @task


### PR DESCRIPTION
### What does this PR do?
- add `//pkg/config/schema:compress` (`run_binary`) to compress the YAML schemas via the existing compressor binary,
- add `//pkg/config/schema:install_compressed` (`pkg_install`) to copy the generated `.zstd` files outside the sandbox,
- let `gazelle` wire `embedsrcs` in the `go_library` to the `bazel`-generated outputs so `//go:embed all:compressed` works without a prior manual step,
- run it through `dda inv schema.compress`.

### Motivation
```sh
$ bazel run //:gazelle
...
gazelle: /home/regisdesgroppes/go/src/github.com/DataDog/datadog-agent/pkg/config/schema/BUILD.bazel:6.17-11.6: could not merge expression
```

The previous `dda inv schema.compress` task called `go run` on the compressor source directly to write the `.zstd` files into the source tree.
There were no `bazel` targets for this, so the `.zstd` files were absent from the `bazel` build: `glob()` in `embedsrcs` cannot match generated outputs, meaning `//go:embed all:compressed` silently embedded nothing beyond the `.embed` placeholder.

### Describe how you validated your changes
- `gazelle` no longer warns about the `embedsrcs` expression,
- the `.zstd` files produced by `bazel` are byte-for-byte identical to those produced by the previous `go run`-based implementation.