### PR TITLE
Remove stripping exclusions which are no longer relevant

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -157,20 +157,6 @@ build do
             delete "#{install_dir}/embedded/share/system-probe/ebpf/co-re/error_telemetry.o"
             delete "#{install_dir}/embedded/share/system-probe/ebpf/co-re/logdebug-test.o"
 
-            # linux build will be stripped - but psycopg2 affected by bug in the way binutils
-            # and patchelf work together:
-            #    https://github.com/pypa/manylinux/issues/119
-            #    https://github.com/NixOS/patchelf
-            #
-            # Only affects psycopg2 - any binary whose path matches the pattern will be
-            # skipped.
-            strip_exclude("*psycopg2*")
-            strip_exclude("*cffi_backend*")
-
-            # We get the following error when the aerospike lib is stripped:
-            # The `aerospike` client is not installed: /opt/datadog-agent/embedded/lib/python2.7/site-packages/aerospike.so: ELF load command address/offset not properly aligned
-            strip_exclude("*aerospike*")
-
             # Do not strip eBPF programs
             strip_exclude("#{install_dir}/embedded/share/system-probe/ebpf/*.o")
             strip_exclude("#{install_dir}/embedded/share/system-probe/ebpf/co-re/*.o")


### PR DESCRIPTION
### What does this PR do?

Removes stripping exclusions that are no longer necessary.

### Motivation

Remove unnecessary weight. We generally strip all binaries included with the Agent (based on the code [here](https://github.com/DataDog/omnibus-ruby/blob/8548f93c51d59b1defcef08d00b618ce7107ea01/lib/omnibus/stripper.rb#L79-L97)), but we realized that we had a few exclusions. I had a closer look at them and it turns out it's safe to remove them (see below for the explanation).

### Describe how you validated your changes

I'm fairly confident in the safeness of this change based on the fact that we are stripping other binaries that go through the same auditwheel / patchelf process and have never caused any problems.

### Additional Notes

The original reason for adding these exclusions had to do with how wheels processed via [auditwheel](https://github.com/pypa/auditwheel), which uses patchelf to adjust rpath's for native libraries bundled with wheels.
This is mentioned in https://github.com/DataDog/datadog-agent/pull/4135 (which added one of the exceptions), pointing at this upstream manylinux issue: https://github.com/pypa/manylinux/issues/119.

The underlying issue came from how patchelf used to work, which prevented safely stripping binaries after patching. This was, however, fixed in https://github.com/NixOS/patchelf/pull/117. This fix was released with [patchelf 0.10](https://github.com/NixOS/patchelf/releases/tag/0.10). Given that we now build all our wheels with native code ourselves, and that the build image being used to build them comes with patchelf 0.17.2, we no longer have this problem, and stripping can be considered safe.

For extra context, there have been significant changes since the exclusions were originally introduced. At the time, we were using upstream wheels, for which we didn't have control over the build and what version of auditwheel / patchelf they were using. This is no longer the case, as we now build everything. We also sometimes fall behind on dependency versions for various reasons, which could have also caused us to be using wheels built with even older tooling.