### PR TITLE
[AGNTLOG-587 ] Add per-source adaptive sampler config parity

### DIFF
--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -160,10 +160,27 @@ type SourceAutoMultiLineOptions struct {
 }
 
 // SourceAdaptiveSamplingOptions defines per-source overrides for the experimental adaptive sampler.
-// Additional per-source filters can be added here later.
 type SourceAdaptiveSamplingOptions struct {
 	// Enabled overrides the global adaptive sampling toggle for this source when set.
 	Enabled *bool `mapstructure:"enabled" json:"enabled" yaml:"enabled"`
+
+	// MaxPatterns overrides the maximum number of patterns tracked for this source when set.
+	MaxPatterns *int `mapstructure:"max_patterns" json:"max_patterns" yaml:"max_patterns"`
+
+	// RateLimit overrides the steady-state logs per second allowed per pattern for this source when set.
+	RateLimit *float64 `mapstructure:"rate_limit" json:"rate_limit" yaml:"rate_limit"`
+
+	// BurstSize overrides the maximum accumulated credits per pattern for this source when set.
+	BurstSize *float64 `mapstructure:"burst_size" json:"burst_size" yaml:"burst_size"`
+
+	// MatchThreshold overrides the token match threshold for this source when set.
+	MatchThreshold *float64 `mapstructure:"match_threshold" json:"match_threshold" yaml:"match_threshold"`
+
+	// TokenizerMaxInputBytes overrides the sampler tokenizer minimum input bytes for this source when set.
+	TokenizerMaxInputBytes *int `mapstructure:"tokenizer_max_input_bytes" json:"tokenizer_max_input_bytes" yaml:"tokenizer_max_input_bytes"`
+
+	// ProtectImportantLogs overrides whether important logs bypass adaptive sampling for this source when set.
+	ProtectImportantLogs *bool `mapstructure:"protect_important_logs" json:"protect_important_logs" yaml:"protect_important_logs"`
 }
 
 // AutoMultilineSample defines a sample used to create auto multiline detection

--- a/comp/logs/agent/config/integration_config_test.go
+++ b/comp/logs/agent/config/integration_config_test.go
@@ -90,10 +90,22 @@ func TestAutoMultilineEnabled(t *testing.T) {
 }
 
 func TestExperimentalAdaptiveSamplingOptionsDecode(t *testing.T) {
-	cfg := decode(`{"experimental_adaptive_sampling":{"enabled":true}}`)
+	cfg := decode(`{"experimental_adaptive_sampling":{"enabled":true,"max_patterns":42,"rate_limit":2.5,"burst_size":17.5,"match_threshold":0.75,"tokenizer_max_input_bytes":512,"protect_important_logs":false}}`)
 	require.NotNil(t, cfg.ExperimentalAdaptiveSampling)
 	require.NotNil(t, cfg.ExperimentalAdaptiveSampling.Enabled)
 	assert.True(t, *cfg.ExperimentalAdaptiveSampling.Enabled)
+	require.NotNil(t, cfg.ExperimentalAdaptiveSampling.MaxPatterns)
+	assert.Equal(t, 42, *cfg.ExperimentalAdaptiveSampling.MaxPatterns)
+	require.NotNil(t, cfg.ExperimentalAdaptiveSampling.RateLimit)
+	assert.Equal(t, 2.5, *cfg.ExperimentalAdaptiveSampling.RateLimit)
+	require.NotNil(t, cfg.ExperimentalAdaptiveSampling.BurstSize)
+	assert.Equal(t, 17.5, *cfg.ExperimentalAdaptiveSampling.BurstSize)
+	require.NotNil(t, cfg.ExperimentalAdaptiveSampling.MatchThreshold)
+	assert.Equal(t, 0.75, *cfg.ExperimentalAdaptiveSampling.MatchThreshold)
+	require.NotNil(t, cfg.ExperimentalAdaptiveSampling.TokenizerMaxInputBytes)
+	assert.Equal(t, 512, *cfg.ExperimentalAdaptiveSampling.TokenizerMaxInputBytes)
+	require.NotNil(t, cfg.ExperimentalAdaptiveSampling.ProtectImportantLogs)
+	assert.False(t, *cfg.ExperimentalAdaptiveSampling.ProtectImportantLogs)
 }
 
 func TestAutoMultiLineStatus(t *testing.T) {

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1836,7 +1836,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 	// Maximum number of distinct patterns the sampler tracks at once.
 	config.BindEnvAndSetDefault("logs_config.experimental_adaptive_sampling.max_patterns", 1000)
 	// Steady-state logs per second allowed for each matched pattern.
-	config.BindEnvAndSetDefault("logs_config.experimental_adaptive_sampling.rate_limit", 1)
+	config.BindEnvAndSetDefault("logs_config.experimental_adaptive_sampling.rate_limit", 1.0)
 	// Maximum burst allowance per pattern, measured in accumulated credits/logs.
 	config.BindEnvAndSetDefault("logs_config.experimental_adaptive_sampling.burst_size", 1000.0)
 	// Fraction of tokens that must match for two logs to be treated as the same pattern.

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -153,7 +153,11 @@ func resolveTokenizerAndLabelerMaxInputBytes(sourceAutoMLSettings *config.Source
 
 	tokenizerMaxInputBytes = labelerMaxBytes
 	if resolveAdaptiveSamplerEnabled(sourceAdaptiveSampling) {
-		if samplerMin := pkgconfigsetup.Datadog().GetInt("logs_config.experimental_adaptive_sampling.tokenizer_max_input_bytes"); samplerMin > tokenizerMaxInputBytes {
+		samplerMin := pkgconfigsetup.Datadog().GetInt("logs_config.experimental_adaptive_sampling.tokenizer_max_input_bytes")
+		if sourceAdaptiveSampling != nil && sourceAdaptiveSampling.TokenizerMaxInputBytes != nil {
+			samplerMin = *sourceAdaptiveSampling.TokenizerMaxInputBytes
+		}
+		if samplerMin > tokenizerMaxInputBytes {
 			tokenizerMaxInputBytes = samplerMin
 		}
 	}
@@ -169,13 +173,31 @@ func resolveAdaptiveSamplerEnabled(sourceAdaptiveSampling *config.SourceAdaptive
 	return pkgconfigsetup.Datadog().GetBool("logs_config.experimental_adaptive_sampling.enabled")
 }
 
-func resolveAdaptiveSamplerConfig() preprocessor.AdaptiveSamplerConfig {
+func resolveAdaptiveSamplerConfig(sourceAdaptiveSampling *config.SourceAdaptiveSamplingOptions) preprocessor.AdaptiveSamplerConfig {
 	c := preprocessor.AdaptiveSamplerConfig{
 		MaxPatterns:          pkgconfigsetup.Datadog().GetInt("logs_config.experimental_adaptive_sampling.max_patterns"),
 		RateLimit:            pkgconfigsetup.Datadog().GetFloat64("logs_config.experimental_adaptive_sampling.rate_limit"),
 		BurstSize:            pkgconfigsetup.Datadog().GetFloat64("logs_config.experimental_adaptive_sampling.burst_size"),
 		MatchThreshold:       pkgconfigsetup.Datadog().GetFloat64("logs_config.experimental_adaptive_sampling.match_threshold"),
 		ProtectImportantLogs: pkgconfigsetup.Datadog().GetBool("logs_config.experimental_adaptive_sampling.protect_important_logs"),
+	}
+
+	if sourceAdaptiveSampling != nil {
+		if sourceAdaptiveSampling.MaxPatterns != nil {
+			c.MaxPatterns = *sourceAdaptiveSampling.MaxPatterns
+		}
+		if sourceAdaptiveSampling.RateLimit != nil {
+			c.RateLimit = *sourceAdaptiveSampling.RateLimit
+		}
+		if sourceAdaptiveSampling.BurstSize != nil {
+			c.BurstSize = *sourceAdaptiveSampling.BurstSize
+		}
+		if sourceAdaptiveSampling.MatchThreshold != nil {
+			c.MatchThreshold = *sourceAdaptiveSampling.MatchThreshold
+		}
+		if sourceAdaptiveSampling.ProtectImportantLogs != nil {
+			c.ProtectImportantLogs = *sourceAdaptiveSampling.ProtectImportantLogs
+		}
 	}
 
 	return validateAdaptiveSamplerConfig(c)
@@ -187,7 +209,7 @@ func buildLineHandler(source *sources.ReplaceableSource, multiLinePattern *regex
 
 	var sampler preprocessor.Sampler
 	if resolveAdaptiveSamplerEnabled(source.Config().ExperimentalAdaptiveSampling) {
-		sampler = preprocessor.NewAdaptiveSampler(resolveAdaptiveSamplerConfig(), source.UnderlyingSource().Name)
+		sampler = preprocessor.NewAdaptiveSampler(resolveAdaptiveSamplerConfig(source.Config().ExperimentalAdaptiveSampling), source.UnderlyingSource().Name)
 	} else {
 		sampler = preprocessor.NewNoopSampler()
 	}

--- a/pkg/logs/internal/decoder/decoder_test.go
+++ b/pkg/logs/internal/decoder/decoder_test.go
@@ -341,6 +341,7 @@ func TestResolveTokenizerAndLabelerMaxInputBytes(t *testing.T) {
 
 	sourceOverride20 := 20
 	sourceOverride500 := 500
+	sourceSamplerTokenizerOverride128 := 128
 	enabledTrue := true
 	enabledFalse := false
 
@@ -411,6 +412,15 @@ func TestResolveTokenizerAndLabelerMaxInputBytes(t *testing.T) {
 			wantTokenizerMax: 60,
 			wantLabelerMax:   60,
 		},
+		{
+			name:                 "source sampler tokenizer override wins over global sampler tokenizer",
+			globalSamplerEnabled: true,
+			sourceSamplerSettings: &config.SourceAdaptiveSamplingOptions{
+				TokenizerMaxInputBytes: &sourceSamplerTokenizerOverride128,
+			},
+			wantTokenizerMax: 128,
+			wantLabelerMax:   60,
+		},
 	}
 
 	for _, tt := range tests {
@@ -471,6 +481,60 @@ func TestResolveAdaptiveSamplerEnabled(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestResolveAdaptiveSamplerConfig(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.Set("logs_config.experimental_adaptive_sampling.max_patterns", 100, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.experimental_adaptive_sampling.rate_limit", 2.5, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.experimental_adaptive_sampling.burst_size", 50.0, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.experimental_adaptive_sampling.match_threshold", 0.8, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.experimental_adaptive_sampling.protect_important_logs", true, pkgconfigmodel.SourceAgentRuntime)
+
+	t.Run("falls back to global config", func(t *testing.T) {
+		got := resolveAdaptiveSamplerConfig(nil)
+		assert.Equal(t, 100, got.MaxPatterns)
+		assert.Equal(t, 2.5, got.RateLimit)
+		assert.Equal(t, 50.0, got.BurstSize)
+		assert.Equal(t, 0.8, got.MatchThreshold)
+		assert.True(t, got.ProtectImportantLogs)
+	})
+
+	t.Run("source overrides global config", func(t *testing.T) {
+		maxPatterns := 200
+		rateLimit := 3.5
+		burstSize := 75.0
+		matchThreshold := 0.65
+		protectImportantLogs := false
+
+		got := resolveAdaptiveSamplerConfig(&config.SourceAdaptiveSamplingOptions{
+			MaxPatterns:          &maxPatterns,
+			RateLimit:            &rateLimit,
+			BurstSize:            &burstSize,
+			MatchThreshold:       &matchThreshold,
+			ProtectImportantLogs: &protectImportantLogs,
+		})
+
+		assert.Equal(t, 200, got.MaxPatterns)
+		assert.Equal(t, 3.5, got.RateLimit)
+		assert.Equal(t, 75.0, got.BurstSize)
+		assert.Equal(t, 0.65, got.MatchThreshold)
+		assert.False(t, got.ProtectImportantLogs)
+	})
+
+	t.Run("source partial override preserves global values", func(t *testing.T) {
+		rateLimit := 9.5
+
+		got := resolveAdaptiveSamplerConfig(&config.SourceAdaptiveSamplingOptions{
+			RateLimit: &rateLimit,
+		})
+
+		assert.Equal(t, 100, got.MaxPatterns)
+		assert.Equal(t, 9.5, got.RateLimit)
+		assert.Equal(t, 50.0, got.BurstSize)
+		assert.Equal(t, 0.8, got.MatchThreshold)
+		assert.True(t, got.ProtectImportantLogs)
+	})
 }
 
 func TestDecoderWithDockerJSONPartialLineDetectionOnlyMarksOversizedLogicalLineTruncated(t *testing.T) {

--- a/pkg/logs/launchers/container/tailerfactory/file_test.go
+++ b/pkg/logs/launchers/container/tailerfactory/file_test.go
@@ -59,6 +59,18 @@ func fileTestSetup(t *testing.T) {
 	})
 }
 
+func testAdaptiveSamplingOptions(enabled bool) *config.SourceAdaptiveSamplingOptions {
+	return &config.SourceAdaptiveSamplingOptions{
+		Enabled:                pointer.Ptr(enabled),
+		MaxPatterns:            pointer.Ptr(321),
+		RateLimit:              pointer.Ptr(2.5),
+		BurstSize:              pointer.Ptr(17.5),
+		MatchThreshold:         pointer.Ptr(0.75),
+		TokenizerMaxInputBytes: pointer.Ptr(512),
+		ProtectImportantLogs:   pointer.Ptr(false),
+	}
+}
+
 func makeTestPod() (*workloadmeta.KubernetesPod, *workloadmeta.Container) {
 	podID := "poduuid"
 	containerID := "abc"
@@ -134,18 +146,17 @@ func TestMakeFileSource_docker_success(t *testing.T) {
 		cop:              containersorpods.NewDecidedChooser(containersorpods.LogContainers),
 		dockerUtilGetter: &dockerUtilGetterImpl{},
 	}
+	adaptiveSampling := testAdaptiveSamplingOptions(true)
 	source := sources.NewLogSource("test", &config.LogsConfig{
-		Type:                        "docker",
-		Identifier:                  "abc",
-		Source:                      "src",
-		Service:                     "svc",
-		Tags:                        []string{"tag!"},
-		AutoMultiLine:               pointer.Ptr(true),
-		AutoMultiLineSampleSize:     123,
-		AutoMultiLineMatchThreshold: 0.123,
-		ExperimentalAdaptiveSampling: &config.SourceAdaptiveSamplingOptions{
-			Enabled: pointer.Ptr(true),
-		},
+		Type:                         "docker",
+		Identifier:                   "abc",
+		Source:                       "src",
+		Service:                      "svc",
+		Tags:                         []string{"tag!"},
+		AutoMultiLine:                pointer.Ptr(true),
+		AutoMultiLineSampleSize:      123,
+		AutoMultiLineMatchThreshold:  0.123,
+		ExperimentalAdaptiveSampling: adaptiveSampling,
 	})
 	child, err := tf.makeFileSource(source)
 	require.NoError(t, err)
@@ -160,9 +171,36 @@ func TestMakeFileSource_docker_success(t *testing.T) {
 	require.Equal(t, *source.Config.AutoMultiLine, true)
 	require.Equal(t, source.Config.AutoMultiLineSampleSize, 123)
 	require.Equal(t, source.Config.AutoMultiLineMatchThreshold, 0.123)
-	require.NotNil(t, child.Config.ExperimentalAdaptiveSampling)
-	require.NotNil(t, child.Config.ExperimentalAdaptiveSampling.Enabled)
-	require.True(t, *child.Config.ExperimentalAdaptiveSampling.Enabled)
+	require.Equal(t, adaptiveSampling, child.Config.ExperimentalAdaptiveSampling)
+}
+
+func TestMakeFileSource_docker_containerRestartPreservesAdaptiveSamplingConfig(t *testing.T) {
+	fileTestSetup(t)
+
+	tf := &factory{
+		pipelineProvider: pipeline.NewMockProvider(),
+		cop:              containersorpods.NewDecidedChooser(containersorpods.LogContainers),
+		dockerUtilGetter: &dockerUtilGetterImpl{},
+	}
+
+	for _, containerID := range []string{"abc", "def"} {
+		p := filepath.Join(platformDockerLogsBasePath, "containers", containerID, containerID+"-json.log")
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o777))
+		require.NoError(t, os.WriteFile(p, []byte("{}"), 0o666))
+
+		adaptiveSampling := testAdaptiveSamplingOptions(true)
+		source := sources.NewLogSource("test", &config.LogsConfig{
+			Type:                         "docker",
+			Identifier:                   containerID,
+			Source:                       "src",
+			Service:                      "svc",
+			ExperimentalAdaptiveSampling: adaptiveSampling,
+		})
+		child, err := tf.makeFileSource(source)
+		require.NoError(t, err)
+		require.Equal(t, containerID, child.Config.Identifier)
+		require.Equal(t, adaptiveSampling, child.Config.ExperimentalAdaptiveSampling)
+	}
 }
 
 func TestMakeFileSource_podman_success(t *testing.T) {
@@ -471,18 +509,17 @@ func TestMakeK8sSource(t *testing.T) {
 	}
 	for _, sourceConfigType := range []string{"docker", "containerd"} {
 		t.Run("source.Config.Type="+sourceConfigType, func(t *testing.T) {
+			adaptiveSampling := testAdaptiveSamplingOptions(false)
 			source := sources.NewLogSource("test", &config.LogsConfig{
-				Type:                        sourceConfigType,
-				Identifier:                  "abc",
-				Source:                      "src",
-				Service:                     "svc",
-				Tags:                        []string{"tag!"},
-				AutoMultiLine:               pointer.Ptr(true),
-				AutoMultiLineSampleSize:     123,
-				AutoMultiLineMatchThreshold: 0.123,
-				ExperimentalAdaptiveSampling: &config.SourceAdaptiveSamplingOptions{
-					Enabled: pointer.Ptr(false),
-				},
+				Type:                         sourceConfigType,
+				Identifier:                   "abc",
+				Source:                       "src",
+				Service:                      "svc",
+				Tags:                         []string{"tag!"},
+				AutoMultiLine:                pointer.Ptr(true),
+				AutoMultiLineSampleSize:      123,
+				AutoMultiLineMatchThreshold:  0.123,
+				ExperimentalAdaptiveSampling: adaptiveSampling,
 			})
 			child, err := tf.makeK8sFileSource(source)
 			require.NoError(t, err)
@@ -496,9 +533,7 @@ func TestMakeK8sSource(t *testing.T) {
 			require.Equal(t, *child.Config.AutoMultiLine, true)
 			require.Equal(t, child.Config.AutoMultiLineSampleSize, 123)
 			require.Equal(t, child.Config.AutoMultiLineMatchThreshold, 0.123)
-			require.NotNil(t, child.Config.ExperimentalAdaptiveSampling)
-			require.NotNil(t, child.Config.ExperimentalAdaptiveSampling.Enabled)
-			require.False(t, *child.Config.ExperimentalAdaptiveSampling.Enabled)
+			require.Equal(t, adaptiveSampling, child.Config.ExperimentalAdaptiveSampling)
 			switch sourceConfigType {
 			case "docker":
 				require.Equal(t, sources.DockerSourceType, child.GetSourceType())


### PR DESCRIPTION
### What does this PR do?

Adds per source settings for adaptive sampling.

### Motivation

Needed for customer who don't wish to enable adaptive sampling globally.

### Describe how you validated your changes

Tested on a source locally.

### Additional Notes
