### PR TITLE
[AGENTRUN-1275] packaging/aix: remove --rebuild from inv agent.build

### DIFF
--- a/packaging/aix/stages/04-agent.sh
+++ b/packaging/aix/stages/04-agent.sh
@@ -108,7 +108,6 @@ log "Building agent binary via inv agent.build"
 cd /opt/datadog-agent
 rm -f "$STAGING/opt/datadog-agent/bin/agent/agent"
 python3.12 -m invoke agent.build \
-    --rebuild \
     --skip-assets \
     --exclude-rtloader \
     --rtloader-root=/opt/datadog-agent/rtloader \


### PR DESCRIPTION
### What does this PR do?

Removes `--rebuild` from the `inv agent.build` call in `packaging/aix/stages/04-agent.sh`.

### Motivation

`--rebuild` passes `-a` to `go build`, forcing a complete recompilation of all packages from scratch on every build. On the 4 GB AIX build host this causes multi-hour builds: the `aws-sdk-go-v2/service/ec2` package alone (one of the largest in the tree) can take over an hour to compile with `-a` due to constant page-faulting into swap.

Without `--rebuild`, `go build` uses the content-addressed build cache (`$GOCACHE`). Only packages whose source has actually changed are recompiled. The first build is equivalent to the old behavior; subsequent builds are dramatically faster.

### Describe how you validated your changes

Stage 04 on the AIX 7.3 build host completed in a few minutes (agent + trace-agent) vs sometimes hours before (with a little build host).

### Additional Notes

N/A