### PR TITLE
APM: Limit accepted payload sizes in trace-agent

### DIFF
--- a/comp/trace/config/impl/setup.go
+++ b/comp/trace/config/impl/setup.go
@@ -604,6 +604,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "apm_config.profiling_receiver_timeout"; core.IsConfigured(k) {
 		c.ProfilingProxy.ReceiverTimeout = core.GetInt(k)
 	}
+	c.ProfilingProxy.MaxRequestBytes = int64(core.GetInt("apm_config.profiling_max_request_bytes"))
 	if k := "apm_config.debugger_dd_url"; core.IsConfigured(k) {
 		c.DebuggerProxy.DDURL = core.GetString(k)
 	}

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -134,6 +134,7 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.profiling_dd_url", "", "DD_APM_PROFILING_DD_URL")
 	config.BindEnvAndSetDefault("apm_config.profiling_additional_endpoints", map[string][]string{}, "DD_APM_PROFILING_ADDITIONAL_ENDPOINTS")
 	config.BindEnvAndSetDefault("apm_config.profiling_receiver_timeout", 5, "DD_APM_PROFILING_RECEIVER_TIMEOUT")
+	config.BindEnvAndSetDefault("apm_config.profiling_max_request_bytes", 50*1024*1024, "DD_APM_PROFILING_MAX_REQUEST_BYTES")
 	config.BindEnvAndSetDefault("apm_config.additional_profile_tags", map[string]string{}, "DD_APM_ADDITIONAL_PROFILE_TAGS")
 	config.BindEnvAndSetDefault("apm_config.additional_endpoints", map[string][]string{}, "DD_APM_ADDITIONAL_ENDPOINTS")
 	config.BindEnvAndSetDefault("apm_config.replace_tags", []map[string]string{}, "DD_APM_REPLACE_TAGS")

--- a/pkg/proto/pbgo/trace/BUILD.bazel
+++ b/pkg/proto/pbgo/trace/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "convert_test.go",
         "decoder_bytes_test.go",
         "decoder_v05_test.go",
+        "limit_test.go",
         "span_gen_modifs_test.go",
         "span_gen_test.go",
         "stats_gen_test.go",

--- a/pkg/proto/pbgo/trace/limit_test.go
+++ b/pkg/proto/pbgo/trace/limit_test.go
@@ -1,0 +1,131 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Tests for VULN-80981 / VULN-963 regression: element-count bounds checks on
+// msgpack decoders to prevent memory-exhaustion DoS via crafted array headers.
+
+package trace
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+// maliciousArrayHeader32 returns a 5-byte msgpack array32 header declaring n elements.
+func maliciousArrayHeader32(n uint32) []byte {
+	return []byte{
+		0xdd,
+		byte(n >> 24),
+		byte(n >> 16),
+		byte(n >> 8),
+		byte(n),
+	}
+}
+
+// TestUnmarshalMsgLargeArrayCount verifies that Traces.UnmarshalMsg rejects a
+// payload whose declared element count exceeds the configured limit, preventing
+// the ~48 GB heap allocation a crafted 5-byte body would otherwise trigger.
+func TestUnmarshalMsgLargeArrayCount(t *testing.T) {
+	// array32 with 2^31-1 elements: 5 bytes total, within the 25 MB byte cap
+	// but would allocate ~48 GB before the fix.
+	payload := maliciousArrayHeader32(0x7FFFFFFF)
+
+	var traces Traces
+	_, err := traces.UnmarshalMsg(payload)
+	if err != msgp.ErrLimitExceeded {
+		t.Fatalf("expected msgp.ErrLimitExceeded, got %v", err)
+	}
+}
+
+// TestUnmarshalMsgMaxUint32ArrayCount is the worst-case variant using the full
+// uint32 maximum (4,294,967,295 elements).
+func TestUnmarshalMsgMaxUint32ArrayCount(t *testing.T) {
+	payload := maliciousArrayHeader32(0xFFFFFFFF)
+
+	var traces Traces
+	_, err := traces.UnmarshalMsg(payload)
+	if err != msgp.ErrLimitExceeded {
+		t.Fatalf("expected msgp.ErrLimitExceeded, got %v", err)
+	}
+}
+
+// TestUnmarshalMsgWithinLimit confirms that payloads within the element-count
+// limit are still accepted.
+func TestUnmarshalMsgWithinLimit(t *testing.T) {
+	// Build a legitimate small Traces payload.
+	traces := Traces{Trace{}}
+	bts, err := traces.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result Traces
+	_, err = result.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatalf("unexpected error for payload within limit: %v", err)
+	}
+}
+
+// TestDecodeStatsLargeArrayCount verifies that ClientStatsPayload.DecodeMsg
+// rejects a payload whose declared Stats bucket count exceeds the configured
+// limit.  A 12-byte body (well within the 25 MB byte cap) is sufficient to
+// declare 4,294,967,295 buckets.
+func TestDecodeStatsLargeArrayCount(t *testing.T) {
+	// fixmap {1 entry}, key "Stats", array32 max count
+	// fixmap with 1 entry: 0x81
+	// fixstr "Stats" (5 bytes): 0xa5 0x53 0x74 0x61 0x74 0x73
+	// array32 max: 0xdd 0xff 0xff 0xff 0xff
+	payload := []byte{
+		0x81,
+		0xa5, 'S', 't', 'a', 't', 's',
+		0xdd, 0xff, 0xff, 0xff, 0xff,
+	}
+
+	var p ClientStatsPayload
+	reader := msgp.NewReader(bytes.NewReader(payload))
+	err := p.DecodeMsg(reader)
+	if err != msgp.ErrLimitExceeded {
+		t.Fatalf("expected msgp.ErrLimitExceeded, got %v", err)
+	}
+}
+
+// TestUnmarshalStatsLargeArrayCount covers the same attack via the binary
+// UnmarshalMsg path (used when the body is already buffered).
+func TestUnmarshalStatsLargeArrayCount(t *testing.T) {
+	// Same 12-byte payload as TestDecodeStatsLargeArrayCount.
+	payload := []byte{
+		0x81,
+		0xa5, 'S', 't', 'a', 't', 's',
+		0xdd, 0xff, 0xff, 0xff, 0xff,
+	}
+
+	var p ClientStatsPayload
+	_, err := p.UnmarshalMsg(payload)
+	if err != msgp.ErrLimitExceeded {
+		t.Fatalf("expected msgp.ErrLimitExceeded, got %v", err)
+	}
+}
+
+// TestDecodeStatsWithinLimit confirms that valid stats payloads still decode
+// correctly after the limit check was added.
+func TestDecodeStatsWithinLimit(t *testing.T) {
+	p := ClientStatsPayload{
+		Env:     "prod",
+		Service: "web",
+		Stats:   []*ClientStatsBucket{},
+	}
+	bts, err := p.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result ClientStatsPayload
+	reader := msgp.NewReader(bytes.NewReader(bts))
+	if err := result.DecodeMsg(reader); err != nil {
+		t.Fatalf("unexpected error for valid payload: %v", err)
+	}
+}

--- a/pkg/proto/pbgo/trace/stats_gen.go
+++ b/pkg/proto/pbgo/trace/stats_gen.go
@@ -6,6 +6,12 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
+// Size limits for msgp deserialization
+const (
+	z586aeb0climitArrays = 500000
+	z586aeb0climitMaps   = 500000
+)
+
 // DecodeMsg implements msgp.Decodable
 func (z *ClientGroupedStats) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
@@ -14,6 +20,10 @@ func (z *ClientGroupedStats) DecodeMsg(dc *msgp.Reader) (err error) {
 	zb0001, err = dc.ReadMapHeader()
 	if err != nil {
 		err = msgp.WrapError(err)
+		return
+	}
+	if zb0001 > z586aeb0climitMaps {
+		err = msgp.ErrLimitExceeded
 		return
 	}
 	for zb0001 > 0 {
@@ -79,13 +89,19 @@ func (z *ClientGroupedStats) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "OkSummary":
-			z.OkSummary, err = dc.ReadBytes(z.OkSummary)
+			z.OkSummary, err = dc.ReadBytesLimit(z.OkSummary, z586aeb0climitArrays)
+			if err == nil && z.OkSummary == nil {
+				z.OkSummary = []byte{}
+			}
 			if err != nil {
 				err = msgp.WrapError(err, "OkSummary")
 				return
 			}
 		case "ErrorSummary":
-			z.ErrorSummary, err = dc.ReadBytes(z.ErrorSummary)
+			z.ErrorSummary, err = dc.ReadBytesLimit(z.ErrorSummary, z586aeb0climitArrays)
+			if err == nil && z.ErrorSummary == nil {
+				z.ErrorSummary = []byte{}
+			}
 			if err != nil {
 				err = msgp.WrapError(err, "ErrorSummary")
 				return
@@ -113,6 +129,10 @@ func (z *ClientGroupedStats) DecodeMsg(dc *msgp.Reader) (err error) {
 			zb0002, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "PeerTags")
+				return
+			}
+			if zb0002 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
 				return
 			}
 			if cap(z.PeerTags) >= int(zb0002) {
@@ -168,6 +188,10 @@ func (z *ClientGroupedStats) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "SpanDerivedPrimaryTags")
 				return
 			}
+			if zb0004 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
+				return
+			}
 			if cap(z.SpanDerivedPrimaryTags) >= int(zb0004) {
 				z.SpanDerivedPrimaryTags = (z.SpanDerivedPrimaryTags)[:zb0004]
 			} else {
@@ -185,6 +209,10 @@ func (z *ClientGroupedStats) DecodeMsg(dc *msgp.Reader) (err error) {
 			zb0005, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "AdditionalMetricTags")
+				return
+			}
+			if zb0005 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
 				return
 			}
 			if cap(z.AdditionalMetricTags) >= int(zb0005) {
@@ -549,6 +577,10 @@ func (z *ClientGroupedStats) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
+	if zb0001 > z586aeb0climitMaps {
+		err = msgp.ErrLimitExceeded
+		return
+	}
 	for zb0001 > 0 {
 		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
@@ -612,17 +644,49 @@ func (z *ClientGroupedStats) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "OkSummary":
-			z.OkSummary, bts, err = msgp.ReadBytesBytes(bts, z.OkSummary)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "OkSummary")
 				return
 			}
+			if zb0002 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
+				return
+			}
+			if z.OkSummary == nil || uint32(cap(z.OkSummary)) < zb0002 {
+				z.OkSummary = make([]byte, zb0002)
+			} else {
+				z.OkSummary = z.OkSummary[:zb0002]
+			}
+			if uint32(len(bts)) < zb0002 {
+				err = msgp.ErrShortBytes
+				return
+			}
+			copy(z.OkSummary, bts[:zb0002])
+			bts = bts[zb0002:]
 		case "ErrorSummary":
-			z.ErrorSummary, bts, err = msgp.ReadBytesBytes(bts, z.ErrorSummary)
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ErrorSummary")
 				return
 			}
+			if zb0003 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
+				return
+			}
+			if z.ErrorSummary == nil || uint32(cap(z.ErrorSummary)) < zb0003 {
+				z.ErrorSummary = make([]byte, zb0003)
+			} else {
+				z.ErrorSummary = z.ErrorSummary[:zb0003]
+			}
+			if uint32(len(bts)) < zb0003 {
+				err = msgp.ErrShortBytes
+				return
+			}
+			copy(z.ErrorSummary, bts[:zb0003])
+			bts = bts[zb0003:]
 		case "Synthetics":
 			z.Synthetics, bts, err = msgp.ReadBoolBytes(bts)
 			if err != nil {
@@ -642,16 +706,20 @@ func (z *ClientGroupedStats) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "PeerTags":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "PeerTags")
 				return
 			}
-			if cap(z.PeerTags) >= int(zb0002) {
-				z.PeerTags = (z.PeerTags)[:zb0002]
+			if zb0004 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
+				return
+			}
+			if cap(z.PeerTags) >= int(zb0004) {
+				z.PeerTags = (z.PeerTags)[:zb0004]
 			} else {
-				z.PeerTags = make([]string, zb0002)
+				z.PeerTags = make([]string, zb0004)
 			}
 			for za0001 := range z.PeerTags {
 				z.PeerTags[za0001], bts, err = msgp.ReadStringBytes(bts)
@@ -662,13 +730,13 @@ func (z *ClientGroupedStats) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 		case "IsTraceRoot":
 			{
-				var zb0003 int32
-				zb0003, bts, err = msgp.ReadInt32Bytes(bts)
+				var zb0005 int32
+				zb0005, bts, err = msgp.ReadInt32Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "IsTraceRoot")
 					return
 				}
-				z.IsTraceRoot = Trilean(zb0003)
+				z.IsTraceRoot = Trilean(zb0005)
 			}
 		case "GRPCStatusCode":
 			z.GRPCStatusCode, bts, err = msgp.ReadStringBytes(bts)
@@ -695,16 +763,20 @@ func (z *ClientGroupedStats) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "SpanDerivedPrimaryTags":
-			var zb0004 uint32
-			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0006 uint32
+			zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "SpanDerivedPrimaryTags")
 				return
 			}
-			if cap(z.SpanDerivedPrimaryTags) >= int(zb0004) {
-				z.SpanDerivedPrimaryTags = (z.SpanDerivedPrimaryTags)[:zb0004]
+			if zb0006 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
+				return
+			}
+			if cap(z.SpanDerivedPrimaryTags) >= int(zb0006) {
+				z.SpanDerivedPrimaryTags = (z.SpanDerivedPrimaryTags)[:zb0006]
 			} else {
-				z.SpanDerivedPrimaryTags = make([]string, zb0004)
+				z.SpanDerivedPrimaryTags = make([]string, zb0006)
 			}
 			for za0002 := range z.SpanDerivedPrimaryTags {
 				z.SpanDerivedPrimaryTags[za0002], bts, err = msgp.ReadStringBytes(bts)
@@ -714,16 +786,20 @@ func (z *ClientGroupedStats) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 		case "AdditionalMetricTags":
-			var zb0005 uint32
-			zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0007 uint32
+			zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "AdditionalMetricTags")
 				return
 			}
-			if cap(z.AdditionalMetricTags) >= int(zb0005) {
-				z.AdditionalMetricTags = (z.AdditionalMetricTags)[:zb0005]
+			if zb0007 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
+				return
+			}
+			if cap(z.AdditionalMetricTags) >= int(zb0007) {
+				z.AdditionalMetricTags = (z.AdditionalMetricTags)[:zb0007]
 			} else {
-				z.AdditionalMetricTags = make([]string, zb0005)
+				z.AdditionalMetricTags = make([]string, zb0007)
 			}
 			for za0003 := range z.AdditionalMetricTags {
 				z.AdditionalMetricTags[za0003], bts, err = msgp.ReadStringBytes(bts)
@@ -771,6 +847,10 @@ func (z *ClientStatsBucket) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
+	if zb0001 > z586aeb0climitMaps {
+		err = msgp.ErrLimitExceeded
+		return
+	}
 	for zb0001 > 0 {
 		zb0001--
 		field, err = dc.ReadMapKeyPtr()
@@ -796,6 +876,10 @@ func (z *ClientStatsBucket) DecodeMsg(dc *msgp.Reader) (err error) {
 			zb0002, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Stats")
+				return
+			}
+			if zb0002 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
 				return
 			}
 			if cap(z.Stats) >= int(zb0002) {
@@ -972,6 +1056,10 @@ func (z *ClientStatsBucket) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
+	if zb0001 > z586aeb0climitMaps {
+		err = msgp.ErrLimitExceeded
+		return
+	}
 	for zb0001 > 0 {
 		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
@@ -997,6 +1085,10 @@ func (z *ClientStatsBucket) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Stats")
+				return
+			}
+			if zb0002 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
 				return
 			}
 			if cap(z.Stats) >= int(zb0002) {
@@ -1064,6 +1156,10 @@ func (z *ClientStatsPayload) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
+	if zb0001 > z586aeb0climitMaps {
+		err = msgp.ErrLimitExceeded
+		return
+	}
 	for zb0001 > 0 {
 		zb0001--
 		field, err = dc.ReadMapKeyPtr()
@@ -1095,6 +1191,10 @@ func (z *ClientStatsPayload) DecodeMsg(dc *msgp.Reader) (err error) {
 			zb0002, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Stats")
+				return
+			}
+			if zb0002 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
 				return
 			}
 			if cap(z.Stats) >= int(zb0002) {
@@ -1168,6 +1268,10 @@ func (z *ClientStatsPayload) DecodeMsg(dc *msgp.Reader) (err error) {
 			zb0003, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Tags")
+				return
+			}
+			if zb0003 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
 				return
 			}
 			if cap(z.Tags) >= int(zb0003) {
@@ -1516,6 +1620,10 @@ func (z *ClientStatsPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
+	if zb0001 > z586aeb0climitMaps {
+		err = msgp.ErrLimitExceeded
+		return
+	}
 	for zb0001 > 0 {
 		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
@@ -1547,6 +1655,10 @@ func (z *ClientStatsPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Stats")
+				return
+			}
+			if zb0002 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
 				return
 			}
 			if cap(z.Stats) >= int(zb0002) {
@@ -1619,6 +1731,10 @@ func (z *ClientStatsPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Tags")
+				return
+			}
+			if zb0003 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
 				return
 			}
 			if cap(z.Tags) >= int(zb0003) {
@@ -1697,6 +1813,10 @@ func (z *StatsPayload) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
+	if zb0001 > z586aeb0climitMaps {
+		err = msgp.ErrLimitExceeded
+		return
+	}
 	for zb0001 > 0 {
 		zb0001--
 		field, err = dc.ReadMapKeyPtr()
@@ -1722,6 +1842,10 @@ func (z *StatsPayload) DecodeMsg(dc *msgp.Reader) (err error) {
 			zb0002, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Stats")
+				return
+			}
+			if zb0002 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
 				return
 			}
 			if cap(z.Stats) >= int(zb0002) {
@@ -1936,6 +2060,10 @@ func (z *StatsPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
+	if zb0001 > z586aeb0climitMaps {
+		err = msgp.ErrLimitExceeded
+		return
+	}
 	for zb0001 > 0 {
 		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
@@ -1961,6 +2089,10 @@ func (z *StatsPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Stats")
+				return
+			}
+			if zb0002 > z586aeb0climitArrays {
+				err = msgp.ErrLimitExceeded
 				return
 			}
 			if cap(z.Stats) >= int(zb0002) {

--- a/pkg/proto/pbgo/trace/trace.go
+++ b/pkg/proto/pbgo/trace/trace.go
@@ -7,6 +7,8 @@ package trace
 
 import "maps"
 
+//msgp:limit arrays:500000 maps:500000
+
 //go:generate go run github.com/tinylib/msgp -file=span.pb.go -o span_gen.go -io=false
 //go:generate go run github.com/tinylib/msgp -file=tracer_payload.pb.go -o tracer_payload_gen.go -io=false
 //go:generate go run github.com/tinylib/msgp -io=false

--- a/pkg/proto/pbgo/trace/trace_gen.go
+++ b/pkg/proto/pbgo/trace/trace_gen.go
@@ -6,6 +6,12 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
+// Size limits for msgp deserialization
+const (
+	zb632dfd4limitArrays = 500000
+	zb632dfd4limitMaps   = 500000
+)
+
 // MarshalMsg implements msgp.Marshaler
 func (z Trace) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
@@ -30,6 +36,10 @@ func (z *Trace) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 	if err != nil {
 		err = msgp.WrapError(err)
+		return
+	}
+	if zb0002 > zb632dfd4limitArrays {
+		err = msgp.ErrLimitExceeded
 		return
 	}
 	if cap((*z)) >= int(zb0002) {
@@ -101,6 +111,10 @@ func (z *Traces) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
+	if zb0003 > zb632dfd4limitArrays {
+		err = msgp.ErrLimitExceeded
+		return
+	}
 	if cap((*z)) >= int(zb0003) {
 		(*z) = (*z)[:zb0003]
 	} else {
@@ -111,6 +125,10 @@ func (z *Traces) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err, zb0001)
+			return
+		}
+		if zb0004 > zb632dfd4limitArrays {
+			err = msgp.ErrLimitExceeded
 			return
 		}
 		if cap((*z)[zb0001]) >= int(zb0004) {

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -16,7 +16,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"strconv"
 	"sync"
 	"testing"
@@ -39,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tinylib/msgp/msgp"
 	vmsgp "github.com/vmihailenco/msgpack/v4"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
@@ -1079,7 +1079,7 @@ func TestHandleStats(t *testing.T) {
 
 		resp.Body.Close()
 		gotp, gotlang, gotTracerVersion, containerID := mockProcessor.Got()
-		assert.True(t, reflect.DeepEqual(gotp, p), "payload did not match")
+		assert.True(t, proto.Equal(gotp, p), "payload did not match")
 		assert.Equal(t, "lang1", gotlang, "lang did not match")
 		assert.Equal(t, "0.1.0", gotTracerVersion, "tracerVersion did not match")
 		assert.Equal(t, "abcdef123789456", containerID, "containerID did not match")

--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -75,7 +75,7 @@ func (r *HTTPReceiver) debuggerProxyHandler(urlTemplate string, proxyConfig conf
 		apiKey = strings.TrimSpace(k)
 	}
 	transport := newMeasuringForwardingTransport(
-		r.conf.NewHTTPTransport(), target, apiKey, proxyConfig.AdditionalEndpoints, "datadog.trace_agent.debugger", []string{}, r.statsd)
+		r.conf.NewHTTPTransport(), target, apiKey, proxyConfig.AdditionalEndpoints, r.conf.MaxRequestBytes, "datadog.trace_agent.debugger", []string{}, r.statsd)
 	return newDebuggerProxy(r.conf, transport, hostTags)
 }
 

--- a/pkg/trace/api/dogstatsd.go
+++ b/pkg/trace/api/dogstatsd.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/api/apiutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 )
 
@@ -39,6 +40,7 @@ func (r *HTTPReceiver) dogstatsdProxyHandler() http.Handler {
 		})
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		req.Body = apiutil.NewLimitedReader(req.Body, r.conf.MaxRequestBytes)
 		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/trace/api/openlineage.go
+++ b/pkg/trace/api/openlineage.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/api/apiutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -135,7 +136,7 @@ func newOpenLineageProxy(conf *config.AgentConfig, urls []*url.URL, keys []strin
 	return &httputil.ReverseProxy{
 		Director:  director,
 		ErrorLog:  stdlog.New(logger, "openlineage.Proxy: ", 0),
-		Transport: &openLineageTransport{rt: conf.NewHTTPTransport(), urls: urls, keys: keys},
+		Transport: &openLineageTransport{rt: conf.NewHTTPTransport(), urls: urls, keys: keys, maxRequestBytes: conf.MaxRequestBytes},
 	}
 }
 
@@ -146,9 +147,10 @@ func newOpenLineageProxy(conf *config.AgentConfig, urls []*url.URL, keys []strin
 // response is discarded. There is no de-duplication done between endpoint
 // hosts or api keys.
 type openLineageTransport struct {
-	rt   http.RoundTripper
-	urls []*url.URL
-	keys []string
+	rt              http.RoundTripper
+	urls            []*url.URL
+	keys            []string
+	maxRequestBytes int64
 }
 
 func (m *openLineageTransport) RoundTrip(req *http.Request) (rresp *http.Response, rerr error) {
@@ -169,6 +171,7 @@ func (m *openLineageTransport) RoundTrip(req *http.Request) (rresp *http.Respons
 
 		return rresp, rerr
 	}
+	req.Body = apiutil.NewLimitedReader(req.Body, m.maxRequestBytes)
 	slurp, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err

--- a/pkg/trace/api/pipeline_stats.go
+++ b/pkg/trace/api/pipeline_stats.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/api/apiutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -94,7 +95,7 @@ func newPipelineStatsProxy(conf *config.AgentConfig, urls []*url.URL, apiKeys []
 	return &httputil.ReverseProxy{
 		Director:  director,
 		ErrorLog:  stdlog.New(logger, "pipeline_stats.Proxy: ", 0),
-		Transport: &multiDataStreamsTransport{rt: conf.NewHTTPTransport(), targets: urls, keys: apiKeys},
+		Transport: &multiDataStreamsTransport{rt: conf.NewHTTPTransport(), targets: urls, keys: apiKeys, maxRequestBytes: conf.MaxRequestBytes},
 	}
 }
 
@@ -105,9 +106,10 @@ func newPipelineStatsProxy(conf *config.AgentConfig, urls []*url.URL, apiKeys []
 // response is discarded. There is no de-duplication done between endpoint
 // hosts or api keys.
 type multiDataStreamsTransport struct {
-	rt      http.RoundTripper
-	targets []*url.URL
-	keys    []string
+	rt              http.RoundTripper
+	targets         []*url.URL
+	keys            []string
+	maxRequestBytes int64
 }
 
 func (m *multiDataStreamsTransport) RoundTrip(req *http.Request) (rresp *http.Response, rerr error) {
@@ -127,6 +129,7 @@ func (m *multiDataStreamsTransport) RoundTrip(req *http.Request) (rresp *http.Re
 
 		return rresp, rerr
 	}
+	req.Body = apiutil.NewLimitedReader(req.Body, m.maxRequestBytes)
 	slurp, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/api/apiutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -171,7 +172,7 @@ func newProfileProxy(conf *config.AgentConfig, targets []*url.URL, keys []string
 	return &httputil.ReverseProxy{
 		Director:     director,
 		ErrorLog:     stdlog.New(logger, "profiling.Proxy: ", 0),
-		Transport:    &multiTransport{ptransport, targets, keys},
+		Transport:    &multiTransport{rt: ptransport, targets: targets, keys: keys, maxRequestBytes: conf.ProfilingProxy.MaxRequestBytes},
 		ErrorHandler: handleProxyError,
 	}
 }
@@ -240,9 +241,10 @@ func handleProxyError(w http.ResponseWriter, r *http.Request, err error) {
 // response is discarded. There is no de-duplication done between endpoint
 // hosts or api keys.
 type multiTransport struct {
-	rt      http.RoundTripper
-	targets []*url.URL
-	keys    []string
+	rt              http.RoundTripper
+	targets         []*url.URL
+	keys            []string
+	maxRequestBytes int64
 }
 
 func (m *multiTransport) RoundTrip(req *http.Request) (rresp *http.Response, rerr error) {
@@ -270,6 +272,7 @@ func (m *multiTransport) RoundTrip(req *http.Request) (rresp *http.Response, rer
 		}
 		return rresp, rerr
 	}
+	req.Body = apiutil.NewLimitedReader(req.Body, m.maxRequestBytes)
 	slurp, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err

--- a/pkg/trace/api/profiles_test.go
+++ b/pkg/trace/api/profiles_test.go
@@ -264,6 +264,7 @@ func TestProfileProxyHandler(t *testing.T) {
 				// this should be ignored
 				"foobar": {"invalid_url"},
 			},
+			MaxRequestBytes: cfg.ProfilingProxy.MaxRequestBytes,
 		}
 
 		req, err := http.NewRequest("POST", "/some/path", bytes.NewBuffer([]byte("abc")))

--- a/pkg/trace/api/symdb.go
+++ b/pkg/trace/api/symdb.go
@@ -43,7 +43,7 @@ func (r *HTTPReceiver) symDBProxyHandler() http.Handler {
 		apiKey = strings.TrimSpace(k)
 	}
 	transport := newMeasuringForwardingTransport(
-		r.conf.NewHTTPTransport(), target, apiKey, r.conf.SymDBProxy.AdditionalEndpoints, "datadog.trace_agent.debugger.", []string{}, r.statsd)
+		r.conf.NewHTTPTransport(), target, apiKey, r.conf.SymDBProxy.AdditionalEndpoints, r.conf.MaxRequestBytes, "datadog.trace_agent.debugger.", []string{}, r.statsd)
 	return newSymDBProxy(r.conf, transport, hostTags)
 }
 

--- a/pkg/trace/api/transports.go
+++ b/pkg/trace/api/transports.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/api/apiutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 )
 
@@ -54,10 +55,11 @@ func (m *measuringTransport) RoundTrip(req *http.Request) (rres *http.Response, 
 // be returned to the client. Responses of additional endpoints in the targets
 // slice are dropped. Errors on additional endpoints will be logged.
 type forwardingTransport struct {
-	rt      http.RoundTripper
-	targets []*url.URL
-	keys    []string
-	logger  *log.ThrottledLogger
+	rt              http.RoundTripper
+	targets         []*url.URL
+	keys            []string
+	logger          *log.ThrottledLogger
+	maxRequestBytes int64
 }
 
 // newForwardingTransport creates a new forwardingTransport, wrapping another
@@ -68,6 +70,7 @@ func newForwardingTransport(
 	mainEndpoint *url.URL,
 	mainEndpointKey string,
 	additionalEndpoints map[string][]string,
+	maxRequestBytes int64,
 ) *forwardingTransport {
 	targets := []*url.URL{mainEndpoint}
 	apiKeys := []string{mainEndpointKey}
@@ -82,7 +85,7 @@ func newForwardingTransport(
 			apiKeys = append(apiKeys, strings.TrimSpace(key))
 		}
 	}
-	return &forwardingTransport{rt, targets, apiKeys, log.NewThrottled(10, 10*time.Second)}
+	return &forwardingTransport{rt: rt, targets: targets, keys: apiKeys, logger: log.NewThrottled(10, 10*time.Second), maxRequestBytes: maxRequestBytes}
 }
 
 // RoundTrip makes an HTTP round trip forwarding one request to multiple
@@ -102,6 +105,7 @@ func (m *forwardingTransport) RoundTrip(req *http.Request) (*http.Response, erro
 
 	var body []byte
 	if req.Body != nil {
+		req.Body = apiutil.NewLimitedReader(req.Body, m.maxRequestBytes)
 		slurp, err := io.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
@@ -152,10 +156,11 @@ func newMeasuringForwardingTransport(
 	mainEndpoint *url.URL,
 	mainEndpointKey string,
 	additionalEndpoints map[string][]string,
+	maxRequestBytes int64,
 	metricPrefix string,
 	metricTags []string,
 	statsd statsd.ClientInterface,
 ) http.RoundTripper {
-	forwardingTransport := newForwardingTransport(rt, mainEndpoint, mainEndpointKey, additionalEndpoints)
+	forwardingTransport := newForwardingTransport(rt, mainEndpoint, mainEndpointKey, additionalEndpoints, maxRequestBytes)
 	return newMeasuringTransport(forwardingTransport, metricPrefix, metricTags, statsd)
 }

--- a/pkg/trace/api/transports_test.go
+++ b/pkg/trace/api/transports_test.go
@@ -27,7 +27,7 @@ func (m *nilResponseTransport) RoundTrip(_ *http.Request) (*http.Response, error
 // when the underlying transport returns a nil response with an error.
 func TestForwardingTransport_NilResponse(t *testing.T) {
 	mainEndpoint, _ := url.Parse("http://localhost:8080")
-	ft := newForwardingTransport(&nilResponseTransport{}, mainEndpoint, "test-key", nil)
+	ft := newForwardingTransport(&nilResponseTransport{}, mainEndpoint, "test-key", nil, 25*1024*1024)
 	req, err := http.NewRequest("POST", "http://localhost:8080/v1/traces", strings.NewReader("test body"))
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
@@ -56,7 +56,7 @@ func TestForwardingTransport_MultipleTargetsNilResponse(t *testing.T) {
 		"http://localhost:8081": {"key1"},
 	}
 
-	ft := newForwardingTransport(&nilResponseTransport{}, mainEndpoint, "test-key", additionalEndpoints)
+	ft := newForwardingTransport(&nilResponseTransport{}, mainEndpoint, "test-key", additionalEndpoints, 25*1024*1024)
 	req, err := http.NewRequest("POST", "http://localhost:8080/v1/traces", strings.NewReader("test body"))
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
@@ -96,7 +96,7 @@ func TestForwardingTransport_MultipleTargets(t *testing.T) {
 		additionalEndpoints := map[string][]string{
 			additionalEndpoint.String(): {"key1"},
 		}
-		return newForwardingTransport(http.DefaultTransport, mainEndpoint, "test-key", additionalEndpoints)
+		return newForwardingTransport(http.DefaultTransport, mainEndpoint, "test-key", additionalEndpoints, 25*1024*1024)
 	}
 	validateResponse := func(t *testing.T, rt http.RoundTripper, req *http.Request) {
 		resp, err := rt.RoundTrip(req)

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -274,6 +274,9 @@ type ProfilingProxyConfig struct {
 	AdditionalEndpoints map[string][]string
 	// ReceiverTimeout is the timeout in seconds for profile upload requests
 	ReceiverTimeout int
+	// MaxRequestBytes is the maximum body size buffered when fanning out to
+	// multiple profiling endpoints. Defaults to 50 MB.
+	MaxRequestBytes int64
 }
 
 // EVPProxy contains the settings for the EVPProxy proxy.
@@ -643,11 +646,14 @@ func New() *AgentConfig {
 
 		ErrorTrackingStandalone: false,
 
-		ReceiverEnabled:        true,
-		ReceiverHost:           "localhost",
-		ReceiverPort:           8126,
-		ReceiverIdleTimeout:    60 * time.Second,
-		MaxRequestBytes:        25 * 1024 * 1024, // 25MB
+		ReceiverEnabled:     true,
+		ReceiverHost:        "localhost",
+		ReceiverPort:        8126,
+		ReceiverIdleTimeout: 60 * time.Second,
+		MaxRequestBytes:     25 * 1024 * 1024, // 25MB
+		ProfilingProxy: ProfilingProxyConfig{
+			MaxRequestBytes: 50 * 1024 * 1024, // 50MB
+		},
 		PipeBufferSize:         1_000_000,
 		PipeSecurityDescriptor: "D:AI(A;;GA;;;WD)",
 		GUIPort:                "5002",

--- a/pkg/trace/stats/client_stats_aggregator.go
+++ b/pkg/trace/stats/client_stats_aggregator.go
@@ -287,7 +287,7 @@ func (b *bucket) aggregateStatsBucket(sb *pb.ClientStatsBucket, payloadAggKey Pa
 		agg.duration += gs.Duration
 
 		// Decode, if needed, the raw ddsketches from the first payload that reached the bucket
-		if agg.okDistributionRaw != nil {
+		if len(agg.okDistributionRaw) > 0 {
 			sketch, err := decodeSketch(agg.okDistributionRaw)
 			if err != nil {
 				log.Errorf("Unable to decode OK distribution ddsketch: %v", err)
@@ -296,7 +296,7 @@ func (b *bucket) aggregateStatsBucket(sb *pb.ClientStatsBucket, payloadAggKey Pa
 			}
 			agg.okDistributionRaw = nil
 		}
-		if agg.errDistributionRaw != nil {
+		if len(agg.errDistributionRaw) > 0 {
 			sketch, err := decodeSketch(agg.errDistributionRaw)
 			if err != nil {
 				log.Errorf("Unable to decode Error distribution ddsketch: %v", err)
@@ -458,7 +458,7 @@ type aggregatedStats struct {
 
 // mergeSketch take an existing DDSketch, and merges a second one, decoding its contents
 func mergeSketch(s1 *ddsketch.DDSketch, raw []byte) (*ddsketch.DDSketch, error) {
-	if raw == nil {
+	if len(raw) == 0 {
 		return s1, nil
 	}
 
@@ -479,6 +479,9 @@ func mergeSketch(s1 *ddsketch.DDSketch, raw []byte) (*ddsketch.DDSketch, error) 
 }
 
 func normalizeSketch(s *ddsketch.DDSketch) *ddsketch.DDSketch {
+	if s == nil {
+		return nil
+	}
 	if s.IndexMapping.Equals(ddsketchMapping) {
 		// already normalized
 		return s

--- a/releasenotes/notes/apm-trace-agent-proxy-size-limits-b0a08c716b9e585c.yaml
+++ b/releasenotes/notes/apm-trace-agent-proxy-size-limits-b0a08c716b9e585c.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    APM : Enforce body-size limits on trace-agent proxy endpoints (DogStatsD,
+    pipeline stats, OpenLineage, Debugger, SymDB). All endpoints are capped at
+    ``apm_config.max_request_bytes`` (default 25 MB). The profiling proxy uses
+    a separate limit configurable via ``apm_config.profiling_max_request_bytes``
+    (default 50 MB, env ``DD_APM_PROFILING_MAX_REQUEST_BYTES``).
+    The ``Traces`` and ``ClientStatsPayload`` msgpack decoders now reject
+    payloads declaring more than 500,000 elements in a single array.

--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -146,12 +146,20 @@ def generate(ctx, pre_commit=False):
         ],
         'core': [('remoteconfig.pb.go', False)],
     }
+    # Per-file extra directives, keyed by (pkg, src).
+    # stats.pb.go is protoc-generated so the limit directive cannot live in the
+    # file itself; pass it on the command line instead.
+    msgp_file_directives = {
+        ('trace', 'stats.pb.go'): '-d "limit arrays:500000 maps:500000"',
+    }
     for pkg, files in msgp_targets.items():
         for src, io_gen in files:
             dst = os.path.splitext(os.path.basename(src))[0]  # .go
             dst = os.path.splitext(dst)[0]  # .pb
+            extra_flags = msgp_file_directives.get((pkg, src), '')
             ctx.run(
-                f"{bt.msgp} -file {pbgo_dir}/{pkg}/{src} -o={pbgo_dir}/{pkg}/{dst}_gen.go -io={io_gen}", env=bt.go_env
+                f"{bt.msgp} -file {pbgo_dir}/{pkg}/{src} -o={pbgo_dir}/{pkg}/{dst}_gen.go -io={io_gen} {extra_flags}",
+                env=bt.go_env,
             )
 
     # Apply msgp patches


### PR DESCRIPTION
### What does this PR do?

Adds two classes of size limit to the trace-agent to prevent memory exhaustion from oversized payloads:

**1. msgpack element-count limits on decoders (`pkg/proto/pbgo/trace/`)**

Adds a `//msgp:limit arrays:500000 maps:500000` directive to `trace.go` and passes the equivalent `-d` flag when generating `stats_gen.go`. The regenerated `Traces.UnmarshalMsg` and `ClientStatsPayload.DecodeMsg` now check the declared element count before calling `make()`. Without this, a 5-byte payload encoding `0x7FFFFFFF` array elements would trigger a ~48 GB heap allocation.

**2. Body-size limits on proxy endpoints (`pkg/trace/api/`)**

Several proxy handlers called `io.ReadAll(req.Body)` without a prior size cap and were registered outside `handleWithVersion`, so they did not inherit the existing `LimitedReader`. Each transport struct now carries a `maxRequestBytes int64` field threaded from the agent config:

- DogStatsD, pipeline stats, OpenLineage, Debugger, SymDB → `apm_config.max_request_bytes` (25 MB)
- Profiling → new `apm_config.profiling_max_request_bytes` (default 50 MB, `DD_APM_PROFILING_MAX_REQUEST_BYTES`) because profiling heap/CPU dumps can legitimately exceed 25 MB

**3. Defensive fixes in the sketch aggregator (`pkg/trace/stats/`)**

The msgp code generator, when limits are active, changed the `DecodeMsg` path for `[]byte` fields: it now uses `ReadBytesLimit` and emits a post-read `nil → []byte{}` coercion for zero-length binaries. This exposed a pre-existing fragility in `client_stats_aggregator.go`: `mergeSketch` guarded on `raw == nil` (not `len(raw) == 0`), and `normalizeSketch` had no nil guard on its `*DDSketch` argument. Passing `[]byte{}` instead of `nil` would bypass the early return in `mergeSketch`, call `decodeSketch([]byte{})` → `(nil, nil)`, then `normalizeSketch(nil)` → nil-pointer panic. Three fixes are made to make the sketch handling robust to both representations:
- `mergeSketch`: `raw == nil` → `len(raw) == 0`
- `okDistributionRaw`/`errDistributionRaw` decode guards: `!= nil` → `len(...) > 0`
- `normalizeSketch`: add `if s == nil { return nil }`

### Motivation

The trace-agent had no upper bound on how much memory it would allocate when decoding incoming payloads. A misconfigured tracer or a runaway fanout to multiple endpoints could exhaust agent memory, affecting the host.

### Describe how you validated your changes

- New unit tests in `pkg/proto/pbgo/trace/limit_test.go`: send the exact PoC payloads (5-byte `Traces` and 12-byte `ClientStatsPayload`) and assert `msgp.ErrLimitExceeded` is returned without OOM.
- Existing `pkg/trace/api/` and `pkg/trace/stats/` test suites all pass, including `TestProfileProxyHandler/multiple_targets` and `TestHandleStats/on`.

### Additional Notes

The `profiling_max_request_bytes` limit only applies in multi-endpoint (dual-shipping) deployments; in single-target mode the body is streamed directly by `httputil.ReverseProxy` without buffering. The same is true for pipeline stats, OpenLineage, Debugger, and SymDB — only DogStatsD always buffers.