### PR TITLE
[ACTP] PAR: fix rshell allow-list intersection bugs

### DIFF
--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -38,6 +38,11 @@ const (
 	// Restricted Shell
 	PARRestrictedShellAllowedPaths    = "private_action_runner.restricted_shell.allowed_paths"
 	PARRestrictedShellAllowedCommands = "private_action_runner.restricted_shell.allowed_commands"
+	// RShellCommandNamespacePrefix is the prefix the backend stamps onto
+	// every command in its allow-list. Operator entries in datadog.yaml
+	// must use the same form to intersect; otherwise they silently fail
+	// to match.
+	RShellCommandNamespacePrefix = "rshell:"
 )
 
 // setupPrivateActionRunner registers all configuration keys for the private action runner

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/modes"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -128,23 +129,45 @@ func makeActionsAllowlist(config config.Component) map[string]sets.Set[string] {
 }
 
 // rshellAllowedCommands returns the operator-configured rshell command
-// allowlist, or nil when the operator did not configure one. Nil signals
-// "pass-through" so the handler forwards the backend list unchanged.
+// allowlist. Nil = pass-through; non-nil empty = kill-switch.
+// Operator entries must be in the backend's namespaced form ("rshell:<name>");
+// any other spelling is warned at load time.
 func rshellAllowedCommands(config config.Component) []string {
-	if !config.IsConfigured(setup.PARRestrictedShellAllowedCommands) {
-		return nil
+	commands := configuredStringSliceOrNil(config, setup.PARRestrictedShellAllowedCommands)
+	warnUnnamespacedCommands(commands)
+	return commands
+}
+
+// warnUnnamespacedCommands logs a warning per entry missing the "rshell:"
+// prefix so the silent no-match failure mode is observable.
+func warnUnnamespacedCommands(commands []string) {
+	for _, c := range commands {
+		if !strings.HasPrefix(c, setup.RShellCommandNamespacePrefix) {
+			log.Warnf("%s entry %q is missing the %q prefix and will never match a backend command; use %q instead",
+				setup.PARRestrictedShellAllowedCommands, c, setup.RShellCommandNamespacePrefix, setup.RShellCommandNamespacePrefix+c)
+		}
 	}
-	return config.GetStringSlice(setup.PARRestrictedShellAllowedCommands)
 }
 
 // rshellAllowedPaths mirrors rshellAllowedCommands for the filesystem
-// allowlist. Nil means "operator unset" — the handler will pass the backend
-// list through unchanged rather than tightening to an empty intersection.
+// allowlist.
 func rshellAllowedPaths(config config.Component) []string {
-	if !config.IsConfigured(setup.PARRestrictedShellAllowedPaths) {
+	return configuredStringSliceOrNil(config, setup.PARRestrictedShellAllowedPaths)
+}
+
+// configuredStringSliceOrNil returns the configured value only when the
+// user explicitly set the key. Normalizes the YAML-empty-list edge case,
+// where GetStringSlice returns a nil slice indistinguishable from "unset",
+// into a non-nil empty slice so the kill-switch is honored.
+func configuredStringSliceOrNil(config config.Component, key string) []string {
+	if !config.IsConfigured(key) {
 		return nil
 	}
-	return config.GetStringSlice(setup.PARRestrictedShellAllowedPaths)
+	v := config.GetStringSlice(key)
+	if v == nil {
+		return []string{}
+	}
+	return v
 }
 
 // getDatadogHost extracts and normalizes the Datadog host from the main endpoint.

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -374,3 +374,52 @@ func TestFromDDConfigPARRestrictedShellAllowedCommandsEmpty(t *testing.T) {
 	assert.NotNil(t, cfg.RShellAllowedCommands)
 	assert.Empty(t, cfg.RShellAllowedCommands)
 }
+
+// TestFromDDConfigPARRestrictedShellAllowedPathsEmptyYAML reproduces the
+// real-world failure observed in PAR: when datadog.yaml contains
+// `allowed_paths: []` the transform must preserve the explicit-empty value
+// so the handler treats it as "block everything", not "operator unset".
+// This exercises the YAML parsing path rather than SetWithoutSource; the
+// two differ in whether GetStringSlice round-trips the empty list as nil.
+func TestFromDDConfigPARRestrictedShellAllowedPathsEmptyYAML(t *testing.T) {
+	yaml := `
+private_action_runner:
+  restricted_shell:
+    allowed_paths: []
+`
+	mockConfig := configmock.NewFromYAML(t, yaml)
+
+	cfg, err := FromDDConfig(mockConfig)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg.RShellAllowedPaths, "YAML [] must reach the handler as a non-nil slice so the kill-switch is honored")
+	assert.Empty(t, cfg.RShellAllowedPaths)
+}
+
+func TestFromDDConfigPARRestrictedShellAllowedCommandsEmptyYAML(t *testing.T) {
+	yaml := `
+private_action_runner:
+  restricted_shell:
+    allowed_commands: []
+`
+	mockConfig := configmock.NewFromYAML(t, yaml)
+
+	cfg, err := FromDDConfig(mockConfig)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg.RShellAllowedCommands, "YAML [] must reach the handler as a non-nil slice so the kill-switch is honored")
+	assert.Empty(t, cfg.RShellAllowedCommands)
+}
+
+func TestFromDDConfigPARRestrictedShellAllowedAbsentYAML(t *testing.T) {
+	// No restricted_shell block at all: both axes nil, handler passes
+	// the backend list through.
+	yaml := `
+private_action_runner:
+  enabled: true
+`
+	mockConfig := configmock.NewFromYAML(t, yaml)
+
+	cfg, err := FromDDConfig(mockConfig)
+	require.NoError(t, err)
+	assert.Nil(t, cfg.RShellAllowedPaths)
+	assert.Nil(t, cfg.RShellAllowedCommands)
+}

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -37,60 +37,54 @@ var statFn = os.Stat
 
 // RunCommandHandler implements the runCommand action.
 //
-// Both allow-lists follow the same pattern: the operator list is stored as a
-// set for O(1) lookup, and the filter functions do plain string-equality
-// intersection with the backend list. Nil means the operator did not
-// configure the axis (backend list passes through); an empty list means the
-// operator explicitly restricts to nothing.
+// Commands intersect by exact string equality (operator must use the
+// "rshell:<name>" form). Paths intersect by containment with "narrower
+// wins"; prefix siblings like "/var/logger" do not match "/var/log".
 type RunCommandHandler struct {
-	// operatorAllowedPaths is the operator's filesystem allowlist from
-	// datadog.yaml. Populated only when filtering is enabled.
-	operatorAllowedPaths map[string]struct{}
-	// operatorPathsFilterEnabled distinguishes "unset" (nil map, no
-	// filtering) from "empty list" (operator explicitly allowed nothing).
+	// Nil = operator did not configure (backend passes through). Empty =
+	// explicit kill-switch.
+	operatorAllowedPaths       []string
 	operatorPathsFilterEnabled bool
-	// operatorAllowedCommands is the set of bare command names the
-	// operator has allow-listed. Populated only when filtering is enabled.
-	operatorAllowedCommands map[string]struct{}
-	// operatorCommandsFilterEnabled distinguishes "unset" from "empty".
+
+	operatorAllowedCommands       []string
 	operatorCommandsFilterEnabled bool
 }
 
-// NewRunCommandHandler creates a new RunCommandHandler. Pass nil for either
-// operator list to disable filtering on that axis. A non-nil empty slice is
-// an explicit "block everything on this axis" and is honored as such.
+// NewRunCommandHandler creates a new RunCommandHandler. Pass nil to leave
+// filtering off on an axis; a non-nil empty slice is the explicit
+// kill-switch.
 func NewRunCommandHandler(operatorAllowedPaths []string, operatorAllowedCommands []string) *RunCommandHandler {
 	h := &RunCommandHandler{}
 	if operatorAllowedPaths != nil {
 		h.operatorPathsFilterEnabled = true
-		h.operatorAllowedPaths = make(map[string]struct{}, len(operatorAllowedPaths))
-		for _, p := range operatorAllowedPaths {
-			if p == "" {
-				continue
-			}
-			h.operatorAllowedPaths[p] = struct{}{}
-		}
+		h.operatorAllowedPaths = dedupeNonEmpty(operatorAllowedPaths)
 	}
 	if operatorAllowedCommands != nil {
 		h.operatorCommandsFilterEnabled = true
-		h.operatorAllowedCommands = make(map[string]struct{}, len(operatorAllowedCommands))
-		for _, c := range operatorAllowedCommands {
-			if c == "" {
-				continue
-			}
-			h.operatorAllowedCommands[c] = struct{}{}
-		}
+		h.operatorAllowedCommands = dedupeNonEmpty(operatorAllowedCommands)
 	}
 	return h
 }
 
-// filterAllowedCommands returns the effective command allowlist given the
-// per-task list from the backend.
-//
-// The backend is the authoritative gate. A nil backend list (field absent)
-// produces an empty result — rshell then blocks every command. The operator
-// config can only tighten further; it cannot grant commands the backend did
-// not.
+// dedupeNonEmpty drops empties and duplicates, preserving first-seen order.
+func dedupeNonEmpty(in []string) []string {
+	out := make([]string, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// filterAllowedCommands returns the operator ∩ backend command list.
+// Plain string equality; nil backend short-circuits to nil (rshell blocks).
 func (h *RunCommandHandler) filterAllowedCommands(backendAllowed []string) []string {
 	if backendAllowed == nil {
 		return nil
@@ -98,18 +92,21 @@ func (h *RunCommandHandler) filterAllowedCommands(backendAllowed []string) []str
 	if !h.operatorCommandsFilterEnabled {
 		return backendAllowed
 	}
+	operatorSet := make(map[string]struct{}, len(h.operatorAllowedCommands))
+	for _, c := range h.operatorAllowedCommands {
+		operatorSet[c] = struct{}{}
+	}
 	filtered := make([]string, 0, len(backendAllowed))
 	for _, c := range backendAllowed {
-		if _, ok := h.operatorAllowedCommands[c]; ok {
+		if _, ok := operatorSet[c]; ok {
 			filtered = append(filtered, c)
 		}
 	}
 	return filtered
 }
 
-// filterAllowedPaths is the paths analogue of filterAllowedCommands. Both
-// do plain string-equality intersection — paths must be spelled identically
-// on the backend and in datadog.yaml to be admitted.
+// filterAllowedPaths returns the operator ∩ backend path list with
+// "narrower wins" containment matching.
 func (h *RunCommandHandler) filterAllowedPaths(backendAllowed []string) []string {
 	if backendAllowed == nil {
 		return nil
@@ -118,12 +115,40 @@ func (h *RunCommandHandler) filterAllowedPaths(backendAllowed []string) []string
 		return backendAllowed
 	}
 	filtered := make([]string, 0, len(backendAllowed))
-	for _, p := range backendAllowed {
-		if _, ok := h.operatorAllowedPaths[p]; ok {
-			filtered = append(filtered, p)
+	seen := make(map[string]struct{})
+	admit := func(p string) {
+		if _, dup := seen[p]; dup {
+			return
+		}
+		seen[p] = struct{}{}
+		filtered = append(filtered, p)
+	}
+	for _, b := range backendAllowed {
+		for _, o := range h.operatorAllowedPaths {
+			switch {
+			case pathContains(b, o):
+				admit(o)
+			case pathContains(o, b):
+				admit(b)
+			}
 		}
 	}
 	return filtered
+}
+
+// pathContains reports whether parent is an ancestor of (or equal to)
+// child, with the path separator as the boundary so "/var/logger" does not
+// match "/var/log".
+func pathContains(parent, child string) bool {
+	parent = path.Clean(parent)
+	child = path.Clean(child)
+	if parent == child {
+		return true
+	}
+	if !strings.HasSuffix(parent, "/") {
+		parent += "/"
+	}
+	return strings.HasPrefix(child, parent)
 }
 
 // RunCommandInputs defines the inputs for the runCommand action.

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -268,8 +268,9 @@ func TestFilterAllowedCommandsMatrix(t *testing.T) {
 }
 
 // TestFilterAllowedPathsMatrix is the paths analogue of
-// TestFilterAllowedCommandsMatrix. Twelve scenarios with the same shape:
-// path intersection is plain string equality, identical to commands.
+// TestFilterAllowedCommandsMatrix. Path intersection is containment-aware
+// ("narrower wins") rather than plain set equality, so the non-empty x
+// non-empty cell has extra sub-cases for sub-path interplay.
 func TestFilterAllowedPathsMatrix(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -304,6 +305,24 @@ func TestFilterAllowedPathsMatrix(t *testing.T) {
 			[]string{"/var/log"}},
 		{"backend set, operator disjoint",
 			[]string{"/etc"}, []string{"/var/log"}, nil},
+
+		// Containment / "narrower wins" cases.
+		{"operator narrower than backend (sub-path wins)",
+			[]string{"/var/log"}, []string{"/var/log/nginx"},
+			[]string{"/var/log/nginx"}},
+		{"backend narrower than operator (backend wins)",
+			[]string{"/var/log/nginx"}, []string{"/var/log"},
+			[]string{"/var/log/nginx"}},
+		{"operator selects two siblings under one backend parent",
+			[]string{"/var/log"}, []string{"/var/log/nginx", "/var/log/apache"},
+			[]string{"/var/log/nginx", "/var/log/apache"}},
+		{"trailing slash on operator entry is normalized",
+			[]string{"/var/log"}, []string{"/var/log/"},
+			[]string{"/var/log/"}},
+		{"prefix sibling is not a sub-path (/var/logger vs /var/log)",
+			[]string{"/var/log"}, []string{"/var/logger"}, nil},
+		{"backend prefix sibling is not a sub-path",
+			[]string{"/var/logger"}, []string{"/var/log"}, nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -320,12 +339,22 @@ func TestFilterAllowedPathsMatrix(t *testing.T) {
 	}
 }
 
+// TestFilterAllowedCommandsRequiresNamespacedForm pins the exact-match
+// contract: bare names like "cat" don't match backend "rshell:cat".
+func TestFilterAllowedCommandsRequiresNamespacedForm(t *testing.T) {
+	handler := NewRunCommandHandler(nil, []string{"cat", "rshell:echo"})
+
+	got := handler.filterAllowedCommands([]string{"rshell:cat", "rshell:echo", "rshell:ls"})
+
+	assert.Equal(t, []string{"rshell:echo"}, got)
+}
+
 func TestNewRunCommandHandlerStoresAllowedPaths(t *testing.T) {
 	paths := []string{"/var/log", "/tmp"}
 
 	handler := NewRunCommandHandler(paths, nil)
 
-	assert.Equal(t, map[string]struct{}{"/var/log": {}, "/tmp": {}}, handler.operatorAllowedPaths)
+	assert.Equal(t, []string{"/var/log", "/tmp"}, handler.operatorAllowedPaths)
 	assert.True(t, handler.operatorPathsFilterEnabled)
 }
 
@@ -337,7 +366,7 @@ func TestNewRshellBundleUsesConfiguredAllowedPaths(t *testing.T) {
 
 	handler, ok := action.(*RunCommandHandler)
 	require.True(t, ok)
-	assert.Equal(t, map[string]struct{}{"/var/log": {}, "/tmp": {}}, handler.operatorAllowedPaths)
+	assert.Equal(t, []string{"/var/log", "/tmp"}, handler.operatorAllowedPaths)
 }
 
 func mockStatFn(existing map[string]bool) func(string) (os.FileInfo, error) {


### PR DESCRIPTION
### What does this PR do?

Fixes three bugs in the operator-side tightening layer for `private_action_runner.restricted_shell.{allowed_commands,allowed_paths}`:

1. **YAML `[]` was treated as "operator unset."** `GetStringSlice` returns nil for an explicit YAML empty sequence, indistinguishable from "key absent." The transform now gates on `IsConfigured` and normalizes nil → non-nil empty so the kill-switch row of the truth table behaves as documented.
2. **Path intersection used plain string equality.** An operator entry narrower than a backend entry (e.g. `/host/var/log/par-probe.txt` against backend `/host/var/log`) was dropped instead of admitted. `filterAllowedPaths` now does containment-aware "narrower wins" matching. The boundary check uses the path separator, so prefix siblings like `/var/logger` still do not match `/var/log`.
3. **Bare operator command entries silently produced empty intersections.** Backend ships `rshell:<name>`; operator-written `cat` never matched. The transform now logs a startup warning for each entry missing the prefix, pointing at the corrected form.

### Motivation

Discovered during end-to-end PAR validation against a prod-connected test drive. Findings and reproduction traces: [experimental/.../rshell-permission-test.md](https://github.com/DataDog/experimental/blob/main/users/jules.macret/q_branch/agent_mcp/k8s_setup/rshell-permission-test.md).

Parent PRs:
- #49536 (operator-side intersection)
- DataDog/dd-source#414468 (backend injects allowedPaths into every task)

### Describe how you validated your changes

- **YAML-backed unit tests** (`TestFromDDConfigPARRestrictedShell*YAML`) exercise the real YAML-parsing path; the existing `SetWithoutSource`-based tests don't reproduce the nil-from-empty-YAML behavior, which is why bug #1 went undetected on `main`.
- **Extended path matrix** in `TestFilterAllowedPathsMatrix` covers the containment cases (operator narrower, backend narrower, trailing-slash, prefix-sibling rejection).
- `TestFilterAllowedCommandsRequiresNamespacedForm` pins the exact-match contract.
- 364 tests pass across `pkg/privateactionrunner/adapters/config`, `pkg/privateactionrunner/bundles/remoteaction/rshell`, and `pkg/config/setup`. Linter clean.

### Additional Notes

This PR is the first of four splitting the larger redesign in #49825:

1. **This PR** — the three bug fixes.
2. Backslash + non-directory advisory warnings.
3. Sentinel-default contract redesign + helper extraction.
4. Per-environment paths (wire-format change, requires Balto coordination).

Each subsequent PR rebases on the previous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)