### PR TITLE
fix(chainguard): Use the correct workflow name

### DIFF
--- a/.github/chainguard/self.check-issue-status.label-issue.sts.yaml
+++ b/.github/chainguard/self.check-issue-status.label-issue.sts.yaml
@@ -6,7 +6,7 @@ subject: repo:DataDog/datadog-agent:environment:main
 claim_pattern:
   event_name: (issue_comment|workflow_dispatch)
   ref: refs/heads/main
-  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/check_issue_status\.yml@refs/heads/main
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/check-issue-status\.yml@refs/heads/main
 
 permissions:
   actions: read


### PR DESCRIPTION
### What does this PR do?
Use the correct workflow name with `-` instead of `_`. Update that was missed within https://github.com/DataDog/datadog-agent/pull/47805

### Motivation
Prevent errors like https://github.com/DataDog/datadog-agent/actions/runs/24995095668/job/73189893157

### Describe how you validated your changes
n/a

### Additional Notes
