### PR TITLE
[EBPF-1102] Stabilize DeviceEvents refresh sequence test

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
@@ -106,16 +106,12 @@ func TestDeviceEventsGatherer_RefreshGetSequence(t *testing.T) {
 	assert.Empty(t, events)
 
 	// after refreshing, the event should be present
-	require.Eventually(t, func() bool {
-		if err := gatherer.Refresh(); err != nil {
-			return false
-		}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.NoError(c, gatherer.Refresh())
 		events, err = gatherer.GetEvents(uuid)
-		if err != nil {
-			return false
-		}
-		return len(events) == 1
-	}, 2*time.Second, time.Millisecond)
+		require.NoError(c, err)
+		require.Len(c, events, 1)
+	}, 200*time.Millisecond, 2*time.Millisecond)
 	assert.Equal(t, safenvml.DeviceEventData{
 		DeviceUUID: uuid,
 		EventType:  sampleDeviceEvent.EventType,

--- a/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
@@ -106,10 +106,16 @@ func TestDeviceEventsGatherer_RefreshGetSequence(t *testing.T) {
 	assert.Empty(t, events)
 
 	// after refreshing, the event should be present
-	require.NoError(t, gatherer.Refresh())
-	events, err = gatherer.GetEvents(uuid)
-	require.NoError(t, err)
-	require.Len(t, events, 1)
+	require.Eventually(t, func() bool {
+		if err := gatherer.Refresh(); err != nil {
+			return false
+		}
+		events, err = gatherer.GetEvents(uuid)
+		if err != nil {
+			return false
+		}
+		return len(events) == 1
+	}, 2*time.Second, time.Millisecond)
 	assert.Equal(t, safenvml.DeviceEventData{
 		DeviceUUID: uuid,
 		EventType:  sampleDeviceEvent.EventType,


### PR DESCRIPTION
### What does this PR do?
Stabilizes `TestDeviceEventsGatherer_RefreshGetSequence` by removing a one-shot timing assumption between event production and cache refresh.

### Motivation
The test was flaky because it asserted immediately after a single `Refresh()` call while event ingestion happens asynchronously.

### Describe how you validated your changes
- Reproduced the flake before the change: `dda inv test --targets=./pkg/collector/corechecks/gpu/nvidia --extra-args='-run TestDeviceEventsGatherer_RefreshGetSequence -count=200'` (failed with `"[]" should have 1 item(s), but has 0`).
- Verified after the change with longer runs:
  - `-count=200` passed
  - `-count=2000` passed

### Additional Notes