### PR TITLE
Bump rshell dependency from v0.0.13 to v0.0.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -966,7 +966,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.64.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5
-	github.com/DataDog/rshell v0.0.13
+	github.com/DataDog/rshell v0.0.14
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8
 	github.com/aymerick/raymond v2.0.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2594,8 +2594,6 @@ github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816 h1:8diKw2aLYE6LsjWfYxD
 github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816/go.mod h1:7cPuErOAt7k/oVWAVJnxqAC6mwArrAazkvk0RXiih2A=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260416144717-96f8924d6e18 h1:VbUS1B3mpSjponiKDWHXtofoNBp99Nckf5uZaBeQyPo=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260416144717-96f8924d6e18/go.mod h1:34LtYk9Gh/SCItzi7v8ok9E5lk88AA5I+5aKoVKQClI=
-github.com/DataDog/rshell v0.0.13 h1:fPb2Zmpjx6vhLMG7LThgz6mnVo2eNy9Gdcn1+00HXEo=
-github.com/DataDog/rshell v0.0.13/go.mod h1:r2pK0NQpE1SL+ESYjlfhigWDEELPY5LacwLbisR9nxI=
 github.com/DataDog/rshell v0.0.14 h1:1BJxm8FQ0uZ6amxItyKmlG4e2y2CPTNvjxtY/Nx1Pg0=
 github.com/DataDog/rshell v0.0.14/go.mod h1:r2pK0NQpE1SL+ESYjlfhigWDEELPY5LacwLbisR9nxI=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=

--- a/go.sum
+++ b/go.sum
@@ -2596,6 +2596,8 @@ github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260416144717-96f8924d6e1
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260416144717-96f8924d6e18/go.mod h1:34LtYk9Gh/SCItzi7v8ok9E5lk88AA5I+5aKoVKQClI=
 github.com/DataDog/rshell v0.0.13 h1:fPb2Zmpjx6vhLMG7LThgz6mnVo2eNy9Gdcn1+00HXEo=
 github.com/DataDog/rshell v0.0.13/go.mod h1:r2pK0NQpE1SL+ESYjlfhigWDEELPY5LacwLbisR9nxI=
+github.com/DataDog/rshell v0.0.14 h1:1BJxm8FQ0uZ6amxItyKmlG4e2y2CPTNvjxtY/Nx1Pg0=
+github.com/DataDog/rshell v0.0.14/go.mod h1:r2pK0NQpE1SL+ESYjlfhigWDEELPY5LacwLbisR9nxI=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=
 github.com/DataDog/sketches-go v1.4.8/go.mod h1:a/wjRUqzqtGS8qRHRPDCs4EAQfmvPDZGDlMIF5mxXOE=
 github.com/DataDog/trivy v0.0.0-20260407220859-6cf8ddc1826c h1:oiwmRrkRVblZBI3SFVEnrwxkQ28W7nmwwI/VHgex0ZU=

--- a/releasenotes/notes/bump-rshell-v0.0.14-9f648c7f74024a46.yaml
+++ b/releasenotes/notes/bump-rshell-v0.0.14-9f648c7f74024a46.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    Bump ``rshell`` to v0.0.14 for the Private Action Runner. v0.0.14 adds
+    library-internal hooks (``WarningsWriter`` option and ``Warnings()``
+    accessor) that let callers route sandbox diagnostic messages to a
+    dedicated sink. The Private Action Runner does not yet adopt these
+    hooks, so user-visible behaviour is unchanged; a follow-up will use
+    them to stop sandbox warnings from polluting command stderr in the
+    ``runCommand`` action response.

--- a/releasenotes/notes/bump-rshell-v0.0.14-9f648c7f74024a46.yaml
+++ b/releasenotes/notes/bump-rshell-v0.0.14-9f648c7f74024a46.yaml
@@ -1,10 +1,4 @@
 ---
 enhancements:
   - |
-    Bump ``rshell`` to v0.0.14 for the Private Action Runner. v0.0.14 adds
-    library-internal hooks (``WarningsWriter`` option and ``Warnings()``
-    accessor) that let callers route sandbox diagnostic messages to a
-    dedicated sink. The Private Action Runner does not yet adopt these
-    hooks, so user-visible behaviour is unchanged; a follow-up will use
-    them to stop sandbox warnings from polluting command stderr in the
-    ``runCommand`` action response.
+    Bump ``rshell`` to v0.0.14 for the Private Action Runner.

--- a/releasenotes/notes/bump-rshell-v0.0.14-9f648c7f74024a46.yaml
+++ b/releasenotes/notes/bump-rshell-v0.0.14-9f648c7f74024a46.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    Bump ``rshell`` to v0.0.14 for the Private Action Runner.
+    Bump ``rshell`` to v0.0.14.


### PR DESCRIPTION
### What does this PR do?

- Bumps `github.com/DataDog/rshell` from `v0.0.13` to `v0.0.14`. No call-site changes.

### Motivation

- v0.0.13..v0.0.14 contains a single commit, [DataDog/rshell#200](https://github.com/DataDog/rshell/pull/200), which adds an opt-in `interp.WarningsWriter(io.Writer)` option and a `Runner.Warnings() []string` accessor. Today's PAR rshell handler does not pass either, so behaviour is byte-for-byte unchanged: sandbox warnings continue to fall back to `r.stderr`, which is where the handler already routes them.
- This bump lands in isolation so the follow-up PR — wiring the new accessor into `RunCommandOutputs.SandboxWarnings` to fix [DataDog/rshell#191](https://github.com/DataDog/rshell/issues/191) — is a clean, reviewable diff with no `go.mod`/`go.sum` noise.

### Describe how you validated your changes

- `go get github.com/DataDog/rshell@v0.0.14` — single-line `go.mod` change, expected `go.sum` update.
- `go build ./pkg/privateactionrunner/...` — clean.
- `go test -count=1 ./pkg/privateactionrunner/bundles/remoteaction/rshell/...` — all tests pass.

### Additional Notes

- Follow-up PR (forthcoming) will wire `runner.Warnings()` into the PAR rshell handler's response. The corresponding contract change in dd-source (additive `sandboxWarnings?: string[]` field on `RunCommandOutputs`) is open at [DataDog/dd-source#423305](https://github.com/DataDog/dd-source/pull/423305).

🤖 Generated with [Claude Code](https://claude.com/claude-code)