### PR TITLE
[CNM-5250] Fix misattributed NAT gateways for AWS_VPC_K8S_CNI_EXTERNALSNAT

### DIFF
--- a/pkg/network/gateway_lookup_linux.go
+++ b/pkg/network/gateway_lookup_linux.go
@@ -202,10 +202,33 @@ func (g *gatewayLookup) LookupWithIPs(source util.Address, dest util.Address, ne
 		}
 		return nil
 	case *Via:
+		if isVPCRouterIP(r.Gateway, cv.Subnet.Cidr) {
+			return nil
+		}
 		return cv
 	default:
 		return nil
 	}
+}
+
+// isVPCRouterIP returns true if gateway is the VPC router IP for the given
+// subnet CIDR. In AWS, the VPC router is always the first usable IP in the
+// subnet (network base + 1, e.g. 10.0.0.1 for 10.0.0.0/24). Traffic routed
+// through the VPC router is intra-VPC and should not be attributed as NAT
+// gateway traffic.
+func isVPCRouterIP(gateway util.Address, cidr string) bool {
+	if cidr == "" {
+		return false
+	}
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false
+	}
+	routerIP := make(net.IP, len(ipNet.IP))
+	copy(routerIP, ipNet.IP)
+	// increment last byte to get the first usable IP (.1)
+	routerIP[len(routerIP)-1]++
+	return gateway == util.AddressFromNetIP(routerIP)
 }
 
 // Close cleans up resources allocated
@@ -232,7 +255,7 @@ func awsSubnetForHardwareAddr(hwAddr net.HardwareAddr) (Subnet, error) {
 		return Subnet{}, err
 	}
 
-	return Subnet{Alias: snet.ID}, nil
+	return Subnet{Alias: snet.ID, Cidr: snet.Cidr}, nil
 }
 
 type cloudProviderImpl struct{}

--- a/pkg/network/gateway_lookup_linux_test.go
+++ b/pkg/network/gateway_lookup_linux_test.go
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux || linux_bpf
+
+package network
+
+import (
+	"net"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
+
+func TestIsVPCRouterIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		gateway util.Address
+		cidr    string
+		want    bool
+	}{
+		{
+			name:    "gateway is VPC router for /24 subnet",
+			gateway: util.AddressFromNetIP(net.ParseIP("10.0.1.1")),
+			cidr:    "10.0.1.0/24",
+			want:    true,
+		},
+		{
+			name:    "gateway is not VPC router",
+			gateway: util.AddressFromNetIP(net.ParseIP("10.0.1.55")),
+			cidr:    "10.0.1.0/24",
+			want:    false,
+		},
+		{
+			name:    "gateway is VPC router for /16 subnet",
+			gateway: util.AddressFromNetIP(net.ParseIP("10.0.0.1")),
+			cidr:    "10.0.0.0/16",
+			want:    true,
+		},
+		{
+			name:    "gateway is VPC router for 172.16 subnet",
+			gateway: util.AddressFromNetIP(net.ParseIP("172.16.0.1")),
+			cidr:    "172.16.0.0/20",
+			want:    true,
+		},
+		{
+			name:    "empty CIDR returns false",
+			gateway: util.AddressFromNetIP(net.ParseIP("10.0.0.1")),
+			cidr:    "",
+			want:    false,
+		},
+		{
+			name:    "malformed CIDR returns false",
+			gateway: util.AddressFromNetIP(net.ParseIP("10.0.0.1")),
+			cidr:    "not-a-cidr",
+			want:    false,
+		},
+		{
+			name:    "gateway in different subnet",
+			gateway: util.AddressFromNetIP(net.ParseIP("10.0.2.1")),
+			cidr:    "10.0.1.0/24",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isVPCRouterIP(tt.gateway, tt.cidr))
+		})
+	}
+}
+
+func TestLookupWithIPs_SkipsVPCRouter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockRouteCache := NewMockRouteCache(ctrl)
+	subnetCache, _ := simplelru.NewLRU[int, any](10, nil)
+
+	gl := &gatewayLookup{
+		routeCache:  mockRouteCache,
+		subnetCache: subnetCache,
+	}
+
+	src := util.AddressFromString("10.0.1.5")
+	dst := util.AddressFromString("10.0.1.100")
+	ifIndex := 3
+
+	// Pre-populate subnet cache with a Via that includes the CIDR
+	subnetCache.Add(ifIndex, &Via{
+		Subnet: Subnet{Alias: "subnet-abc", Cidr: "10.0.1.0/24"},
+	})
+
+	// Route has gateway = VPC router IP for subnet 10.0.1.0/24
+	mockRouteCache.EXPECT().Get(src, dst, uint32(0)).Return(Route{
+		Gateway: util.AddressFromNetIP(net.ParseIP("10.0.1.1")),
+		IfIndex: ifIndex,
+	}, true)
+
+	// Should return nil because gateway is the VPC router
+	assert.Nil(t, gl.LookupWithIPs(src, dst, 0))
+
+	// Now test that a non-router gateway DOES return the Via
+	mockRouteCache.EXPECT().Get(src, dst, uint32(0)).Return(Route{
+		Gateway: util.AddressFromNetIP(net.ParseIP("10.0.1.55")),
+		IfIndex: ifIndex,
+	}, true)
+
+	via := gl.LookupWithIPs(src, dst, 0)
+	assert.NotNil(t, via)
+	assert.Equal(t, "subnet-abc", via.Subnet.Alias)
+}

--- a/pkg/network/payload/types.go
+++ b/pkg/network/payload/types.go
@@ -20,4 +20,5 @@ type Interface struct {
 // Subnet stores info about a subnet
 type Subnet struct {
 	Alias string `json:"alias,omitempty"`
+	Cidr  string `json:"-"` // not serialized; used internally for VPC router detection
 }


### PR DESCRIPTION
### What does this PR do?

Skip gateway/subnet attribution in NPM when the route's gateway IP is the AWS VPC router (the `.1` address of the subnet). The subnet CIDR from EC2 IMDS (already fetched but previously
discarded) is now preserved and used to detect this case.

### Motivation

In EKS environments with `AWS_VPC_K8S_CNI_EXTERNALSNAT=true` and nftables-based kube-proxy, routing table entries for Kubernetes service CIDRs include the VPC router as the next-hop gateway.
The gateway lookup treats these as gatewayed routes and attaches subnet info, causing the backend to misclassify private intra-VPC pod-to-service traffic as NAT gateway traffic.

### Describe how you validated your changes

Unit tests for `isVPCRouterIP` covering matching/non-matching gateway IPs, various subnet sizes, empty/malformed CIDRs, and cross-subnet cases. Existing gateway lookup integration tests
continue to pass (they mock `SubnetForHwAddrFunc` without a CIDR, so the new check is a no-op for them). Additionally, `TestLookupWithIPs_SkipsVPCRouter` tests that gateway lookup ignores this scenario.