### PR TITLE
Use sysroot repo rule to reference the macos sdk

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -257,7 +257,7 @@ use_repo(
 # buildifier: leave-alone
 llvm.sysroot(
     name = "llvm_toolchain",
-    label = "@macos_sdk//sysroot:sysroot",
+    label = "@macos_sdk//sysroot",
     targets = [
         "darwin-aarch64",
         "darwin-x86_64",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -237,17 +237,12 @@ use_repo(gcc_toolchains, "gcc_toolchain_aarch64")
 
 bazel_dep(name = "toolchains_llvm", version = "1.6.0")
 
-http_archive(
+sysroot = use_repo_rule("@toolchains_llvm//toolchain:sysroot.bzl", "sysroot")
+
+sysroot(
     name = "macos_sdk",
-    build_file_content = """
-filegroup(
-    name = "sysroot",
-    srcs = glob(["**"], exclude = ["usr/share/man/**"]),
-    visibility = ["//visibility:public"],
-)
-""",
     sha256 = "c15cf0f3f17d714d1aa5a642da8e118db53d79429eb015771ba816aa7c6c1cbd",
-    strip_prefix = "MacOSX15.5.sdk",
+    strip_components = 1,
     url = "https://github.com/joseluisq/macosx-sdks/releases/download/15.5/MacOSX15.5.sdk.tar.xz",
 )
 
@@ -262,7 +257,7 @@ use_repo(
 # buildifier: leave-alone
 llvm.sysroot(
     name = "llvm_toolchain",
-    label = "@macos_sdk//:sysroot",
+    label = "@macos_sdk//sysroot:sysroot",
     targets = [
         "darwin-aarch64",
         "darwin-x86_64",


### PR DESCRIPTION
### What does this PR do?

It replaces how we get the macos sdk for the hermetic toolchain from http_archive to the sysroot repository rule.

toolchains_llvm got a `sysroot` repo rule in https://github.com/bazel-contrib/toolchains_llvm/pull/572, which reduces Bazel overhead by avoiding enumerating individual files, treating it as a directory instead.

### Motivation

After https://github.com/DataDog/datadog-agent/pull/42894, building anything printed this warning a couple of times:

```
DEBUG: /Users/alex.lopez/Library/Caches/bazel/_bazel_alex.lopez/7a4d107c5f8bd1c8a832a90593fd2c47/external/toolchains_llvm+/toolchain/internal/system_module_map.bzl:88:18: WARNING: Sysroot @@toolchains_llvm++llvm+llvm_toolchain//:sysroot-components-aarch64-darwin resolved to 50474 files. Consider using the `sysroot` repository rule in @toolchains_llvm//toolchain:sysroot.bzl which provides a single-file (directory) sysroot for more efficient builds.
```
([example from a job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1632523912#L84))

This was coming from https://github.com/bazel-contrib/toolchains_llvm/blob/2d71fbaf870a69cd6d0e4f6fc74326c8aa47a08b/toolchain/internal/system_module_map.bzl#L88.

### Describe how you validated your changes

Ran build commands locally and the warning disappeared. Builds are still green.

### Additional Notes
