### PR TITLE
[AGENTRUN-1276] packaging/aix: set AIX_OBJECT_MODE=64 so gcc-8 uses 64-bit startup files

### DIFF
--- a/packaging/aix/lib/env.sh
+++ b/packaging/aix/lib/env.sh
@@ -76,8 +76,12 @@ CXX=/opt/freeware/bin/g++-8
 NM="/usr/bin/nm -X64"
 ARFLAGS="-X64 -cru"
 OBJECT_MODE=64
+# gcc-8 checks AIX_OBJECT_MODE (not OBJECT_MODE) for startup-file selection.
+# Without it, gcc-8 passes 32-bit /lib/crt0.o to ld, which ld running in
+# 64-bit mode rejects. AIX_OBJECT_MODE=64 makes gcc-8 use /lib/crt0_64.o.
+AIX_OBJECT_MODE=64
 
-export CC CXX NM ARFLAGS OBJECT_MODE
+export CC CXX NM ARFLAGS OBJECT_MODE AIX_OBJECT_MODE
 
 # ── Compiler/linker flags ─────────────────────────────────────────────────────
 # -I and -L always reference $EMBEDDED_DESTDIR (staging), not $EMBEDDED (final path).


### PR DESCRIPTION
### What does this PR do?

Adds `AIX_OBJECT_MODE=64` to `packaging/aix/lib/env.sh`, exported alongside `OBJECT_MODE=64`.

### Motivation

`go tool link` calls `IsDWARFEnabledOnAIXLd` (`cmd/internal/dwarf/dwarf.go`) which probes the external C linker with `$CC -Wl,-V`. The function expects the failure to be error `0711-317` (undefined symbol `.main` — normal when no input files are given). If it sees any other error it returns a hard failure and the link aborts.

With `CC=gcc-8` and only `OBJECT_MODE=64` set, the probe fails with:

```
ld: 0711-738 ERROR: Input file /lib/crt0.o:
    XCOFF32 object files are not allowed in 64-bit mode.
```

This is because gcc-8 checks `AIX_OBJECT_MODE` (not `OBJECT_MODE`) for startup-file selection. Without it, gcc-8 passes the 32-bit `/lib/crt0.o` to ld; ld running in 64-bit mode rejects it. Setting `AIX_OBJECT_MODE=64` makes gcc-8 use `/lib/crt0_64.o` instead, the probe produces the expected `0711-317`, and the check passes.

### Describe how you validated your changes

```sh
# Without fix:
OBJECT_MODE=64 /opt/freeware/bin/gcc-8 -Wl,-V 2>&1
# → ld: 0711-738 ERROR: Input file /lib/crt0.o: XCOFF32 not allowed in 64-bit mode

# With fix:
AIX_OBJECT_MODE=64 /opt/freeware/bin/gcc-8 -Wl,-V 2>&1
# → ld: 0711-317 ERROR: Undefined symbol: .main  ← expected, probe passes
```

Built the full AIX 7.80 package on AIX 7.3, installed on AIX 7.2 TL2. Agent and trace-agent are XCOFF64, agent runs correctly.

### Additional Notes

N/A