### PR TITLE
[AGENTRUN-1240] fix(loader): retry unix.Poll on EINTR instead of starting trace-agent

### DIFF
--- a/cmd/loader/main_nix.go
+++ b/cmd/loader/main_nix.go
@@ -136,7 +136,12 @@ func main() {
 	for {
 		n, err := unix.Poll(pollfds, -1)
 		if err != nil {
-			log.Warnf("error while polling: %v", err)
+			if err == unix.EINTR {
+				// EINTR means a signal interrupted the syscall; this is not an error, retry
+				log.Warnf("Polling interrupted by signal, retrying...")
+				continue
+			}
+			log.Errorf("error while polling: %v", err)
 			break
 		}
 


### PR DESCRIPTION
## What does this PR do?

When `unix.Poll` is interrupted by a signal, it returns `EINTR` (interrupted system call). This is not a real error — the signal did not kill the process, so it's safe and correct to retry the poll.

Previously, any `EINTR` from `poll(2)` caused the loader to immediately exec the trace-agent, spiking its PSS even when no traces were arriving. This was the root cause of the quality gate PSS failure in incident-53566.

## Changes

- On `EINTR`, log a warning and retry the poll loop
- Promote the non-EINTR poll error from `Warn` to `Error` (it's an unexpected failure)

## Testing

Verified the binary builds cleanly. The fix is behaviorally equivalent to the `SA_RESTART` convention for signal-interrupted syscalls.