### PR TITLE
Change default admission controller registry to registry.datadoghq.com

### DIFF
--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
-const commonRegistry = "gcr.io/datadoghq"
+const commonRegistry = "registry.datadoghq.com"
 
 func TestInjectAgentSidecar(t *testing.T) {
 	mockConfig := configmock.New(t)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1381,7 +1381,7 @@ func TestAutoinstrumentation(t *testing.T) {
 			shouldMutate: true,
 			expected: &expected{
 				initContainerImages: []string{
-					"gcr.io/datadoghq/dd-lib-php-init:v1",
+					"registry.datadoghq.com/dd-lib-php-init:v1",
 					"docker.io/library/apm-inject-package:v27",
 				},
 				containerNames: defaultContainerNames,
@@ -1409,7 +1409,7 @@ func TestAutoinstrumentation(t *testing.T) {
 			shouldMutate: true,
 			expected: &expected{
 				initContainerImages: []string{
-					"gcr.io/datadoghq/apm-inject:0",
+					"registry.datadoghq.com/apm-inject:0",
 					"foo/bar:1",
 				},
 				containerNames: defaultContainerNames,

--- a/pkg/config/schema/core_schema.yaml
+++ b/pkg/config/schema/core_schema.yaml
@@ -7462,7 +7462,7 @@ properties:
       container_registry:
         node_type: setting
         type: string
-        default: gcr.io/datadoghq
+        default: registry.datadoghq.com
       cws_instrumentation:
         node_type: section
         type: object

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -632,7 +632,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.mutation.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.mutate_unlabelled", false)
 	config.BindEnvAndSetDefault("admission_controller.port", 8000)
-	config.BindEnvAndSetDefault("admission_controller.container_registry", "gcr.io/datadoghq")
+	config.BindEnvAndSetDefault("admission_controller.container_registry", "registry.datadoghq.com")
 	config.BindEnvAndSetDefault("admission_controller.timeout_seconds", 10) // in seconds (see kubernetes/kubernetes#71508)
 	config.BindEnvAndSetDefault("admission_controller.service_name", "datadog-admission-controller")
 	config.BindEnvAndSetDefault("admission_controller.certificate.validity_bound", 365*24)             // validity bound of the certificate created by the controller (in hours, default 1 year)

--- a/releasenotes-dca/notes/default-registry-datadoghq-5fa6b8f0655f6d22.yaml
+++ b/releasenotes-dca/notes/default-registry-datadoghq-5fa6b8f0655f6d22.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    Change the default ``admission_controller.container_registry`` from
+    ``gcr.io/datadoghq`` to ``registry.datadoghq.com`` to align with the
+    Helm chart registry migration initiative. Users who rely on the previous
+    default can set ``admission_controller.container_registry`` back to
+    ``gcr.io/datadoghq`` explicitly.


### PR DESCRIPTION
### What does this PR do?

Changes the default value of ``admission_controller.container_registry`` from ``gcr.io/datadoghq`` to ``registry.datadoghq.com``.

### Motivation

The Helm charts repository has already migrated the default container registry to ``registry.datadoghq.com`` as part of the registry migration initiative (BARX-1655/BARX-1656). The agent-side default was still pointing at ``gcr.io/datadoghq``, meaning users of the admission controller webhooks (agent sidecar, CWS instrumentation, auto instrumentation) who did not explicitly set a registry would pull from GCR instead of the cheaper Datadog-owned registry.

This aligns the agent's default with the Helm chart so that standalone cluster-agent deployments also benefit from the migration.

### Describe how you validated your changes

Unit tests and CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)