### PR TITLE
[ACTP] PAR: redesign rshell allow-list contract (sentinel defaults)

### DIFF
--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -40,9 +40,17 @@ const (
 	PARRestrictedShellAllowedCommands = "private_action_runner.restricted_shell.allowed_commands"
 	// RShellCommandNamespacePrefix is the prefix the backend stamps onto
 	// every command in its allow-list. Operator entries in datadog.yaml
-	// must use the same form to intersect; otherwise they silently fail
-	// to match.
+	// must use the same form to intersect.
 	RShellCommandNamespacePrefix = "rshell:"
+	// RShellCommandAllowAllWildcard is the operator-side sentinel that
+	// admits every backend command in the rshell namespace. It is the
+	// default value, so an operator who has not narrowed gets the backend
+	// list as-is.
+	RShellCommandAllowAllWildcard = RShellCommandNamespacePrefix + "*"
+	// RShellPathAllowAll is the operator-side sentinel that admits every
+	// backend path through containment matching. It is the default value
+	// for allowed_paths.
+	RShellPathAllowAll = "/"
 )
 
 // setupPrivateActionRunner registers all configuration keys for the private action runner
@@ -79,14 +87,19 @@ func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
 	})
 	config.BindEnvAndSetDefault(PARHttpAllowImdsEndpoint, false)
 
-	// Restricted shell allow-lists are opt-in restrictions layered on top of
-	// the backend-injected lists. When unset, the agent forwards the
-	// backend list unchanged (pass-through). When set to a non-empty list,
-	// the runtime takes the intersection. An explicit empty list blocks
-	// all access on its axis. The []string{} default keeps IsConfigured
-	// false when the user has not set the key, so the pass-through vs.
-	// explicit-empty distinction is preserved.
-	config.BindEnvAndSetDefault(PARRestrictedShellAllowedPaths, []string{})
+	// Restricted shell allow-lists are opt-in restrictions layered on top
+	// of the backend-injected lists. Both axes use a sentinel value as
+	// their "allow whatever the backend allowed" default, so the
+	// operator-side intersection runs uniformly. An explicit YAML empty
+	// list on either axis is the kill-switch.
+	//
+	//   - allowed_paths defaults to ["/"]; pathContains("/", X) is true
+	//     for any absolute X, so the intersection returns the backend
+	//     list as-is when the operator has not narrowed.
+	//   - allowed_commands defaults to ["rshell:*"]; the wildcard is a
+	//     special case in the intersection that admits every backend
+	//     command in the "rshell:" namespace.
+	config.BindEnvAndSetDefault(PARRestrictedShellAllowedPaths, []string{RShellPathAllowAll})
 	config.ParseEnvAsStringSlice(PARRestrictedShellAllowedPaths, func(s string) []string {
 		if s == "" {
 			return nil
@@ -94,7 +107,7 @@ func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
 		return strings.Split(s, ",")
 	})
 
-	config.BindEnvAndSetDefault(PARRestrictedShellAllowedCommands, []string{})
+	config.BindEnvAndSetDefault(PARRestrictedShellAllowedCommands, []string{RShellCommandAllowAllWildcard})
 	config.ParseEnvAsStringSlice(PARRestrictedShellAllowedCommands, func(s string) []string {
 		if s == "" {
 			return nil

--- a/pkg/config/setup/privateactionrunner_test.go
+++ b/pkg/config/setup/privateactionrunner_test.go
@@ -44,8 +44,11 @@ func TestPrivateActionRunnerHttpAllowlistFromEnv(t *testing.T) {
 func TestPrivateActionRunnerRestrictedShellAllowedPathsUnsetByDefault(t *testing.T) {
 	cfg := newTestConf(t)
 
+	// Default is the ["/"] sentinel; the operator-side intersection
+	// admits every backend-allowed path through containment when the
+	// operator hasn't narrowed.
 	assert.False(t, cfg.IsConfigured(PARRestrictedShellAllowedPaths))
-	assert.Empty(t, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
+	assert.Equal(t, []string{RShellPathAllowAll}, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
 }
 
 func TestPrivateActionRunnerRestrictedShellAllowedPathsFromEnv(t *testing.T) {
@@ -62,10 +65,11 @@ func TestPrivateActionRunnerRestrictedShellAllowedPathsEmptyEnv(t *testing.T) {
 
 	cfg := newTestConf(t)
 
-	// Empty env is treated the same as unset so a stray empty var does not
-	// accidentally block every filesystem access.
+	// Empty env is treated the same as unset; the default ["/"] sentinel
+	// applies, which the operator-side intersection treats as "allow
+	// whatever the backend allowed".
 	assert.False(t, cfg.IsConfigured(PARRestrictedShellAllowedPaths))
-	assert.Empty(t, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
+	assert.Equal(t, []string{RShellPathAllowAll}, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
 }
 
 func TestPrivateActionRunnerAllowlistDefaultsEmpty(t *testing.T) {
@@ -73,14 +77,18 @@ func TestPrivateActionRunnerAllowlistDefaultsEmpty(t *testing.T) {
 
 	assert.Empty(t, cfg.GetStringSlice(PARActionsAllowlist))
 	assert.Empty(t, cfg.GetStringSlice(PARHttpAllowlist))
-	assert.Empty(t, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
+	// PARRestrictedShellAllowedPaths intentionally defaults to ["/"]
+	// rather than empty — the sentinel makes the operator-side
+	// intersection a no-op when the user hasn't narrowed.
+	assert.Equal(t, []string{RShellPathAllowAll}, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
 }
 
 func TestPrivateActionRunnerRestrictedShellAllowedCommandsUnsetByDefault(t *testing.T) {
 	cfg := newTestConf(t)
 
+	// Default is the ["rshell:*"] wildcard sentinel.
 	assert.False(t, cfg.IsConfigured(PARRestrictedShellAllowedCommands))
-	assert.Empty(t, cfg.GetStringSlice(PARRestrictedShellAllowedCommands))
+	assert.Equal(t, []string{RShellCommandAllowAllWildcard}, cfg.GetStringSlice(PARRestrictedShellAllowedCommands))
 }
 
 func TestPrivateActionRunnerRestrictedShellAllowedCommandsFromEnv(t *testing.T) {
@@ -97,8 +105,7 @@ func TestPrivateActionRunnerRestrictedShellAllowedCommandsEmptyEnv(t *testing.T)
 
 	cfg := newTestConf(t)
 
-	// Empty env is treated the same as unset so a stray empty var does not
-	// accidentally block every command on the agent.
+	// Empty env is treated the same as unset; default sentinel applies.
 	assert.False(t, cfg.IsConfigured(PARRestrictedShellAllowedCommands))
-	assert.Empty(t, cfg.GetStringSlice(PARRestrictedShellAllowedCommands))
+	assert.Equal(t, []string{RShellCommandAllowAllWildcard}, cfg.GetStringSlice(PARRestrictedShellAllowedCommands))
 }

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -130,11 +130,11 @@ func makeActionsAllowlist(config config.Component) map[string]sets.Set[string] {
 }
 
 // rshellAllowedCommands returns the operator-configured rshell command
-// allowlist. Nil = pass-through; non-nil empty = kill-switch.
-// Operator entries must be in the backend's namespaced form ("rshell:<name>");
-// any other spelling is warned at load time.
+// allowlist. The default is ["rshell:*"]; an explicit YAML empty list is
+// the kill-switch. Other entries must use the backend's "rshell:<name>"
+// form; any other spelling is warned at load time.
 func rshellAllowedCommands(config config.Component) []string {
-	commands := configuredStringSliceOrNil(config, setup.PARRestrictedShellAllowedCommands)
+	commands := config.GetStringSlice(setup.PARRestrictedShellAllowedCommands)
 	warnUnnamespacedCommands(commands)
 	return commands
 }
@@ -150,13 +150,10 @@ func warnUnnamespacedCommands(commands []string) {
 	}
 }
 
-// rshellAllowedPaths mirrors rshellAllowedCommands for the filesystem
-// allowlist. Two advisory warnings fire at load time: backslash entries
-// (forward-slash contract) and non-directory entries (rshell's os.Root
-// sandbox is directory-only). Entries still flow through; the warnings
-// surface silent-failure modes in agent logs.
+// rshellAllowedPaths mirrors rshellAllowedCommands. Default is ["/"];
+// explicit YAML empty list is the kill-switch.
 func rshellAllowedPaths(config config.Component) []string {
-	paths := configuredStringSliceOrNil(config, setup.PARRestrictedShellAllowedPaths)
+	paths := config.GetStringSlice(setup.PARRestrictedShellAllowedPaths)
 	warnBackslashPaths(paths)
 	warnNonDirectoryPaths(paths)
 	return paths
@@ -187,21 +184,6 @@ func warnNonDirectoryPaths(paths []string) {
 				setup.PARRestrictedShellAllowedPaths, p)
 		}
 	}
-}
-
-// configuredStringSliceOrNil returns the configured value only when the
-// user explicitly set the key. Normalizes the YAML-empty-list edge case,
-// where GetStringSlice returns a nil slice indistinguishable from "unset",
-// into a non-nil empty slice so the kill-switch is honored.
-func configuredStringSliceOrNil(config config.Component, key string) []string {
-	if !config.IsConfigured(key) {
-		return nil
-	}
-	v := config.GetStringSlice(key)
-	if v == nil {
-		return []string{}
-	}
-	return v
 }
 
 // getDatadogHost extracts and normalizes the Datadog host from the main endpoint.

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -307,13 +307,14 @@ func TestMakeActionsAllowlistDefaultActionsEnabled(t *testing.T) {
 }
 
 func TestFromDDConfigPARRestrictedShellAllowedPathsUnset(t *testing.T) {
+	// Unset: registered default ["/"] flows through.
 	mockConfig := configmock.New(t)
 	mockConfig.SetWithoutSource(setup.PARPrivateKey, "")
 	mockConfig.SetWithoutSource(setup.PARUrn, "")
 
 	cfg, err := FromDDConfig(mockConfig)
 	require.NoError(t, err)
-	assert.Nil(t, cfg.RShellAllowedPaths)
+	assert.Equal(t, []string{setup.RShellPathAllowAll}, cfg.RShellAllowedPaths)
 }
 
 func TestFromDDConfigPARRestrictedShellAllowedPathsSet(t *testing.T) {
@@ -341,15 +342,14 @@ func TestFromDDConfigPARRestrictedShellAllowedPathsEmpty(t *testing.T) {
 }
 
 func TestFromDDConfigPARRestrictedShellAllowedCommandsUnset(t *testing.T) {
+	// Unset: registered default ["rshell:*"] flows through.
 	mockConfig := configmock.New(t)
 	mockConfig.SetWithoutSource(setup.PARPrivateKey, "")
 	mockConfig.SetWithoutSource(setup.PARUrn, "")
 
 	cfg, err := FromDDConfig(mockConfig)
 	require.NoError(t, err)
-	// Unset: operator opts out of filtering, handler will pass through the
-	// backend list unchanged.
-	assert.Nil(t, cfg.RShellAllowedCommands)
+	assert.Equal(t, []string{setup.RShellCommandAllowAllWildcard}, cfg.RShellAllowedCommands)
 }
 
 func TestFromDDConfigPARRestrictedShellAllowedCommandsSet(t *testing.T) {
@@ -377,12 +377,11 @@ func TestFromDDConfigPARRestrictedShellAllowedCommandsEmpty(t *testing.T) {
 	assert.Empty(t, cfg.RShellAllowedCommands)
 }
 
-// TestFromDDConfigPARRestrictedShellAllowedPathsEmptyYAML reproduces the
-// real-world failure observed in PAR: when datadog.yaml contains
-// `allowed_paths: []` the transform must preserve the explicit-empty value
-// so the handler treats it as "block everything", not "operator unset".
-// This exercises the YAML parsing path rather than SetWithoutSource; the
-// two differ in whether GetStringSlice round-trips the empty list as nil.
+// TestFromDDConfigPARRestrictedShellAllowedPathsEmptyYAML pins the
+// kill-switch contract for `allowed_paths: []`. The handler's
+// always-intersect logic produces an empty effective list when the
+// operator is empty, regardless of nil-vs-non-nil shape from the
+// transform.
 func TestFromDDConfigPARRestrictedShellAllowedPathsEmptyYAML(t *testing.T) {
 	yaml := `
 private_action_runner:
@@ -393,8 +392,7 @@ private_action_runner:
 
 	cfg, err := FromDDConfig(mockConfig)
 	require.NoError(t, err)
-	assert.NotNil(t, cfg.RShellAllowedPaths, "YAML [] must reach the handler as a non-nil slice so the kill-switch is honored")
-	assert.Empty(t, cfg.RShellAllowedPaths)
+	assert.Empty(t, cfg.RShellAllowedPaths, "YAML [] must surface as an empty slice; kill-switch is enforced by the handler intersection on this input")
 }
 
 func TestFromDDConfigPARRestrictedShellAllowedCommandsEmptyYAML(t *testing.T) {
@@ -407,8 +405,7 @@ private_action_runner:
 
 	cfg, err := FromDDConfig(mockConfig)
 	require.NoError(t, err)
-	assert.NotNil(t, cfg.RShellAllowedCommands, "YAML [] must reach the handler as a non-nil slice so the kill-switch is honored")
-	assert.Empty(t, cfg.RShellAllowedCommands)
+	assert.Empty(t, cfg.RShellAllowedCommands, "YAML [] must surface as an empty slice; kill-switch is enforced by the handler intersection on this input")
 }
 
 // TestFromDDConfigPARRestrictedShellAllowedPathsPassesThroughBackslash
@@ -444,8 +441,10 @@ func TestFromDDConfigPARRestrictedShellAllowedPathsPassesThroughFileEntries(t *t
 }
 
 func TestFromDDConfigPARRestrictedShellAllowedAbsentYAML(t *testing.T) {
-	// No restricted_shell block at all: both axes nil, handler passes
-	// the backend list through.
+	// No restricted_shell block: both axes fall back to their registered
+	// sentinels — ["/"] for paths, ["rshell:*"] for commands — which the
+	// operator-side intersection treats as "allow whatever the backend
+	// allowed".
 	yaml := `
 private_action_runner:
   enabled: true
@@ -454,6 +453,6 @@ private_action_runner:
 
 	cfg, err := FromDDConfig(mockConfig)
 	require.NoError(t, err)
-	assert.Nil(t, cfg.RShellAllowedPaths)
-	assert.Nil(t, cfg.RShellAllowedCommands)
+	assert.Equal(t, []string{setup.RShellPathAllowAll}, cfg.RShellAllowedPaths)
+	assert.Equal(t, []string{setup.RShellCommandAllowAllWildcard}, cfg.RShellAllowedCommands)
 }

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/helper.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/helper.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_remoteaction_rshell
+
+import (
+	"path"
+	"slices"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+// onlyRshellPrefixedCommands returns the commands that are prefixed with the
+// rshell namespace, excluding the wildcard token and the bare prefix.
+func onlyRshellPrefixedCommands(commands []string) []string {
+	prefixedCommands := make([]string, 0, len(commands))
+	for _, c := range commands {
+		if strings.HasPrefix(c, setup.RShellCommandNamespacePrefix) &&
+			c != setup.RShellCommandAllowAllWildcard &&
+			c != setup.RShellCommandNamespacePrefix {
+			prefixedCommands = append(prefixedCommands, c)
+		}
+	}
+	return prefixedCommands
+}
+
+// cleanPathList applies path.Clean to each element and ensures every path
+// ends with a separator so "/var/log" is a prefix of "/var/log/nginx" but
+// not of "/var/logger".
+func cleanPathList(paths []string) []string {
+	cleaned := make([]string, len(paths))
+	for i, p := range paths {
+		cleaned[i] = path.Clean(p)
+		if !strings.HasSuffix(cleaned[i], "/") {
+			cleaned[i] += "/"
+		}
+	}
+	return cleaned
+}
+
+// reducePathListToBroadest removes duplicates and keeps the broadest path
+// for each common prefix.
+//
+// Assumes inputs are already cleaned (path.Clean + trailing "/").
+func reducePathListToBroadest(paths []string) []string {
+	reduced := make([]string, 0)
+	for _, p := range paths {
+		added := false
+		for j := range reduced {
+			if _, broadest := commonPath(p, reduced[j]); broadest != "" {
+				reduced[j] = broadest
+				added = true
+			}
+		}
+		if !added {
+			reduced = append(reduced, p)
+		}
+	}
+	slices.Sort(reduced)
+	return slices.Compact(reduced)
+}
+
+// intersectPathLists returns the containment intersection of two reduced
+// path lists. The narrower side of each matching pair wins.
+func intersectPathLists(list1, list2 []string) []string {
+	intersection := make([]string, 0)
+	for _, p1 := range list1 {
+		for _, p2 := range list2 {
+			if deepest, _ := commonPath(p1, p2); deepest != "" {
+				intersection = append(intersection, deepest)
+				if deepest == p1 {
+					break
+				}
+			}
+		}
+	}
+	return intersection
+}
+
+// commonPath returns the deepest and broadest common path between two
+// cleaned + trailing-slash-normalized paths.
+func commonPath(a, b string) (deepest string, broadest string) {
+	if a == b {
+		return a, a
+	}
+	if strings.HasPrefix(a, b) {
+		return a, b
+	}
+	if strings.HasPrefix(b, a) {
+		return b, a
+	}
+	return "", ""
+}

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/helper_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/helper_test.go
@@ -1,0 +1,482 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_remoteaction_rshell
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestOnlyRshellPrefixedCommands pins the namespace-scoping the wildcard
+// branch of filterAllowedCommands relies on. Without it, the wildcard
+// sentinel would either admit arbitrary backend entries (security
+// weakness) or admit nothing (kill-switch).
+func TestOnlyRshellPrefixedCommands(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "nil",
+			in:   nil,
+			want: []string{},
+		},
+		{
+			name: "empty",
+			in:   []string{},
+			want: []string{},
+		},
+		{
+			name: "all in namespace",
+			in:   []string{"rshell:cat", "rshell:ls"},
+			want: []string{"rshell:cat", "rshell:ls"},
+		},
+		{
+			name: "none in namespace",
+			in:   []string{"evil:cat", "git:checkout"},
+			want: []string{},
+		},
+		{
+			name: "mixed: only namespaced kept",
+			in:   []string{"rshell:cat", "evil:cat", "rshell:ls", "ls"},
+			want: []string{"rshell:cat", "rshell:ls"},
+		},
+		{
+			name: "the wildcard token itself is rshell-prefixed and would be admitted, note that this should never happen in practice",
+			in:   []string{setup.RShellCommandAllowAllWildcard},
+			want: []string{},
+		},
+		{
+			name: "bare 'rshell' without colon is not admitted (the colon is part of the prefix)",
+			in:   []string{"rshell"},
+			want: []string{},
+		},
+		{
+			name: "'rshell:' alone (empty name after prefix) is admitted by the prefix check",
+			in:   []string{"rshell:"},
+			want: []string{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := onlyRshellPrefixedCommands(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestCommonPath pins every shape of the (a, b) pair commonPath can see.
+// Pre-condition: both inputs are cleaned and end with "/". Tests follow that
+// contract, since callers always pass cleaned forms.
+func TestCommonPath(t *testing.T) {
+	cases := []struct {
+		name         string
+		a            string
+		b            string
+		wantDeepest  string
+		wantBroadest string
+	}{
+		{
+			name:         "equal paths",
+			a:            "/var/log/",
+			b:            "/var/log/",
+			wantDeepest:  "/var/log/",
+			wantBroadest: "/var/log/",
+		},
+		{
+			name:         "a deeper than b",
+			a:            "/var/log/nginx/",
+			b:            "/var/log/",
+			wantDeepest:  "/var/log/nginx/",
+			wantBroadest: "/var/log/",
+		},
+		{
+			name:         "b deeper than a",
+			a:            "/var/log/",
+			b:            "/var/log/nginx/",
+			wantDeepest:  "/var/log/nginx/",
+			wantBroadest: "/var/log/",
+		},
+		{
+			name:         "root contains everything",
+			a:            "/",
+			b:            "/var/log/",
+			wantDeepest:  "/var/log/",
+			wantBroadest: "/",
+		},
+		{
+			name:         "everything is contained by root",
+			a:            "/var/log/",
+			b:            "/",
+			wantDeepest:  "/var/log/",
+			wantBroadest: "/",
+		},
+		{
+			name:         "both root",
+			a:            "/",
+			b:            "/",
+			wantDeepest:  "/",
+			wantBroadest: "/",
+		},
+		{
+			name:         "no relation: prefix siblings (var/log vs var/logger)",
+			a:            "/var/log/",
+			b:            "/var/logger/",
+			wantDeepest:  "",
+			wantBroadest: "",
+		},
+		{
+			name:         "no relation: prefix siblings reversed",
+			a:            "/var/logger/",
+			b:            "/var/log/",
+			wantDeepest:  "",
+			wantBroadest: "",
+		},
+		{
+			name:         "no relation: disjoint paths",
+			a:            "/var/log/",
+			b:            "/etc/",
+			wantDeepest:  "",
+			wantBroadest: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			deepest, broadest := commonPath(tc.a, tc.b)
+			assert.Equal(t, tc.wantDeepest, deepest, "deepest")
+			assert.Equal(t, tc.wantBroadest, broadest, "broadest")
+		})
+	}
+}
+
+// TestCleanPathList covers the post-condition that every entry is
+// path.Clean-normalized AND ends with a single separator. Empty input must
+// not panic (this was a regression in an earlier draft).
+func TestCleanPathList(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "nil input",
+			in:   nil,
+			want: []string{},
+		},
+		{
+			name: "empty input",
+			in:   []string{},
+			want: []string{},
+		},
+		{
+			name: "single path without trailing slash",
+			in:   []string{"/var/log"},
+			want: []string{"/var/log/"},
+		},
+		{
+			name: "single path with trailing slash",
+			in:   []string{"/var/log/"},
+			want: []string{"/var/log/"},
+		},
+		{
+			name: "root",
+			in:   []string{"/"},
+			want: []string{"/"},
+		},
+		{
+			name: "redundant separators collapsed",
+			in:   []string{"//var//log//"},
+			want: []string{"/var/log/"},
+		},
+		{
+			name: "multiple paths",
+			in:   []string{"/var/log", "/etc/"},
+			want: []string{"/var/log/", "/etc/"},
+		},
+		{
+			name: "path.Clean resolves dot segments",
+			in:   []string{"/var/./log/../log"},
+			want: []string{"/var/log/"},
+		},
+		{
+			name: "empty string becomes ./",
+			in:   []string{""},
+			want: []string{"./"},
+		},
+		{
+			name: "parent (..) escape to root collapses to /",
+			in:   []string{"/.."},
+			want: []string{"/"},
+		},
+		{
+			name: "interior parent segments are resolved",
+			in:   []string{"/var/../etc/../usr/local"},
+			want: []string{"/usr/local/"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cleanPathList(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestCleanPathListDoesNotMutateInput pins the API contract that cleanPathList
+// allocates a fresh output slice rather than rewriting in place.
+func TestCleanPathListDoesNotMutateInput(t *testing.T) {
+	in := []string{"/var/log", "/etc"}
+	original := slices.Clone(in)
+
+	cleanPathList(in)
+
+	assert.Equal(t, original, in, "input must not be mutated")
+}
+
+// TestReducePathListToBroadest covers single-input cases, full-domination
+// scenarios (one entry absorbs others), prefix-sibling preservation, and
+// the multi-domination case (regression: an earlier draft only absorbed
+// the first dominated entry).
+//
+// Pre-condition: inputs are already cleaned (path.Clean + trailing "/").
+//
+// Post-condition: output is deduplicated, sorted (the implementation uses
+// slices.Sort + slices.Compact), and contains no two entries where one
+// contains the other.
+func TestReducePathListToBroadest(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "nil",
+			in:   nil,
+			want: []string{},
+		},
+		{
+			name: "empty",
+			in:   []string{},
+			want: []string{},
+		},
+		{
+			name: "single entry",
+			in:   []string{"/var/log/"},
+			want: []string{"/var/log/"},
+		},
+		{
+			name: "exact duplicates collapse",
+			in:   []string{"/var/log/", "/var/log/"},
+			want: []string{"/var/log/"},
+		},
+		{
+			name: "broader entry first absorbs deeper",
+			in:   []string{"/var/", "/var/log/"},
+			want: []string{"/var/"},
+		},
+		{
+			name: "deeper entry first is absorbed by broader",
+			in:   []string{"/var/log/", "/var/"},
+			want: []string{"/var/"},
+		},
+		{
+			name: "broader at the end absorbs MULTIPLE deeper entries",
+			in:   []string{"/var/log/a/", "/var/log/b/", "/var/"},
+			want: []string{"/var/"},
+		},
+		{
+			name: "broader at the beginning absorbs MULTIPLE deeper entries",
+			in:   []string{"/var/", "/var/log/a/", "/var/log/b/"},
+			want: []string{"/var/"},
+		},
+		{
+			name: "broader in the middle absorbs MULTIPLE deeper entries",
+			in:   []string{"/var/log/a/", "/var/", "/var/log/b/"},
+			want: []string{"/var/"},
+		},
+		{
+			name: "root absorbs everything",
+			in:   []string{"/var/log/", "/etc/", "/"},
+			want: []string{"/"},
+		},
+		{
+			name: "prefix siblings are kept separately",
+			in:   []string{"/var/log/", "/var/logger/"},
+			want: []string{"/var/log/", "/var/logger/"},
+		},
+		{
+			name: "disjoint paths kept and sorted",
+			in:   []string{"/var/log/", "/etc/", "/tmp/"},
+			want: []string{"/etc/", "/tmp/", "/var/log/"},
+		},
+		{
+			name: "three siblings under one parent collapse to parent",
+			in:   []string{"/var/a/", "/var/b/", "/var/c/", "/var/"},
+			want: []string{"/var/"},
+		},
+		{
+			name: "interleaved related and unrelated",
+			in:   []string{"/var/log/", "/etc/foo/", "/var/", "/etc/"},
+			want: []string{"/etc/", "/var/"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := reducePathListToBroadest(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestReducePathListToBroadestIsIdempotent pins the property that running
+// reduce on an already-reduced list is a no-op. The post-condition implies
+// this, but a direct check guards against subtle bugs where a second pass
+// drops or reorders entries.
+func TestReducePathListToBroadestIsIdempotent(t *testing.T) {
+	in := []string{"/var/log/a/", "/var/log/b/", "/var/", "/etc/foo/"}
+	once := reducePathListToBroadest(in)
+	twice := reducePathListToBroadest(slices.Clone(once))
+
+	assert.Equal(t, once, twice, "reduce(reduce(x)) must equal reduce(x)")
+}
+
+// TestReducePathListToBroadestIsOrderIndependent pins the property that
+// the same set of input paths yields the same reduced output regardless of
+// iteration order. The implementation sorts at the end, but order can still
+// matter inside the loop (e.g. if an early reduction would have absorbed a
+// later entry differently).
+func TestReducePathListToBroadestIsOrderIndependent(t *testing.T) {
+	permutations := [][]string{
+		{"/var/", "/var/log/a/", "/var/log/b/", "/etc/"},
+		{"/var/log/a/", "/var/", "/var/log/b/", "/etc/"},
+		{"/var/log/a/", "/var/log/b/", "/var/", "/etc/"},
+		{"/var/log/b/", "/var/log/a/", "/etc/", "/var/"},
+		{"/etc/", "/var/log/a/", "/var/log/b/", "/var/"},
+	}
+	expected := reducePathListToBroadest(permutations[0])
+	for i := 1; i < len(permutations); i++ {
+		got := reducePathListToBroadest(permutations[i])
+		assert.Equal(t, expected, got, "permutation #%d must match the canonical reduction", i)
+	}
+}
+
+// TestIntersectPathLists pins the "narrower side wins" semantics of the
+// containment-based intersection. Pre-condition: both inputs are cleaned
+// AND reduced (no two entries on the same side dominate each other).
+//
+// The matrix below covers: empty inputs, equal lists, single-entry
+// containment in either direction, multiple narrower entries under one
+// broader entry (regression: an earlier draft broke too eagerly out of the
+// inner loop), prefix siblings, fully disjoint, and a multi-element
+// real-world-shaped case.
+func TestIntersectPathLists(t *testing.T) {
+	cases := []struct {
+		name         string
+		list1, list2 []string
+		want         []string
+	}{
+		{
+			name:  "both empty",
+			list1: []string{},
+			list2: []string{},
+			want:  []string{},
+		},
+		{
+			name:  "list1 empty",
+			list1: []string{},
+			list2: []string{"/var/log/"},
+			want:  []string{},
+		},
+		{
+			name:  "list2 empty",
+			list1: []string{"/var/log/"},
+			list2: []string{},
+			want:  []string{},
+		},
+		{
+			name:  "equal single-entry lists",
+			list1: []string{"/var/log/"},
+			list2: []string{"/var/log/"},
+			want:  []string{"/var/log/"},
+		},
+		{
+			name:  "list1 contains list2 (narrower wins; list2 admitted)",
+			list1: []string{"/var/"},
+			list2: []string{"/var/log/"},
+			want:  []string{"/var/log/"},
+		},
+		{
+			name:  "list2 contains list1 (narrower wins; list1 admitted)",
+			list1: []string{"/var/log/"},
+			list2: []string{"/var/"},
+			want:  []string{"/var/log/"},
+		},
+		{
+			name:  "list1 broader admits MULTIPLE list2 narrower entries",
+			list1: []string{"/var/"},
+			list2: []string{"/var/log/", "/var/spool/"},
+			want:  []string{"/var/log/", "/var/spool/"},
+		},
+		{
+			name:  "list2 broader admits MULTIPLE list1 narrower entries",
+			list1: []string{"/var/log/", "/var/spool/"},
+			list2: []string{"/var/"},
+			want:  []string{"/var/log/", "/var/spool/"},
+		},
+		{
+			name:  "prefix siblings produce no intersection",
+			list1: []string{"/var/log/"},
+			list2: []string{"/var/logger/"},
+			want:  []string{},
+		},
+		{
+			name:  "disjoint paths produce no intersection",
+			list1: []string{"/var/log/"},
+			list2: []string{"/etc/"},
+			want:  []string{},
+		},
+		{
+			name:  "root in list1 admits all list2 entries",
+			list1: []string{"/"},
+			list2: []string{"/var/log/", "/etc/"},
+			want:  []string{"/var/log/", "/etc/"},
+		},
+		{
+			name:  "two-by-two: each side has unrelated entries; only related pair admits",
+			list1: []string{"/var/", "/etc/"},
+			list2: []string{"/var/log/", "/opt/"},
+			want:  []string{"/var/log/"},
+		},
+		{
+			name:  "root in list2 admits all list1 entries (symmetry)",
+			list1: []string{"/var/log/", "/etc/"},
+			list2: []string{"/"},
+			want:  []string{"/var/log/", "/etc/"},
+		},
+		{
+			name:  "two-by-two: each list1 entry has a containing list2 entry",
+			list1: []string{"/var/log/", "/etc/foo/"},
+			list2: []string{"/var/", "/etc/"},
+			want:  []string{"/var/log/", "/etc/foo/"},
+		},
+		{
+			name:  "three-by-three with mixed disjoint, contained, and matching pairs",
+			list1: []string{"/var/", "/etc/", "/opt/"},
+			list2: []string{"/var/log/", "/etc/", "/srv/"},
+			want:  []string{"/var/log/", "/etc/"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := intersectPathLists(tc.list1, tc.list2)
+			assert.ElementsMatch(t, tc.want, got, "set of admitted paths")
+		})
+	}
+}

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"slices"
 	"strings"
 
 	"mvdan.cc/sh/v3/syntax"
@@ -19,6 +20,7 @@ import (
 	"github.com/DataDog/rshell/interp"
 
 	"github.com/DataDog/datadog-agent/pkg/config/env"
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/observability"
@@ -37,118 +39,62 @@ var statFn = os.Stat
 
 // RunCommandHandler implements the runCommand action.
 //
-// Commands intersect by exact string equality (operator must use the
-// "rshell:<name>" form). Paths intersect by containment with "narrower
-// wins"; prefix siblings like "/var/logger" do not match "/var/log".
+// Both axes use a sentinel value that means "allow whatever the backend
+// allowed":
+//
+//   - commands compare by exact string equality, with "rshell:*" as a
+//     special case admitting every backend entry in the rshell namespace.
+//   - paths compare by containment with the narrower side winning; the
+//     sentinel "/" admits every absolute path.
+//
+// On either axis, an explicit empty operator list is the kill-switch.
 type RunCommandHandler struct {
-	// Nil = operator did not configure (backend passes through). Empty =
-	// explicit kill-switch.
-	operatorAllowedPaths       []string
-	operatorPathsFilterEnabled bool
-
-	operatorAllowedCommands       []string
-	operatorCommandsFilterEnabled bool
+	operatorAllowedPaths    []string
+	operatorAllowedCommands []string
 }
 
-// NewRunCommandHandler creates a new RunCommandHandler. Pass nil to leave
-// filtering off on an axis; a non-nil empty slice is the explicit
-// kill-switch.
+// NewRunCommandHandler clones, sorts, and deduplicates the operator
+// commands; cleans and reduces the operator paths to broadest form. The
+// caller's slices are not mutated.
 func NewRunCommandHandler(operatorAllowedPaths []string, operatorAllowedCommands []string) *RunCommandHandler {
-	h := &RunCommandHandler{}
-	if operatorAllowedPaths != nil {
-		h.operatorPathsFilterEnabled = true
-		h.operatorAllowedPaths = dedupeNonEmpty(operatorAllowedPaths)
+	commands := slices.Clone(operatorAllowedCommands)
+	slices.Sort(commands)
+	return &RunCommandHandler{
+		operatorAllowedPaths:    reducePathListToBroadest(cleanPathList(operatorAllowedPaths)),
+		operatorAllowedCommands: slices.Compact(commands),
 	}
-	if operatorAllowedCommands != nil {
-		h.operatorCommandsFilterEnabled = true
-		h.operatorAllowedCommands = dedupeNonEmpty(operatorAllowedCommands)
-	}
-	return h
 }
 
-// dedupeNonEmpty drops empties and duplicates, preserving first-seen order.
-func dedupeNonEmpty(in []string) []string {
-	out := make([]string, 0, len(in))
-	seen := make(map[string]struct{}, len(in))
-	for _, s := range in {
-		if s == "" {
-			continue
-		}
-		if _, dup := seen[s]; dup {
-			continue
-		}
-		seen[s] = struct{}{}
-		out = append(out, s)
-	}
-	return out
-}
-
-// filterAllowedCommands returns the operator ∩ backend command list.
-// Plain string equality; nil backend short-circuits to nil (rshell blocks).
+// filterAllowedCommands returns the operator ∩ backend list. Plain string
+// equality except for the "rshell:*" sentinel which admits every backend
+// entry in the rshell namespace.
 func (h *RunCommandHandler) filterAllowedCommands(backendAllowed []string) []string {
-	if backendAllowed == nil {
-		return nil
+	if len(backendAllowed) == 0 || len(h.operatorAllowedCommands) == 0 {
+		return []string{}
 	}
-	if !h.operatorCommandsFilterEnabled {
-		return backendAllowed
+	if slices.Contains(h.operatorAllowedCommands, setup.RShellCommandAllowAllWildcard) {
+		return onlyRshellPrefixedCommands(backendAllowed)
 	}
-	operatorSet := make(map[string]struct{}, len(h.operatorAllowedCommands))
-	for _, c := range h.operatorAllowedCommands {
-		operatorSet[c] = struct{}{}
-	}
-	filtered := make([]string, 0, len(backendAllowed))
+	filtered := make([]string, 0)
 	for _, c := range backendAllowed {
-		if _, ok := operatorSet[c]; ok {
+		if slices.Contains(h.operatorAllowedCommands, c) {
 			filtered = append(filtered, c)
 		}
 	}
 	return filtered
 }
 
-// filterAllowedPaths returns the operator ∩ backend path list with
-// "narrower wins" containment matching.
-func (h *RunCommandHandler) filterAllowedPaths(backendAllowed []string) []string {
-	if backendAllowed == nil {
-		return nil
+// filterAllowedPaths returns the operator ∩ backend list with "narrower
+// wins" containment matching. Sentinel "/" admits every backend entry.
+func (h *RunCommandHandler) filterAllowedPaths(backend []string) []string {
+	if len(backend) == 0 || len(h.operatorAllowedPaths) == 0 {
+		return []string{}
 	}
-	if !h.operatorPathsFilterEnabled {
-		return backendAllowed
+	backend = reducePathListToBroadest(cleanPathList(backend))
+	if slices.Contains(h.operatorAllowedPaths, setup.RShellPathAllowAll) {
+		return backend
 	}
-	filtered := make([]string, 0, len(backendAllowed))
-	seen := make(map[string]struct{})
-	admit := func(p string) {
-		if _, dup := seen[p]; dup {
-			return
-		}
-		seen[p] = struct{}{}
-		filtered = append(filtered, p)
-	}
-	for _, b := range backendAllowed {
-		for _, o := range h.operatorAllowedPaths {
-			switch {
-			case pathContains(b, o):
-				admit(o)
-			case pathContains(o, b):
-				admit(b)
-			}
-		}
-	}
-	return filtered
-}
-
-// pathContains reports whether parent is an ancestor of (or equal to)
-// child, with the path separator as the boundary so "/var/logger" does not
-// match "/var/log".
-func pathContains(parent, child string) bool {
-	parent = path.Clean(parent)
-	child = path.Clean(child)
-	if parent == child {
-		return true
-	}
-	if !strings.HasSuffix(parent, "/") {
-		parent += "/"
-	}
-	return strings.HasPrefix(child, parent)
+	return intersectPathLists(h.operatorAllowedPaths, backend)
 }
 
 // RunCommandInputs defines the inputs for the runCommand action.

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -9,11 +9,13 @@ import (
 	"context"
 	"errors"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 )
@@ -21,7 +23,7 @@ import (
 func makeTask(command string, allowedCommands []string) *types.Task {
 	task := &types.Task{}
 	task.Data.Attributes = &types.Attributes{
-		Inputs: map[string]interface{}{
+		Inputs: map[string]any{
 			"command":         command,
 			"allowedCommands": allowedCommands,
 		},
@@ -30,8 +32,8 @@ func makeTask(command string, allowedCommands []string) *types.Task {
 }
 
 // makeTaskWithPaths constructs a task whose inputs include the allowedPaths
-// field. Use makeTask (without this helper) to exercise the "backend did not
-// send the field" branch — absent JSON fields and explicit null both
+// field. Use makeTask (without this helper) to exercise the "backend did
+// not send the field" branch — absent JSON fields and explicit null both
 // round-trip to a nil Go slice.
 func makeTaskWithPaths(command string, allowedCommands, allowedPaths []string) *types.Task {
 	task := makeTask(command, allowedCommands)
@@ -39,218 +41,107 @@ func makeTaskWithPaths(command string, allowedCommands, allowedPaths []string) *
 	return task
 }
 
-func TestRunCommandEmptyCommandReturnsError(t *testing.T) {
-	handler := NewRunCommandHandler(nil, nil)
-
-	_, err := handler.Run(context.Background(), makeTask("", nil), nil)
-
-	assert.ErrorContains(t, err, "command is required")
-}
-
-func TestRunCommandNoAllowedCommandsBlocksExecution(t *testing.T) {
-	handler := NewRunCommandHandler(nil, nil)
-
-	out, err := handler.Run(context.Background(), makeTask("echo hello", nil), nil)
-
-	require.NoError(t, err)
-	result := out.(*RunCommandOutputs)
-	assert.Equal(t, 127, result.ExitCode)
-	assert.Contains(t, result.Stderr, "command not allowed")
-}
-
-func TestRunCommandWithAllowedCommandSucceeds(t *testing.T) {
-	handler := NewRunCommandHandler(nil, nil)
-
-	out, err := handler.Run(context.Background(), makeTask("echo hello", []string{"rshell:echo"}), nil)
-
-	require.NoError(t, err)
-	result := out.(*RunCommandOutputs)
-	assert.Equal(t, 0, result.ExitCode)
-	assert.Equal(t, "hello\n", result.Stdout)
-}
-
-func TestRunCommandDisallowedCommandBlocked(t *testing.T) {
-	handler := NewRunCommandHandler(nil, nil)
-
-	out, err := handler.Run(context.Background(), makeTask("grep foo", []string{"rshell:echo"}), nil)
-
-	require.NoError(t, err)
-	result := out.(*RunCommandOutputs)
-	assert.Equal(t, 127, result.ExitCode)
-	assert.Contains(t, result.Stderr, "command not allowed")
-}
-
-func TestRunCommandOperatorIntersectionAllows(t *testing.T) {
-	// Operator allowed "rshell:echo"; backend allowed "rshell:echo" and
-	// "rshell:cat" — echo should run.
-	handler := NewRunCommandHandler(nil, []string{"rshell:echo"})
-
-	out, err := handler.Run(context.Background(),
-		makeTask("echo hi", []string{"rshell:echo", "rshell:cat"}), nil)
-
-	require.NoError(t, err)
-	result := out.(*RunCommandOutputs)
-	assert.Equal(t, 0, result.ExitCode)
-	assert.Equal(t, "hi\n", result.Stdout)
-}
-
-func TestRunCommandOperatorIntersectionBlocksDisjoint(t *testing.T) {
-	// Operator allowed "rshell:cat" only; backend allowed "rshell:echo".
-	// Intersection is empty, so echo is rejected.
-	handler := NewRunCommandHandler(nil, []string{"rshell:cat"})
-
-	out, err := handler.Run(context.Background(),
-		makeTask("echo hi", []string{"rshell:echo"}), nil)
-
-	require.NoError(t, err)
-	result := out.(*RunCommandOutputs)
-	assert.Equal(t, 127, result.ExitCode)
-	assert.Contains(t, result.Stderr, "command not allowed")
-}
-
-func TestRunCommandOperatorEmptyListBlocksEverything(t *testing.T) {
-	// Operator explicitly set an empty allowlist — nothing runs, even when
-	// the backend approved commands.
-	handler := NewRunCommandHandler(nil, []string{})
-
-	out, err := handler.Run(context.Background(),
-		makeTask("echo hi", []string{"rshell:echo"}), nil)
-
-	require.NoError(t, err)
-	result := out.(*RunCommandOutputs)
-	assert.Equal(t, 127, result.ExitCode)
-	assert.Contains(t, result.Stderr, "command not allowed")
-}
-
-func TestFilterAllowedCommandsNilOperatorPassesThrough(t *testing.T) {
-	handler := NewRunCommandHandler(nil, nil)
-
-	got := handler.filterAllowedCommands([]string{"rshell:echo", "rshell:cat"})
-
-	assert.Equal(t, []string{"rshell:echo", "rshell:cat"}, got)
-}
-
-func TestFilterAllowedCommandsIntersection(t *testing.T) {
-	handler := NewRunCommandHandler(nil, []string{"rshell:echo", "rshell:ls"})
-
-	got := handler.filterAllowedCommands([]string{"rshell:echo", "rshell:cat", "rshell:ls"})
-
-	assert.Equal(t, []string{"rshell:echo", "rshell:ls"}, got)
-}
-
-func TestFilterAllowedPathsNilBackendBlocksAll(t *testing.T) {
-	// Backend did not send the field — fail closed. The operator cannot
-	// grant filesystem access the backend withheld.
-	handler := NewRunCommandHandler([]string{"/var/log"}, nil)
-
-	got := handler.filterAllowedPaths(nil)
-
-	assert.Empty(t, got)
-}
-
-func TestFilterAllowedPathsOperatorUnsetPassesThrough(t *testing.T) {
-	// Operator left allowed_paths unset in datadog.yaml — the backend list
-	// passes through unchanged (no operator-side tightening).
-	handler := NewRunCommandHandler(nil, nil)
-
-	got := handler.filterAllowedPaths([]string{"/var/log/nginx", "/etc"})
-
-	assert.Equal(t, []string{"/var/log/nginx", "/etc"}, got)
-}
-
-func TestFilterAllowedCommandsNilBackendBlocksAll(t *testing.T) {
-	// Same principle for commands: no backend list → rshell blocks all,
-	// regardless of what the operator configured.
-	handler := NewRunCommandHandler(nil, []string{"rshell:echo", "rshell:cat"})
-
-	got := handler.filterAllowedCommands(nil)
-
-	assert.Empty(t, got)
-}
-
-func TestFilterAllowedPathsExplicitEmptyBackendBlocksAll(t *testing.T) {
-	// Backend explicitly sent []. Distinct from the nil case: it signals
-	// "the backend chose to restrict everything". rshell will block access.
-	handler := NewRunCommandHandler([]string{"/var/log"}, nil)
-
-	got := handler.filterAllowedPaths([]string{})
-
-	assert.Empty(t, got)
-}
-
-func TestFilterAllowedPathsIntersection(t *testing.T) {
-	handler := NewRunCommandHandler([]string{"/var/log", "/tmp"}, nil)
-
-	got := handler.filterAllowedPaths([]string{"/var/log", "/etc", "/tmp"})
-
-	assert.Equal(t, []string{"/var/log", "/tmp"}, got)
-}
-
-func TestFilterAllowedPathsDisjointDropped(t *testing.T) {
-	handler := NewRunCommandHandler([]string{"/var/log"}, nil)
-
-	got := handler.filterAllowedPaths([]string{"/etc"})
-
-	assert.Empty(t, got)
-}
-
-func TestRunCommandBackendAllowedPathsRestrictsAccess(t *testing.T) {
-	// End-to-end: operator allows /var/log, backend lists only /tmp so
-	// reading /var/log/syslog must fail because /var/log is absent from
-	// the backend side of the intersection.
-	handler := NewRunCommandHandler([]string{"/var/log"}, []string{"rshell:cat"})
-
-	task := makeTaskWithPaths("cat /var/log/syslog",
-		[]string{"rshell:cat"}, []string{"/tmp"})
-
-	out, err := handler.Run(context.Background(), task, nil)
-
-	require.NoError(t, err)
-	result := out.(*RunCommandOutputs)
-	assert.NotEqual(t, 0, result.ExitCode, "expected cat to fail because /var/log is not in the backend list")
-}
-
-// TestFilterAllowedCommandsMatrix pins every cell of the 3x3 grid
-// (backend in {nil, [], non-empty} x operator in {nil, [], non-empty}) with
-// four sub-cases splitting the non-empty x non-empty cell by the set
-// relationship between operator and backend. Twelve scenarios total. The
-// truth table is documented in the PR description; this is its executable
-// form.
+// TestFilterAllowedCommandsMatrix pins backend × operator combinations.
+// The match is plain string equality except for the "rshell:*" sentinel,
+// which admits every backend entry in the rshell namespace.
 func TestFilterAllowedCommandsMatrix(t *testing.T) {
 	cases := []struct {
 		name     string
 		backend  []string
 		operator []string
-		want     []string // nil or empty both mean "nothing allowed"
+		want     []string
 	}{
-		// Backend nil — fail-closed regardless of what the operator said.
-		{"backend nil, operator nil", nil, nil, nil},
-		{"backend nil, operator empty list", nil, []string{}, nil},
-		{"backend nil, operator set", nil, []string{"rshell:echo"}, nil},
+		// Empty/nil short-circuits.
+		{
+			name:     "backend nil, operator wildcard",
+			backend:  nil,
+			operator: []string{setup.RShellCommandAllowAllWildcard},
+			want:     []string{},
+		},
+		{
+			name:     "backend nil, operator empty",
+			backend:  nil,
+			operator: []string{},
+			want:     []string{},
+		},
+		{
+			name:     "backend nil, operator set",
+			backend:  nil,
+			operator: []string{"rshell:echo"},
+			want:     []string{},
+		},
+		{
+			name:     "backend empty, operator wildcard",
+			backend:  []string{},
+			operator: []string{setup.RShellCommandAllowAllWildcard},
+			want:     []string{},
+		},
+		{
+			name:     "backend set, operator nil (handler treats as kill-switch)",
+			backend:  []string{"rshell:echo"},
+			operator: nil,
+			want:     []string{},
+		},
+		{
+			name:     "backend set, operator empty (kill-switch)",
+			backend:  []string{"rshell:echo"},
+			operator: []string{},
+			want:     []string{},
+		},
+		// Wildcard branch.
+		{
+			name:     "wildcard admits all rshell-prefixed backend entries",
+			backend:  []string{"rshell:echo", "rshell:cat"},
+			operator: []string{setup.RShellCommandAllowAllWildcard},
+			want:     []string{"rshell:echo", "rshell:cat"},
+		},
+		{
+			name:     "wildcard scoped: non-namespaced backend entry rejected",
+			backend:  []string{"rshell:echo", "evil:cat"},
+			operator: []string{setup.RShellCommandAllowAllWildcard},
+			want:     []string{"rshell:echo"}},
+		{
+			name:     "wildcard coexists with explicit entries (wildcard subsumes them)",
+			backend:  []string{"rshell:echo", "rshell:cat"},
+			operator: []string{setup.RShellCommandAllowAllWildcard, "rshell:echo"},
+			want:     []string{"rshell:echo", "rshell:cat"}},
 
-		// Backend explicit empty list — same outcome as nil.
-		{"backend empty list, operator nil", []string{}, nil, nil},
-		{"backend empty list, operator empty list", []string{}, []string{}, nil},
-		{"backend empty list, operator set", []string{}, []string{"rshell:echo"}, nil},
-
-		// Backend non-empty: the non-empty x non-empty cell splits into
-		// four sub-cases by set relationship.
-		{"backend set, operator nil (pass-through)",
-			[]string{"rshell:echo", "rshell:cat"}, nil,
-			[]string{"rshell:echo", "rshell:cat"}},
-		{"backend set, operator empty list (operator blocks all)",
-			[]string{"rshell:echo"}, []string{}, nil},
-		{"backend set, operator is superset of backend",
-			[]string{"rshell:echo", "rshell:cat"}, []string{"rshell:echo", "rshell:cat", "rshell:ls"},
-			[]string{"rshell:echo", "rshell:cat"}},
-		{"backend set, backend is superset of operator",
-			[]string{"rshell:echo", "rshell:cat", "rshell:ls"}, []string{"rshell:echo"},
-			[]string{"rshell:echo"}},
-		{"backend set, operator partial overlap",
-			[]string{"rshell:echo", "rshell:cat"}, []string{"rshell:cat", "rshell:ls"},
-			[]string{"rshell:cat"}},
-		{"backend set, operator disjoint",
-			[]string{"rshell:echo"}, []string{"rshell:cat"}, nil},
+		// Exact-match intersection.
+		{
+			name:     "operator superset of backend",
+			backend:  []string{"rshell:echo", "rshell:cat"},
+			operator: []string{"rshell:echo", "rshell:cat", "rshell:ls"},
+			want:     []string{"rshell:echo", "rshell:cat"}},
+		{
+			name:     "backend superset of operator",
+			backend:  []string{"rshell:echo", "rshell:cat", "rshell:ls"},
+			operator: []string{"rshell:echo"},
+			want:     []string{"rshell:echo"}},
+		{
+			name:     "partial overlap",
+			backend:  []string{"rshell:echo", "rshell:cat"},
+			operator: []string{"rshell:cat", "rshell:ls"},
+			want:     []string{"rshell:cat"}},
+		{
+			name:     "disjoint",
+			backend:  []string{"rshell:echo"},
+			operator: []string{"rshell:cat"},
+			want:     []string{}},
+		{
+			name:     "bare-name operator entry never matches namespaced backend",
+			backend:  []string{"rshell:cat"},
+			operator: []string{"cat"},
+			want:     []string{}},
+		{
+			name:     "output preserves backend iteration order",
+			backend:  []string{"rshell:ls", "rshell:cat", "rshell:echo"},
+			operator: []string{"rshell:cat", "rshell:echo", "rshell:ls"},
+			want:     []string{"rshell:ls", "rshell:cat", "rshell:echo"}},
+		{
+			name:     "duplicate operator entries are deduped at handler creation",
+			backend:  []string{"rshell:echo"},
+			operator: []string{"rshell:echo", "rshell:echo"},
+			want:     []string{"rshell:echo"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -267,10 +158,13 @@ func TestFilterAllowedCommandsMatrix(t *testing.T) {
 	}
 }
 
-// TestFilterAllowedPathsMatrix is the paths analogue of
-// TestFilterAllowedCommandsMatrix. Path intersection is containment-aware
-// ("narrower wins") rather than plain set equality, so the non-empty x
-// non-empty cell has extra sub-cases for sub-path interplay.
+// TestFilterAllowedPathsMatrix pins backend × operator combinations for
+// containment-aware intersection. The function is pure: it takes the
+// already-selected per-environment slice (env-routing happens in
+// backendPathsForEnv, tested separately). Operator paths are stored in
+// cleaned form (path.Clean + trailing "/"), and backend is normalized
+// inside filterAllowedPaths, so all expected outputs in this matrix carry
+// trailing slashes.
 func TestFilterAllowedPathsMatrix(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -278,51 +172,134 @@ func TestFilterAllowedPathsMatrix(t *testing.T) {
 		operator []string
 		want     []string
 	}{
-		// Backend nil — fail-closed.
-		{"backend nil, operator nil", nil, nil, nil},
-		{"backend nil, operator empty list", nil, []string{}, nil},
-		{"backend nil, operator set", nil, []string{"/var/log"}, nil},
+		// Empty/nil short-circuits.
+		{
+			name:     "backend nil, operator wildcard",
+			backend:  nil,
+			operator: []string{setup.RShellPathAllowAll},
+			want:     []string{},
+		},
+		{
+			name:     "backend nil, operator empty",
+			backend:  nil,
+			operator: []string{},
+			want:     []string{},
+		},
+		{
+			name:     "backend nil, operator set",
+			backend:  nil,
+			operator: []string{"/var/log"},
+			want:     []string{},
+		},
+		{
+			name:     "backend empty, operator wildcard",
+			backend:  []string{},
+			operator: []string{setup.RShellPathAllowAll},
+			want:     []string{},
+		},
+		{
+			name:     "backend set, operator nil (kill-switch)",
+			backend:  []string{"/var/log"},
+			operator: nil,
+			want:     []string{},
+		},
+		{
+			name:     "backend set, operator empty (kill-switch)",
+			backend:  []string{"/var/log"},
+			operator: []string{},
+			want:     []string{},
+		},
 
-		// Backend explicit empty list — same outcome as nil.
-		{"backend empty list, operator nil", []string{}, nil, nil},
-		{"backend empty list, operator empty list", []string{}, []string{}, nil},
-		{"backend empty list, operator set", []string{}, []string{"/var/log"}, nil},
+		// Wildcard branch — operator "/" passes the backend through.
+		// Output is the cleaned/reduced backend list (sorted, trailing "/").
+		{
+			name:     "wildcard root operator passes backend through",
+			backend:  []string{"/var/log", "/etc"},
+			operator: []string{"/"},
+			want:     []string{"/etc/", "/var/log/"},
+		},
 
-		// Backend non-empty: four sub-cases for the set relationship.
-		{"backend set, operator nil (pass-through)",
-			[]string{"/var/log", "/etc"}, nil,
-			[]string{"/var/log", "/etc"}},
-		{"backend set, operator empty list (operator blocks all)",
-			[]string{"/var/log"}, []string{}, nil},
-		{"backend set, operator is superset of backend",
-			[]string{"/var/log", "/tmp"}, []string{"/var/log", "/tmp", "/etc"},
-			[]string{"/var/log", "/tmp"}},
-		{"backend set, backend is superset of operator",
-			[]string{"/var/log", "/tmp", "/etc"}, []string{"/var/log"},
-			[]string{"/var/log"}},
-		{"backend set, operator partial overlap",
-			[]string{"/var/log", "/opt"}, []string{"/var/log", "/etc"},
-			[]string{"/var/log"}},
-		{"backend set, operator disjoint",
-			[]string{"/etc"}, []string{"/var/log"}, nil},
+		// Exact-match (after normalization).
+		{
+			name:     "operator superset of backend",
+			backend:  []string{"/var/log", "/tmp"},
+			operator: []string{"/var/log", "/tmp", "/etc"},
+			want:     []string{"/tmp/", "/var/log/"},
+		},
+		{
+			name:     "backend superset of operator",
+			backend:  []string{"/var/log", "/tmp", "/etc"},
+			operator: []string{"/var/log"},
+			want:     []string{"/var/log/"},
+		},
+		{
+			name:     "partial overlap",
+			backend:  []string{"/var/log", "/opt"},
+			operator: []string{"/var/log", "/etc"},
+			want:     []string{"/var/log/"},
+		},
+		{
+			name:     "disjoint",
+			backend:  []string{"/etc"},
+			operator: []string{"/var/log"},
+			want:     []string{},
+		},
 
-		// Containment / "narrower wins" cases.
-		{"operator narrower than backend (sub-path wins)",
-			[]string{"/var/log"}, []string{"/var/log/nginx"},
-			[]string{"/var/log/nginx"}},
-		{"backend narrower than operator (backend wins)",
-			[]string{"/var/log/nginx"}, []string{"/var/log"},
-			[]string{"/var/log/nginx"}},
-		{"operator selects two siblings under one backend parent",
-			[]string{"/var/log"}, []string{"/var/log/nginx", "/var/log/apache"},
-			[]string{"/var/log/nginx", "/var/log/apache"}},
-		{"trailing slash on operator entry is normalized",
-			[]string{"/var/log"}, []string{"/var/log/"},
-			[]string{"/var/log/"}},
-		{"prefix sibling is not a sub-path (/var/logger vs /var/log)",
-			[]string{"/var/log"}, []string{"/var/logger"}, nil},
-		{"backend prefix sibling is not a sub-path",
-			[]string{"/var/logger"}, []string{"/var/log"}, nil},
+		// Containment / "narrower wins".
+		{
+			name:     "operator narrower than backend",
+			backend:  []string{"/var/log"},
+			operator: []string{"/var/log/nginx"},
+			want:     []string{"/var/log/nginx/"},
+		},
+		{
+			name:     "backend narrower than operator",
+			backend:  []string{"/var/log/nginx"},
+			operator: []string{"/var/log"},
+			want:     []string{"/var/log/nginx/"},
+		},
+		{
+			name:     "operator selects two siblings under one backend parent",
+			backend:  []string{"/var/log"},
+			operator: []string{"/var/log/nginx", "/var/log/apache"},
+			want:     []string{"/var/log/apache/", "/var/log/nginx/"},
+		},
+		{
+			name:     "trailing slash on operator entry is normalized",
+			backend:  []string{"/var/log"},
+			operator: []string{"/var/log/"},
+			want:     []string{"/var/log/"},
+		},
+
+		// Prefix-sibling rejection.
+		{
+			name:     "prefix sibling: /var/logger does not satisfy /var/log",
+			backend:  []string{"/var/log"},
+			operator: []string{"/var/logger"},
+			want:     []string{},
+		},
+		{
+			name:     "prefix sibling reversed",
+			backend:  []string{"/var/logger"},
+			operator: []string{"/var/log"},
+			want:     []string{},
+		},
+
+		// Operator-side reduction: redundant operator entries collapse.
+		{
+			name:     "operator entries one inside the other collapse to broader",
+			backend:  []string{"/var/log/nginx"},
+			operator: []string{"/var/log", "/var/log/nginx"},
+			want:     []string{"/var/log/nginx/"},
+		},
+
+		// Multi-narrower stress (regression for the intersection bug).
+		{
+			name:     "operator broad, backend has many narrower siblings — all admitted",
+			backend:  []string{"/var/a", "/var/b", "/var/c"},
+			operator: []string{"/var"},
+			want:     []string{"/var/a/", "/var/b/", "/var/c/"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -333,29 +310,59 @@ func TestFilterAllowedPathsMatrix(t *testing.T) {
 			if len(tc.want) == 0 {
 				assert.Empty(t, got)
 			} else {
-				assert.Equal(t, tc.want, got)
+				assert.ElementsMatch(t, tc.want, got)
 			}
 		})
 	}
 }
 
-// TestFilterAllowedCommandsRequiresNamespacedForm pins the exact-match
-// contract: bare names like "cat" don't match backend "rshell:cat".
-func TestFilterAllowedCommandsRequiresNamespacedForm(t *testing.T) {
-	handler := NewRunCommandHandler(nil, []string{"cat", "rshell:echo"})
+// TestNewRunCommandHandlerDoesNotMutateInputs guards against the
+// constructor sorting (or otherwise reordering) the caller's slices in
+// place. The bundle wiring in entrypoint.go passes the same slice we read
+// from cfg, so any mutation here would leak into the rest of the agent.
+func TestNewRunCommandHandlerDoesNotMutateInputs(t *testing.T) {
+	paths := []string{"/var/log", "/etc"}
+	commands := []string{"rshell:zls", "rshell:cat", "rshell:cat"}
+	pathsCopy := slices.Clone(paths)
+	commandsCopy := slices.Clone(commands)
 
-	got := handler.filterAllowedCommands([]string{"rshell:cat", "rshell:echo", "rshell:ls"})
+	NewRunCommandHandler(paths, commands)
 
-	assert.Equal(t, []string{"rshell:echo"}, got)
+	assert.Equal(t, pathsCopy, paths, "operatorAllowedPaths input must not be mutated")
+	assert.Equal(t, commandsCopy, commands, "operatorAllowedCommands input must not be mutated")
 }
 
-func TestNewRunCommandHandlerStoresAllowedPaths(t *testing.T) {
-	paths := []string{"/var/log", "/tmp"}
+func TestNewRunCommandHandlerNormalizesOperatorPaths(t *testing.T) {
+	// Cleanup+reduce in action: redundant entries collapse, paths get
+	// a trailing slash, and the result is sorted.
+	handler := NewRunCommandHandler(
+		[]string{"/var/log/nginx", "/var/log", "/etc/"},
+		nil,
+	)
 
-	handler := NewRunCommandHandler(paths, nil)
+	assert.Equal(t, []string{"/etc/", "/var/log/"}, handler.operatorAllowedPaths)
+}
 
-	assert.Equal(t, []string{"/var/log", "/tmp"}, handler.operatorAllowedPaths)
-	assert.True(t, handler.operatorPathsFilterEnabled)
+func TestNewRunCommandHandlerDedupesOperatorCommands(t *testing.T) {
+	// Sort+Compact yields a sorted, deduplicated slice. Order is the
+	// implementation detail; what matters is "no duplicates."
+	handler := NewRunCommandHandler(
+		nil,
+		[]string{"rshell:cat", "rshell:echo", "rshell:cat", "rshell:ls"},
+	)
+
+	assert.Equal(t,
+		[]string{"rshell:cat", "rshell:echo", "rshell:ls"},
+		handler.operatorAllowedCommands,
+	)
+}
+
+func TestNewRunCommandHandlerNilInputs(t *testing.T) {
+	// Both sides nil: handler treats both as kill-switches downstream.
+	handler := NewRunCommandHandler(nil, nil)
+
+	assert.Empty(t, handler.operatorAllowedPaths)
+	assert.Empty(t, handler.operatorAllowedCommands)
 }
 
 func TestNewRshellBundleUsesConfiguredAllowedPaths(t *testing.T) {
@@ -366,7 +373,113 @@ func TestNewRshellBundleUsesConfiguredAllowedPaths(t *testing.T) {
 
 	handler, ok := action.(*RunCommandHandler)
 	require.True(t, ok)
-	assert.Equal(t, []string{"/var/log", "/tmp"}, handler.operatorAllowedPaths)
+	// Bundle wires the cleaned/reduced form into the handler.
+	assert.Equal(t, []string{"/tmp/", "/var/log/"}, handler.operatorAllowedPaths)
+}
+
+func TestRunCommandEmptyCommandReturnsError(t *testing.T) {
+	handler := NewRunCommandHandler(nil, nil)
+
+	_, err := handler.Run(context.Background(), makeTask("", nil), nil)
+
+	assert.ErrorContains(t, err, "command is required")
+}
+
+func TestRunCommandNoAllowedCommandsBlocksExecution(t *testing.T) {
+	// Operator nil + backend nil → empty effective list → rshell rejects.
+	handler := NewRunCommandHandler(nil, nil)
+
+	out, err := handler.Run(context.Background(), makeTask("echo hello", nil), nil)
+
+	require.NoError(t, err)
+	result := out.(*RunCommandOutputs)
+	assert.Equal(t, 127, result.ExitCode)
+	assert.Contains(t, result.Stderr, "command not allowed")
+}
+
+func TestRunCommandWithWildcardOperatorAndBackendAllowed(t *testing.T) {
+	// Operator uses the default ["rshell:*"] wildcard sentinel; backend
+	// allowed "rshell:echo"; echo runs.
+	handler := NewRunCommandHandler(nil, []string{setup.RShellCommandAllowAllWildcard})
+
+	out, err := handler.Run(context.Background(),
+		makeTask("echo hello", []string{"rshell:echo"}), nil)
+
+	require.NoError(t, err)
+	result := out.(*RunCommandOutputs)
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Equal(t, "hello\n", result.Stdout)
+}
+
+func TestRunCommandDisallowedCommandBlocked(t *testing.T) {
+	// Operator wildcard, but backend only allowed "rshell:echo"; grep is
+	// blocked because it isn't in the backend list.
+	handler := NewRunCommandHandler(nil, []string{setup.RShellCommandAllowAllWildcard})
+
+	out, err := handler.Run(context.Background(),
+		makeTask("grep foo", []string{"rshell:echo"}), nil)
+
+	require.NoError(t, err)
+	result := out.(*RunCommandOutputs)
+	assert.Equal(t, 127, result.ExitCode)
+	assert.Contains(t, result.Stderr, "command not allowed")
+}
+
+func TestRunCommandOperatorIntersectionAllows(t *testing.T) {
+	// Operator narrowed to "rshell:echo"; backend allowed echo and cat;
+	// echo passes the intersection.
+	handler := NewRunCommandHandler(nil, []string{"rshell:echo"})
+
+	out, err := handler.Run(context.Background(),
+		makeTask("echo hi", []string{"rshell:echo", "rshell:cat"}), nil)
+
+	require.NoError(t, err)
+	result := out.(*RunCommandOutputs)
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Equal(t, "hi\n", result.Stdout)
+}
+
+func TestRunCommandOperatorIntersectionBlocksDisjoint(t *testing.T) {
+	// Operator narrowed to "rshell:cat"; backend allowed only echo —
+	// disjoint, intersection empty, echo rejected.
+	handler := NewRunCommandHandler(nil, []string{"rshell:cat"})
+
+	out, err := handler.Run(context.Background(),
+		makeTask("echo hi", []string{"rshell:echo"}), nil)
+
+	require.NoError(t, err)
+	result := out.(*RunCommandOutputs)
+	assert.Equal(t, 127, result.ExitCode)
+	assert.Contains(t, result.Stderr, "command not allowed")
+}
+
+func TestRunCommandOperatorEmptyListBlocksEverything(t *testing.T) {
+	// Explicit empty operator command list is the kill-switch.
+	handler := NewRunCommandHandler(nil, []string{})
+
+	out, err := handler.Run(context.Background(),
+		makeTask("echo hi", []string{"rshell:echo"}), nil)
+
+	require.NoError(t, err)
+	result := out.(*RunCommandOutputs)
+	assert.Equal(t, 127, result.ExitCode)
+	assert.Contains(t, result.Stderr, "command not allowed")
+}
+
+func TestRunCommandBackendAllowedPathsRestrictsAccess(t *testing.T) {
+	// End-to-end: operator allows /var/log, backend only allows /tmp; the
+	// intersection drops /var/log so cat /var/log/syslog must fail.
+	handler := NewRunCommandHandler([]string{"/var/log"}, []string{"rshell:cat"})
+
+	task := makeTaskWithPaths("cat /var/log/syslog",
+		[]string{"rshell:cat"}, []string{"/tmp"})
+
+	out, err := handler.Run(context.Background(), task, nil)
+
+	require.NoError(t, err)
+	result := out.(*RunCommandOutputs)
+	assert.NotEqual(t, 0, result.ExitCode,
+		"expected cat to fail because /var/log is not in the backend list")
 }
 
 func mockStatFn(existing map[string]bool) func(string) (os.FileInfo, error) {


### PR DESCRIPTION
### What does this PR do?

Replaces the three-way `nil` / `[]` / `[X]` slice contract for the operator-side allow-lists with a uniform "always intersect" contract using sentinel defaults:

- **`allowed_paths`** default is `["/"]`. `pathContains("/", X)` is true for any absolute path, so the intersection passes the backend list through when the operator hasn't narrowed.
- **`allowed_commands`** default is `["rshell:*"]`. The wildcard token is a special case in the operator-side intersection: when present, every backend entry in the `rshell:` namespace is admitted (scoped via `onlyRshellPrefixedCommands`).

The `IsConfigured` gate and the handler's nil-pass-through bypass are gone. End-user behavior is preserved on every axis:

| Operator config | Effective list |
|---|---|
| Unset (sentinel default) | Backend list as-is |
| Explicit `[]` | Kill-switch (empty) |
| Explicit non-empty | Narrowed intersection |

### Helper extraction

Pure path utilities moved to a new `helper.go`:
- `cleanPathList`, `reducePathListToBroadest`, `intersectPathLists`, `commonPath` — containment-aware path matching with normalized canonical forms.
- `onlyRshellPrefixedCommands` — namespace scoping for the wildcard branch.

Comprehensive unit tests in `helper_test.go` cover every helper plus property tests (idempotence, order-independence) for `reducePathListToBroadest`.

### Stacked on top of #49948 (PR2 in the split)

This is PR3 of 4 splitting #49825. **Base**: PR2 branch. Will retarget after PR1+PR2 land.

### Describe how you validated your changes

- 425 tests pass across `pkg/privateactionrunner/adapters/config`, `pkg/privateactionrunner/bundles/remoteaction/rshell`, and `pkg/config/setup`. Linter clean.
- New `helper_test.go` covers: `commonPath` (every shape), `cleanPathList` (incl. dot-segment edge cases), `reducePathListToBroadest` (incl. multi-domination + idempotence + order-independence), `intersectPathLists` (incl. multi-pair containment regression cases), `onlyRshellPrefixedCommands` (incl. wildcard token / bare `rshell` / `rshell:` alone).
- Updated handler matrices in `run_command_test.go` use the sentinels for the pass-through case and pin the kill-switch / containment / namespace-required scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)