### PR TITLE
[ACTP] PAR: per-environment paths for rshell allow-list

### DIFF
--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -51,6 +51,12 @@ const (
 	// backend path through containment matching. It is the default value
 	// for allowed_paths.
 	RShellPathAllowAll = "/"
+	// RShellPathAllowMap*Key are the keys used in the per-environment
+	// backend-shipped allowedPaths map. The runner picks the relevant
+	// slice based on env.IsContainerized() before running the
+	// intersection.
+	RShellPathAllowMapContainerizedKey = "containerized"
+	RShellPathAllowMapBareMetalKey     = "bare_metal"
 )
 
 // setupPrivateActionRunner registers all configuration keys for the private action runner

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/helper.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/helper.go
@@ -10,8 +10,20 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
 )
+
+// selectBackendPathsFromEnv returns the per-environment slice from the
+// backend-supplied allowed-paths map. Falls back to the bare-metal key
+// when not running in a container; returns nil if the relevant key is
+// missing (downstream treats nil as the kill-switch).
+func selectBackendPathsFromEnv(m map[string][]string) []string {
+	if env.IsContainerized() {
+		return m[setup.RShellPathAllowMapContainerizedKey]
+	}
+	return m[setup.RShellPathAllowMapBareMetalKey]
+}
 
 // onlyRshellPrefixedCommands returns the commands that are prefixed with the
 // rshell namespace, excluding the wildcard token and the bare prefix.

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/helper_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/helper_test.go
@@ -6,6 +6,7 @@
 package com_datadoghq_remoteaction_rshell
 
 import (
+	"os"
 	"slices"
 	"testing"
 
@@ -477,6 +478,84 @@ func TestIntersectPathLists(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := intersectPathLists(tc.list1, tc.list2)
 			assert.ElementsMatch(t, tc.want, got, "set of admitted paths")
+		})
+	}
+}
+
+// TestSelectBackendPathsFromEnv pins the env-driven dispatch and the
+// failure modes when the relevant key is missing.
+func TestSelectBackendPathsFromEnv(t *testing.T) {
+	cases := []struct {
+		name          string
+		containerized bool
+		in            map[string][]string
+		want          []string
+	}{
+		{
+			name:          "nil map → nil slice (kill-switch downstream)",
+			containerized: false,
+			in:            nil,
+			want:          nil,
+		},
+		{
+			name:          "empty map → nil slice (kill-switch downstream)",
+			containerized: false,
+			in:            map[string][]string{},
+			want:          nil,
+		},
+		{
+			name:          "bare-metal runner picks the bare_metal key",
+			containerized: false,
+			in: map[string][]string{
+				setup.RShellPathAllowMapBareMetalKey:     {"/var/log", "/etc"},
+				setup.RShellPathAllowMapContainerizedKey: {"/host/var/log"},
+			},
+			want: []string{"/var/log", "/etc"},
+		},
+		{
+			name:          "containerized runner picks the containerized key",
+			containerized: true,
+			in: map[string][]string{
+				setup.RShellPathAllowMapBareMetalKey:     {"/var/log", "/etc"},
+				setup.RShellPathAllowMapContainerizedKey: {"/host/var/log"},
+			},
+			want: []string{"/host/var/log"},
+		},
+		{
+			name:          "bare-metal runner with only the containerized key → nil (kill-switch)",
+			containerized: false,
+			in: map[string][]string{
+				setup.RShellPathAllowMapContainerizedKey: {"/host/var/log"},
+			},
+			want: nil,
+		},
+		{
+			name:          "containerized runner with only the bare_metal key → nil (kill-switch)",
+			containerized: true,
+			in: map[string][]string{
+				setup.RShellPathAllowMapBareMetalKey: {"/var/log"},
+			},
+			want: nil,
+		},
+		{
+			name:          "unknown keys are ignored",
+			containerized: false,
+			in: map[string][]string{
+				setup.RShellPathAllowMapBareMetalKey: {"/var/log"},
+				"some_future_env":                    {"/some/path"},
+			},
+			want: []string{"/var/log"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.containerized {
+				t.Setenv("DOCKER_DD_AGENT", "true")
+			} else {
+				os.Unsetenv("DOCKER_DD_AGENT")
+			}
+			got := selectBackendPathsFromEnv(tc.in)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -105,9 +105,9 @@ func (h *RunCommandHandler) filterAllowedPaths(backend []string) []string {
 // A non-nil list is intersected with the operator config before being
 // handed to rshell.
 type RunCommandInputs struct {
-	Command         string   `json:"command"`
-	AllowedCommands []string `json:"allowedCommands"`
-	AllowedPaths    []string `json:"allowedPaths"`
+	Command         string              `json:"command"`
+	AllowedCommands []string            `json:"allowedCommands"`
+	AllowedPaths    map[string][]string `json:"allowedPaths"`
 }
 
 // RunCommandOutputs defines the outputs for the runCommand action.
@@ -132,10 +132,11 @@ func (h *RunCommandHandler) Run(
 		return nil, errors.New("command is required")
 	}
 
+	backendPaths := selectBackendPathsFromEnv(inputs.AllowedPaths)
 	effectiveAllowedCommands := h.filterAllowedCommands(inputs.AllowedCommands)
-	effectiveAllowedPaths := h.filterAllowedPaths(inputs.AllowedPaths)
+	effectiveAllowedPaths := h.filterAllowedPaths(backendPaths)
 	log.Debugf("rshell runCommand: command=%q backendAllowedCommands=%v effectiveAllowedCommands=%v backendAllowedPaths=%v effectiveAllowedPaths=%v",
-		inputs.Command, inputs.AllowedCommands, effectiveAllowedCommands, inputs.AllowedPaths, effectiveAllowedPaths)
+		inputs.Command, inputs.AllowedCommands, effectiveAllowedCommands, backendPaths, effectiveAllowedPaths)
 
 	prog, err := syntax.NewParser().Parse(strings.NewReader(inputs.Command), "")
 	if err != nil {

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -32,10 +32,10 @@ func makeTask(command string, allowedCommands []string) *types.Task {
 }
 
 // makeTaskWithPaths constructs a task whose inputs include the allowedPaths
-// field. Use makeTask (without this helper) to exercise the "backend did
-// not send the field" branch — absent JSON fields and explicit null both
-// round-trip to a nil Go slice.
-func makeTaskWithPaths(command string, allowedCommands, allowedPaths []string) *types.Task {
+// field. The backend ships allowedPaths as a per-environment map keyed by
+// "bare_metal" / "containerized"; the runner picks the relevant slice
+// based on env.IsContainerized at task time.
+func makeTaskWithPaths(command string, allowedCommands []string, allowedPaths map[string][]string) *types.Task {
 	task := makeTask(command, allowedCommands)
 	task.Data.Attributes.Inputs["allowedPaths"] = allowedPaths
 	return task
@@ -467,12 +467,14 @@ func TestRunCommandOperatorEmptyListBlocksEverything(t *testing.T) {
 }
 
 func TestRunCommandBackendAllowedPathsRestrictsAccess(t *testing.T) {
-	// End-to-end: operator allows /var/log, backend only allows /tmp; the
-	// intersection drops /var/log so cat /var/log/syslog must fail.
+	// End-to-end: operator allows /var/log, backend only allows /tmp on
+	// bare-metal hosts (the env this test process runs in); /var/log
+	// isn't in the backend list, so cat /var/log/syslog must fail.
 	handler := NewRunCommandHandler([]string{"/var/log"}, []string{"rshell:cat"})
 
 	task := makeTaskWithPaths("cat /var/log/syslog",
-		[]string{"rshell:cat"}, []string{"/tmp"})
+		[]string{"rshell:cat"},
+		map[string][]string{setup.RShellPathAllowMapBareMetalKey: {"/tmp"}})
 
 	out, err := handler.Run(context.Background(), task, nil)
 


### PR DESCRIPTION
### What does this PR do?

Adds per-environment routing to the rshell `allowedPaths` task input. The backend now ships `allowedPaths` as a map keyed by execution environment:

```json
{
  "bare_metal":    ["/var/log"],
  "containerized": ["/host/var/log"]
}
```

The runner picks the relevant slice based on `env.IsContainerized()` via the new `selectBackendPathsFromEnv` helper, then the slice flows through the existing intersection logic. This lets a single Balto rule cover both host-installed agents (which see `/var/log`) and containerized agents (which see `/host/var/log`).

### ⚠️ Wire-format change

`allowedPaths` is no longer a slice on the wire. The runner ships in this PR; Balto / `wf-actions-server` need to ship the new shape **concurrently**. Old tasks (slice shape) will fail to deserialize on the new runner — coordinate the rollout.

### Stacked on top of #49949 (PR3 in the split)

This is PR4 of 4 splitting #49825. **Base**: PR3 branch. Will retarget after PR1+PR2+PR3 land.

### Describe how you validated your changes

- New `TestSelectBackendPathsFromEnv` in `helper_test.go` covers 7 cases: nil/empty maps (kill-switch), bare-metal/containerized branches, missing-key kill-switch in either direction, and unknown future keys ignored. Uses `t.Setenv("DOCKER_DD_AGENT", ...)` to flip `env.IsContainerized()`.
- End-to-end `TestRunCommandBackendAllowedPathsRestrictsAccess` updated to use the map shape with the bare-metal key.
- 432 tests pass across `pkg/privateactionrunner/adapters/config`, `pkg/privateactionrunner/bundles/remoteaction/rshell`, and `pkg/config/setup`. Linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)