### PR TITLE
cleanup(rtloader): remove dead Python 2 code support

### DIFF
--- a/rtloader/BUILD.bazel
+++ b/rtloader/BUILD.bazel
@@ -168,11 +168,9 @@ cc_library(
     local_defines = select({
         "@platforms//os:windows": [
             "_hypot=hypot",
-            "DATADOG_AGENT_THREE",
         ],
         "//conditions:default": [
             "_GLIBCXX_USE_CXX11_ABI=0",
-            "DATADOG_AGENT_THREE",
         ],
     }),
     visibility = ["//visibility:public"],

--- a/rtloader/README.md
+++ b/rtloader/README.md
@@ -25,8 +25,7 @@ that must be implemented by any supported backend, see `include/rtloader.h` for 
 
 ### Common
 
-The `common` folder contains C/C++ modules that are compiled into both
-`libdatadog-agent-three` and `libdatadog-agent-two` to avoid code duplication.
+The `common` folder contains C/C++ modules that are compiled into `libdatadog-agent-three`.
 Most of the code used to extend the embedded interpreter is there.
 
 ## Requirements

--- a/rtloader/common/builtins/_util.c
+++ b/rtloader/common/builtins/_util.c
@@ -265,11 +265,7 @@ PyObject *subprocess_output(PyObject *self, PyObject *args, PyObject *kw)
         pyStderr = Py_None;
     }
 
-#ifdef DATADOG_AGENT_THREE
     pyRetCode = PyLong_FromLong(ret_code);
-#else
-    pyRetCode = PyInt_FromLong(ret_code);
-#endif
     if (pyRetCode == NULL) {
         goto cleanup;
     }

--- a/rtloader/common/builtins/containers.h
+++ b/rtloader/common/builtins/containers.h
@@ -32,9 +32,7 @@
 #include <Python.h>
 #include <rtloader_types.h>
 
-#ifdef DATADOG_AGENT_THREE
 PyMODINIT_FUNC PyInit_containers(void);
-#endif
 
 #define CONTAINERS_MODULE_NAME "containers"
 

--- a/rtloader/test/datadog_agent/datadog_agent_test.go
+++ b/rtloader/test/datadog_agent/datadog_agent_test.go
@@ -35,10 +35,7 @@ func TestGetVersion(t *testing.T) {
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		version = datadog_agent.get_version()
-		if sys.version_info.major == 2:
-			assert type(version) == type(b"")
-		else:
-			assert type(version) == type(u"")
+		assert type(version) == type(u"")
 		f.write(version)
 	`, tmpfile.Name())
 	out, err := run(code)
@@ -102,10 +99,7 @@ func TestGetHostname(t *testing.T) {
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		name = datadog_agent.get_hostname()
-		if sys.version_info.major == 2:
-			assert type(name) == type(b"")
-		else:
-			assert type(name) == type(u"")
+		assert type(name) == type(u"")
 		f.write(name)
 	`, tmpfile.Name())
 	out, err := run(code)
@@ -127,10 +121,7 @@ func TestGetClustername(t *testing.T) {
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		name = datadog_agent.get_clustername()
-		if sys.version_info.major == 2:
-			assert type(name) == type(b"")
-		else:
-			assert type(name) == type(u"")
+		assert type(name) == type(u"")
 		f.write(name)
 	`, tmpfile.Name())
 

--- a/rtloader/test/uutil/uutil_test.go
+++ b/rtloader/test/uutil/uutil_test.go
@@ -33,8 +33,7 @@ func TestSubprocessOutputWrongArg(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "TypeError: get_subprocess_output() missing required argument 'command' (pos 1)" && // Python 3
-		out != "TypeError: Required argument 'command' (pos 1) not found" { // Python 2
+	if out != "TypeError: get_subprocess_output() missing required argument 'command' (pos 1)" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 

--- a/rtloader/three/CMakeLists.txt
+++ b/rtloader/three/CMakeLists.txt
@@ -55,7 +55,6 @@ elseif(APPLE)
   set_target_properties(datadog-agent-three PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
 endif()
 
-add_compile_definitions(DATADOG_AGENT_THREE)
 target_include_directories(datadog-agent-three PRIVATE .)
 target_include_directories(datadog-agent-three PUBLIC
     ${CMAKE_SOURCE_DIR}/include

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -110,7 +110,7 @@ bool Three::init()
     }
 
     // add custom builtins init funcs to Python inittab, one by one
-    // Unlinke its py2 counterpart, these need to be called before Py_Initialize
+    // These must be called before Py_Initialize.
     PyImport_AppendInittab(AGGREGATOR_MODULE_NAME, PyInit_aggregator);
     PyImport_AppendInittab(DATADOG_AGENT_MODULE_NAME, PyInit_datadog_agent);
     PyImport_AppendInittab(UTIL_MODULE_NAME, PyInit_util);
@@ -347,7 +347,7 @@ bool Three::getCheck(RtLoaderPyObject *py_class, const char *init_config_str, co
         goto done;
     }
     // As stated in the Python C-API documentation
-    // https://github.com/python/cpython/blob/2.7/Doc/c-api/intro.rst#reference-count-details, PyTuple_SetItem takes
+    // https://github.com/python/cpython/blob/3.10/Doc/c-api/intro.rst#reference-count-details, PyTuple_SetItem takes
     // over ownership of the given item (instance in this case). This means that we should NOT DECREF it
     if (PyTuple_SetItem(instances, 0, instance) != 0) {
         setError("could not set instance item on instances: " + _fetchPythonError());
@@ -775,7 +775,7 @@ std::string Three::_fetchPythonError() const
                 if (fmt_exc != NULL) {
                     Py_ssize_t len = PyList_Size(fmt_exc);
                     // docs are not clear but `PyList_Size` can actually fail and in case it would
-                    // return -1, see https://github.com/python/cpython/blob/2.7/Objects/listobject.c#L170
+                    // return -1, see https://github.com/python/cpython/blob/3.12/Objects/listobject.c#L224
                     if (len == -1) {
                         // don't fetch the actual error or the caller might think it was the root cause,
                         // while it's not. Setting `ret_val` empty will make the function return "unknown error".


### PR DESCRIPTION
### What does this PR do?

Removes dead Python 2 code from `rtloader/`.
- `DATADOG_AGENT_THREE` compile flag and the `#ifdef` blocks it gated (in `_util.c`, `containers.h`, `BUILD.bazel`, `three/CMakeLists.txt`)
- `if sys.version_info.major == 2` branches in `datadog_agent_test.go`
- Dead Py2 `TypeError` clause in `uutil_test.go`
- `libdatadog-agent-two` reference in the README

Refreshed outdated Python 2.7 documentation references in `three.cpp` comments to Python 3 equivalents

### Motivation

- Python 2 is no longer supported
- Was recommended to remove lingering code in the following PR https://github.com/DataDog/datadog-agent/pull/49909#discussion_r3146936760

### Describe how you validated your changes

Agent builds and runs successfully. Existing unit tests continue to pass.

### Additional Notes
