### PR TITLE
fix(par/rshell): separate /host/ paths from bare-metal paths

### DIFF
--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -27,13 +27,46 @@ import (
 )
 
 const (
-	defaultProcPath         = "/proc"
-	containerizedPathPrefix = "/host"
+	defaultProcPath = "/proc"
+	// containerizedHostPrefix is the path namespace under which
+	// containerized runners see the host filesystem. Paths outside this
+	// prefix belong to the bare-metal namespace. The trailing slash matters
+	// for prefix matching: "/host" alone would match "/hostname".
+	containerizedHostPrefix = "/host/"
 )
 
 // statFn is the function used to check path existence. It defaults to os.Stat
 // and can be overridden in tests.
 var statFn = os.Stat
+
+// envAllowsPath reports whether p belongs to the path namespace of the
+// current runtime environment. Containerized runners see the host
+// filesystem mounted under /host/; bare-metal runners see it directly.
+// Crossing the line would point rshell at a tree that does not exist in
+// the runner's namespace.
+func envAllowsPath(p string) bool {
+	if env.IsContainerized() {
+		return strings.HasPrefix(p, containerizedHostPrefix)
+	}
+	return !strings.HasPrefix(p, containerizedHostPrefix)
+}
+
+// envFilterAllowedPaths drops paths that do not belong to the current
+// runtime environment. Nil is preserved so the nil-vs-empty contract used
+// by filterAllowedPaths (nil = "field absent", empty = "explicit no
+// paths") survives the filter.
+func envFilterAllowedPaths(paths []string) []string {
+	if paths == nil {
+		return nil
+	}
+	filtered := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if envAllowsPath(p) {
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
+}
 
 // RunCommandHandler implements the runCommand action.
 //
@@ -59,12 +92,18 @@ type RunCommandHandler struct {
 // NewRunCommandHandler creates a new RunCommandHandler. Pass nil for either
 // operator list to disable filtering on that axis. A non-nil empty slice is
 // an explicit "block everything on this axis" and is honored as such.
+//
+// Operator paths are env-filtered at construction: containerized runners
+// drop entries outside /host/, bare-metal runners drop entries inside it.
+// An operator who lists only wrong-namespace paths will get an empty
+// operator allowlist and block all access.
 func NewRunCommandHandler(operatorAllowedPaths []string, operatorAllowedCommands []string) *RunCommandHandler {
 	h := &RunCommandHandler{}
 	if operatorAllowedPaths != nil {
 		h.operatorPathsFilterEnabled = true
-		h.operatorAllowedPaths = make(map[string]struct{}, len(operatorAllowedPaths))
-		for _, p := range operatorAllowedPaths {
+		envFiltered := envFilterAllowedPaths(operatorAllowedPaths)
+		h.operatorAllowedPaths = make(map[string]struct{}, len(envFiltered))
+		for _, p := range envFiltered {
 			if p == "" {
 				continue
 			}
@@ -162,7 +201,9 @@ func (h *RunCommandHandler) Run(
 	}
 
 	effectiveAllowedCommands := h.filterAllowedCommands(inputs.AllowedCommands)
-	effectiveAllowedPaths := h.filterAllowedPaths(inputs.AllowedPaths)
+	// Env-filter the backend list before intersection: paths from the
+	// wrong namespace would not exist on this runner.
+	effectiveAllowedPaths := h.filterAllowedPaths(envFilterAllowedPaths(inputs.AllowedPaths))
 	log.Debugf("rshell runCommand: command=%q backendAllowedCommands=%v effectiveAllowedCommands=%v backendAllowedPaths=%v effectiveAllowedPaths=%v",
 		inputs.Command, inputs.AllowedCommands, effectiveAllowedCommands, inputs.AllowedPaths, effectiveAllowedPaths)
 
@@ -212,7 +253,7 @@ func (h *RunCommandHandler) Run(
 // /host/proc; otherwise it falls back to /proc.
 func resolveProcPath() string {
 	if env.IsContainerized() {
-		hostProc := path.Join(containerizedPathPrefix, defaultProcPath)
+		hostProc := path.Join(containerizedHostPrefix, defaultProcPath)
 		if _, err := statFn(hostProc); err == nil {
 			return hostProc
 		}

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -92,18 +92,12 @@ type RunCommandHandler struct {
 // NewRunCommandHandler creates a new RunCommandHandler. Pass nil for either
 // operator list to disable filtering on that axis. A non-nil empty slice is
 // an explicit "block everything on this axis" and is honored as such.
-//
-// Operator paths are env-filtered at construction: containerized runners
-// drop entries outside /host/, bare-metal runners drop entries inside it.
-// An operator who lists only wrong-namespace paths will get an empty
-// operator allowlist and block all access.
 func NewRunCommandHandler(operatorAllowedPaths []string, operatorAllowedCommands []string) *RunCommandHandler {
 	h := &RunCommandHandler{}
 	if operatorAllowedPaths != nil {
 		h.operatorPathsFilterEnabled = true
-		envFiltered := envFilterAllowedPaths(operatorAllowedPaths)
-		h.operatorAllowedPaths = make(map[string]struct{}, len(envFiltered))
-		for _, p := range envFiltered {
+		h.operatorAllowedPaths = make(map[string]struct{}, len(operatorAllowedPaths))
+		for _, p := range operatorAllowedPaths {
 			if p == "" {
 				continue
 			}

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -179,6 +179,7 @@ func TestFilterAllowedPathsExplicitEmptyBackendBlocksAll(t *testing.T) {
 }
 
 func TestFilterAllowedPathsIntersection(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "")
 	handler := NewRunCommandHandler([]string{"/var/log", "/tmp"}, nil)
 
 	got := handler.filterAllowedPaths([]string{"/var/log", "/etc", "/tmp"})
@@ -271,6 +272,7 @@ func TestFilterAllowedCommandsMatrix(t *testing.T) {
 // TestFilterAllowedCommandsMatrix. Twelve scenarios with the same shape:
 // path intersection is plain string equality, identical to commands.
 func TestFilterAllowedPathsMatrix(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "")
 	cases := []struct {
 		name     string
 		backend  []string
@@ -321,6 +323,7 @@ func TestFilterAllowedPathsMatrix(t *testing.T) {
 }
 
 func TestNewRunCommandHandlerStoresAllowedPaths(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "")
 	paths := []string{"/var/log", "/tmp"}
 
 	handler := NewRunCommandHandler(paths, nil)
@@ -330,6 +333,7 @@ func TestNewRunCommandHandlerStoresAllowedPaths(t *testing.T) {
 }
 
 func TestNewRshellBundleUsesConfiguredAllowedPaths(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "")
 	cfg := &config.Config{RShellAllowedPaths: []string{"/var/log", "/tmp"}}
 
 	bundle := NewRshellBundle(cfg)
@@ -338,6 +342,139 @@ func TestNewRshellBundleUsesConfiguredAllowedPaths(t *testing.T) {
 	handler, ok := action.(*RunCommandHandler)
 	require.True(t, ok)
 	assert.Equal(t, map[string]struct{}{"/var/log": {}, "/tmp": {}}, handler.operatorAllowedPaths)
+}
+
+// TestEnvFilterAllowedPaths covers the path-namespace separation between
+// containerized and bare-metal runners. The constant is /host/ (with trailing
+// slash) so /hostname is correctly classified as bare-metal, not /host/.
+func TestEnvFilterAllowedPaths(t *testing.T) {
+	cases := []struct {
+		name          string
+		containerized bool
+		input         []string
+		want          []string
+	}{
+		// Bare-metal: keep paths outside /host/, drop paths inside.
+		{"bare-metal nil preserved", false, nil, nil},
+		{"bare-metal empty preserved", false, []string{}, []string{}},
+		{"bare-metal keeps non-host paths", false,
+			[]string{"/var/log", "/tmp"}, []string{"/var/log", "/tmp"}},
+		{"bare-metal drops /host/ paths", false,
+			[]string{"/host/var/log", "/host/etc"}, []string{}},
+		{"bare-metal mixed", false,
+			[]string{"/var/log", "/host/var/log", "/etc"},
+			[]string{"/var/log", "/etc"}},
+		{"bare-metal allows /hostname (not under /host/)", false,
+			[]string{"/hostname"}, []string{"/hostname"}},
+
+		// Containerized: keep paths under /host/, drop paths outside.
+		{"containerized nil preserved", true, nil, nil},
+		{"containerized empty preserved", true, []string{}, []string{}},
+		{"containerized keeps /host/ paths", true,
+			[]string{"/host/var/log", "/host/etc"},
+			[]string{"/host/var/log", "/host/etc"}},
+		{"containerized drops non-host paths", true,
+			[]string{"/var/log", "/tmp"}, []string{}},
+		{"containerized mixed", true,
+			[]string{"/var/log", "/host/var/log", "/etc"},
+			[]string{"/host/var/log"}},
+		{"containerized rejects /hostname (not under /host/)", true,
+			[]string{"/hostname"}, []string{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.containerized {
+				t.Setenv("DOCKER_DD_AGENT", "true")
+			} else {
+				t.Setenv("DOCKER_DD_AGENT", "")
+			}
+
+			got := envFilterAllowedPaths(tc.input)
+
+			if tc.input == nil {
+				assert.Nil(t, got)
+			} else if len(tc.want) == 0 {
+				assert.Empty(t, got)
+			} else {
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestNewRunCommandHandlerOperatorPathsFilteredBareMetal(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "")
+
+	handler := NewRunCommandHandler(
+		[]string{"/var/log", "/host/var/log", "/etc"}, nil)
+
+	assert.Equal(t,
+		map[string]struct{}{"/var/log": {}, "/etc": {}},
+		handler.operatorAllowedPaths)
+	assert.True(t, handler.operatorPathsFilterEnabled)
+}
+
+func TestNewRunCommandHandlerOperatorPathsFilteredContainerized(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "true")
+
+	handler := NewRunCommandHandler(
+		[]string{"/var/log", "/host/var/log", "/host/etc"}, nil)
+
+	assert.Equal(t,
+		map[string]struct{}{"/host/var/log": {}, "/host/etc": {}},
+		handler.operatorAllowedPaths)
+	assert.True(t, handler.operatorPathsFilterEnabled)
+}
+
+func TestNewRunCommandHandlerOperatorPathsAllWrongEnvBlocksAll(t *testing.T) {
+	// Operator misconfigured for the runner's environment. The filter
+	// strips every entry, leaving an empty allowlist — operatorPathsFilter
+	// stays enabled, so rshell will block all filesystem access regardless
+	// of what the backend approves.
+	t.Setenv("DOCKER_DD_AGENT", "true")
+
+	handler := NewRunCommandHandler([]string{"/var/log", "/etc"}, nil)
+
+	assert.Empty(t, handler.operatorAllowedPaths)
+	assert.True(t, handler.operatorPathsFilterEnabled)
+}
+
+func TestRunCommandBackendPathsEnvFilteredContainerized(t *testing.T) {
+	// Containerized runner; backend sent a bare-metal path. After env
+	// filtering, the backend list is empty — the intersection with the
+	// (also bare-metal-only) operator list collapses to nothing and rshell
+	// rejects the read.
+	t.Setenv("DOCKER_DD_AGENT", "true")
+
+	handler := NewRunCommandHandler(
+		[]string{"/host/var/log"}, []string{"rshell:cat"})
+	task := makeTaskWithPaths("cat /var/log/syslog",
+		[]string{"rshell:cat"}, []string{"/var/log"})
+
+	out, err := handler.Run(context.Background(), task, nil)
+
+	require.NoError(t, err)
+	result := out.(*RunCommandOutputs)
+	assert.NotEqual(t, 0, result.ExitCode,
+		"expected cat to fail because /var/log was env-filtered out of the backend list")
+}
+
+func TestRunCommandBackendPathsEnvFilteredBareMetal(t *testing.T) {
+	// Bare-metal runner; backend sent a containerized path. Env filtering
+	// drops it before intersection — rshell never sees /host/var/log.
+	t.Setenv("DOCKER_DD_AGENT", "")
+
+	handler := NewRunCommandHandler(
+		[]string{"/var/log"}, []string{"rshell:cat"})
+	task := makeTaskWithPaths("cat /var/log/syslog",
+		[]string{"rshell:cat"}, []string{"/host/var/log"})
+
+	out, err := handler.Run(context.Background(), task, nil)
+
+	require.NoError(t, err)
+	result := out.(*RunCommandOutputs)
+	assert.NotEqual(t, 0, result.ExitCode,
+		"expected cat to fail because /host/var/log was env-filtered out of the backend list")
 }
 
 func mockStatFn(existing map[string]bool) func(string) (os.FileInfo, error) {

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -179,7 +179,6 @@ func TestFilterAllowedPathsExplicitEmptyBackendBlocksAll(t *testing.T) {
 }
 
 func TestFilterAllowedPathsIntersection(t *testing.T) {
-	t.Setenv("DOCKER_DD_AGENT", "")
 	handler := NewRunCommandHandler([]string{"/var/log", "/tmp"}, nil)
 
 	got := handler.filterAllowedPaths([]string{"/var/log", "/etc", "/tmp"})
@@ -272,7 +271,6 @@ func TestFilterAllowedCommandsMatrix(t *testing.T) {
 // TestFilterAllowedCommandsMatrix. Twelve scenarios with the same shape:
 // path intersection is plain string equality, identical to commands.
 func TestFilterAllowedPathsMatrix(t *testing.T) {
-	t.Setenv("DOCKER_DD_AGENT", "")
 	cases := []struct {
 		name     string
 		backend  []string
@@ -323,7 +321,6 @@ func TestFilterAllowedPathsMatrix(t *testing.T) {
 }
 
 func TestNewRunCommandHandlerStoresAllowedPaths(t *testing.T) {
-	t.Setenv("DOCKER_DD_AGENT", "")
 	paths := []string{"/var/log", "/tmp"}
 
 	handler := NewRunCommandHandler(paths, nil)
@@ -333,7 +330,6 @@ func TestNewRunCommandHandlerStoresAllowedPaths(t *testing.T) {
 }
 
 func TestNewRshellBundleUsesConfiguredAllowedPaths(t *testing.T) {
-	t.Setenv("DOCKER_DD_AGENT", "")
 	cfg := &config.Config{RShellAllowedPaths: []string{"/var/log", "/tmp"}}
 
 	bundle := NewRshellBundle(cfg)
@@ -400,43 +396,6 @@ func TestEnvFilterAllowedPaths(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestNewRunCommandHandlerOperatorPathsFilteredBareMetal(t *testing.T) {
-	t.Setenv("DOCKER_DD_AGENT", "")
-
-	handler := NewRunCommandHandler(
-		[]string{"/var/log", "/host/var/log", "/etc"}, nil)
-
-	assert.Equal(t,
-		map[string]struct{}{"/var/log": {}, "/etc": {}},
-		handler.operatorAllowedPaths)
-	assert.True(t, handler.operatorPathsFilterEnabled)
-}
-
-func TestNewRunCommandHandlerOperatorPathsFilteredContainerized(t *testing.T) {
-	t.Setenv("DOCKER_DD_AGENT", "true")
-
-	handler := NewRunCommandHandler(
-		[]string{"/var/log", "/host/var/log", "/host/etc"}, nil)
-
-	assert.Equal(t,
-		map[string]struct{}{"/host/var/log": {}, "/host/etc": {}},
-		handler.operatorAllowedPaths)
-	assert.True(t, handler.operatorPathsFilterEnabled)
-}
-
-func TestNewRunCommandHandlerOperatorPathsAllWrongEnvBlocksAll(t *testing.T) {
-	// Operator misconfigured for the runner's environment. The filter
-	// strips every entry, leaving an empty allowlist — operatorPathsFilter
-	// stays enabled, so rshell will block all filesystem access regardless
-	// of what the backend approves.
-	t.Setenv("DOCKER_DD_AGENT", "true")
-
-	handler := NewRunCommandHandler([]string{"/var/log", "/etc"}, nil)
-
-	assert.Empty(t, handler.operatorAllowedPaths)
-	assert.True(t, handler.operatorPathsFilterEnabled)
 }
 
 func TestRunCommandBackendPathsEnvFilteredContainerized(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

In the Private Action Runner's `rshell` `runCommand` handler, filter both the backend (Balto) and operator allowed-paths lists by the runner's environment before passing them to rshell:

- **Containerized runners** (i.e. `DOCKER_DD_AGENT` is set) — only paths under `/host/` are kept; other paths are dropped.
- **Bare-metal runners** — only paths outside `/host/` are kept; `/host/...` paths are dropped.

The existing string-equality intersection between Balto and the operator allowlist is preserved on top of the env filter. The nil-vs-empty contract in `filterAllowedPaths` (nil = "field absent → block all", empty = "explicit no paths") is preserved by `envFilterAllowedPaths`, which short-circuits on nil.

Operator paths are filtered once at handler construction; backend paths are filtered per-task in `Run`.

### Motivation

Today, Balto's allowed-paths list is forwarded to rshell verbatim. That makes the runner sensitive to which path namespace Balto happens to send:

- A containerized runner that received bare-metal paths (e.g. `/var/log`) would point rshell at directories that don't exist inside the container.
- A bare-metal runner that received `/host/var/log` would point rshell at a path that only exists in containerized deployments.

Filtering at the runner side makes the allowlist robust to mismatched configuration and gives each environment exactly the paths that exist in its filesystem namespace.

### Describe how you validated your changes

- New unit tests cover both environments and the boundary cases:
  - `TestEnvFilterAllowedPaths` — table of 12 cases including the `/hostname` boundary (must not match `/host/`).
  - `TestNewRunCommandHandlerOperatorPathsFilteredBareMetal` / `…Containerized` / `…AllWrongEnvBlocksAll` — operator-side filter at construction, including the misconfiguration case where every operator path is wrong-namespace and the result is an empty allowlist (still blocks all access).
  - `TestRunCommandBackendPathsEnvFiltered{Containerized,BareMetal}` — end-to-end through `Run`, verifying that a wrong-namespace backend path is dropped before intersection.
- Added `t.Setenv(\"DOCKER_DD_AGENT\", \"\")` to four existing tests that depend on bare-metal-namespace paths in their assertions, so they remain deterministic if the env leaks.
- `dda inv test --targets=./pkg/privateactionrunner/bundles/remoteaction/rshell` — 62/62 passing.

### Additional Notes

- The constant `containerizedPathPrefix = \"/host\"` was renamed to `containerizedHostPrefix = \"/host/\"`. The trailing slash matters for prefix matching (otherwise `/host` would match `/hostname`); the existing `path.Join(containerizedHostPrefix, \"/proc\")` in `resolveProcPath` collapses the slash, so the resolved `/host/proc` is unchanged.
- No new logging is emitted for dropped paths. The existing `Debugf` line in `Run` continues to log the raw backend list and the final effective list — the env-filter step is implementation detail in between.
- The filter is path-only. `AllowedCommands` is environment-agnostic and unchanged.