### PR TITLE
Try to not use LB by default, reducing resources load

### DIFF
--- a/test/e2e-framework/common/config/environment.go
+++ b/test/e2e-framework/common/config/environment.go
@@ -212,7 +212,7 @@ func (e *CommonEnvironment) CommonNamer() namer.Namer {
 // Infra namespace
 
 func (e *CommonEnvironment) InfraShouldDeployFakeintakeWithLB() bool {
-	return e.GetBoolWithDefault(e.InfraConfig, DDInfraDeployFakeintakeWithLoadBalancer, true)
+	return e.GetBoolWithDefault(e.InfraConfig, DDInfraDeployFakeintakeWithLoadBalancer, false)
 }
 
 func (e *CommonEnvironment) InfraEnvironmentNames() []string {

--- a/test/e2e-framework/scenarios/aws/eks/run.go
+++ b/test/e2e-framework/scenarios/aws/eks/run.go
@@ -84,9 +84,6 @@ func RunWithEnv(ctx *pulumi.Context, awsEnv resourcesAws.Environment, env output
 			fakeintake.WithCPU(1024),
 			fakeintake.WithMemory(6144),
 		}
-		if awsEnv.GetCommonEnvironment().InfraShouldDeployFakeintakeWithLB() {
-			fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithLoadBalancer())
-		}
 
 		if fakeIntake, err = fakeintake.NewECSFargateInstance(awsEnv, "ecs", fakeIntakeOptions...); err != nil {
 			return err

--- a/test/e2e-framework/scenarios/aws/kindvm/run.go
+++ b/test/e2e-framework/scenarios/aws/kindvm/run.go
@@ -74,8 +74,6 @@ func RunWithEnv(ctx *pulumi.Context, awsEnv resAws.Environment, env outputs.Kube
 	var err error
 	var fakeIntake *fakeintakeComp.Fakeintake
 	if params.fakeintakeOptions != nil {
-		fakeintakeOpts := []fakeintake.Option{fakeintake.WithLoadBalancer()}
-		params.fakeintakeOptions = append(fakeintakeOpts, params.fakeintakeOptions...)
 		fakeIntake, err = fakeintake.NewECSFargateInstance(awsEnv, params.Name, params.fakeintakeOptions...)
 		if err != nil {
 			return err


### PR DESCRIPTION
### What does this PR do?

By default every fakeintake deployment comes with a load balancer target group. It is an important source of load on the AWS infrastructure, when we reach the maximum number of target group on a load balancer it creates error.
The load balancer was added in front of fakeintake because this is a best-practice. However it should not be required in a testing setup 

### Motivation

Simplify the infrastructure to avoid load issues

### Describe how you validated your changes

The green pipeline with all tests triggered

### Additional Notes
