### PR TITLE
Use os.makedirs in refresh_assets when building agent

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -252,9 +252,8 @@ def refresh_assets(_, build_tags, development=True, flavor=AgentFlavor.base.name
     Clean up and refresh Collector's assets and config files
     """
     flavor = AgentFlavor[flavor]
-    # ensure BIN_PATH exists
-    if not os.path.exists(BIN_PATH):
-        os.mkdir(BIN_PATH)
+    # ensure BIN_PATH exists (makedirs handles missing parents, e.g. on AIX build hosts)
+    os.makedirs(BIN_PATH, exist_ok=True)
 
     dist_folder = os.path.join(BIN_PATH, "dist")
     if os.path.exists(dist_folder):


### PR DESCRIPTION
### What does this PR do?

Replaces `os.mkdir(BIN_PATH)` with `os.makedirs(BIN_PATH, exist_ok=True)` in the `refresh_assets` invoke task (`tasks/agent.py`).

### Motivation

`os.mkdir` raises `FileNotFoundError` if any parent directory does not exist. On AIX build hosts the agent binary is written to a staging path via `--agent-bin`, so `./bin/` or `./bin/agent/` may not have been created by the time `refresh_assets` runs. `os.makedirs(exist_ok=True)` creates the full path regardless.

### Describe how you validated your changes

Reproduced the `FileNotFoundError: [Errno 2] No such file or directory: './bin/agent'` on an AIX build host and confirmed it is resolved by this change.

### Additional Notes

N/A