### PR TITLE
fix(renovate): Remove `github-action[bot]` as ignored authors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "minimumReleaseAge": "7 days",
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",
-    "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com", "200755185+dd-octo-sts[bot]@users.noreply.github.com"],
+    "gitIgnoredAuthors": ["200755185+dd-octo-sts[bot]@users.noreply.github.com"],
     "platformCommit": "enabled",
     "packageRules": [
       {


### PR DESCRIPTION
### What does this PR do?
All updates are done with dd-octo-sts now. This author is not requested anymore.

### Motivation
Comply with dd-source rule here
https://github.com/DataDog/dd-source/pull/421853

### Describe how you validated your changes

### Additional Notes
