### PR TITLE
[AGENTRUN-1274] packaging/aix: add lparstats check to AIX package

### DIFF
--- a/packaging/aix/stages/08-integrations.sh
+++ b/packaging/aix/stages/08-integrations.sh
@@ -91,7 +91,7 @@ log "Built-in check configs copied"
 # ImportError at runtime if the missing native extension is not present on the
 # target system.
 
-PYTHON_CHECKS="openmetrics ibm_mq ibm_ace ibm_db2 ibm_i ibm_was ibm_spectrum_lsf"
+PYTHON_CHECKS="lparstats openmetrics ibm_mq ibm_ace ibm_db2 ibm_i ibm_was ibm_spectrum_lsf"
 
 log "Installing Python checks: $PYTHON_CHECKS"
 


### PR DESCRIPTION
### What does this PR do?

Adds `lparstats` to `PYTHON_CHECKS` in `packaging/aix/stages/08-integrations.sh`.

### Motivation

`lparstats` is an integrations-core Python check that collects IBM LPAR (Logical Partition) statistics via `lparstat`. It is AIX-specific, only depends on `datadog-checks-base` (already installed by stage 07), and ships with a default instance config so it runs without any operator configuration.

### Describe how you validated your changes

Installed the AIX package on an AIX 7.2 TL2 host. `agent status` shows `lparstats (0.1.0) [OK]` with 24 metric samples on the first collection.

### Additional Notes

N/A