### PR TITLE
Use buildbarn frontend for default remote cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -70,7 +70,7 @@ common:windows --extra_toolchains=@rust_toolchains//:rw-2070622084
 # Remote cache config --------------------------------------------------------------------------------------------------
 # datadog-agent virtually isolates caching instance from its parent (which is remote-caching).
 # If entry isn't found in datadog-agent, it will be searched in remote-caching.
-common:cache --remote_cache=grpcs://buildbarn-frontend.us1.ddbuild.io:443
+common:cache --remote_cache=grpcs://buildbarn-frontend-datadog-agent.us1.ddbuild.io:443
 common:cache --remote_instance_name=ci/datadog-agent
 common:cache --remote_local_fallback # best-effort on transient connection errors (no such host)
 common:cache --incompatible_remote_local_fallback_for_remote_cache # works only if --remote_local_fallback is also set

--- a/.bazelrc
+++ b/.bazelrc
@@ -70,7 +70,7 @@ common:windows --extra_toolchains=@rust_toolchains//:rw-2070622084
 # Remote cache config --------------------------------------------------------------------------------------------------
 # datadog-agent virtually isolates caching instance from its parent (which is remote-caching).
 # If entry isn't found in datadog-agent, it will be searched in remote-caching.
-common:cache --remote_cache=grpc://buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog:443
+common:cache --remote_cache=grpcs://buildbarn-frontend.us1.ddbuild.io:443
 common:cache --remote_instance_name=ci/datadog-agent
 common:cache --remote_local_fallback # best-effort on transient connection errors (no such host)
 common:cache --incompatible_remote_local_fallback_for_remote_cache # works only if --remote_local_fallback is also set
@@ -80,6 +80,7 @@ common:cache --remote_timeout=60
 # CI config ------------------------------------------------------------------------------------------------------------
 common:ci --config=adms
 common:ci --config=cache
+common:ci --remote_cache=grpc://buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog:443
 common:ci --config=lint
 common:ci --noexperimental_convenience_symlinks # not CI-suitable: "These symlinks are only for the user's convenience"
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -80,8 +80,10 @@ common:cache --remote_timeout=60
 # CI config ------------------------------------------------------------------------------------------------------------
 common:ci --config=adms
 common:ci --config=cache
-common:ci --remote_cache=grpc://buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog:443
 common:ci --config=lint
+# Opt-in override: only Linux CI runs in k8s and can reach the in-cluster edge cache.
+# tools/bazel adds `--config=ci-edge-cache` when `uname -s = Linux`.
+common:ci-edge-cache --remote_cache=grpc://buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog:443
 common:ci --noexperimental_convenience_symlinks # not CI-suitable: "These symlinks are only for the user's convenience"
 
 # Project/Language configs --------------------------------------------------------------------------------------

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -395,7 +395,7 @@
         "usagesDigest": "CKsn1dtme4oztWA0td45Tt6oCZK6MZnpIocVVZK14sU=",
         "recordedInputs": [
           "FILE:@@//.bazelversion 077ee5b3a3a7fc2622ceff6466fea0c28f3fb08b24653dcc7f4baab29b9aef36",
-          "FILE:@@//tools/bazel 1dae499bda6b507adc6a400d1118c997b363267f2b697bb16452e87023d95f55",
+          "FILE:@@//tools/bazel 8cd8e05bc6563f0ec312c10447f63c0d984f3bee34418ee07490e007f3ebfc3f",
           "FILE:@@//tools/bazel.bat 24c80eecf763cf0f70ef5919413247b8e3dbc9eecd41dd63bc21f7c461b8a010",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
         ],

--- a/tools/bazel
+++ b/tools/bazel
@@ -33,6 +33,8 @@ if [ -n "${XDG_CACHE_HOME-}" ]; then
   # https://github.com/bazelbuild/bazel/issues/26384
   [ "$XDG_CACHE_HOME" = "$(dirname "$(dirname "$0")")/.cache" ] && extra_args+=(--repo_contents_cache=)
   [ -n "${CI-}" ] && [ -z "${GITHUB_ACTIONS-}" ] && extra_args+=(--config=ci)
+  # Edge cache is only reachable from inside the k8s cluster (Linux CI runners).
+  [ -n "${CI-}" ] && [ -z "${GITHUB_ACTIONS-}" ] && [ "$(uname -s)" = Linux ] && extra_args+=(--config=ci-edge-cache)
 else
   # Without `XDG_CACHE_HOME`, fall back Go caches to official defaults so Go repo rules work under strict repo_env
   [ -z "${GOCACHE-}" ] && export GOCACHE=~/.cache/go-build


### PR DESCRIPTION
## Summary
- Default `common:cache --remote_cache` switched from the in-cluster edge cache (`grpc://buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog:443`) to the public buildbarn frontend (`grpcs://buildbarn-frontend.us1.ddbuild.io:443`).
- New opt-in `common:ci-edge-cache` config restores the edge endpoint, and `tools/bazel` enables it only on Linux CI (`uname -s = Linux`). macOS/Windows CI runners (and all dev machines) stay on the public frontend.

## Rationale
The edge cache is only reachable from inside the k8s cluster. Linux CI runs in k8s, so it gets the lower-latency in-cluster endpoint; macOS/Windows CI runners (and developer laptops/VMs) can't resolve `*.local-cluster.local-dc.fabric.dog` and would otherwise fail. Defaulting `--config=cache` to the public frontend makes remote caching usable everywhere, with the wrapper opting Linux CI back into the edge cache.
