### PR TITLE
[ AGNTLOG-617 ] Fix anchored log_processing_rules broken by DetectingAggregator missing TrimSpace

### DIFF
--- a/pkg/logs/internal/decoder/auto_multiline_handler_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler_test.go
@@ -246,11 +246,11 @@ func TestAutoMultilineHandler_DetectionOnlyMode_MultilineTagged(t *testing.T) {
 	assert.Contains(t, msg1.ParsingExtra.Tags, "auto_multiline_detected:true", "First line should be tagged")
 
 	msg2 := <-outputChan
-	assert.Equal(t, []byte(`  at com.example.MyClass.method1(MyClass.java:123)`), msg2.GetContent())
+	assert.Equal(t, []byte(`at com.example.MyClass.method1(MyClass.java:123)`), msg2.GetContent())
 	assert.Empty(t, msg2.ParsingExtra.Tags, "Continuation line should not have tags")
 
 	msg3 := <-outputChan
-	assert.Equal(t, []byte(`  at com.example.MyClass.method2(MyClass.java:456)`), msg3.GetContent())
+	assert.Equal(t, []byte(`at com.example.MyClass.method2(MyClass.java:456)`), msg3.GetContent())
 	assert.Empty(t, msg3.ParsingExtra.Tags, "Continuation line should not have tags")
 
 	// Next single-line log should not be tagged
@@ -274,7 +274,7 @@ func TestAutoMultilineHandler_DetectionOnlyMode_TwoLineGroup(t *testing.T) {
 	assert.Contains(t, msg1.ParsingExtra.Tags, "auto_multiline_detected:true")
 
 	msg2 := <-outputChan
-	assert.Equal(t, []byte(`  continuation line`), msg2.GetContent())
+	assert.Equal(t, []byte(`continuation line`), msg2.GetContent())
 	assert.Empty(t, msg2.ParsingExtra.Tags, "Continuation line should not have tags")
 
 	// Verify no more messages
@@ -307,7 +307,7 @@ func TestAutoMultilineHandler_DetectionOnlyMode_MixedLogs(t *testing.T) {
 	assert.Contains(t, msg2.ParsingExtra.Tags, "auto_multiline_detected:true")
 
 	msg3 := <-outputChan
-	assert.Equal(t, []byte(`  continuation`), msg3.GetContent())
+	assert.Equal(t, []byte(`continuation`), msg3.GetContent())
 	assert.Empty(t, msg3.ParsingExtra.Tags, "Continuation line should not have tags")
 
 	// Second single line - not tagged

--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -390,18 +390,18 @@ func TestDetectingAggregator_TagsMultilineStartOnly(t *testing.T) {
 	// startGroup: stored as pending, nothing emitted
 	require.Empty(t, processMsg(ag, newMessage("Error: Exception"), startGroup))
 
-	// First aggregate: emits tagged startGroup + current line
+	// First aggregate: emits tagged startGroup + current line (leading spaces trimmed)
 	msgs := processMsg(ag, newMessage("  at line 1"), aggregate)
 	require.Len(t, msgs, 2)
 	assert.Equal(t, "Error: Exception", string(msgs[0].GetContent()))
 	assert.Contains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
-	assert.Equal(t, "  at line 1", string(msgs[1].GetContent()))
+	assert.Equal(t, "at line 1", string(msgs[1].GetContent()))
 	assert.NotContains(t, msgs[1].ParsingExtra.Tags, "auto_multiline_detected:true")
 
-	// Subsequent aggregate: emitted immediately without tags
+	// Subsequent aggregate: emitted immediately without tags (leading spaces trimmed)
 	msgs = processMsg(ag, newMessage("  at line 2"), aggregate)
 	require.Len(t, msgs, 1)
-	assert.Equal(t, "  at line 2", string(msgs[0].GetContent()))
+	assert.Equal(t, "at line 2", string(msgs[0].GetContent()))
 	assert.NotContains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
 }
 
@@ -461,12 +461,12 @@ func TestDetectingAggregator_MixedSingleAndMultiLine(t *testing.T) {
 	assert.Equal(t, "Single", string(msgs[0].GetContent()))
 	assert.NotContains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
 
-	// aggregate: tags "Multi start" and emits + continuation
+	// aggregate: tags "Multi start" and emits + continuation (leading spaces trimmed)
 	msgs = processMsg(ag, newMessage("  continuation"), aggregate)
 	require.Len(t, msgs, 2)
 	assert.Equal(t, "Multi start", string(msgs[0].GetContent()))
 	assert.Contains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
-	assert.Equal(t, "  continuation", string(msgs[1].GetContent()))
+	assert.Equal(t, "continuation", string(msgs[1].GetContent()))
 	assert.NotContains(t, msgs[1].ParsingExtra.Tags, "auto_multiline_detected:true")
 
 	// Another single line stored
@@ -572,6 +572,73 @@ func TestDetectingAggregator_UsesExistingTruncatedFlag(t *testing.T) {
 }
 
 // COAT telemetry tests
+
+// AGNTLOG-617: The DetectingAggregator must TrimSpace content just like SingleLineHandler,
+// PassThroughAggregator, and CombiningAggregator do. Without TrimSpace, trailing \r from
+// CRLF line endings (or other trailing whitespace) breaks anchored log_processing_rules
+// like ^\{.*\}$ because the anchor can't match past the trailing bytes.
+func TestDetectingAggregator_TrimSpaceMatchesOtherAggregators(t *testing.T) {
+	jsonPattern := regexp.MustCompile(`^\{.*\}$`)
+
+	testCases := []struct {
+		name    string
+		content string
+		label   Label
+	}{
+		{"trailing CR (noAggregate)", `{"key":"val"}` + "\r", noAggregate},
+		{"trailing space (noAggregate)", `{"key":"val"}` + " ", noAggregate},
+		{"trailing tab (noAggregate)", `{"key":"val"}` + "\t", noAggregate},
+		{"leading space (noAggregate)", " " + `{"key":"val"}`, noAggregate},
+		{"leading+trailing whitespace (noAggregate)", " \t" + `{"key":"val"}` + "\r ", noAggregate},
+		{"trailing CR (aggregate)", `{"key":"val"}` + "\r", aggregate},
+		{"trailing CR (startGroup then flush)", `{"key":"val"}` + "\r", startGroup},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
+
+			var msgs []*message.Message
+			msgs = processMsg(ag, newMessage(tc.content), tc.label)
+			if tc.label == startGroup {
+				require.Empty(t, msgs)
+				msgs = flushMsgs(ag)
+			}
+			require.Len(t, msgs, 1)
+
+			emitted := string(msgs[0].GetContent())
+			assert.True(t, jsonPattern.MatchString(emitted),
+				"anchored pattern should match trimmed content %q but got %q", `{"key":"val"}`, emitted)
+			assert.Equal(t, `{"key":"val"}`, emitted,
+				"content should be trimmed to match SingleLineHandler / PassThroughAggregator behavior")
+		})
+	}
+}
+
+// Verify that PassThroughAggregator and CombiningAggregator already handle trailing
+// whitespace correctly (they call bytes.TrimSpace), serving as the baseline.
+func TestPassThroughAndCombiningAggregator_TrimSpaceBaseline(t *testing.T) {
+	jsonPattern := regexp.MustCompile(`^\{.*\}$`)
+	contentWithCR := `{"key":"val"}` + "\r"
+
+	t.Run("PassThroughAggregator", func(t *testing.T) {
+		ag := NewPassThroughAggregator(100)
+		msgs := processMsg(ag, newMessage(contentWithCR), noAggregate)
+		require.Len(t, msgs, 1)
+		emitted := string(msgs[0].GetContent())
+		assert.True(t, jsonPattern.MatchString(emitted),
+			"PassThroughAggregator should trim; got %q", emitted)
+	})
+
+	t.Run("CombiningAggregator_noAggregate", func(t *testing.T) {
+		ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
+		msgs := processMsg(ag, newMessage(contentWithCR), noAggregate)
+		require.Len(t, msgs, 1)
+		emitted := string(msgs[0].GetContent())
+		assert.True(t, jsonPattern.MatchString(emitted),
+			"CombiningAggregator should trim; got %q", emitted)
+	})
+}
 
 func TestDetectingAggregator_COATTelemetry_WouldCombine(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 1000, false, true)

--- a/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
+++ b/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
@@ -6,6 +6,8 @@
 package preprocessor
 
 import (
+	"bytes"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
@@ -191,6 +193,8 @@ func (d *detectingAggregator) emit(msg *message.Message, tokens []Token) {
 	lastWasTruncated := d.shouldTruncate
 	content := msg.GetContent()
 	d.shouldTruncate = len(content) > d.maxContentSize || msg.ParsingExtra.IsTruncated
+
+	content = bytes.TrimSpace(content)
 
 	if lastWasTruncated {
 		content = append(message.TruncatedFlag, content...)

--- a/releasenotes/notes/fix-detecting-aggregator-trimspace-7ecb2f7b0e2137e9.yaml
+++ b/releasenotes/notes/fix-detecting-aggregator-trimspace-7ecb2f7b0e2137e9.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix a regression introduced in Agent 7.76 where anchored ``log_processing_rules``
+    (using ``^`` and ``$``) stopped matching log lines. This was caused by the new
+    default auto-multiline detection tagging path not trimming trailing whitespace
+    from log content before forwarding it to processing rules.


### PR DESCRIPTION
### What does this PR do?

Adds a missing `bytes.TrimSpace(content)` call to the `detectingAggregator.emit()` method, aligning it with every other line handler and aggregator in the decoder pipeline.

The `DetectingAggregator` was introduced in 7.76 (PR #44030) as the default line handler when `auto_multi_line_detection_tagging` is `true` (which it is by default). It was the **only** handler in the decoder that did not trim whitespace from message content before emitting. Every other path — `SingleLineHandler`, `PassThroughAggregator`, `CombiningAggregator`, `RegexAggregator`, and `MultiLineHandler` — calls `bytes.TrimSpace`.

Without the trim, trailing `\r` from CRLF line endings (or other trailing whitespace) breaks anchored regex patterns in `log_processing_rules` (e.g. `^\{.*\}$`), because the `$` anchor cannot match past the trailing bytes. This caused a customer regression where `include_at_match` and `exclude_at_match` rules stopped working after upgrading from 7.75 to 7.76+.

### Motivation

Customers using anchored `log_processing_rules` (with `^` and `$`) saw their rules silently stop matching after upgrading to Agent 7.76+. The `datadog-agent status` output showed "No rules applied" even though the rules were configured correctly. Removing the anchors restored matching but made patterns too broad.

The root cause: PR #44030 added `auto_multi_line_detection_tagging` (default `true`), which changed the default line handler from `SingleLineHandler` to `DetectingAggregator`. The new handler was missing the `bytes.TrimSpace` call that the old handler applied.

### Describe how you validated your changes

- Added `TestDetectingAggregator_TrimSpaceMatchesOtherAggregators` — 7 subtests covering trailing `\r`, space, tab, leading space, and mixed whitespace across all label types (`noAggregate`, `aggregate`, `startGroup`). Tests confirm the anchored regex `^\{.*\}$` now matches after trimming.
- Added `TestPassThroughAndCombiningAggregator_TrimSpaceBaseline` — baseline tests proving the other aggregators already trim correctly.
- Updated 2 existing tests whose expectations included leading whitespace that is now correctly trimmed.
- All 192 tests in the preprocessor package pass: `dda inv test --only-modified-packages`
- Linting clean: `dda inv linter.go --only-modified-packages`

[](https://datadoghq.atlassian.net/browse/AGNTLOG-617)