### PR TITLE
[ACTP] PAR: warn on misconfigured rshell allowed_paths entries

### DIFF
--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -8,6 +8,7 @@ package config
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -150,9 +151,42 @@ func warnUnnamespacedCommands(commands []string) {
 }
 
 // rshellAllowedPaths mirrors rshellAllowedCommands for the filesystem
-// allowlist.
+// allowlist. Two advisory warnings fire at load time: backslash entries
+// (forward-slash contract) and non-directory entries (rshell's os.Root
+// sandbox is directory-only). Entries still flow through; the warnings
+// surface silent-failure modes in agent logs.
 func rshellAllowedPaths(config config.Component) []string {
-	return configuredStringSliceOrNil(config, setup.PARRestrictedShellAllowedPaths)
+	paths := configuredStringSliceOrNil(config, setup.PARRestrictedShellAllowedPaths)
+	warnBackslashPaths(paths)
+	warnNonDirectoryPaths(paths)
+	return paths
+}
+
+// warnBackslashPaths logs a warning per entry containing a backslash. The
+// operator-side allow-list is forward-slash only; backslash paths never
+// match the backend's Linux-style entries.
+func warnBackslashPaths(paths []string) {
+	for _, p := range paths {
+		if strings.ContainsRune(p, '\\') {
+			log.Warnf("%s entry %q contains a backslash; only forward-slash paths are supported and this entry will never match a backend path",
+				setup.PARRestrictedShellAllowedPaths, p)
+		}
+	}
+}
+
+// warnNonDirectoryPaths logs a warning for entries that exist on disk but
+// are not directories. rshell's sandbox is built on os.Root, which only
+// accepts directory handles; file entries are silently dropped at runner
+// creation. Entries that don't exist are not warned about — rshell's own
+// "path not found" warning at task time covers that case.
+func warnNonDirectoryPaths(paths []string) {
+	for _, p := range paths {
+		info, err := os.Stat(p)
+		if err == nil && !info.IsDir() {
+			log.Warnf("%s entry %q is not a directory; rshell's sandbox only accepts directory entries and will drop this entry at runtime. Use the containing directory instead.",
+				setup.PARRestrictedShellAllowedPaths, p)
+		}
+	}
 }
 
 // configuredStringSliceOrNil returns the configured value only when the

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -6,6 +6,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -407,6 +409,38 @@ private_action_runner:
 	require.NoError(t, err)
 	assert.NotNil(t, cfg.RShellAllowedCommands, "YAML [] must reach the handler as a non-nil slice so the kill-switch is honored")
 	assert.Empty(t, cfg.RShellAllowedCommands)
+}
+
+// TestFromDDConfigPARRestrictedShellAllowedPathsPassesThroughBackslash
+// pins that backslash entries flow through the transform unchanged. The
+// warning is a side effect; the test ensures we don't accidentally drop
+// the entry, which would change the operator's written list.
+func TestFromDDConfigPARRestrictedShellAllowedPathsPassesThroughBackslash(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource(setup.PARPrivateKey, "")
+	mockConfig.SetWithoutSource(setup.PARUrn, "")
+	mockConfig.SetWithoutSource(setup.PARRestrictedShellAllowedPaths, []string{`C:\Data`, "/var/log"})
+
+	cfg, err := FromDDConfig(mockConfig)
+	require.NoError(t, err)
+	assert.Equal(t, []string{`C:\Data`, "/var/log"}, cfg.RShellAllowedPaths)
+}
+
+// TestFromDDConfigPARRestrictedShellAllowedPathsPassesThroughFileEntries
+// pins the same pass-through contract for non-directory entries.
+func TestFromDDConfigPARRestrictedShellAllowedPathsPassesThroughFileEntries(t *testing.T) {
+	tmpDir := t.TempDir()
+	fp := filepath.Join(tmpDir, "file.txt")
+	require.NoError(t, os.WriteFile(fp, []byte("x"), 0o600))
+
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource(setup.PARPrivateKey, "")
+	mockConfig.SetWithoutSource(setup.PARUrn, "")
+	mockConfig.SetWithoutSource(setup.PARRestrictedShellAllowedPaths, []string{tmpDir, fp})
+
+	cfg, err := FromDDConfig(mockConfig)
+	require.NoError(t, err)
+	assert.Equal(t, []string{tmpDir, fp}, cfg.RShellAllowedPaths)
 }
 
 func TestFromDDConfigPARRestrictedShellAllowedAbsentYAML(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Adds two advisory warnings at PAR config load that surface common `allowed_paths` misconfigurations which would otherwise silently fail at task execution:

- **Backslash entries**: the operator-side allow-list is forward-slash (Linux-form) only; Windows-native paths never match the backend's Linux-style list.
- **Non-directory entries**: rshell's sandbox is built on `os.Root`, which only accepts directory handles. File entries get silently dropped at runner creation, producing permission-denied for every open.

Both warnings are advisory — entries still flow through to the handler; the warnings make the silent-failure modes observable in agent logs.

### Stacked on top of #49945 (PR1 in the split)

This is PR2 of 4 splitting #49825. **Base**: PR1 branch. Will retarget to `main` after PR1 lands.

### Describe how you validated your changes

- New pass-through tests in `transform_test.go` verify that backslash and non-directory entries flow to the handler unchanged (the warnings are side effects).
- All 36 tests in `pkg/privateactionrunner/adapters/config` pass; linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)