### PR TITLE
Migrate operators.go to bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -544,6 +544,7 @@ gazelle(
 gazelle_binary(
     name = "gazelle_binary",
     languages = DEFAULT_LANGUAGES + [
+        "//bazel/rules/cws_codegen:gazelle_extension",
         "//bazel/rules/go_build_tags:gazelle_extension",
         "//bazel/rules/go_stringer:gazelle_extension",
         "//bazel/rules/write_pb_go:gazelle_extension",

--- a/bazel/rules/cws_codegen/BUILD.bazel
+++ b/bazel/rules/cws_codegen/BUILD.bazel
@@ -1,1 +1,22 @@
-# Package marker so //bazel/rules/cws_codegen:defs.bzl resolves.
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@rules_go//go:def.bzl", "go_library")
+
+# strip the leading _ solely meant to prevent `go mod tidy` from adding @gazelle deps to the root go.mod
+copy_file(
+    name = "gazelle_extension_src",
+    src = "_gazelle_extension.go",
+    out = "gazelle_extension.go",
+)
+
+# prevent `bazel run //:gazelle` from removing @gazelle deps (reentrancy guard)
+# gazelle:ignore
+go_library(
+    name = "gazelle_extension",
+    srcs = [":gazelle_extension_src"],
+    importpath = "github.com/DataDog/datadog-agent/bazel/rules/cws_codegen",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@gazelle//language",
+        "@gazelle//rule",
+    ],
+)

--- a/bazel/rules/cws_codegen/BUILD.bazel
+++ b/bazel/rules/cws_codegen/BUILD.bazel
@@ -1,0 +1,1 @@
+# Package marker so //bazel/rules/cws_codegen:defs.bzl resolves.

--- a/bazel/rules/cws_codegen/_gazelle_extension.go
+++ b/bazel/rules/cws_codegen/_gazelle_extension.go
@@ -1,0 +1,133 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package cws_codegen registers a Gazelle language for the CWS codegen macros
+// declared in //bazel/rules/cws_codegen:defs.bzl.
+//
+// It scans `//go:generate <gen> ...` directives in regular .go files and emits
+// the matching macro call (currently: operators) into the package's BUILD.bazel.
+package cws_codegen
+
+import (
+	"bufio"
+	"flag"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+const name = "cws_codegen"
+
+type lang struct {
+	language.BaseLang
+}
+
+//goland:noinspection GoUnusedExportedFunction
+func NewLanguage() language.Language {
+	return &lang{}
+}
+
+func (*lang) Name() string {
+	return name
+}
+
+func (*lang) Kinds() map[string]rule.KindInfo {
+	return map[string]rule.KindInfo{
+		"operators": {
+			MatchAttrs:    []string{"output"},
+			NonEmptyAttrs: map[string]bool{"output": true},
+		},
+	}
+}
+
+func (*lang) KnownDirectives() []string {
+	return []string{name}
+}
+
+func (*lang) Loads() []rule.LoadInfo {
+	return []rule.LoadInfo{{
+		Name:    "//bazel/rules/cws_codegen:defs.bzl",
+		Symbols: []string{"operators"},
+	}}
+}
+
+func (*lang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
+	if args.File != nil {
+		for _, d := range args.File.Directives {
+			if d.Key == name && d.Value == "off" {
+				return language.GenerateResult{}
+			}
+		}
+	}
+	var rules []*rule.Rule
+	for _, f := range args.RegularFiles {
+		if !strings.HasSuffix(f, ".go") {
+			continue
+		}
+		directives, err := readDirectives(filepath.Join(args.Dir, f))
+		if err != nil {
+			continue
+		}
+		rules = append(rules, directives...)
+	}
+	if len(rules) == 0 {
+		return language.GenerateResult{}
+	}
+	return language.GenerateResult{
+		Gen:     rules,
+		Imports: make([]interface{}, len(rules)),
+	}
+}
+
+func readDirectives(src string) ([]*rule.Rule, error) {
+	f, err := os.Open(src)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	var directives []*rule.Rule
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		goGenerate, ok := strings.CutPrefix(scanner.Text(), "//go:generate ")
+		if !ok {
+			continue
+		}
+		if r := parseOperators(goGenerate); r != nil {
+			directives = append(directives, r)
+		}
+	}
+	return directives, scanner.Err()
+}
+
+func parseOperators(goGenerate string) *rule.Rule {
+	fields := strings.Fields(goGenerate)
+	var args []string
+	for i, f := range fields {
+		if path.Base(f) == "operators" {
+			args = fields[i+1:]
+			break
+		}
+	}
+	if args == nil {
+		return nil
+	}
+	fs := flag.NewFlagSet("operators", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	output := fs.String("output", "", "")
+	if err := fs.Parse(args); err != nil {
+		return nil
+	}
+	if *output == "" {
+		return nil
+	}
+	r := rule.NewRule("operators", strings.TrimSuffix(*output, ".go"))
+	r.SetAttr("output", *output)
+	return r
+}

--- a/bazel/rules/cws_codegen/defs.bzl
+++ b/bazel/rules/cws_codegen/defs.bzl
@@ -1,0 +1,34 @@
+"""CWS code generation macros.
+
+These macros wrap the per-generator binaries under //pkg/security/generators/...
+into hermetic Bazel actions whose outputs are written back into the source tree
+via `write_source_file`. They follow the same shape as
+//bazel/rules/go_stringer:defs.bzl.
+"""
+
+load("@bazel_lib//lib:run_binary.bzl", "run_binary")
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
+
+def _operators_impl(name, output, visibility):
+    gen = "{}_gen".format(name)
+    run_binary(
+        name = gen,
+        args = ["-output=$(execpath {}/{})".format(name, output)],
+        outs = ["{}/{}".format(name, output)],
+        tool = "//pkg/security/generators/operators",
+    )
+    native.exports_files([output], visibility)
+    write_source_file(
+        name = name,
+        in_file = ":{}".format(gen),
+        out_file = output,
+        check_that_out_file_exists = False,
+    )
+
+operators = macro(
+    implementation = _operators_impl,
+    doc = "Generate eval operators using //pkg/security/generators/operators and write the result back to the source tree.",
+    attrs = {
+        "output": attr.string(mandatory = True, configurable = False, doc = "Name of the generated .go file (e.g. eval_operators.go)."),
+    },
+)

--- a/pkg/security/generators/operators/operators.go
+++ b/pkg/security/generators/operators/operators.go
@@ -6,10 +6,11 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
+	"go/format"
 	"os"
-	"os/exec"
 	"text/template"
 )
 
@@ -315,10 +316,7 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, state *State) (*{{ 
 {{end}}
 `))
 
-	outputFile, err := os.Create(output)
-	if err != nil {
-		panic(err)
-	}
+	var buf bytes.Buffer
 
 	stdCompare := func(op string) func(a string, b string) string {
 		return func(a string, b string) string {
@@ -668,16 +666,16 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, state *State) (*{{ 
 		},
 	}
 
-	if err := tmpl.Execute(outputFile, data); err != nil {
+	if err := tmpl.Execute(&buf, data); err != nil {
 		panic(err)
 	}
 
-	if err := outputFile.Close(); err != nil {
+	formatted, err := format.Source(buf.Bytes())
+	if err != nil {
 		panic(err)
 	}
 
-	cmd := exec.Command("gofmt", "-s", "-w", output)
-	if err := cmd.Run(); err != nil {
+	if err := os.WriteFile(output, formatted, 0644); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/security/secl/compiler/eval/BUILD.bazel
+++ b/pkg/security/secl/compiler/eval/BUILD.bazel
@@ -1,4 +1,10 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("//bazel/rules/cws_codegen:defs.bzl", "operators")
+
+operators(
+    name = "eval_operators",
+    output = "eval_operators.go",
+)
 
 go_library(
     name = "eval",

--- a/pkg/security/secl/compiler/eval/BUILD.bazel
+++ b/pkg/security/secl/compiler/eval/BUILD.bazel
@@ -1,11 +1,6 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 load("//bazel/rules/cws_codegen:defs.bzl", "operators")
 
-operators(
-    name = "eval_operators",
-    output = "eval_operators.go",
-)
-
 go_library(
     name = "eval",
     srcs = [
@@ -85,4 +80,9 @@ go_test(
         ],
         "//conditions:default": [],
     }),
+)
+
+operators(
+    name = "eval_operators",
+    output = "eval_operators.go",
 )

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -525,13 +525,16 @@ def cws_go_generate(ctx, verbose=False):
     ctx.run("go install github.com/mailru/easyjson/easyjson")
     ctx.run("go install github.com/DataDog/datadog-agent/pkg/security/generators/accessors")
     ctx.run("go install github.com/DataDog/datadog-agent/pkg/security/generators/event_deep_copy")
-    ctx.run("go install github.com/DataDog/datadog-agent/pkg/security/generators/operators")
+    # operators codegen is driven by Bazel via //bazel/rules/cws_codegen:defs.bzl%operators.
+    # Run it first so eval_operators.go is fresh for subsequent generators, then skip
+    # the //go:generate directive in `go generate` calls below. See ABLD-420.
+    bazel(ctx, "run", "//pkg/security/secl/compiler/eval:eval_operators")
     with ctx.cd("./pkg/security/secl"):
         if sys.platform == "linux":
             ctx.run("GOOS=windows go generate -run=-tag.+windows ./...")
         elif is_windows:
             ctx.run('set "GOOS=linux" && go generate -run=-tag.+unix ./...')
-        cmd = "go generate"
+        cmd = "go generate -skip=operators"
         if verbose:
             cmd += " -v"
         ctx.run(cmd + " ./...")
@@ -544,7 +547,7 @@ def cws_go_generate(ctx, verbose=False):
 
     ctx.run("go generate ./pkg/security/probe/remediations_linux.go")
     ctx.run("go generate ./pkg/security/probe/custom_events.go")
-    ctx.run("go generate -tags=linux_bpf,cws_go_generate ./pkg/security/...")
+    ctx.run("go generate -skip=operators -tags=linux_bpf,cws_go_generate ./pkg/security/...")
 
     # synchronize the seclwin package from the secl package
     bazel(ctx, "run", "//pkg/security/seclwin:sync")


### PR DESCRIPTION
### What does this PR do?

First chunk of the [ABLD-420](https://datadoghq.atlassian.net/browse/ABLD-420) effort to move CWS codegens off the Python `cws_go_generate` task onto hermetic Bazel rules. This PR migrates the `operators` generator (`pkg/security/generators/operators`, output: `pkg/security/secl/compiler/eval/eval_operators.go`):

- **Hermetic generator.** `operators.go` now formats its output via the stdlib `go/format.Source`, removing the `exec.Command("gofmt", ...)` shell-out so the binary is fully self-contained.
- **Bazel macro.** New `operators(name, output)` macro under `//bazel/rules/cws_codegen:defs.bzl`. Runs the generator via `run_binary` and writes the result back into the source tree via `write_source_file`, which also emits an implicit `_diff_test` that fails if the checked-in file ever drifts.
- **Gazelle extension.** New language `cws_codegen` at `//bazel/rules/cws_codegen:gazelle_extension`. Scans `//go:generate operators -output ...` directives in Go source files and auto-emits the matching macro call in the package's `BUILD.bazel`. Registered in the root `gazelle_binary` so `bazel run //:gazelle -- update <pkg>` keeps things in sync. Same shape as `//bazel/rules/go_stringer` and `//bazel/rules/write_pb_go`.
- **Python task wiring.** `cws_go_generate` no longer `go install`s the `operators` binary. Instead it runs `bazel run //pkg/security/secl/compiler/eval:eval_operators` once, and adds `-skip=operators` to the surrounding `go generate ./...` invocations so the directive isn't doubled up. The `//go:generate operators -output eval_operators.go` line in `eval.go` stays — it's now the source of truth for the Gazelle extension.

### Motivation

Operators is the smallest, simplest CWS generator and is a good reference for the pattern (`run_binary` → `write_source_file` + Gazelle extension) that the rest of the codegens (`accessors`, `event_deep_copy`, `easyjson`, `bpf_maps_generator`, ...) will follow in subsequent PRs. Moving each generator to Bazel buys us:

- Hermeticity — no host `gofmt`, no `go install` of the generator binary on dev/CI machines.
- Cross-platform reproducibility — the macro runs identically on Linux, macOS, and Windows hosts.
- A `_diff_test` gate that catches drift in standard `bazel test //pkg/...` runs, eventually replacing the bespoke Python `go_generate_check` for this generator.

### Describe how you validated your changes

- `bazel build //pkg/security/generators/operators` and `bazel build //pkg/security/secl/compiler/eval:eval_operators_gen` succeed.
- `bazel test //pkg/security/secl/compiler/eval:eval_operators_diff_test` passes — the file produced by the Bazel action matches `eval_operators.go` checked in.
- `bazel test //pkg/security/secl/compiler/eval:eval_test` passes.
- Gazelle round-trip: removed the hand-written `operators(...)` block from `pkg/security/secl/compiler/eval/BUILD.bazel`, ran `bazel run //:gazelle -- update pkg/security/secl/compiler/eval`, confirmed gazelle re-emitted the rule with attrs identical to the hand-written version (including the `load(...)`).
- `bazel run //pkg/security/secl/compiler/eval:eval_operators` followed by `git diff --exit-code -- pkg/security/secl/compiler/eval/eval_operators.go` shows no drift.
- `bazel build //bazel/rules/cws_codegen:gazelle_extension //:gazelle_binary` succeed (the extension links cleanly into the gazelle binary).
- Locally on darwin_arm64: `bazel run //pkg/security/secl/compiler/eval:eval_operators` produces a byte-identical file — confirming the cross-platform claim.

### Additional Notes

- The `operators` Bazel target is intentionally **not** restricted via `target_compatible_with`. The generator is pure Go with no platform-specific code, and its output is host-independent. Restricting it would defeat the cross-platform win for no real benefit.
- `//bazel/rules/cws_codegen` is shared infrastructure for the upcoming codegen migrations — `accessors`, `event_deep_copy`, etc. will land as additional Kinds under the same Gazelle language and additional symbols in the same `defs.bzl`, each as its own follow-up PR for review tractability.
- Pre-existing drift in `pkg/security/secl/compiler/eval/BUILD.bazel`: re-running `gazelle update` on this directory (since #48373 changed Gazelle's `test`-tag handling on Apr 15) drops `strings_linux.go` from `go_library.srcs` because its build constraint `(linux && seclmax) || (linux && test)` is no longer satisfiable by recognized tags. **Out of scope here** — `srcs`/`deps` are manually preserved to match `HEAD`. Tracking a follow-up PR (likely `# gazelle:build_tags seclmax,test` or simplification of the source-file constraint).

[ABLD-420](https://datadoghq.atlassian.net/browse/ABLD-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[ABLD-420]: https://datadoghq.atlassian.net/browse/ABLD-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ABLD-420]: https://datadoghq.atlassian.net/browse/ABLD-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ