### PR TITLE
ci(workflows): trigger merge queue on dd-prapprover[bot] approval

### DIFF
--- a/.github/workflows/add-dependabot-pr-to-mq.yml
+++ b/.github/workflows/add-dependabot-pr-to-mq.yml
@@ -9,7 +9,7 @@ on:
 permissions: {}
 jobs:
   add_to_merge_queue:
-    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]' || github.event.review.user.login == 'dd-prapprover[bot]'
     runs-on: ubuntu-latest
     environment:
       name: dependabot

--- a/.github/workflows/add-dependabot-pr-to-mq.yml
+++ b/.github/workflows/add-dependabot-pr-to-mq.yml
@@ -23,6 +23,10 @@ jobs:
           scope: DataDog/datadog-agent
           policy: self.add-dependabot-pr-to-mq.comment-pr
       - name: Check if the PR is mergeable
+        # dd-prapprover[bot] has branch-protection bypass, so reviewDecision
+        # never reaches APPROVED for its reviews. Skip the check and let the
+        # merge comment step fire directly.
+        if: github.event.review.user.login != 'dd-prapprover[bot]'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: check-mergeable
         with:
@@ -50,7 +54,7 @@ jobs:
             return `${reviewDecision === 'APPROVED'}`;
           result-encoding: string
       - name: Add Merge Comment to Pull Request
-        if: ${{ steps.check-mergeable.outputs.result == 'true' }}
+        if: ${{ steps.check-mergeable.outputs.result == 'true' || (github.event.review.user.login == 'dd-prapprover[bot]' && github.event.review.state == 'approved') }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ steps.octo-sts.outputs.token }}


### PR DESCRIPTION
### What does this PR do?

Extends the `add_to_merge_queue` job in `.github/workflows/add-dependabot-pr-to-mq.yml` to also fire when a review is submitted by `dd-prapprover[bot]`, in addition to the existing dependabot/renovate-authored PR triggers.

The downstream GraphQL `reviewDecision == APPROVED` check still gates the `/merge` comment on all required reviewers having approved.

### Motivation

[PRApprover](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/5319362854/PR+Auto-Approver) (`dd-prapprover[bot]`) is the centralized auto-approval/auto-merge service from the SCM team. With this change, PRs approved by PRApprover are enqueued through the same `/merge` merge-queue path the repo already uses for dependency-bot PRs.

`dd-prapprover` is already in the branch-protection bypass list for this repo (handled by `#dx-source-code-management` per [the onboarding docs](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/5367693666/Use+Case+Onboarding)).

### Describe how you validated your changes

The change is a one-line condition extension. Behavior will be observed on the first PRApprover-approved PR after merge — the workflow run should appear under the PR's checks and post `/merge` once `reviewDecision` is `APPROVED`.

### Additional Notes

PRApprover normally merges PRs directly via its branch-protection bypass. On this repo we route through the merge queue instead, so the workflow posts `/merge` to enqueue rather than relying on direct merge.