### PR TITLE
Add knobs for NCM store

### DIFF
--- a/pkg/networkconfigmanagement/config/config.go
+++ b/pkg/networkconfigmanagement/config/config.go
@@ -248,7 +248,6 @@ func (ic *InitConfig) applyDefaults() {
 	if ic.Store == nil {
 		ic.Store = &StoreConfig{}
 	}
-	ic.Store.applyDefaults()
 }
 
 // Validate checks that the InitConfig has all required fields and applies defaults where needed
@@ -367,7 +366,7 @@ func (sc *SSHConfig) hasRequiredFields() error {
 	return nil
 }
 
-func (st *StoreConfig) applyDefaults() {
+func (st *StoreConfig) validate() error {
 	if st.MinConfigsPerDevice <= 0 {
 		log.Debugf("No or invalid min_configs_per_device specified, applying default: %d", defaultMinConfigsPerDevice)
 		st.MinConfigsPerDevice = defaultMinConfigsPerDevice
@@ -376,25 +375,13 @@ func (st *StoreConfig) applyDefaults() {
 		log.Debugf("No or invalid max_configs_per_device specified, applying default: %d", defaultMaxConfigsPerDevice)
 		st.MaxConfigsPerDevice = defaultMaxConfigsPerDevice
 	}
-	if st.MaxRawConfigStoreBytes <= 0 {
-		log.Debugf("No or invalid max_raw_config_store_bytes specified, applying default: %d", defaultMaxRawConfigStoreBytes)
-		st.MaxRawConfigStoreBytes = defaultMaxRawConfigStoreBytes
-	}
-}
-
-func (st *StoreConfig) validate() error {
-	if st.MinConfigsPerDevice <= 0 {
-		return errors.New("store.min_configs_per_device must be greater than zero")
-	}
-	if st.MaxConfigsPerDevice <= 0 {
-		return errors.New("store.max_configs_per_device must be greater than zero")
-	}
 	if st.MinConfigsPerDevice > st.MaxConfigsPerDevice {
 		return fmt.Errorf("store.min_configs_per_device (%d) must not exceed store.max_configs_per_device (%d)",
 			st.MinConfigsPerDevice, st.MaxConfigsPerDevice)
 	}
 	if st.MaxRawConfigStoreBytes <= 0 {
-		return errors.New("store.max_raw_config_store_bytes must be greater than zero")
+		log.Debugf("No or invalid max_raw_config_store_bytes specified, applying default: %d", defaultMaxRawConfigStoreBytes)
+		st.MaxRawConfigStoreBytes = defaultMaxRawConfigStoreBytes
 	}
 	return nil
 }

--- a/pkg/networkconfigmanagement/config/config.go
+++ b/pkg/networkconfigmanagement/config/config.go
@@ -63,7 +63,7 @@ type InitConfig struct {
 	Namespace             string       `yaml:"namespace"`               // Namespace for the NCM devices where configs are retrieved from, to help match a device on DD
 	MinCollectionInterval int          `yaml:"min_collection_interval"` // Interval in seconds to check for config changes
 	SSH                   *SSHConfig   `yaml:"ssh"`                     // SSH holds global connection configurations that can apply to all devices if pertinent
-	Store                 *StoreConfig `yaml:"store"`                   // Store holds configuration for the local config store and its eviction policy
+	StoreConfig           *StoreConfig `yaml:"store"`                   // StoreConfig holds configuration for the local config store and its eviction policy
 }
 
 // SSHConfig holds the configuration (either globally if in init config or for the specific device instance) to use when connecting to the configured device via SSH
@@ -95,7 +95,7 @@ type NcmCheckContext struct {
 	Namespace             string
 	Device                *DeviceInstance
 	MinCollectionInterval time.Duration
-	Store                 *StoreConfig
+	StoreConfig           *StoreConfig
 	ProfileMap            profile.Map
 	ProfileCache          *profile.Cache
 }
@@ -157,7 +157,7 @@ func NewNcmCheckContext(rawInstance integration.Data, rawInitConfig integration.
 		Namespace:             initConfig.Namespace,
 		MinCollectionInterval: time.Duration(initConfig.MinCollectionInterval) * time.Second,
 		Device:                &deviceInstance,
-		Store:                 initConfig.Store,
+		StoreConfig:           initConfig.StoreConfig,
 		ProfileMap:            profMap,
 		ProfileCache:          profileCache,
 	}
@@ -245,8 +245,8 @@ func (ic *InitConfig) applyDefaults() {
 		log.Debugf("No or invalid min_collection_interval specified in init config, applying default: %d", defaultCheckInterval)
 		ic.MinCollectionInterval = int(defaultCheckInterval.Seconds()) // Default to 15 minutes
 	}
-	if ic.Store == nil {
-		ic.Store = &StoreConfig{}
+	if ic.StoreConfig == nil {
+		ic.StoreConfig = &StoreConfig{}
 	}
 }
 
@@ -269,8 +269,8 @@ func (ic *InitConfig) Validate() error {
 		}
 	}
 
-	if ic.Store != nil {
-		ic.Store.validate()
+	if ic.StoreConfig != nil {
+		ic.StoreConfig.validate()
 	}
 
 	return nil

--- a/pkg/networkconfigmanagement/config/config.go
+++ b/pkg/networkconfigmanagement/config/config.go
@@ -26,12 +26,10 @@ import (
 	"go.yaml.in/yaml/v2"
 )
 
-var checkName = "network_config_management"
-var defaultCheckInterval = 15 * time.Minute
-var defaultSSHTimeout = 30 * time.Second
-
-// Store defaults
 var (
+	checkName = "network_config_management"
+	defaultCheckInterval = 15 * time.Minute
+	defaultSSHTimeout = 30 * time.Second
 	defaultMinConfigsPerDevice    = 5
 	defaultMaxConfigsPerDevice    = 10
 	defaultMaxRawConfigStoreBytes = int64(500 * 10 * 5000000 / 5) // 500 devices × 10 configs per device × 5 MB per config / 5 (5:1 compression ratio estimate)
@@ -86,12 +84,10 @@ type SSHConfig struct {
 }
 
 // StoreConfig holds the configuration for the local bbolt config store and its eviction policy.
-// These can be set globally in init_config to control how many configs are retained per device
-// and the maximum on-disk size of the store.
 type StoreConfig struct {
-	MinConfigsPerDevice    int   `yaml:"min_configs_per_device"`      // minimum configs retained per device even under size pressure
-	MaxConfigsPerDevice    int   `yaml:"max_configs_per_device"`      // hard cap; configs beyond this are evicted oldest-first
-	MaxRawConfigStoreBytes int64 `yaml:"max_raw_config_store_bytes"`  // maximum on-disk size of the store in bytes
+	MinConfigsPerDevice    int   `yaml:"min_configs_per_device"`      // Minimum configs retained per device even under size pressure
+	MaxConfigsPerDevice    int   `yaml:"max_configs_per_device"`      // Hard cap; configs beyond this are evicted oldest-first
+	MaxRawConfigStoreBytes int64 `yaml:"max_raw_config_store_bytes"`  // Maximum on-disk size of the store in bytes
 }
 
 // NcmCheckContext holds the processed config needed for an integration instance to run

--- a/pkg/networkconfigmanagement/config/config.go
+++ b/pkg/networkconfigmanagement/config/config.go
@@ -32,9 +32,9 @@ var defaultSSHTimeout = 30 * time.Second
 
 // Store defaults
 var (
-	defaultMinConfigsPerDevice    = 2
-	defaultMaxConfigsPerDevice    = 50
-	defaultMaxRawConfigStoreBytes = int64(512 * 1024 * 1024) // 512 MB
+	defaultMinConfigsPerDevice    = 5
+	defaultMaxConfigsPerDevice    = 10
+	defaultMaxRawConfigStoreBytes = int64(500 * 10 * 5000000 / 5) // 500 devices × 10 configs per device × 5 MB per config / 5 (5:1 compression ratio estimate)
 )
 
 // AuthCredentials holds the authentication credentials to connect to a network device.

--- a/pkg/networkconfigmanagement/config/config.go
+++ b/pkg/networkconfigmanagement/config/config.go
@@ -27,9 +27,9 @@ import (
 )
 
 var (
-	checkName = "network_config_management"
-	defaultCheckInterval = 15 * time.Minute
-	defaultSSHTimeout = 30 * time.Second
+	checkName                     = "network_config_management"
+	defaultCheckInterval          = 15 * time.Minute
+	defaultSSHTimeout             = 30 * time.Second
 	defaultMinConfigsPerDevice    = 5
 	defaultMaxConfigsPerDevice    = 10
 	defaultMaxRawConfigStoreBytes = int64(500 * 10 * 5000000 / 5) // 500 devices × 10 configs per device × 5 MB per config / 5 (5:1 compression ratio estimate)
@@ -85,9 +85,9 @@ type SSHConfig struct {
 
 // StoreConfig holds the configuration for the local bbolt config store and its eviction policy.
 type StoreConfig struct {
-	MinConfigsPerDevice    int   `yaml:"min_configs_per_device"`      // Minimum configs retained per device even under size pressure
-	MaxConfigsPerDevice    int   `yaml:"max_configs_per_device"`      // Hard cap; configs beyond this are evicted oldest-first
-	MaxRawConfigStoreBytes int64 `yaml:"max_raw_config_store_bytes"`  // Maximum on-disk size of the store in bytes
+	MinConfigsPerDevice    int   `yaml:"min_configs_per_device"`     // Minimum configs retained per device even under size pressure
+	MaxConfigsPerDevice    int   `yaml:"max_configs_per_device"`     // Hard cap; configs beyond this are evicted oldest-first
+	MaxRawConfigStoreBytes int64 `yaml:"max_raw_config_store_bytes"` // Maximum on-disk size of the store in bytes
 }
 
 // NcmCheckContext holds the processed config needed for an integration instance to run

--- a/pkg/networkconfigmanagement/config/config.go
+++ b/pkg/networkconfigmanagement/config/config.go
@@ -376,8 +376,10 @@ func (st *StoreConfig) validate() error {
 		st.MaxConfigsPerDevice = defaultMaxConfigsPerDevice
 	}
 	if st.MinConfigsPerDevice > st.MaxConfigsPerDevice {
-		return fmt.Errorf("store.min_configs_per_device (%d) must not exceed store.max_configs_per_device (%d)",
+		log.Warnf("store.min_configs_per_device (%d) exceeds store.max_configs_per_device (%d), resetting both to defaults",
 			st.MinConfigsPerDevice, st.MaxConfigsPerDevice)
+		st.MinConfigsPerDevice = defaultMinConfigsPerDevice
+		st.MaxConfigsPerDevice = defaultMaxConfigsPerDevice
 	}
 	if st.MaxRawConfigStoreBytes <= 0 {
 		log.Debugf("No or invalid max_raw_config_store_bytes specified, applying default: %d", defaultMaxRawConfigStoreBytes)

--- a/pkg/networkconfigmanagement/config/config.go
+++ b/pkg/networkconfigmanagement/config/config.go
@@ -270,10 +270,9 @@ func (ic *InitConfig) Validate() error {
 	}
 
 	if ic.Store != nil {
-		if err := ic.Store.validate(); err != nil {
-			return fmt.Errorf("invalid init_config store config: %w", err)
-		}
+		ic.Store.validate()
 	}
+
 	return nil
 }
 
@@ -366,7 +365,7 @@ func (sc *SSHConfig) hasRequiredFields() error {
 	return nil
 }
 
-func (st *StoreConfig) validate() error {
+func (st *StoreConfig) validate() {
 	if st.MinConfigsPerDevice <= 0 {
 		log.Debugf("No or invalid min_configs_per_device specified, applying default: %d", defaultMinConfigsPerDevice)
 		st.MinConfigsPerDevice = defaultMinConfigsPerDevice
@@ -376,7 +375,7 @@ func (st *StoreConfig) validate() error {
 		st.MaxConfigsPerDevice = defaultMaxConfigsPerDevice
 	}
 	if st.MinConfigsPerDevice > st.MaxConfigsPerDevice {
-		log.Warnf("store.min_configs_per_device (%d) exceeds store.max_configs_per_device (%d), resetting both to defaults",
+		log.Debugf("store.min_configs_per_device (%d) exceeds store.max_configs_per_device (%d), resetting both to defaults",
 			st.MinConfigsPerDevice, st.MaxConfigsPerDevice)
 		st.MinConfigsPerDevice = defaultMinConfigsPerDevice
 		st.MaxConfigsPerDevice = defaultMaxConfigsPerDevice
@@ -385,5 +384,4 @@ func (st *StoreConfig) validate() error {
 		log.Debugf("No or invalid max_raw_config_store_bytes specified, applying default: %d", defaultMaxRawConfigStoreBytes)
 		st.MaxRawConfigStoreBytes = defaultMaxRawConfigStoreBytes
 	}
-	return nil
 }

--- a/pkg/networkconfigmanagement/config/config.go
+++ b/pkg/networkconfigmanagement/config/config.go
@@ -30,6 +30,13 @@ var checkName = "network_config_management"
 var defaultCheckInterval = 15 * time.Minute
 var defaultSSHTimeout = 30 * time.Second
 
+// Store defaults
+var (
+	defaultMinConfigsPerDevice    = 2
+	defaultMaxConfigsPerDevice    = 50
+	defaultMaxRawConfigStoreBytes = int64(512 * 1024 * 1024) // 512 MB
+)
+
 // AuthCredentials holds the authentication credentials to connect to a network device.
 type AuthCredentials struct { // auth_credentials
 	// Authenticate via password (fallback after private key if provided)
@@ -55,9 +62,10 @@ type DeviceInstance struct {
 
 // InitConfig holds the initial configuration for the NCM component, including the namespace and check interval.
 type InitConfig struct {
-	Namespace             string     `yaml:"namespace"`               // Namespace for the NCM devices where configs are retrieved from, to help match a device on DD
-	MinCollectionInterval int        `yaml:"min_collection_interval"` // Interval in seconds to check for config changes
-	SSH                   *SSHConfig `yaml:"ssh"`                     // SSH holds global connection configurations that can apply to all devices if pertinent
+	Namespace             string       `yaml:"namespace"`               // Namespace for the NCM devices where configs are retrieved from, to help match a device on DD
+	MinCollectionInterval int          `yaml:"min_collection_interval"` // Interval in seconds to check for config changes
+	SSH                   *SSHConfig   `yaml:"ssh"`                     // SSH holds global connection configurations that can apply to all devices if pertinent
+	Store                 *StoreConfig `yaml:"store"`                   // Store holds configuration for the local config store and its eviction policy
 }
 
 // SSHConfig holds the configuration (either globally if in init config or for the specific device instance) to use when connecting to the configured device via SSH
@@ -77,11 +85,21 @@ type SSHConfig struct {
 	AllowLegacyAlgorithms bool `yaml:"allow_legacy_algorithms"`
 }
 
+// StoreConfig holds the configuration for the local bbolt config store and its eviction policy.
+// These can be set globally in init_config to control how many configs are retained per device
+// and the maximum on-disk size of the store.
+type StoreConfig struct {
+	MinConfigsPerDevice    int   `yaml:"min_configs_per_device"`      // minimum configs retained per device even under size pressure
+	MaxConfigsPerDevice    int   `yaml:"max_configs_per_device"`      // hard cap; configs beyond this are evicted oldest-first
+	MaxRawConfigStoreBytes int64 `yaml:"max_raw_config_store_bytes"`  // maximum on-disk size of the store in bytes
+}
+
 // NcmCheckContext holds the processed config needed for an integration instance to run
 type NcmCheckContext struct {
 	Namespace             string
 	Device                *DeviceInstance
 	MinCollectionInterval time.Duration
+	Store                 *StoreConfig
 	ProfileMap            profile.Map
 	ProfileCache          *profile.Cache
 }
@@ -143,6 +161,7 @@ func NewNcmCheckContext(rawInstance integration.Data, rawInitConfig integration.
 		Namespace:             initConfig.Namespace,
 		MinCollectionInterval: time.Duration(initConfig.MinCollectionInterval) * time.Second,
 		Device:                &deviceInstance,
+		Store:                 initConfig.Store,
 		ProfileMap:            profMap,
 		ProfileCache:          profileCache,
 	}
@@ -230,6 +249,10 @@ func (ic *InitConfig) applyDefaults() {
 		log.Debugf("No or invalid min_collection_interval specified in init config, applying default: %d", defaultCheckInterval)
 		ic.MinCollectionInterval = int(defaultCheckInterval.Seconds()) // Default to 15 minutes
 	}
+	if ic.Store == nil {
+		ic.Store = &StoreConfig{}
+	}
+	ic.Store.applyDefaults()
 }
 
 // Validate checks that the InitConfig has all required fields and applies defaults where needed
@@ -248,6 +271,12 @@ func (ic *InitConfig) Validate() error {
 	if ic.SSH != nil {
 		if err := ic.SSH.validate(); err != nil {
 			return fmt.Errorf("invalid init_config SSH config: %w", err)
+		}
+	}
+
+	if ic.Store != nil {
+		if err := ic.Store.validate(); err != nil {
+			return fmt.Errorf("invalid init_config store config: %w", err)
 		}
 	}
 	return nil
@@ -338,6 +367,38 @@ func (sc *SSHConfig) hasRequiredFields() error {
 	// must have at least a known paths specified or skip verification (insecure, only for development/testing purposes)
 	if sc.KnownHostsPath == "" && !sc.InsecureSkipVerify {
 		return errors.New("no SSH host key verification configured: set known_hosts_path or enable insecure_skip_verify")
+	}
+	return nil
+}
+
+func (st *StoreConfig) applyDefaults() {
+	if st.MinConfigsPerDevice <= 0 {
+		log.Debugf("No or invalid min_configs_per_device specified, applying default: %d", defaultMinConfigsPerDevice)
+		st.MinConfigsPerDevice = defaultMinConfigsPerDevice
+	}
+	if st.MaxConfigsPerDevice <= 0 {
+		log.Debugf("No or invalid max_configs_per_device specified, applying default: %d", defaultMaxConfigsPerDevice)
+		st.MaxConfigsPerDevice = defaultMaxConfigsPerDevice
+	}
+	if st.MaxRawConfigStoreBytes <= 0 {
+		log.Debugf("No or invalid max_raw_config_store_bytes specified, applying default: %d", defaultMaxRawConfigStoreBytes)
+		st.MaxRawConfigStoreBytes = defaultMaxRawConfigStoreBytes
+	}
+}
+
+func (st *StoreConfig) validate() error {
+	if st.MinConfigsPerDevice <= 0 {
+		return errors.New("store.min_configs_per_device must be greater than zero")
+	}
+	if st.MaxConfigsPerDevice <= 0 {
+		return errors.New("store.max_configs_per_device must be greater than zero")
+	}
+	if st.MinConfigsPerDevice > st.MaxConfigsPerDevice {
+		return fmt.Errorf("store.min_configs_per_device (%d) must not exceed store.max_configs_per_device (%d)",
+			st.MinConfigsPerDevice, st.MaxConfigsPerDevice)
+	}
+	if st.MaxRawConfigStoreBytes <= 0 {
+		return errors.New("store.max_raw_config_store_bytes must be greater than zero")
 	}
 	return nil
 }

--- a/pkg/networkconfigmanagement/config/config_test.go
+++ b/pkg/networkconfigmanagement/config/config_test.go
@@ -359,6 +359,8 @@ ssh:
 	ic.applyDefaults()
 	require.NotNil(t, ic.Store)
 	assert.Equal(t, defaultMinConfigsPerDevice, ic.Store.MinConfigsPerDevice)
+	assert.Equal(t, defaultMaxConfigsPerDevice, ic.Store.MaxConfigsPerDevice)
+	assert.Equal(t, defaultMaxRawConfigStoreBytes, ic.Store.MaxRawConfigStoreBytes)
 }
 
 func TestNewNcmCheckContext_WithStoreConfig(t *testing.T) {

--- a/pkg/networkconfigmanagement/config/config_test.go
+++ b/pkg/networkconfigmanagement/config/config_test.go
@@ -225,7 +225,6 @@ func TestStoreConfig_Validation(t *testing.T) {
 		name           string
 		config         *StoreConfig
 		expectedConfig *StoreConfig
-		errMsg         string
 	}{
 		{
 			name: "valid config",
@@ -330,13 +329,8 @@ func TestStoreConfig_Validation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.validate()
-			if tt.errMsg != "" {
-				assert.EqualError(t, err, tt.errMsg)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.expectedConfig, tt.config)
-			}
+			tt.config.validate()
+			assert.Equal(t, tt.expectedConfig, tt.config)
 		})
 	}
 }
@@ -451,8 +445,7 @@ ssh:
 	ic.applyDefaults()
 	require.NotNil(t, ic.Store)
 
-	err = ic.Store.validate()
-	require.NoError(t, err)
+	ic.Store.validate()
 	assert.Equal(t, defaultMinConfigsPerDevice, ic.Store.MinConfigsPerDevice)
 	assert.Equal(t, defaultMaxConfigsPerDevice, ic.Store.MaxConfigsPerDevice)
 	assert.Equal(t, defaultMaxRawConfigStoreBytes, ic.Store.MaxRawConfigStoreBytes)

--- a/pkg/networkconfigmanagement/config/config_test.go
+++ b/pkg/networkconfigmanagement/config/config_test.go
@@ -222,13 +222,19 @@ func TestAuthCredentials_DefaultValues(t *testing.T) {
 
 func TestStoreConfig_Validation(t *testing.T) {
 	tests := []struct {
-		name   string
-		config *StoreConfig
-		errMsg string
+		name           string
+		config         *StoreConfig
+		expectedConfig *StoreConfig
+		errMsg         string
 	}{
 		{
 			name: "valid config",
 			config: &StoreConfig{
+				MinConfigsPerDevice:    2,
+				MaxConfigsPerDevice:    50,
+				MaxRawConfigStoreBytes: 512 * 1024 * 1024,
+			},
+			expectedConfig: &StoreConfig{
 				MinConfigsPerDevice:    2,
 				MaxConfigsPerDevice:    50,
 				MaxRawConfigStoreBytes: 512 * 1024 * 1024,
@@ -241,24 +247,37 @@ func TestStoreConfig_Validation(t *testing.T) {
 				MaxConfigsPerDevice:    10,
 				MaxRawConfigStoreBytes: 1024,
 			},
+			expectedConfig: &StoreConfig{
+				MinConfigsPerDevice:    10,
+				MaxConfigsPerDevice:    10,
+				MaxRawConfigStoreBytes: 1024,
+			},
 		},
 		{
-			name: "min_configs_per_device zero",
+			name: "min_configs_per_device zero falls back to default",
 			config: &StoreConfig{
 				MinConfigsPerDevice:    0,
 				MaxConfigsPerDevice:    50,
 				MaxRawConfigStoreBytes: 512 * 1024 * 1024,
 			},
-			errMsg: "store.min_configs_per_device must be greater than zero",
+			expectedConfig: &StoreConfig{
+				MinConfigsPerDevice:    defaultMinConfigsPerDevice,
+				MaxConfigsPerDevice:    50,
+				MaxRawConfigStoreBytes: 512 * 1024 * 1024,
+			},
 		},
 		{
-			name: "max_configs_per_device zero",
+			name: "max_configs_per_device zero falls back to default",
 			config: &StoreConfig{
 				MinConfigsPerDevice:    2,
 				MaxConfigsPerDevice:    0,
 				MaxRawConfigStoreBytes: 512 * 1024 * 1024,
 			},
-			errMsg: "store.max_configs_per_device must be greater than zero",
+			expectedConfig: &StoreConfig{
+				MinConfigsPerDevice:    2,
+				MaxConfigsPerDevice:    defaultMaxConfigsPerDevice,
+				MaxRawConfigStoreBytes: 512 * 1024 * 1024,
+			},
 		},
 		{
 			name: "min exceeds max",
@@ -270,22 +289,39 @@ func TestStoreConfig_Validation(t *testing.T) {
 			errMsg: "store.min_configs_per_device (100) must not exceed store.max_configs_per_device (10)",
 		},
 		{
-			name: "max_raw_config_store_bytes zero",
+			name: "max_raw_config_store_bytes zero falls back to default",
 			config: &StoreConfig{
 				MinConfigsPerDevice:    2,
 				MaxConfigsPerDevice:    50,
 				MaxRawConfigStoreBytes: 0,
 			},
-			errMsg: "store.max_raw_config_store_bytes must be greater than zero",
+			expectedConfig: &StoreConfig{
+				MinConfigsPerDevice:    2,
+				MaxConfigsPerDevice:    50,
+				MaxRawConfigStoreBytes: defaultMaxRawConfigStoreBytes,
+			},
 		},
 		{
-			name: "max_raw_config_store_bytes negative",
+			name: "max_raw_config_store_bytes negative falls back to default",
 			config: &StoreConfig{
 				MinConfigsPerDevice:    2,
 				MaxConfigsPerDevice:    50,
 				MaxRawConfigStoreBytes: -1,
 			},
-			errMsg: "store.max_raw_config_store_bytes must be greater than zero",
+			expectedConfig: &StoreConfig{
+				MinConfigsPerDevice:    2,
+				MaxConfigsPerDevice:    50,
+				MaxRawConfigStoreBytes: defaultMaxRawConfigStoreBytes,
+			},
+		},
+		{
+			name:   "all zero falls back to all defaults",
+			config: &StoreConfig{},
+			expectedConfig: &StoreConfig{
+				MinConfigsPerDevice:    defaultMinConfigsPerDevice,
+				MaxConfigsPerDevice:    defaultMaxConfigsPerDevice,
+				MaxRawConfigStoreBytes: defaultMaxRawConfigStoreBytes,
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -295,6 +331,7 @@ func TestStoreConfig_Validation(t *testing.T) {
 				assert.EqualError(t, err, tt.errMsg)
 			} else {
 				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedConfig, tt.config)
 			}
 		})
 	}
@@ -302,9 +339,12 @@ func TestStoreConfig_Validation(t *testing.T) {
 
 func TestStoreConfig_Defaults(t *testing.T) {
 	ic := InitConfig{
-		Namespace: "default",
+		Namespace:             "default",
+		MinCollectionInterval: 900,
 	}
 	ic.applyDefaults()
+	err := ic.Validate()
+	require.NoError(t, err)
 
 	require.NotNil(t, ic.Store)
 	assert.Equal(t, defaultMinConfigsPerDevice, ic.Store.MinConfigsPerDevice)
@@ -314,12 +354,14 @@ func TestStoreConfig_Defaults(t *testing.T) {
 
 func TestStoreConfig_PartialDefaults(t *testing.T) {
 	ic := InitConfig{
-		Namespace: "default",
+		Namespace:             "default",
+		MinCollectionInterval: 900,
 		Store: &StoreConfig{
 			MinConfigsPerDevice: 5,
 		},
 	}
-	ic.applyDefaults()
+	err := ic.Validate()
+	require.NoError(t, err)
 
 	assert.Equal(t, 5, ic.Store.MinConfigsPerDevice)
 	assert.Equal(t, defaultMaxConfigsPerDevice, ic.Store.MaxConfigsPerDevice)
@@ -345,9 +387,55 @@ store:
 	assert.Equal(t, int64(1073741824), ic.Store.MaxRawConfigStoreBytes)
 }
 
+func TestInitConfig_PartialStoreValidatesWithoutApplyDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "only max_configs_per_device set",
+			yaml: `
+namespace: production
+min_collection_interval: 900
+store:
+  max_configs_per_device: 20
+`,
+		},
+		{
+			name: "empty store block",
+			yaml: `
+namespace: production
+min_collection_interval: 900
+store: {}
+`,
+		},
+		{
+			name: "only max_raw_config_store_bytes set",
+			yaml: `
+namespace: production
+min_collection_interval: 900
+store:
+  max_raw_config_store_bytes: 1073741824
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ic InitConfig
+			err := yaml.Unmarshal([]byte(tt.yaml), &ic)
+			require.NoError(t, err)
+
+			err = ic.Validate()
+			assert.NoError(t, err, "partial store config should be valid without calling applyDefaults() first")
+		})
+	}
+}
+
 func TestStoreConfig_YAMLUnmarshalOmitted(t *testing.T) {
 	yamlData := `
 namespace: production
+min_collection_interval: 900
 ssh:
   insecure_skip_verify: true
 `
@@ -358,6 +446,9 @@ ssh:
 
 	ic.applyDefaults()
 	require.NotNil(t, ic.Store)
+
+	err = ic.Store.validate()
+	require.NoError(t, err)
 	assert.Equal(t, defaultMinConfigsPerDevice, ic.Store.MinConfigsPerDevice)
 	assert.Equal(t, defaultMaxConfigsPerDevice, ic.Store.MaxConfigsPerDevice)
 	assert.Equal(t, defaultMaxRawConfigStoreBytes, ic.Store.MaxRawConfigStoreBytes)

--- a/pkg/networkconfigmanagement/config/config_test.go
+++ b/pkg/networkconfigmanagement/config/config_test.go
@@ -220,6 +220,212 @@ func TestAuthCredentials_DefaultValues(t *testing.T) {
 	assert.Equal(t, "tcp", config.Auth.Protocol)
 }
 
+func TestStoreConfig_Validation(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *StoreConfig
+		errMsg string
+	}{
+		{
+			name: "valid config",
+			config: &StoreConfig{
+				MinConfigsPerDevice:    2,
+				MaxConfigsPerDevice:    50,
+				MaxRawConfigStoreBytes: 512 * 1024 * 1024,
+			},
+		},
+		{
+			name: "min equals max is valid",
+			config: &StoreConfig{
+				MinConfigsPerDevice:    10,
+				MaxConfigsPerDevice:    10,
+				MaxRawConfigStoreBytes: 1024,
+			},
+		},
+		{
+			name: "min_configs_per_device zero",
+			config: &StoreConfig{
+				MinConfigsPerDevice:    0,
+				MaxConfigsPerDevice:    50,
+				MaxRawConfigStoreBytes: 512 * 1024 * 1024,
+			},
+			errMsg: "store.min_configs_per_device must be greater than zero",
+		},
+		{
+			name: "max_configs_per_device zero",
+			config: &StoreConfig{
+				MinConfigsPerDevice:    2,
+				MaxConfigsPerDevice:    0,
+				MaxRawConfigStoreBytes: 512 * 1024 * 1024,
+			},
+			errMsg: "store.max_configs_per_device must be greater than zero",
+		},
+		{
+			name: "min exceeds max",
+			config: &StoreConfig{
+				MinConfigsPerDevice:    100,
+				MaxConfigsPerDevice:    10,
+				MaxRawConfigStoreBytes: 512 * 1024 * 1024,
+			},
+			errMsg: "store.min_configs_per_device (100) must not exceed store.max_configs_per_device (10)",
+		},
+		{
+			name: "max_raw_config_store_bytes zero",
+			config: &StoreConfig{
+				MinConfigsPerDevice:    2,
+				MaxConfigsPerDevice:    50,
+				MaxRawConfigStoreBytes: 0,
+			},
+			errMsg: "store.max_raw_config_store_bytes must be greater than zero",
+		},
+		{
+			name: "max_raw_config_store_bytes negative",
+			config: &StoreConfig{
+				MinConfigsPerDevice:    2,
+				MaxConfigsPerDevice:    50,
+				MaxRawConfigStoreBytes: -1,
+			},
+			errMsg: "store.max_raw_config_store_bytes must be greater than zero",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.validate()
+			if tt.errMsg != "" {
+				assert.EqualError(t, err, tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStoreConfig_Defaults(t *testing.T) {
+	ic := InitConfig{
+		Namespace: "default",
+	}
+	ic.applyDefaults()
+
+	require.NotNil(t, ic.Store)
+	assert.Equal(t, defaultMinConfigsPerDevice, ic.Store.MinConfigsPerDevice)
+	assert.Equal(t, defaultMaxConfigsPerDevice, ic.Store.MaxConfigsPerDevice)
+	assert.Equal(t, defaultMaxRawConfigStoreBytes, ic.Store.MaxRawConfigStoreBytes)
+}
+
+func TestStoreConfig_PartialDefaults(t *testing.T) {
+	ic := InitConfig{
+		Namespace: "default",
+		Store: &StoreConfig{
+			MinConfigsPerDevice: 5,
+		},
+	}
+	ic.applyDefaults()
+
+	assert.Equal(t, 5, ic.Store.MinConfigsPerDevice)
+	assert.Equal(t, defaultMaxConfigsPerDevice, ic.Store.MaxConfigsPerDevice)
+	assert.Equal(t, defaultMaxRawConfigStoreBytes, ic.Store.MaxRawConfigStoreBytes)
+}
+
+func TestStoreConfig_YAMLUnmarshal(t *testing.T) {
+	yamlData := `
+namespace: production
+ssh:
+  insecure_skip_verify: true
+store:
+  min_configs_per_device: 3
+  max_configs_per_device: 100
+  max_raw_config_store_bytes: 1073741824
+`
+	var ic InitConfig
+	err := yaml.Unmarshal([]byte(yamlData), &ic)
+	require.NoError(t, err)
+	require.NotNil(t, ic.Store)
+	assert.Equal(t, 3, ic.Store.MinConfigsPerDevice)
+	assert.Equal(t, 100, ic.Store.MaxConfigsPerDevice)
+	assert.Equal(t, int64(1073741824), ic.Store.MaxRawConfigStoreBytes)
+}
+
+func TestStoreConfig_YAMLUnmarshalOmitted(t *testing.T) {
+	yamlData := `
+namespace: production
+ssh:
+  insecure_skip_verify: true
+`
+	var ic InitConfig
+	err := yaml.Unmarshal([]byte(yamlData), &ic)
+	require.NoError(t, err)
+	assert.Nil(t, ic.Store)
+
+	ic.applyDefaults()
+	require.NotNil(t, ic.Store)
+	assert.Equal(t, defaultMinConfigsPerDevice, ic.Store.MinConfigsPerDevice)
+}
+
+func TestNewNcmCheckContext_WithStoreConfig(t *testing.T) {
+	initConfig := `
+namespace: default
+ssh:
+  insecure_skip_verify: true
+store:
+  min_configs_per_device: 5
+  max_configs_per_device: 200
+  max_raw_config_store_bytes: 2147483648
+`
+	instanceConfig := `
+ip_address: 192.168.0.1
+auth:
+  password: 'password'
+  username: 'admin'
+`
+	cfg, err := NewNcmCheckContext([]byte(instanceConfig), []byte(initConfig))
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Store)
+	assert.Equal(t, 5, cfg.Store.MinConfigsPerDevice)
+	assert.Equal(t, 200, cfg.Store.MaxConfigsPerDevice)
+	assert.Equal(t, int64(2147483648), cfg.Store.MaxRawConfigStoreBytes)
+}
+
+func TestNewNcmCheckContext_StoreDefaultsApplied(t *testing.T) {
+	initConfig := `
+namespace: default
+ssh:
+  insecure_skip_verify: true
+`
+	instanceConfig := `
+ip_address: 192.168.0.1
+auth:
+  password: 'password'
+  username: 'admin'
+`
+	cfg, err := NewNcmCheckContext([]byte(instanceConfig), []byte(initConfig))
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Store)
+	assert.Equal(t, defaultMinConfigsPerDevice, cfg.Store.MinConfigsPerDevice)
+	assert.Equal(t, defaultMaxConfigsPerDevice, cfg.Store.MaxConfigsPerDevice)
+	assert.Equal(t, defaultMaxRawConfigStoreBytes, cfg.Store.MaxRawConfigStoreBytes)
+}
+
+func TestNewNcmCheckContext_InvalidStoreConfig(t *testing.T) {
+	initConfig := `
+namespace: default
+ssh:
+  insecure_skip_verify: true
+store:
+  min_configs_per_device: 100
+  max_configs_per_device: 10
+  max_raw_config_store_bytes: 1024
+`
+	instanceConfig := `
+ip_address: 192.168.0.1
+auth:
+  password: 'password'
+  username: 'admin'
+`
+	_, err := NewNcmCheckContext([]byte(instanceConfig), []byte(initConfig))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "store.min_configs_per_device (100) must not exceed store.max_configs_per_device (10)")
+}
+
 func TestParsingSSHTimeoutFromYAML(t *testing.T) {
 	var tests = []struct {
 		name     string

--- a/pkg/networkconfigmanagement/config/config_test.go
+++ b/pkg/networkconfigmanagement/config/config_test.go
@@ -344,26 +344,26 @@ func TestStoreConfig_Defaults(t *testing.T) {
 	err := ic.Validate()
 	require.NoError(t, err)
 
-	require.NotNil(t, ic.Store)
-	assert.Equal(t, defaultMinConfigsPerDevice, ic.Store.MinConfigsPerDevice)
-	assert.Equal(t, defaultMaxConfigsPerDevice, ic.Store.MaxConfigsPerDevice)
-	assert.Equal(t, defaultMaxRawConfigStoreBytes, ic.Store.MaxRawConfigStoreBytes)
+	require.NotNil(t, ic.StoreConfig)
+	assert.Equal(t, defaultMinConfigsPerDevice, ic.StoreConfig.MinConfigsPerDevice)
+	assert.Equal(t, defaultMaxConfigsPerDevice, ic.StoreConfig.MaxConfigsPerDevice)
+	assert.Equal(t, defaultMaxRawConfigStoreBytes, ic.StoreConfig.MaxRawConfigStoreBytes)
 }
 
 func TestStoreConfig_PartialDefaults(t *testing.T) {
 	ic := InitConfig{
 		Namespace:             "default",
 		MinCollectionInterval: 900,
-		Store: &StoreConfig{
+		StoreConfig: &StoreConfig{
 			MinConfigsPerDevice: 5,
 		},
 	}
 	err := ic.Validate()
 	require.NoError(t, err)
 
-	assert.Equal(t, 5, ic.Store.MinConfigsPerDevice)
-	assert.Equal(t, defaultMaxConfigsPerDevice, ic.Store.MaxConfigsPerDevice)
-	assert.Equal(t, defaultMaxRawConfigStoreBytes, ic.Store.MaxRawConfigStoreBytes)
+	assert.Equal(t, 5, ic.StoreConfig.MinConfigsPerDevice)
+	assert.Equal(t, defaultMaxConfigsPerDevice, ic.StoreConfig.MaxConfigsPerDevice)
+	assert.Equal(t, defaultMaxRawConfigStoreBytes, ic.StoreConfig.MaxRawConfigStoreBytes)
 }
 
 func TestStoreConfig_YAMLUnmarshal(t *testing.T) {
@@ -379,10 +379,10 @@ store:
 	var ic InitConfig
 	err := yaml.Unmarshal([]byte(yamlData), &ic)
 	require.NoError(t, err)
-	require.NotNil(t, ic.Store)
-	assert.Equal(t, 3, ic.Store.MinConfigsPerDevice)
-	assert.Equal(t, 100, ic.Store.MaxConfigsPerDevice)
-	assert.Equal(t, int64(1073741824), ic.Store.MaxRawConfigStoreBytes)
+	require.NotNil(t, ic.StoreConfig)
+	assert.Equal(t, 3, ic.StoreConfig.MinConfigsPerDevice)
+	assert.Equal(t, 100, ic.StoreConfig.MaxConfigsPerDevice)
+	assert.Equal(t, int64(1073741824), ic.StoreConfig.MaxRawConfigStoreBytes)
 }
 
 func TestInitConfig_PartialStoreValidatesWithoutApplyDefaults(t *testing.T) {
@@ -440,15 +440,15 @@ ssh:
 	var ic InitConfig
 	err := yaml.Unmarshal([]byte(yamlData), &ic)
 	require.NoError(t, err)
-	assert.Nil(t, ic.Store)
+	assert.Nil(t, ic.StoreConfig)
 
 	ic.applyDefaults()
-	require.NotNil(t, ic.Store)
+	require.NotNil(t, ic.StoreConfig)
 
-	ic.Store.validate()
-	assert.Equal(t, defaultMinConfigsPerDevice, ic.Store.MinConfigsPerDevice)
-	assert.Equal(t, defaultMaxConfigsPerDevice, ic.Store.MaxConfigsPerDevice)
-	assert.Equal(t, defaultMaxRawConfigStoreBytes, ic.Store.MaxRawConfigStoreBytes)
+	ic.StoreConfig.validate()
+	assert.Equal(t, defaultMinConfigsPerDevice, ic.StoreConfig.MinConfigsPerDevice)
+	assert.Equal(t, defaultMaxConfigsPerDevice, ic.StoreConfig.MaxConfigsPerDevice)
+	assert.Equal(t, defaultMaxRawConfigStoreBytes, ic.StoreConfig.MaxRawConfigStoreBytes)
 }
 
 func TestNewNcmCheckContext_WithStoreConfig(t *testing.T) {
@@ -469,10 +469,10 @@ auth:
 `
 	cfg, err := NewNcmCheckContext([]byte(instanceConfig), []byte(initConfig))
 	require.NoError(t, err)
-	require.NotNil(t, cfg.Store)
-	assert.Equal(t, 5, cfg.Store.MinConfigsPerDevice)
-	assert.Equal(t, 200, cfg.Store.MaxConfigsPerDevice)
-	assert.Equal(t, int64(2147483648), cfg.Store.MaxRawConfigStoreBytes)
+	require.NotNil(t, cfg.StoreConfig)
+	assert.Equal(t, 5, cfg.StoreConfig.MinConfigsPerDevice)
+	assert.Equal(t, 200, cfg.StoreConfig.MaxConfigsPerDevice)
+	assert.Equal(t, int64(2147483648), cfg.StoreConfig.MaxRawConfigStoreBytes)
 }
 
 func TestNewNcmCheckContext_StoreDefaultsApplied(t *testing.T) {
@@ -489,10 +489,10 @@ auth:
 `
 	cfg, err := NewNcmCheckContext([]byte(instanceConfig), []byte(initConfig))
 	require.NoError(t, err)
-	require.NotNil(t, cfg.Store)
-	assert.Equal(t, defaultMinConfigsPerDevice, cfg.Store.MinConfigsPerDevice)
-	assert.Equal(t, defaultMaxConfigsPerDevice, cfg.Store.MaxConfigsPerDevice)
-	assert.Equal(t, defaultMaxRawConfigStoreBytes, cfg.Store.MaxRawConfigStoreBytes)
+	require.NotNil(t, cfg.StoreConfig)
+	assert.Equal(t, defaultMinConfigsPerDevice, cfg.StoreConfig.MinConfigsPerDevice)
+	assert.Equal(t, defaultMaxConfigsPerDevice, cfg.StoreConfig.MaxConfigsPerDevice)
+	assert.Equal(t, defaultMaxRawConfigStoreBytes, cfg.StoreConfig.MaxRawConfigStoreBytes)
 }
 
 func TestNewNcmCheckContext_StoreMinExceedsMaxResetsToDefaults(t *testing.T) {
@@ -513,9 +513,9 @@ auth:
 `
 	cfg, err := NewNcmCheckContext([]byte(instanceConfig), []byte(initConfig))
 	require.NoError(t, err)
-	assert.Equal(t, defaultMinConfigsPerDevice, cfg.Store.MinConfigsPerDevice)
-	assert.Equal(t, defaultMaxConfigsPerDevice, cfg.Store.MaxConfigsPerDevice)
-	assert.Equal(t, int64(1024), cfg.Store.MaxRawConfigStoreBytes)
+	assert.Equal(t, defaultMinConfigsPerDevice, cfg.StoreConfig.MinConfigsPerDevice)
+	assert.Equal(t, defaultMaxConfigsPerDevice, cfg.StoreConfig.MaxConfigsPerDevice)
+	assert.Equal(t, int64(1024), cfg.StoreConfig.MaxRawConfigStoreBytes)
 }
 
 func TestParsingSSHTimeoutFromYAML(t *testing.T) {

--- a/pkg/networkconfigmanagement/config/config_test.go
+++ b/pkg/networkconfigmanagement/config/config_test.go
@@ -280,13 +280,17 @@ func TestStoreConfig_Validation(t *testing.T) {
 			},
 		},
 		{
-			name: "min exceeds max",
+			name: "min exceeds max resets both to defaults",
 			config: &StoreConfig{
 				MinConfigsPerDevice:    100,
 				MaxConfigsPerDevice:    10,
 				MaxRawConfigStoreBytes: 512 * 1024 * 1024,
 			},
-			errMsg: "store.min_configs_per_device (100) must not exceed store.max_configs_per_device (10)",
+			expectedConfig: &StoreConfig{
+				MinConfigsPerDevice:    defaultMinConfigsPerDevice,
+				MaxConfigsPerDevice:    defaultMaxConfigsPerDevice,
+				MaxRawConfigStoreBytes: 512 * 1024 * 1024,
+			},
 		},
 		{
 			name: "max_raw_config_store_bytes zero falls back to default",
@@ -498,7 +502,7 @@ auth:
 	assert.Equal(t, defaultMaxRawConfigStoreBytes, cfg.Store.MaxRawConfigStoreBytes)
 }
 
-func TestNewNcmCheckContext_InvalidStoreConfig(t *testing.T) {
+func TestNewNcmCheckContext_StoreMinExceedsMaxResetsToDefaults(t *testing.T) {
 	initConfig := `
 namespace: default
 ssh:
@@ -514,9 +518,11 @@ auth:
   password: 'password'
   username: 'admin'
 `
-	_, err := NewNcmCheckContext([]byte(instanceConfig), []byte(initConfig))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "store.min_configs_per_device (100) must not exceed store.max_configs_per_device (10)")
+	cfg, err := NewNcmCheckContext([]byte(instanceConfig), []byte(initConfig))
+	require.NoError(t, err)
+	assert.Equal(t, defaultMinConfigsPerDevice, cfg.Store.MinConfigsPerDevice)
+	assert.Equal(t, defaultMaxConfigsPerDevice, cfg.Store.MaxConfigsPerDevice)
+	assert.Equal(t, int64(1024), cfg.Store.MaxRawConfigStoreBytes)
 }
 
 func TestParsingSSHTimeoutFromYAML(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

**THIS PR IS OUTDATED -> [PLEASE REFERENCE THIS ONE](https://github.com/DataDog/datadog-agent/pull/50424)**

Allow the user to set knobs for config storage. Specifying these values in the conf.yaml would look like:
```
init_config:
  namespace: "someNamspace"
  min_collection_interval: 1234

  ssh:
    known_hosts_path: "/some/path"
    timeout: 1234

  store:
    min_configs_per_device: 3       
    max_configs_per_device: 100     
    max_raw_config_store_bytes: 100000000
```

Default values for these knobs were determined from the base calculations outlined in the rollback RFC.

Similar to the SSHConfig validation step - if there is a configuration that is invalid, we set the value to the default. 
- **Question: is this expected behavior? Or - should we stop the check/prompt the user to update their config file?**

### Motivation

[Jira Ticket](https://datadoghq.atlassian.net/browse/NDINT-503?selectedIssue=NDINT-563)

### Additional Notes

### Local Validation

/datadog-agent/dev/dist/conf.d/network_config_management.d/conf.yaml
```
init_config:
  min_collection_interval: 60
  namespace: default
  ssh:
    insecure_skip_verify: true
    timeout: 120
  store:
    min_configs_per_device: 50
    max_configs_per_device: 100
    max_raw_config_store_bytes: 500000000

```

/datadog-agent/dev/dist/datadog.yaml
```
api_key: "***"
dd_url: 'https://dd.datad0g.com/'
hostname: "sophie-local"
process_config:
  process_collection:
    enabled: true

```

```
dda inv -e agent.build

./bin/agent/agent run -c ./bin/agent/dist/datadog.yaml
```

<img width="724" height="100" alt="Screenshot 2026-04-28 at 10 02 05 AM" src="https://github.com/user-attachments/assets/5dedfab4-a71e-43b5-8b94-22a35919b458" />

### Command to run unit testing
`dda inv test --targets=./pkg/networkconfigmanagement/config`

### AI Agent Use

<details>
<summary>Initial Claude prompt</summary>

Ok, similar to how ssh can be configures, I want a user to be able to configure values for the db store that we will host on the agent. I want to include 3 kobs for the client. min_configs_per_device (K), max_configs_per_device_total (N), and max_raw_config_store_bytes (B). Help me write the code that will read these configs from the correct .yaml file, and give me an example of what it would look like to set these configurations.

</details>