### PR TITLE
Restrict `objcopy` calls' ambient capability set

### DIFF
--- a/cmd/host-profiler/main.go
+++ b/cmd/host-profiler/main.go
@@ -27,11 +27,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to set PR_SET_NO_NEW_PRIVS: %v\n", err)
 		os.Exit(1)
 	}
-	// Drop ambient capabilities so no child process inherits them.
-	if err := unix.Prctl(unix.PR_CAP_AMBIENT, unix.PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to clear ambient capabilities: %v\n", err)
-		os.Exit(1)
-	}
+
 	flavor.SetFlavor(flavor.HostProfiler)
 	os.Exit(runcmd.Run(command.MakeRootCommand()))
 }

--- a/cmd/host-profiler/main.go
+++ b/cmd/host-profiler/main.go
@@ -9,7 +9,10 @@
 package main
 
 import (
+	"fmt"
 	"os"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/cmd/host-profiler/command"
 	"github.com/DataDog/datadog-agent/cmd/internal/runcmd"
@@ -18,6 +21,12 @@ import (
 )
 
 func main() {
+	// Prevent this process and all children from gaining new privileges via
+	// setuid binaries or file capabilities. Inherited across fork/exec.
+	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set PR_SET_NO_NEW_PRIVS: %v\n", err)
+		os.Exit(1)
+	}
 	flavor.SetFlavor(flavor.HostProfiler)
 	os.Exit(runcmd.Run(command.MakeRootCommand()))
 }

--- a/cmd/host-profiler/main.go
+++ b/cmd/host-profiler/main.go
@@ -27,6 +27,11 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to set PR_SET_NO_NEW_PRIVS: %v\n", err)
 		os.Exit(1)
 	}
+	// Drop ambient capabilities so no child process inherits them.
+	if err := unix.Prctl(unix.PR_CAP_AMBIENT, unix.PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to clear ambient capabilities: %v\n", err)
+		os.Exit(1)
+	}
 	flavor.SetFlavor(flavor.HostProfiler)
 	os.Exit(runcmd.Run(command.MakeRootCommand()))
 }

--- a/comp/host-profiler/symboluploader/symbolcopier/symbolcopier.go
+++ b/comp/host-profiler/symboluploader/symbolcopier/symbolcopier.go
@@ -14,7 +14,6 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"syscall"
 
 	"github.com/DataDog/datadog-agent/comp/host-profiler/oom"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/pclntab"
@@ -134,9 +133,6 @@ func CopySymbols(ctx context.Context, inputPath, outputPath string, goPCLnTabInf
 	args = append(args, inputPath, outputPath)
 
 	cmd := exec.CommandContext(ctx, "objcopy", args...)
-	// objcopy needs no caps: /proc/<self>/fd/<N> ptrace check passes by same-UID,
-	// and executables are world-readable. Non-nil empty slice triggers CLEAR_ALL in the child.
-	cmd.SysProcAttr = &syscall.SysProcAttr{AmbientCaps: []uintptr{}}
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start copying symbols: %w", err)
 	}

--- a/comp/host-profiler/symboluploader/symbolcopier/symbolcopier.go
+++ b/comp/host-profiler/symboluploader/symbolcopier/symbolcopier.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/DataDog/datadog-agent/comp/host-profiler/oom"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/pclntab"
@@ -133,6 +134,9 @@ func CopySymbols(ctx context.Context, inputPath, outputPath string, goPCLnTabInf
 	args = append(args, inputPath, outputPath)
 
 	cmd := exec.CommandContext(ctx, "objcopy", args...)
+	// objcopy needs no caps: /proc/<self>/fd/<N> ptrace check passes by same-UID,
+	// and executables are world-readable. Non-nil empty slice triggers CLEAR_ALL in the child.
+	cmd.SysProcAttr = &syscall.SysProcAttr{AmbientCaps: []uintptr{}}
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start copying symbols: %w", err)
 	}


### PR DESCRIPTION
### What does this PR do?

Restricts the privileges of the host-profiler process and its children:

- Calls `PR_SET_NO_NEW_PRIVS` at startup, preventing the process and any subprocess it spawns from ever gaining new privileges through setuid binaries or file capabilities.

### Motivation

- `PR_SET_NO_NEW_PRIVS`: if file capabilities are ever set on the objcopy binary on the host (malicious or accidental), the profiler would exec it and objcopy would gain those capabilities. With this flag set at startup, file capabilities are silently ignored on exec regardless of what is installed on the binary.