### PR TITLE
linter: fix unchecked io.WriteString calls and remove global errcheck exclusion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -357,9 +357,6 @@ linters:
       - staticcheck
       path: pkg/clusteragent/admission/mutate/cwsinstrumentation/
       text: "SA1019: slices"
-    # io.WriteString to http.ResponseWriter - errors are not actionable
-    - path: (.+)\.go$
-      text: Error return value of `io.WriteString` is not checked
     - linters:
       - revive
       path: (.+)\.go$

--- a/cmd/system-probe/api/debug/handlers_linux.go
+++ b/cmd/system-probe/api/debug/handlers_linux.go
@@ -110,7 +110,7 @@ func HandleLinuxDmesg(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
-	io.WriteString(w, dmesgStr)
+	_, _ = io.WriteString(w, dmesgStr)
 }
 
 // handleCommand runs commandName with the provided arguments and writes it to the HTTP response.

--- a/cmd/system-probe/api/debug/handlers_nolinux.go
+++ b/cmd/system-probe/api/debug/handlers_nolinux.go
@@ -16,17 +16,17 @@ import (
 // HandleLinuxDmesg is not supported
 func HandleLinuxDmesg(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(500)
-	io.WriteString(w, "HandleLinuxDmesg is not supported on this platform")
+	_, _ = io.WriteString(w, "HandleLinuxDmesg is not supported on this platform")
 }
 
 // HandleSelinuxSestatus is not supported
 func HandleSelinuxSestatus(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(500)
-	io.WriteString(w, "HandleSelinuxSestatus is not supported on this platform")
+	_, _ = io.WriteString(w, "HandleSelinuxSestatus is not supported on this platform")
 }
 
 // HandleSelinuxSemoduleList is not supported
 func HandleSelinuxSemoduleList(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(500)
-	io.WriteString(w, "HandleSelinuxSemoduleList is not supported on this platform")
+	_, _ = io.WriteString(w, "HandleSelinuxSemoduleList is not supported on this platform")
 }

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -720,14 +720,14 @@ func (t *Tracer) DebugNetworkMaps() (*network.Connections, error) {
 
 // DebugEBPFMaps returns all maps registered in the eBPF manager
 func (t *Tracer) DebugEBPFMaps(w io.Writer, maps ...string) error {
-	io.WriteString(w, "tracer:\n")
+	_, _ = io.WriteString(w, "tracer:\n")
 	err := t.ebpfTracer.DumpMaps(w, maps...)
 	if err != nil {
 		return err
 	}
 
 	if t.usmMonitor != nil {
-		io.WriteString(w, "usm_monitor:\n")
+		_, _ = io.WriteString(w, "usm_monitor:\n")
 		err := t.usmMonitor.DumpMaps(w, maps...)
 		if err != nil {
 			return err


### PR DESCRIPTION
### What does this PR do?

Fixes all remaining unchecked `io.WriteString` call sites and removes the global `errcheck` exclusion rule that was suppressing them.

The 6 call sites were all writing to `http.ResponseWriter` (or an `io.Writer` debug sink) where write errors are not actionable — the connection may already be closed. They are now explicitly silenced with `_, _ =`.

**Files changed:**
- `cmd/system-probe/api/debug/handlers_nolinux.go` — 3 "not supported" stub handlers
- `cmd/system-probe/api/debug/handlers_linux.go` — dmesg response write
- `pkg/network/tracer/tracer.go` — section headers in `DebugEBPFMaps`

### Motivation

The global exclusion was originally added for a file that has since been deleted. Removing it restores `errcheck` coverage for `io.WriteString` across the whole codebase going forward.

### Describe how you validated your changes

`dda inv linter.go` passes (validated by the pre-push hook).

### Additional Notes

Follow-up to #49907.