### PR TITLE
remove now unneeded #keep comments.

### DIFF
--- a/comp/core/config/BUILD.bazel
+++ b/comp/core/config/BUILD.bazel
@@ -42,7 +42,7 @@ go_test(
         "params_test.go",
     ],
     embed = [":config"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//pkg/config/model",
         "//pkg/util/defaultpaths",

--- a/comp/core/ipc/httphelpers/BUILD.bazel
+++ b/comp/core/ipc/httphelpers/BUILD.bazel
@@ -22,7 +22,7 @@ go_test(
     name = "httphelpers_test",
     srcs = ["client_test.go"],
     embed = [":httphelpers"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//comp/core/config",
         "//comp/core/ipc/def",

--- a/comp/core/log/impl-trace/BUILD.bazel
+++ b/comp/core/log/impl-trace/BUILD.bazel
@@ -19,7 +19,7 @@ go_test(
     name = "impl-trace_test",
     srcs = ["trace_logger_test.go"],
     embed = [":impl-trace"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//comp/core/log/def",
         "//comp/def",

--- a/comp/core/log/impl/BUILD.bazel
+++ b/comp/core/log/impl/BUILD.bazel
@@ -18,7 +18,7 @@ go_test(
     name = "impl_test",
     srcs = ["logger_test.go"],
     embed = [":impl"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//comp/core/log/def",
         "//comp/def",

--- a/comp/core/secrets/impl/BUILD.bazel
+++ b/comp/core/secrets/impl/BUILD.bazel
@@ -59,7 +59,7 @@ go_test(
     ],
     data = ["//comp/core/secrets/impl/test/src/test_command"],  # keep
     embed = [":impl"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//comp/core/secrets/def",
         "//comp/core/telemetry/def",

--- a/comp/core/status/statusimpl/BUILD.bazel
+++ b/comp/core/status/statusimpl/BUILD.bazel
@@ -43,7 +43,7 @@ go_test(
         "status_test.go",
     ],
     embed = [":statusimpl"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//comp/core/config",
         "//comp/core/log/def",

--- a/comp/forwarder/defaultforwarder/BUILD.bazel
+++ b/comp/forwarder/defaultforwarder/BUILD.bazel
@@ -69,7 +69,7 @@ go_test(
         "worker_test.go",
     ],
     embed = [":defaultforwarder"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//comp/core/config",
         "//comp/core/log/def",

--- a/comp/forwarder/defaultforwarder/internal/retry/BUILD.bazel
+++ b/comp/forwarder/defaultforwarder/internal/retry/BUILD.bazel
@@ -48,7 +48,7 @@ go_test(
         "transaction_retry_queue_test.go",
     ],
     embed = [":retry"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//comp/core/log/def",
         "//comp/core/log/mock",

--- a/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
+++ b/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
@@ -23,7 +23,7 @@ go_test(
     name = "resolver_test",
     srcs = ["domain_resolver_test.go"],
     embed = [":resolver"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//comp/core/log/mock",
         "//pkg/config/mock",

--- a/comp/forwarder/defaultforwarder/transaction/BUILD.bazel
+++ b/comp/forwarder/defaultforwarder/transaction/BUILD.bazel
@@ -28,7 +28,7 @@ go_test(
         "transaction_test.go",
     ],
     embed = [":transaction"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//comp/core/log/def",
         "//comp/core/log/mock",

--- a/comp/logs/agent/config/BUILD.bazel
+++ b/comp/logs/agent/config/BUILD.bazel
@@ -42,7 +42,7 @@ go_test(
         "processing_rules_test.go",
     ],
     embed = [":config"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//comp/core/config",
         "//pkg/config/model",

--- a/comp/snmptraps/packet/BUILD.bazel
+++ b/comp/snmptraps/packet/BUILD.bazel
@@ -15,6 +15,6 @@ go_test(
     name = "packet_test",
     srcs = ["packet_test.go"],
     embed = [":packet"],
-    gotags = ["test"],  # keep (needed for test_helpers.go's //go:build test)
+    gotags = ["test"],
     deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/pkg/api/security/BUILD.bazel
+++ b/pkg/api/security/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
     name = "security_test",
     srcs = ["security_test.go"],
     embed = [":security"],
-    gotags = ["test"],  # keep: pkg/config/nodetreemodel SetWithoutSource / assert_testonly
+    gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:aix": [
             "//pkg/config/mock",

--- a/pkg/api/security/cert/BUILD.bazel
+++ b/pkg/api/security/cert/BUILD.bazel
@@ -26,7 +26,7 @@ go_test(
         "cert_getter_test.go",
     ],
     embed = [":cert"],
-    gotags = ["test"],  # keep: pkg/config/nodetreemodel SetWithoutSource / assert_testonly
+    gotags = ["test"],
     deps = [
         "//pkg/config/mock",
         "//pkg/config/model",

--- a/pkg/config/nodetreemodel/BUILD.bazel
+++ b/pkg/config/nodetreemodel/BUILD.bazel
@@ -39,7 +39,7 @@ go_test(
         "reflection_node_test.go",
     ],
     embed = [":nodetreemodel"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//pkg/config/helper",
         "//pkg/config/model",

--- a/pkg/config/remote/api/BUILD.bazel
+++ b/pkg/config/remote/api/BUILD.bazel
@@ -19,7 +19,7 @@ go_test(
     name = "api_test",
     srcs = ["http_test.go"],
     embed = [":api"],
-    gotags = ["test"],  # keep: pkg/config/nodetreemodel SetWithoutSource / assert_testonly
+    gotags = ["test"],
     deps = [
         "//pkg/config/mock",
         "@com_github_coreos_go_semver//semver",

--- a/pkg/config/remote/service/BUILD.bazel
+++ b/pkg/config/remote/service/BUILD.bazel
@@ -42,7 +42,7 @@ go_test(
         "util_test.go",
     ],
     embed = [":service"],
-    gotags = ["test"],  # keep: pkg/config/nodetreemodel SetWithoutSource / assert_testonly
+    gotags = ["test"],
     deps = [
         "//pkg/config/mock",
         "//pkg/config/remote/api",

--- a/pkg/config/remote/uptane/BUILD.bazel
+++ b/pkg/config/remote/uptane/BUILD.bazel
@@ -38,7 +38,7 @@ go_test(
         "util_test.go",
     ],
     embed = [":uptane"],
-    gotags = ["test"],  # keep: pkg/config/nodetreemodel SetWithoutSource / assert_testonly
+    gotags = ["test"],
     deps = [
         "//pkg/config/mock",
         "//pkg/config/model",

--- a/pkg/trace/log/BUILD.bazel
+++ b/pkg/trace/log/BUILD.bazel
@@ -16,6 +16,6 @@ go_test(
     name = "log_test",
     srcs = ["throttled_test.go"],
     embed = [":log"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/pkg/trace/watchdog/BUILD.bazel
+++ b/pkg/trace/watchdog/BUILD.bazel
@@ -71,7 +71,7 @@ go_test(
         "logonpanic_test.go",
     ],
     embed = [":watchdog"],
-    gotags = ["test"],  # keep: log.NewBufferLogger in pkg/trace/log/buflogger.go
+    gotags = ["test"],
     deps = [
         "//pkg/trace/log",
         "@com_github_datadog_datadog_go_v5//statsd",

--- a/pkg/util/fxutil/BUILD.bazel
+++ b/pkg/util/fxutil/BUILD.bazel
@@ -39,7 +39,7 @@ go_test(
         "test_test.go",
     ],
     embed = [":fxutil"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//comp/def",
         "@com_github_stretchr_testify//assert",

--- a/pkg/util/grpc/BUILD.bazel
+++ b/pkg/util/grpc/BUILD.bazel
@@ -45,7 +45,7 @@ go_test(
     name = "grpc_test",
     srcs = ["agent_client_test.go"],
     embed = [":grpc"],
-    gotags = ["test"],  # keep: log.Default from pkg/util/log; nodetreemodel test-only assert
+    gotags = ["test"],
     deps = [
         "//pkg/util/log",
         "@com_github_stretchr_testify//assert",

--- a/pkg/util/log/setup/BUILD.bazel
+++ b/pkg/util/log/setup/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
         "split_writer_test.go",
     ],
     embed = [":setup"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//pkg/config/setup",
         "//pkg/util/log",

--- a/pkg/util/lsof/BUILD.bazel
+++ b/pkg/util/lsof/BUILD.bazel
@@ -42,7 +42,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":lsof"],
-    gotags = ["test"],  # keep - test_utils.go has //go:build test
+    gotags = ["test"],
     deps = [
         "@com_github_stretchr_testify//require",
     ] + select({

--- a/pkg/util/quantile/BUILD.bazel
+++ b/pkg/util/quantile/BUILD.bazel
@@ -40,7 +40,7 @@ go_test(
         "store_test.go",
     ],
     embed = [":quantile"],
-    gotags = ["test"],  # keep
+    gotags = ["test"],
     deps = [
         "//pkg/util/quantile/sketchtest",
         "//pkg/util/quantile/summary",

--- a/pkg/util/subscriptions/BUILD.bazel
+++ b/pkg/util/subscriptions/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
     name = "subscriptions_test",
     srcs = ["subscriptions_test.go"],
     embed = [":subscriptions"],
-    gotags = ["test"],  # keep - uses fxutil.Test which is behind //go:build test
+    gotags = ["test"],
     deps = [
         "//pkg/util/fxutil",
         "@com_github_stretchr_testify//require",

--- a/pkg/util/trie/BUILD.bazel
+++ b/pkg/util/trie/BUILD.bazel
@@ -11,6 +11,6 @@ go_test(
     name = "trie_test",
     srcs = ["trie_test.go"],
     embed = [":trie"],
-    gotags = ["test"],  # keep - trie.go is behind //go:build test
+    gotags = ["test"],
     deps = ["@com_github_stretchr_testify//assert"],
 )


### PR DESCRIPTION
### What does this PR do?

Remove `#keep` comment associated with enforcing `test` go build tags

### Motivation

Cleanup: the `test` build tag is now always added by a gazelle extension
https://datadoghq.atlassian.net/browse/ABLD-462

### Describe how you validated your changes

Local `bazel test //...` invocation & CI

### Additional Notes
