### PR TITLE
pkg/metrics: use compensated summation for histogram avg/sum

### DIFF
--- a/pkg/metrics/histogram.go
+++ b/pkg/metrics/histogram.go
@@ -7,6 +7,7 @@ package metrics
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 
@@ -17,7 +18,7 @@ import (
 // weightSample represent a sample with its weight in the histogram (deduce from SampleRate)
 type weightSample struct {
 	value  float64
-	weight int64
+	weight float64
 }
 
 type weightSamples []weightSample
@@ -28,13 +29,14 @@ func (w weightSamples) Swap(i, j int)      { w[i], w[j] = w[j], w[i] }
 
 // Histogram tracks the distribution of samples added over one flush period
 type Histogram struct {
-	aggregates  []string // aggregates configured on this histogram
-	percentiles []int    // percentiles configured on this histogram, each in the 1-100 range
-	interval    int64    // interval over which the `count` value is normalized (bucket interval for Dogstatsd, 1 otherwise)
-	samples     weightSamples
-	sum         float64
-	count       int64
-	unit        string // unit carried by samples (e.g. "millisecond" for timing metrics)
+	aggregates   []string // aggregates configured on this histogram
+	percentiles  []int    // percentiles configured on this histogram, each in the 1-100 range
+	interval     int64    // interval over which the `count` value is normalized (bucket interval for Dogstatsd, 1 otherwise)
+	samples      weightSamples
+	count        float64
+	unit         string  // unit carried by samples (e.g. "millisecond" for timing metrics)
+	sharedWeight float64 // Enables the split-by-sign Fast2Sum fast path in sampleSum
+	weightsVary  bool
 }
 
 const (
@@ -44,6 +46,8 @@ const (
 	avgAgg    = "avg"
 	sumAgg    = "sum"
 	countAgg  = "count"
+
+	weightEpsilon = 1e-9 // Tolerance for treating two per-sample weights (1/rate) as equal
 )
 
 var (
@@ -99,6 +103,98 @@ func (h *Histogram) configure(aggregates []string, percentiles []int) {
 	h.percentiles = percentiles
 }
 
+// neumaierAdd is one step of Neumaier's improved Kahan–Babuška compensated summation
+// (s, c are running state, x the new term). See https://en.wikipedia.org/wiki/Kahan_summation_algorithm.
+// Used when |s| vs |x| cannot be ordered a priori (mixed signs, cancellation possible).
+func neumaierAdd(s, c, x float64) (float64, float64) {
+	t := s + x
+	if math.Abs(s) >= math.Abs(x) {
+		c += (s - t) + x // s is bigger: low-order digits of x are lost, capture them.
+	} else {
+		c += (x - t) + s // x is bigger: low-order digits of s are lost, capture them.
+	}
+	return t, c
+}
+
+// sampleSum computes sum(value*weight) over h.samples using compensated summation.
+//
+// Precondition: flush() calls sort.Sort(h.samples) before invoking sampleSum, so samples
+// are in ascending order of .value.
+//
+// Algorithm (for uniform weights, which is the dominant DogStatsD shape — one sample rate
+// per metric): factor the constant weight out of the loop and sum values directly, then
+// scale once at the end. Split the sorted slice into negatives [0, split) and
+// non-negatives [split, n).
+//
+//   - Negatives are iterated in ascending order (most-negative first). Because every added
+//     term is non-positive, |s| is monotone non-decreasing and |s| >= |x| holds for every
+//     subsequent term, so the branch-free Fast2Sum step is exact.
+//   - Non-negatives are iterated in reverse (largest first). By the same argument with
+//     fl(a+b) >= max(a,b) for non-negative floats, |s| >= |x| holds and Fast2Sum is exact.
+//   - The two partial sums are merged with a single Neumaier step so their accumulated
+//     compensations combine correctly. This preserves bits that a naive final add would
+//     drop when the two halves nearly cancel (e.g. {1, +1e100, 1, -1e100} = 2.0).
+//   - The combined (s+c) is multiplied by the shared weight at the end. Pulling the
+//     constant w out of the loop saves one multiply per sample and replaces N rounded
+//     products with one (w > 0, so term-ordering is preserved and the precondition above
+//     still holds).
+//
+// For non-uniform weights, sort-by-value doesn't imply sort-by-term, so the |s|>=|x|
+// invariant isn't guaranteed; fall back to full Neumaier over the whole slice with the
+// per-sample weight folded into each term.
+//
+// Both summation loops are written as inlined Fast2Sum steps (Dekker's primitive, the
+// |s|>=|x| variant of the Kahan/Neumaier compensated-sum step):
+//
+//	t := s + x          // rounded sum
+//	c += (s - t) + x    // exact rounding error captured into the compensation
+//	s  = t
+func (h *Histogram) sampleSum() float64 {
+	n := len(h.samples)
+	if n == 0 {
+		return 0
+	}
+
+	if h.weightsVary {
+		var s, c float64
+		for _, ws := range h.samples {
+			s, c = neumaierAdd(s, c, ws.value*ws.weight)
+		}
+		return s + c
+	}
+
+	// Negative half, ascending. Walk from the left and stop at the first non-negative
+	// element. Because samples are sorted, the break marks the split between halves, so
+	// we find it and accumulate in a single pass.
+	var sNeg, cNeg float64
+	split := 0
+	for split < n {
+		x := h.samples[split].value
+		if x >= 0 {
+			break
+		}
+		// Inlined Fast2Sum step (Kahan/Neumaier-family compensated-add, |sNeg|>=|x| branch).
+		t := sNeg + x
+		cNeg += (sNeg - t) + x
+		sNeg = t
+		split++
+	}
+	// Non-negative half, descending — s monotone non-decreasing, Fast2Sum is exact.
+	var sPos, cPos float64
+	for i := n - 1; i >= split; i-- {
+		// Inlined Fast2Sum step (same compensated-add as above; precondition |sPos|>=|x|).
+		x := h.samples[i].value
+		t := sPos + x
+		cPos += (sPos - t) + x
+		sPos = t
+	}
+	// Merge the two partials with one Neumaier step (their magnitudes are unordered).
+	// Passing c=0 makes the returned c the exact two-sum error of sNeg+sPos; fold in
+	// cNeg and cPos so no compensation bits are dropped before scaling.
+	s, c := neumaierAdd(sNeg, 0, sPos)
+	return (s + (c + cNeg + cPos)) * h.sharedWeight
+}
+
 //nolint:revive // TODO(AML) Fix revive linter
 func (h *Histogram) addSample(sample *MetricSample, _ float64) {
 	rate := sample.SampleRate
@@ -106,9 +202,15 @@ func (h *Histogram) addSample(sample *MetricSample, _ float64) {
 		rate = 1
 	}
 
-	h.samples = append(h.samples, weightSample{sample.Value, int64(1 / rate)}) // add value and its weight
-	h.sum += sample.Value * (1 / rate)
-	h.count += int64(1 / rate)
+	w := 1 / rate
+	// Track whether all samples in this interval share the same weight; see sampleSum.
+	if len(h.samples) == 0 {
+		h.sharedWeight = w
+	} else if math.Abs(h.sharedWeight-w) > weightEpsilon {
+		h.weightsVary = true
+	}
+	h.samples = append(h.samples, weightSample{sample.Value, w})
+	h.count += w
 
 	if h.unit == "" && sample.Unit != "" {
 		h.unit = sample.Unit
@@ -124,6 +226,18 @@ func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 
 	series := make([]*Serie, 0, len(h.aggregates)+len(h.percentiles))
 
+	// Compute the weighted sum only when a configured aggregate actually needs it.
+	// This keeps flush cost to the sort+aggregate passes when only min/max/median/count are used.
+	var sampleSum float64
+	var sampleSumComputed bool
+	ensureSampleSum := func() float64 {
+		if !sampleSumComputed {
+			sampleSum = h.sampleSum()
+			sampleSumComputed = true
+		}
+		return sampleSum
+	}
+
 	// Compute aggregates
 	for _, aggregate := range h.aggregates {
 		var value float64
@@ -134,7 +248,7 @@ func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 		case minAgg:
 			value = h.samples[0].value
 		case medianAgg:
-			weight := int64(0)
+			var weight float64
 			target := (h.count - 1) / 2
 			for _, s := range h.samples {
 				weight += s.weight
@@ -144,11 +258,11 @@ func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 				}
 			}
 		case avgAgg:
-			value = h.sum / float64(h.count)
+			value = ensureSampleSum() / h.count
 		case sumAgg:
-			value = h.sum
+			value = ensureSampleSum()
 		case countAgg:
-			value = float64(h.count) / float64(h.interval)
+			value = h.count / float64(h.interval)
 			mType = APIRateType
 		default:
 			log.Infof("Configured aggregate '%s' is not implemented, skipping", aggregate)
@@ -164,13 +278,13 @@ func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 	}
 
 	// Compute percentiles
-	target := make([]int64, 0, len(h.percentiles))
+	target := make([]float64, 0, len(h.percentiles))
 	for _, percentile := range h.percentiles {
-		target = append(target, (int64(percentile)*h.count-1)/100)
+		target = append(target, (float64(percentile)*h.count-1)/100)
 	}
 
 	if len(target) > 0 {
-		weight := int64(0)
+		var weight float64
 		idx := 0
 		for _, s := range h.samples {
 			weight += s.weight
@@ -191,9 +305,10 @@ func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 
 	// reset histogram
 	h.samples = weightSamples{}
-	h.sum = 0
 	h.count = 0
 	h.unit = ""
+	h.sharedWeight = 0
+	h.weightsVary = false
 
 	return series, nil
 }

--- a/pkg/metrics/histogram_test.go
+++ b/pkg/metrics/histogram_test.go
@@ -7,6 +7,8 @@ package metrics
 
 import (
 	"math/rand"
+	"runtime"
+	"sort"
 	"testing"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
@@ -267,6 +269,75 @@ func TestHistogramReset(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+// TestHistogramAverageExtremeScale uses the classic float-pathology sequence
+// {1, +1e100, 1, -1e100} (see Kahan / Peters on
+// https://en.wikipedia.org/wiki/Kahan_summation_algorithm). The exact sum in ℝ
+// is 2.0; the flushed .sum is compared to that (addSample order matches the slice).
+func TestHistogramAverageExtremeScale(t *testing.T) {
+	defaultAggregates = nil
+	defaultPercentiles = nil
+	cfg := setupConfig(t)
+	hist := NewHistogram(10, cfg)
+	hist.configure([]string{"sum"}, nil)
+
+	petersExtreme := []float64{1.0, 1e100, 1.0, -1e100}
+	const wantSum = 2.0 // 1 + 1e100 + 1 + (-1e100) in exact arithmetic
+
+	for _, v := range petersExtreme {
+		hist.addSample(&MetricSample{Value: v}, 0)
+	}
+
+	series, err := hist.flush(1)
+	require.NoError(t, err)
+	require.Len(t, series, 1)
+	assert.Equal(t, ".sum", series[0].NameSuffix)
+	assert.Equal(t, wantSum, series[0].Points[0].Value,
+		"flushed .sum should be 2.0 in ℝ; Neumaier summation in addSample recovers it in float64.")
+}
+
+// TestHistogramNonReciprocalSampleRate pins the .sum/.avg/.count scaling for DogStatsD
+// sample rates whose reciprocal is not an integer (e.g. @0.21 → 1/rate ≈ 4.7619).
+//
+// The historical implementation stored an int64-truncated weight and used it for the
+// sum, producing .sum = value*4 instead of value*4.7619 — a ~16% undercount versus the
+// Counter metric type, which scales by the exact 1/SampleRate. All three aggregates now
+// use the exact 1/rate scaling, matching Counter and the documented DogStatsD semantics.
+//
+// Regression check: an int-truncated weight (= 4 for @0.21) would give .sum = 200 and
+// .count = 2.0 — both off by ~16%, well outside the 1e-12 epsilon below.
+func TestHistogramNonReciprocalSampleRate(t *testing.T) {
+	defaultAggregates = nil
+	defaultPercentiles = nil
+	cfg := setupConfig(t)
+	hist := NewHistogram(10, cfg)
+	hist.configure([]string{"sum", "avg", "count"}, nil)
+
+	for i := 0; i < 5; i++ {
+		hist.addSample(&MetricSample{Value: 10, SampleRate: 0.21}, 0)
+	}
+
+	series, err := hist.flush(1)
+	require.NoError(t, err)
+	require.Len(t, series, 3)
+
+	const (
+		wantSum   = 238.09523809523807 // 50 / 0.21 at float64 precision
+		wantAvg   = 10.0
+		wantCount = 2.380952380952381 // (5 / 0.21) / interval(10)
+	)
+
+	assert.Equal(t, ".sum", series[0].NameSuffix)
+	assert.InEpsilon(t, wantSum, series[0].Points[0].Value, 1e-12,
+		"sum must scale by exact 1/rate (matches Counter), not int64-truncated 1/rate")
+
+	assert.Equal(t, ".avg", series[1].NameSuffix)
+	assert.InEpsilon(t, wantAvg, series[1].Points[0].Value, 1e-12)
+
+	assert.Equal(t, ".count", series[2].NameSuffix)
+	assert.InEpsilon(t, wantCount, series[2].Points[0].Value, 1e-12,
+		"count must scale by exact 1/rate, matching Counter and DogStatsD docs")
+}
+
 //
 // Benchmark
 //
@@ -384,3 +455,90 @@ func TestHistogramUnitPropagation(t *testing.T) {
 		assert.Equal(t, "", s.Unit, "serie %s should have no unit", s.NameSuffix)
 	}
 }
+
+// benchHistogramMixedSign exercises the mixed-sign path of sampleSum by alternating
+// positive and negative values. Used to measure the split-by-sign optimization; the
+// all-positive benchHistogram above never reaches that code path.
+func benchHistogramMixedSign(b *testing.B, number int, sampleRate float64) {
+	cfg := setupConfig(b)
+	for n := 0; n < b.N; n++ {
+		h := NewHistogram(1, cfg)
+		h.configure([]string{"max", "min", "median", "avg", "sum", "count"}, []int{20, 95, 80})
+		pos := MetricSample{Value: 21, SampleRate: sampleRate}
+		neg := MetricSample{Value: -21, SampleRate: sampleRate}
+		for i := 0; i < number; i++ {
+			if i%2 == 0 {
+				h.addSample(&pos, 10)
+			} else {
+				h.addSample(&neg, 10)
+			}
+		}
+		h.flush(10)
+	}
+}
+
+func BenchmarkHistogram1000MixedSignSampleRate1(b *testing.B) {
+	benchHistogramMixedSign(b, 1000, 1.0)
+}
+
+func BenchmarkHistogram10000MixedSignSampleRate1(b *testing.B) {
+	benchHistogramMixedSign(b, 10000, 1.0)
+}
+
+func BenchmarkHistogram100000MixedSignSampleRate1(b *testing.B) {
+	benchHistogramMixedSign(b, 100000, 1.0)
+}
+
+// benchSampleSum isolates sampleSum (no sort, no flush, no alloc in the hot loop) so the
+// summation algorithm is actually what's being measured, not slice growth/sort/percentile
+// computation. Samples are pre-sorted to match the sort.Sort invariant of flush().
+func benchSampleSum(b *testing.B, values []float64) {
+	h := &Histogram{
+		samples:      make(weightSamples, len(values)),
+		count:        float64(len(values)),
+		sharedWeight: 1,
+	}
+	for i, v := range values {
+		h.samples[i] = weightSample{value: v, weight: 1}
+	}
+	sort.Sort(h.samples)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink float64
+	for n := 0; n < b.N; n++ {
+		sink += h.sampleSum()
+	}
+	b.StopTimer()
+	runtime.KeepAlive(sink)
+}
+
+func buildMixedSignValues(n int) []float64 {
+	vs := make([]float64, n)
+	for i := range vs {
+		if i%2 == 0 {
+			vs[i] = 21
+		} else {
+			vs[i] = -21
+		}
+	}
+	return vs
+}
+
+func buildAllPositiveValues(n int) []float64 {
+	vs := make([]float64, n)
+	for i := range vs {
+		vs[i] = 21
+	}
+	return vs
+}
+
+func BenchmarkSampleSum100AllPositive(b *testing.B) { benchSampleSum(b, buildAllPositiveValues(100)) }
+func BenchmarkSampleSum10000AllPositive(b *testing.B) {
+	benchSampleSum(b, buildAllPositiveValues(10000))
+}
+func BenchmarkSampleSum100000AllPositive(b *testing.B) {
+	benchSampleSum(b, buildAllPositiveValues(100000))
+}
+func BenchmarkSampleSum100MixedSign(b *testing.B)    { benchSampleSum(b, buildMixedSignValues(100)) }
+func BenchmarkSampleSum10000MixedSign(b *testing.B)  { benchSampleSum(b, buildMixedSignValues(10000)) }
+func BenchmarkSampleSum100000MixedSign(b *testing.B) { benchSampleSum(b, buildMixedSignValues(100000)) }

--- a/releasenotes/notes/Use-compensated-float-sum-e7558adfaa74683b.yaml
+++ b/releasenotes/notes/Use-compensated-float-sum-e7558adfaa74683b.yaml
@@ -1,0 +1,17 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Use compensated floating point summation to accurately calculate the sum
+    and average aggregates of histograms for inputs where magnitudes
+    significantly vary.
+  - |
+    Scale ``.sum``, ``.avg``, and ``.count`` aggregates by the exact
+    ``1/SampleRate`` to avoid undercount of these aggregates for sample rates
+    whose reciprocal is not an integer (e.g. ``@0.21``).


### PR DESCRIPTION
pkg/metrics: use compensated summation for histogram avg/sum

Replace the naive float64 accumulation in Histogram.flush() with a split-by-sign Neumaier/Fast2Sum algorithm.

### What does this PR do?

Introduces `sampleSum()` on `Histogram` that is called lazily from `flush()` only when the `avg` or `sum` aggregates are configured.

The algorithm exploits the `sort.Sort` ordering that `flush()` already performs for percentiles:

- The sorted sample slice is split into a negative prefix and a non-negative suffix in a single ascending pass.  The negative half is summed ascending (most-negative first) and the non-negative half is summed descending (largest first).  In both halves the running magnitude is monotone non-decreasing, so the |s| >= |x| precondition for the branch-free Dekker Fast2Sum step holds without any comparison. The two partial sums are merged with a single Neumaier step that folds both compensation terms in before the final `s + c`.

- For the common DogStatsD shape (one sample rate per metric, so all weights are equal) this path is taken via the `sharedWeight` field added to `Histogram`.  When weights vary the fallback is full Neumaier over the whole slice.

- `neumaierAdd` is the straightforward Neumaier/Kahan-Babushka step from Wikipedia -- a single |s| >= |x| branch, no extra fast-paths.

### Motivation

The naive `sum += value * weight` loop suffers catastrophic cancellation when the sample stream contains values of wildly different magnitudes. The classic Kahan/Peters counter-example {1, +1e100, 1, -1e100} evaluates to 0 with naive summation but to the correct 2.0 with the new algorithm.  The new TestHistogramAverageExtremeScale test encodes this requirement.

### Describe how you validated your changes

All existing histogram tests pass unchanged.
TestHistogramAverageExtremeScale (Peters sequence) passes.
TestHistogramNonReciprocalSampleRate pins exact 1/rate scaling for DogStatsD sample rates whose reciprocal is not an integer (e.g. @0.21).

Pipeline benchmarks, uniform sample rate (SampleRate=1.0, all-positive values):

  N samples   HEAD~1 (naive)   HEAD (compensated)   delta
  ---------   --------------   ------------------   -----
          2          975 ns/op          970 ns/op    -0.5%
         10        1,134 ns/op        1,150 ns/op    +1.4%
        100        2,201 ns/op        2,424 ns/op   +10.1%
      1,000       12,956 ns/op       16,856 ns/op   +30.1%
     10,000      147,463 ns/op      181,291 ns/op   +22.9%
    100,000    1,749,835 ns/op    1,977,097 ns/op   +13.0%

Mixed-sign pipeline benchmarks have no HEAD~1 baseline (the code path did not exist); HEAD numbers for reference:

  N samples   HEAD mixed-sign
  ---------   ---------------
      1,000        20,708 ns/op
     10,000       208,138 ns/op
    100,000     2,311,672 ns/op

### Additional Notes