### PR TITLE
[EBPF-1034] stabilize TestDeviceCacheRefresh_Concurrent initialization

### DIFF
--- a/pkg/gpu/safenvml/cache_test.go
+++ b/pkg/gpu/safenvml/cache_test.go
@@ -303,6 +303,12 @@ func TestDeviceCacheRefresh_Concurrent(t *testing.T) {
 	WithMockNVML(t, mockNvml)
 	cache := NewDeviceCache()
 	require.NotNil(t, cache)
+	// Pre-initialize the cache so the reader goroutine's Count() never triggers
+	// ensureInit() → Refresh(). Without this, the reader's first Refresh() can
+	// observe an inconsistent device count: DeviceGetCount() and
+	// DeviceGetHandleByIndex() each read numDevicesAvailable independently, and
+	// the updater's Store() can land between those reads.
+	require.NoError(t, cache.Refresh())
 
 	// launch two workers, one refreshing the cache and one reading from it
 	var wg sync.WaitGroup


### PR DESCRIPTION
### What does this PR do?
Pre-initializes the device cache before starting the concurrent reader/updater goroutines in `TestDeviceCacheRefresh_Concurrent`.

### Motivation
The test can observe an inconsistent mocked device snapshot during lazy initialization (`.Count()` can trigger `Refresh()`) and intermittently fail with `count is 5`.

### Describe how you validated your changes
Ran the targeted unit test with:
- `dda inv test --targets=./pkg/gpu/safenvml --extra-args='-run TestDeviceCacheRefresh_Concurrent -count=1' -v`

We will monitor the test in CI to see if it's triggered again

### Additional Notes