### PR TITLE
test/new-e2e/tests/autoscaling/spot: add spot scheduling CI kind cluster e2e tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -848,6 +848,7 @@
 /test/new-e2e/tests/agent-subcommands/run*           @DataDog/agent-runtimes
 /test/new-e2e/tests/agent-subcommands/flare*          @DataDog/agent-configuration
 /test/new-e2e/tests/agent-subcommands/status*         @DataDog/agent-configuration
+/test/new-e2e/tests/autoscaling               @DataDog/container-autoscaling
 /test/new-e2e/tests/containers                @DataDog/container-integrations @DataDog/container-platform
 /test/new-e2e/tests/containers/cluster_agent_sgc_binary_test.go    @DataDog/agent-configuration
 /test/new-e2e/tests/containers/ecs_test.go    @DataDog/ecs-experiences

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1469,6 +1469,14 @@ workflow:
         - comp/core/autodiscovery/listeners/staticconfig.go
       compare_to: $COMPARE_TO_BRANCH
 
+.on_autoscaling_or_e2e_changes:
+  - !reference [.on_e2e_main_release_or_rc]
+  - changes:
+      paths:
+        - test/new-e2e/tests/autoscaling/**/*
+        - pkg/clusteragent/autoscaling/cluster/**/*
+      compare_to: $COMPARE_TO_BRANCH
+
 .on_gpu_integration_tests:
   - !reference [.on_scheduled_main]
   - !reference [.manual]

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -207,6 +207,7 @@ new-e2e-agent-health                    @DataDog/agent-health
 new-e2e-fips-compliance-test*           @DataDog/agent-runtimes
 new-e2e-remote-config                   @DataDog/remote-config
 # --- Containers / orchestration / SSI ---
+new-e2e-autoscaling*                    @DataDog/container-autoscaling
 new-e2e-containers*                     @DataDog/container-integrations @DataDog/container-platform
 new-e2e-orchestrator*                   @DataDog/kubernetes-experiences
 new-e2e-language-detection              @DataDog/container-experiences

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -1159,6 +1159,19 @@ new-e2e-gpu:
       - EXTRA_PARAMS: "--run TestGPUHostSuiteUbuntu1804Driver430" # This driver is not supported by the agent, but we can check that the agent does not crash. No need to test in k8s this one.
   retry: !reference [.retry_only_infra_failure, retry]
 
+new-e2e-autoscaling:
+  extends: .new_e2e_template
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - qa_dca
+  rules:
+    - !reference [.on_autoscaling_or_e2e_changes]
+    - !reference [.manual]
+  variables:
+    TARGETS: ./tests/autoscaling
+    TEAM: container-autoscaling
+  retry: !reference [.retry_only_infra_failure, retry]
+
 all-artifacts: # This job is used to collect all artifacts needed in the flake finder pipeline, because we are limited to 5 cross pipelines needs: https://forum.gitlab.com/t/needs-pipeline-job-limit-on-premise/88731
   stage: e2e
   tags: ["arch:amd64", "specific:true"]

--- a/test/e2e-framework/scenarios/aws/kindvm/run.go
+++ b/test/e2e-framework/scenarios/aws/kindvm/run.go
@@ -110,7 +110,9 @@ func RunWithEnv(ctx *pulumi.Context, awsEnv resAws.Environment, env outputs.Kube
 	if len(params.ciliumOptions) > 0 {
 		kindCluster, err = cilium.NewKindCluster(&awsEnv, host, params.Name, awsEnv.KubernetesVersion(), params.ciliumOptions, utils.PulumiDependsOn(installEcrCredsHelperCmd))
 	} else {
-		kindCluster, err = kubeComp.NewKindCluster(&awsEnv, host, params.Name, awsEnv.KubernetesVersion(), utils.PulumiDependsOn(installEcrCredsHelperCmd))
+		kindCluster, err = kubeComp.NewKindClusterWithConfig(&awsEnv, host, params.Name, awsEnv.KubernetesVersion(),
+			kubeComp.KindConfigFlags{WorkerNodes: params.workerNodes},
+			utils.PulumiDependsOn(installEcrCredsHelperCmd))
 	}
 
 	if err != nil {

--- a/test/e2e-framework/scenarios/aws/kindvm/run_args.go
+++ b/test/e2e-framework/scenarios/aws/kindvm/run_args.go
@@ -44,6 +44,10 @@ type RunParams struct {
 	// using raw Kubernetes resources instead of the Datadog Helm chart.
 	// See StandaloneAgentDeployFunc and WithStandaloneOTelAgent.
 	standaloneAgentFunc StandaloneAgentDeployFunc
+
+	// workerNodes configures the kind cluster worker nodes with custom labels and taints.
+	// When empty the cluster uses the default single worker node.
+	workerNodes []kubecomp.KindWorkerNode
 }
 
 type RunOption = func(*RunParams) error
@@ -60,6 +64,7 @@ func GetRunParams(opts ...RunOption) *RunParams {
 		operatorDDAOptions:  nil, // nil by default - DDA is only deployed when options are explicitly provided
 		deployDogstatsd:     false,
 		deployOperator:      false,
+		workerNodes:         []kubecomp.KindWorkerNode{},
 	}
 	if err := optional.ApplyOptions(p, opts); err != nil {
 		panic(fmt.Errorf("unable to apply RunOption, err: %w", err))
@@ -196,4 +201,13 @@ func WithOperatorOptions(opts ...operatorparams.Option) RunOption {
 // bypassing the Datadog Helm chart.
 func WithStandaloneOTelAgent(fn StandaloneAgentDeployFunc) RunOption {
 	return func(p *RunParams) error { p.standaloneAgentFunc = fn; return nil }
+}
+
+// WithKindWorkerNodes configures the kind cluster worker nodes with custom labels and taints.
+// Use this to test workloads that depend on node topology (e.g. spot vs on-demand capacity types).
+func WithKindWorkerNodes(nodes ...kubecomp.KindWorkerNode) RunOption {
+	return func(p *RunParams) error {
+		p.workerNodes = append(p.workerNodes, nodes...)
+		return nil
+	}
 }

--- a/test/new-e2e/tests/autoscaling/spot/suite_test.go
+++ b/test/new-e2e/tests/autoscaling/spot/suite_test.go
@@ -28,8 +28,10 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
 	kubeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
+	kindvmscen "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awskindvm "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
 	localkubernetes "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/local/kubernetes"
 )
 
@@ -57,12 +59,15 @@ const (
 	rebalanceStabilizationPeriod = 10 * time.Second
 )
 
-var helmValues = fmt.Sprintf(`
+// makeHelmValues returns the Helm values for the spot scheduling suite.
+// pullPolicy should be "Never" when the image is pre-loaded into kind (local dev)
+// or "IfNotPresent" when the image is pulled from a registry (CI).
+func makeHelmValues(pullPolicy string) string {
+	return fmt.Sprintf(`
 clusterAgent:
   enabled: true
   image:
-    # pre-loaded into kind via WithKindLoadImage; Never prevents pulling from a registry
-    pullPolicy: Never
+    pullPolicy: %s
   admissionController:
     enabled: true
     mutateUnlabelled: false
@@ -92,7 +97,20 @@ datadog:
     # the framework sets this to true by default, which unconditionally enables the
     # cluster checks runner deployment regardless of clusterChecksRunner.enabled
     useClusterCheckRunners: false
-`, scheduleTimeout, fallbackDuration, rebalanceStabilizationPeriod)
+`, pullPolicy, scheduleTimeout, fallbackDuration, rebalanceStabilizationPeriod)
+}
+
+// workerNodes defines the kind cluster topology required by the spot scheduling tests:
+// one on-demand worker and one spot worker with the interruptible taint.
+var workerNodes = []kubeComp.KindWorkerNode{
+	{
+		Labels: []kubeComp.Label{{Key: "karpenter.sh/capacity-type", Value: "on-demand"}},
+	},
+	{
+		Labels: []kubeComp.Label{{Key: "karpenter.sh/capacity-type", Value: "spot"}},
+		Taints: []kubeComp.Taint{{Key: "autoscaling.datadoghq.com/capacity-type", Value: "interruptible", Effect: "NoSchedule"}},
+	},
+}
 
 // rebalancingTimeout returns the expected duration to rebalance given number of spot pods.
 func rebalancingTimeout(spotPods int) time.Duration {
@@ -115,29 +133,36 @@ func TestSpotSchedulingKind(t *testing.T) {
 	if image == "" {
 		t.Skip("DD_TEST_CLUSTER_AGENT_IMAGE not set; skipping spot scheduling e2e tests")
 	}
+	e2e.Run(t, new(spotSchedulingSuite), e2e.WithProvisioner(localkubernetes.Provisioner(
+		localkubernetes.WithName(kindClusterName),
+		localkubernetes.WithKindWorkerNodes(workerNodes...),
+		localkubernetes.WithoutFakeIntake(),
+		localkubernetes.WithKindLoadImage(image),
+		localkubernetes.WithAgentOptions(
+			kubernetesagentparams.WithClusterAgentFullImagePath(image),
+			kubernetesagentparams.WithHelmValues(makeHelmValues("Never")),
+		),
+	)))
+}
 
-	workerNodes := []kubeComp.KindWorkerNode{
-		{
-			Labels: []kubeComp.Label{{Key: "karpenter.sh/capacity-type", Value: "on-demand"}},
-		},
-		{
-			Labels: []kubeComp.Label{{Key: "karpenter.sh/capacity-type", Value: "spot"}},
-			Taints: []kubeComp.Taint{{Key: "autoscaling.datadoghq.com/capacity-type", Value: "interruptible", Effect: "NoSchedule"}},
-		},
+// TestSpotSchedulingKindCI runs spot scheduling integration tests on a kind cluster
+// provisioned on AWS. The cluster-agent image is resolved automatically from the
+// qa_dca ECR image built by this pipeline (cluster-agent-qa:{E2E_PIPELINE_ID}-{E2E_COMMIT_SHA}).
+// Requires E2E_PIPELINE_ID to be set (provided by the standard .new_e2e_template CI job).
+func TestSpotSchedulingKindCI(t *testing.T) {
+	if os.Getenv("E2E_PIPELINE_ID") == "" {
+		t.Skip("E2E_PIPELINE_ID not set; this test is for CI use only")
 	}
-
-	e2e.Run(t, &spotSchedulingSuite{}, e2e.WithProvisioner(
-		localkubernetes.Provisioner(
-			localkubernetes.WithName(kindClusterName),
-			localkubernetes.WithKindWorkerNodes(workerNodes...),
-			localkubernetes.WithoutFakeIntake(),
-			localkubernetes.WithKindLoadImage(image),
-			localkubernetes.WithAgentOptions(
-				kubernetesagentparams.WithClusterAgentFullImagePath(image),
-				kubernetesagentparams.WithHelmValues(helmValues),
+	e2e.Run(t, new(spotSchedulingSuite), e2e.WithProvisioner(awskindvm.Provisioner(
+		awskindvm.WithRunOptions(
+			kindvmscen.WithName(kindClusterName),
+			kindvmscen.WithKindWorkerNodes(workerNodes...),
+			kindvmscen.WithoutFakeIntake(),
+			kindvmscen.WithAgentOptions(
+				kubernetesagentparams.WithHelmValues(makeHelmValues("IfNotPresent")),
 			),
 		),
-	))
+	)))
 }
 
 func (s *spotSchedulingSuite) SetupSuite() {


### PR DESCRIPTION
### What does this PR do?

Add a CI path for the spot scheduling e2e test suite using an AWS kindvm provisioner (kind running on an EC2 VM), alongside the existing local kind path.

### Motivation

The local-only e2e tests introduced in #48821 cannot catch regressions introduced on the main branch because they require a Docker daemon and a locally-built image — neither of which is available on CI pod runners. Running on AWS kindvm closes this gap: every change to the spot scheduler or its tests now triggers a real cluster verification automatically.

### Describe how you validated your changes

Newly added `new-e2e-autoscaling` pipeline passed.

### Additional Notes

- Add `TestSpotSchedulingKindCI` — skips unless `E2E_PIPELINE_ID` is set; uses the
  AWS kindvm provisioner with the `cluster-agent-qa` ECR image auto-resolved by the
  framework from pipeline/commit env vars.
- Extend `scenarios/aws/kindvm` with `workerNodes` support (`WithKindWorkerNodes`
  option + `NewKindClusterWithConfig` call) so the cloud kindvm path can provision
  spot/on-demand node topology, matching what `localkubernetes.Provisioner` already
  supported.
- Add `new-e2e-autoscaling` GitLab CI job (depends on `qa_dca` for the ECR
  image, `allow_failure: true`).
- Add `.on_autoscaling_or_e2e_changes` trigger rule covering the spot test
  directory and `pkg/clusteragent/autoscaling/cluster/`.

Updates https://datadoghq.atlassian.net/browse/CASCL-1222






