### PR TITLE
[AGENTRUN-1235] packaging/aix: align paths for Go binaries

### DIFF
--- a/packaging/aix/package-scripts/postinst
+++ b/packaging/aix/package-scripts/postinst
@@ -40,7 +40,7 @@ LIBPATH_VAL=${LIBPATH_VAL}:/opt/freeware/lib64:/opt/freeware/lib
 printf '#!/bin/sh\n'                                                          > "$WRAPPER"
 printf 'export LIBPATH=%s\n' "$LIBPATH_VAL"                                  >> "$WRAPPER"
 printf 'export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:${PATH}\n' >> "$WRAPPER"
-printf 'exec /opt/datadog-agent/bin/agent "$@"\n'                            >> "$WRAPPER"
+printf 'exec /opt/datadog-agent/bin/agent/agent "$@"\n'                      >> "$WRAPPER"
 chmod 755 "$WRAPPER"
 
 # Write SRC wrapper for trace-agent.
@@ -48,7 +48,7 @@ TRACE_WRAPPER=/opt/datadog-agent/bin/trace-agent-svc
 printf '#!/bin/sh\n'                                                              > "$TRACE_WRAPPER"
 printf 'export LIBPATH=%s\n' "$LIBPATH_VAL"                                      >> "$TRACE_WRAPPER"
 printf 'export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:${PATH}\n' >> "$TRACE_WRAPPER"
-printf 'exec /opt/datadog-agent/bin/trace-agent run --config /etc/datadog-agent/datadog.yaml\n' >> "$TRACE_WRAPPER"
+printf 'exec /opt/datadog-agent/embedded/bin/trace-agent run --config /etc/datadog-agent/datadog.yaml\n' >> "$TRACE_WRAPPER"
 chmod 755 "$TRACE_WRAPPER"
 
 # Remove ALL stale SRC entries then register fresh.

--- a/packaging/aix/package.sh
+++ b/packaging/aix/package.sh
@@ -47,7 +47,7 @@ trap cleanup EXIT
 # components. If either is absent the staging tree is incomplete and mkinstallp
 # will produce a broken or empty BFF.
 
-AGENT_BIN="$STAGING/opt/datadog-agent/bin/agent"
+AGENT_BIN="$STAGING/opt/datadog-agent/bin/agent/agent"
 if [ ! -f "$AGENT_BIN" ]; then
     log "ERROR: agent binary not found at $AGENT_BIN"
     log "       Did Stage 04 (04-agent) complete successfully?"
@@ -72,7 +72,7 @@ log "Pre-flight: postinst script found at $POSTINST"
 # AIX mkinstallp USRFiles requires individual file/directory paths; listing a
 # directory path alone only packages the directory entry, not its contents.
 # We use find to enumerate every path under each package directory and strip the
-# staging prefix so each line is the absolute installed path (e.g. /opt/datadog-agent/bin/agent).
+# staging prefix so each line is the absolute installed path (e.g. /opt/datadog-agent/bin/agent/agent).
 
 log "Generating gen.template with VRMF=${AGENT_VRMF}"
 

--- a/packaging/aix/stages/04-agent.sh
+++ b/packaging/aix/stages/04-agent.sh
@@ -102,11 +102,7 @@ log "Building agent version $AGENT_VERSION at commit $COMMIT"
 
 # ─── Step 4: Build the agent binary ───────────────────────────────────────────
 #
-# Build tags are determined by inv agent.build (tasks/build_tags.py).
-#
-# The binary is placed at bin/agent/agent — matching the Linux convention —
-# so the agent's built-in relative path computation (../../embedded) resolves
-# to /opt/datadog-agent/embedded without needing --python-home-3.
+# Build tags and ldflags are determined by inv agent.build (tasks/build_tags.py).
 
 log "Building agent binary via inv agent.build"
 cd /opt/datadog-agent
@@ -124,7 +120,7 @@ log "agent binary build complete: $STAGING/opt/datadog-agent/bin/agent/agent"
 
 # ─── Step 5: Build the trace-agent binary ─────────────────────────────────────
 #
-# Build tags come from tasks/build_tags.py AGENT_TAGS minus AIX_EXCLUDE_TAGS, plus COMMON_TAGS.
+# Build tags are determined by inv trace-agent.build (tasks/build_tags.py).
 
 log "Building trace-agent binary via inv trace-agent.build"
 cd /opt/datadog-agent

--- a/packaging/aix/stages/04-agent.sh
+++ b/packaging/aix/stages/04-agent.sh
@@ -44,8 +44,8 @@ fi
 cleanup() {
     if [ $? -ne 0 ]; then
         log "ERROR: $STAGE_NAME failed. Removing partial outputs."
-        rm -f "$STAGING/opt/datadog-agent/bin/agent"
-        rm -f "$STAGING/opt/datadog-agent/bin/trace-agent"
+        rm -rf "$STAGING/opt/datadog-agent/bin/agent"
+        rm -f "$STAGING/opt/datadog-agent/embedded/bin/trace-agent"
     fi
 }
 trap cleanup EXIT
@@ -53,7 +53,7 @@ trap cleanup EXIT
 # ─── Step 1: Create output directory ──────────────────────────────────────────
 
 log "Creating staging bin directory"
-mkdir -p "$STAGING/opt/datadog-agent/bin"
+mkdir -p "$STAGING/opt/datadog-agent/bin/agent"
 
 # ─── Step 2: Set rtloader CGO flags ───────────────────────────────────────────
 #
@@ -102,38 +102,38 @@ log "Building agent version $AGENT_VERSION at commit $COMMIT"
 
 # ─── Step 4: Build the agent binary ───────────────────────────────────────────
 #
-# Build tags and ldflags are determined by inv agent.build (tasks/build_tags.py).
+# Build tags are determined by inv agent.build (tasks/build_tags.py).
 #
-# --python-home-3 must be set explicitly because on AIX the binary lives at
-# bin/agent (one level shallower than bin/agent/agent on Linux), so the default
-# relative path calculation resolves to /opt/embedded which does not exist.
+# The binary is placed at bin/agent/agent — matching the Linux convention —
+# so the agent's built-in relative path computation (../../embedded) resolves
+# to /opt/datadog-agent/embedded without needing --python-home-3.
 
 log "Building agent binary via inv agent.build"
 cd /opt/datadog-agent
-rm -f "$STAGING/opt/datadog-agent/bin/agent"
+rm -f "$STAGING/opt/datadog-agent/bin/agent/agent"
 python3.12 -m invoke agent.build \
     --rebuild \
     --skip-assets \
     --exclude-rtloader \
     --rtloader-root=/opt/datadog-agent/rtloader \
     --embedded-path="$EMBEDDED_DESTDIR" \
-    --python-home-3="$EMBEDDED" \
-    --agent-bin="$STAGING/opt/datadog-agent/bin/agent"
+    --agent-bin="$STAGING/opt/datadog-agent/bin/agent/agent"
 
-strip -X64 "$STAGING/opt/datadog-agent/bin/agent"
-log "agent binary build complete: $STAGING/opt/datadog-agent/bin/agent"
+strip -X64 "$STAGING/opt/datadog-agent/bin/agent/agent"
+log "agent binary build complete: $STAGING/opt/datadog-agent/bin/agent/agent"
 
 # ─── Step 5: Build the trace-agent binary ─────────────────────────────────────
 #
-# Build tags are determined by inv trace-agent.build (tasks/build_tags.py).
+# Build tags come from tasks/build_tags.py AGENT_TAGS minus AIX_EXCLUDE_TAGS, plus COMMON_TAGS.
 
 log "Building trace-agent binary via inv trace-agent.build"
 cd /opt/datadog-agent
 python3.12 -m invoke trace-agent.build --rebuild
-rm -f "$STAGING/opt/datadog-agent/bin/trace-agent"
-cp /opt/datadog-agent/bin/trace-agent/trace-agent "$STAGING/opt/datadog-agent/bin/trace-agent"
-strip -X64 "$STAGING/opt/datadog-agent/bin/trace-agent"
-log "trace-agent binary build complete: $STAGING/opt/datadog-agent/bin/trace-agent"
+mkdir -p "$STAGING/opt/datadog-agent/embedded/bin"
+rm -f "$STAGING/opt/datadog-agent/embedded/bin/trace-agent"
+cp /opt/datadog-agent/bin/trace-agent/trace-agent "$STAGING/opt/datadog-agent/embedded/bin/trace-agent"
+strip -X64 "$STAGING/opt/datadog-agent/embedded/bin/trace-agent"
+log "trace-agent binary build complete: $STAGING/opt/datadog-agent/embedded/bin/trace-agent"
 
 # ─── Step 6: Verify XCOFF64 magic bytes ───────────────────────────────────────
 #
@@ -141,7 +141,7 @@ log "trace-agent binary build complete: $STAGING/opt/datadog-agent/bin/trace-age
 # would indicate a cross-compile or wrong-format build.
 
 log "Verifying agent binary is XCOFF64"
-MAGIC=$(od -A x -t x1 "$STAGING/opt/datadog-agent/bin/agent" | head -1 | awk '{print $2 $3}')
+MAGIC=$(od -A x -t x1 "$STAGING/opt/datadog-agent/bin/agent/agent" | head -1 | awk '{print $2 $3}')
 if [ "$MAGIC" != "01f7" ]; then
     log "ERROR: agent binary is not XCOFF64 (got: $MAGIC)"
     log "       Expected magic bytes: 01 f7"
@@ -151,7 +151,7 @@ fi
 log "XCOFF64 magic verified for agent binary (magic: $MAGIC)"
 
 log "Verifying trace-agent binary is XCOFF64"
-MAGIC=$(od -A x -t x1 "$STAGING/opt/datadog-agent/bin/trace-agent" | head -1 | awk '{print $2 $3}')
+MAGIC=$(od -A x -t x1 "$STAGING/opt/datadog-agent/embedded/bin/trace-agent" | head -1 | awk '{print $2 $3}')
 if [ "$MAGIC" != "01f7" ]; then
     log "ERROR: trace-agent binary is not XCOFF64 (got: $MAGIC)"
     log "       Expected magic bytes: 01 f7"

--- a/packaging/aix/stages/10-assemble.sh
+++ b/packaging/aix/stages/10-assemble.sh
@@ -46,7 +46,7 @@ trap cleanup EXIT
 # The agent binary is the primary deliverable. If it is absent the staging
 # tree is incomplete and packaging will produce a broken BFF.
 
-AGENT_BIN="$STAGING/opt/datadog-agent/bin/agent"
+AGENT_BIN="$STAGING/opt/datadog-agent/bin/agent/agent"
 if [ ! -f "$AGENT_BIN" ]; then
     log "ERROR: agent binary not found at $AGENT_BIN"
     log "       Did Stage 04 (04-agent) complete successfully?"


### PR DESCRIPTION
### What does this PR do?

Moves the AIX agent binaries to the standard paths used on Linux/macOS:

| Binary | Before | After |
|--------|--------|-------|
| agent | `bin/agent` | `bin/agent/agent` |
| trace-agent | `bin/trace-agent` | `embedded/bin/trace-agent` |

### Motivation

With the agent at `bin/agent` (one level shallower than Linux's `bin/agent/agent`), the built-in relative path computation `filepath.Join(executableFolder, "../../embedded")` resolved to `/opt/embedded` instead of `/opt/datadog-agent/embedded`. This required passing `--python-home-3` explicitly to `inv agent.build` as a workaround.

Moving the binary to `bin/agent/agent` makes the path computation work correctly without any special case, and aligns the AIX package layout with the standard omnibus layout used on all other platforms.

### Describe how you validated your changes

Built the package on AIX 7.3 and installed on a clean AIX 7.2 TL2 host:
- Binary present at `/opt/datadog-agent/bin/agent/agent` ✓
- `agent version` works (no `--python-home-3` needed) ✓
- CPU check and lparstats check collect metrics ✓
- Python 3.13.12 loads via the automatic relative path resolution ✓

### Additional Notes

The `bin/agent-svc` and `bin/trace-agent-svc` SRC wrapper scripts are unchanged — they remain in `bin/` as they wrap the actual binaries and are referenced by the SRC subsystem registration.