### PR TITLE
[EBPF] aggregator: add distribution bucket sender API

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -123,29 +123,30 @@ var (
 	flushTimeStats    = make(map[string]*Stats)
 	flushCountStats   = make(map[string]*Stats)
 
-	aggregatorSeriesFlushed                    = expvar.Int{}
-	aggregatorSeriesFlushErrors                = expvar.Int{}
-	aggregatorServiceCheckFlushErrors          = expvar.Int{}
-	aggregatorServiceCheckFlushed              = expvar.Int{}
-	aggregatorSketchesFlushErrors              = expvar.Int{}
-	aggregatorSketchesFlushed                  = expvar.Int{}
-	aggregatorEventsFlushErrors                = expvar.Int{}
-	aggregatorEventsFlushed                    = expvar.Int{}
-	aggregatorNumberOfFlush                    = expvar.Int{}
-	aggregatorDogstatsdMetricSample            = expvar.Int{}
-	aggregatorChecksMetricSample               = expvar.Int{}
-	aggregatorCheckHistogramBucketMetricSample = expvar.Int{}
-	aggregatorServiceCheck                     = expvar.Int{}
-	aggregatorEvent                            = expvar.Int{}
-	aggregatorHostnameUpdate                   = expvar.Int{}
-	aggregatorOrchestratorMetadata             = expvar.Int{}
-	aggregatorOrchestratorMetadataErrors       = expvar.Int{}
-	aggregatorOrchestratorManifests            = expvar.Int{}
-	aggregatorOrchestratorManifestsErrors      = expvar.Int{}
-	aggregatorDogstatsdContexts                = expvar.Int{}
-	aggregatorDogstatsdContextsByMtype         = []expvar.Int{}
-	aggregatorEventPlatformEvents              = expvar.Map{}
-	aggregatorEventPlatformEventsErrors        = expvar.Map{}
+	aggregatorSeriesFlushed                       = expvar.Int{}
+	aggregatorSeriesFlushErrors                   = expvar.Int{}
+	aggregatorServiceCheckFlushErrors             = expvar.Int{}
+	aggregatorServiceCheckFlushed                 = expvar.Int{}
+	aggregatorSketchesFlushErrors                 = expvar.Int{}
+	aggregatorSketchesFlushed                     = expvar.Int{}
+	aggregatorEventsFlushErrors                   = expvar.Int{}
+	aggregatorEventsFlushed                       = expvar.Int{}
+	aggregatorNumberOfFlush                       = expvar.Int{}
+	aggregatorDogstatsdMetricSample               = expvar.Int{}
+	aggregatorChecksMetricSample                  = expvar.Int{}
+	aggregatorCheckHistogramBucketMetricSample    = expvar.Int{}
+	aggregatorCheckDistributionBucketMetricSample = expvar.Int{}
+	aggregatorServiceCheck                        = expvar.Int{}
+	aggregatorEvent                               = expvar.Int{}
+	aggregatorHostnameUpdate                      = expvar.Int{}
+	aggregatorOrchestratorMetadata                = expvar.Int{}
+	aggregatorOrchestratorMetadataErrors          = expvar.Int{}
+	aggregatorOrchestratorManifests               = expvar.Int{}
+	aggregatorOrchestratorManifestsErrors         = expvar.Int{}
+	aggregatorDogstatsdContexts                   = expvar.Int{}
+	aggregatorDogstatsdContextsByMtype            = []expvar.Int{}
+	aggregatorEventPlatformEvents                 = expvar.Map{}
+	aggregatorEventPlatformEventsErrors           = expvar.Map{}
 
 	tlmFlush = telemetryimpl.GetCompatComponent().NewCounter("aggregator", "flush",
 		[]string{"data_type", "state"}, "Number of metrics/service checks/events flushed")
@@ -208,6 +209,7 @@ func init() {
 	aggregatorExpvars.Set("DogstatsdMetricSample", &aggregatorDogstatsdMetricSample)
 	aggregatorExpvars.Set("ChecksMetricSample", &aggregatorChecksMetricSample)
 	aggregatorExpvars.Set("ChecksHistogramBucketMetricSample", &aggregatorCheckHistogramBucketMetricSample)
+	aggregatorExpvars.Set("ChecksDistributionBucketMetricSample", &aggregatorCheckDistributionBucketMetricSample)
 	aggregatorExpvars.Set("ServiceCheck", &aggregatorServiceCheck)
 	aggregatorExpvars.Set("Event", &aggregatorEvent)
 	aggregatorExpvars.Set("HostnameUpdate", &aggregatorHostnameUpdate)
@@ -478,6 +480,21 @@ func (agg *BufferedAggregator) handleSenderBucket(checkBucket senderHistogramBuc
 		checkSampler.addBucket(checkBucket.bucket, agg.tagFilterList)
 	} else {
 		log.Debugf("CheckSampler with ID '%s' doesn't exist, can't handle histogram bucket", checkBucket.id)
+	}
+}
+
+func (agg *BufferedAggregator) handleSenderDistributionBucket(checkBucket senderDistributionBucket) {
+	agg.mu.Lock()
+	defer agg.mu.Unlock()
+
+	aggregatorCheckDistributionBucketMetricSample.Add(1)
+	tlmProcessed.Inc("", "distribution_bucket")
+
+	if checkSampler, ok := agg.checkSamplers[checkBucket.id]; ok {
+		checkBucket.bucket.Tags = sort.UniqInPlace(checkBucket.bucket.Tags)
+		checkSampler.addDistributionBucket(checkBucket.bucket, agg.tagFilterList)
+	} else {
+		log.Debugf("CheckSampler with ID '%s' doesn't exist, can't handle distribution bucket", checkBucket.id)
 	}
 }
 

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -165,6 +165,59 @@ func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket, tagFilterList
 	cs.sketchMap.insertInterp(int64(bucket.Timestamp), contextKey, bucket.LowerBound, bucket.UpperBound, uint(bucket.Value))
 }
 
+func (cs *CheckSampler) addDistributionBucket(bucket *metrics.DistributionBucket, tagFilterList filterlist.TagMatcher) {
+	if bucket.Count <= 0 {
+		if !cs.logThrottling.ShouldThrottle() {
+			log.Warnf("Non-positive distribution bucket count %d for metric %s discarding", bucket.Count, bucket.Name)
+		}
+		return
+	}
+
+	if math.IsNaN(bucket.LowerBound) || math.IsNaN(bucket.UpperBound) {
+		if !cs.logThrottling.ShouldThrottle() {
+			log.Warnf(
+				"NaN distribution bucket range [%f-%f] for metric %s discarding",
+				bucket.LowerBound, bucket.UpperBound, bucket.Name,
+			)
+		}
+		return
+	}
+
+	if bucket.UpperBound < bucket.LowerBound {
+		if !cs.logThrottling.ShouldThrottle() {
+			log.Warnf(
+				"Negative distribution bucket range [%f-%f] for metric %s discarding",
+				bucket.LowerBound, bucket.UpperBound, bucket.Name,
+			)
+		}
+		return
+	}
+
+	if math.IsInf(bucket.LowerBound, -1) && math.IsInf(bucket.UpperBound, 1) {
+		if !cs.logThrottling.ShouldThrottle() {
+			log.Warnf(
+				"Unbounded distribution bucket range [%f-%f] for metric %s discarding",
+				bucket.LowerBound, bucket.UpperBound, bucket.Name,
+			)
+		}
+		return
+	}
+
+	contextKey := cs.contextResolver.trackContext(bucket, tagFilterList)
+
+	var representativeValue float64
+	switch {
+	case math.IsInf(bucket.UpperBound, 1):
+		representativeValue = bucket.LowerBound
+	case math.IsInf(bucket.LowerBound, -1):
+		representativeValue = bucket.UpperBound
+	default:
+		representativeValue = bucket.LowerBound
+	}
+
+	cs.sketchMap.insertN(int64(bucket.Timestamp), contextKey, representativeValue, uint(bucket.Count))
+}
+
 func (cs *CheckSampler) commitSeries(timestamp float64, filterList *utilstrings.Matcher) {
 
 	series, errors := cs.metrics.Flush(timestamp)

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -450,6 +450,12 @@ func sketchOf(lower, upper float64, count uint) *quantile.Sketch {
 	return s.Finish()
 }
 
+func sketchForValue(value float64, count uint) *quantile.Sketch {
+	s := quantile.Agent{}
+	s.InsertN(value, count)
+	return s.Finish()
+}
+
 func testCheckHistogramBucketInfinityBucket(t *testing.T, store *tags.Store) {
 	taggerComponent := nooptagger.NewComponent()
 	checkSampler := newCheckSampler(1, true, true, 1*time.Second, true, store, checkid.ID("hello:world:1234"), taggerComponent)
@@ -525,6 +531,138 @@ func testCheckDistribution(t *testing.T, store *tags.Store) {
 
 func TestCheckDistribution(t *testing.T) {
 	testWithTagsStore(t, testCheckDistribution)
+}
+
+func testCheckDistributionBucket(t *testing.T, store *tags.Store) {
+	taggerComponent := nooptagger.NewComponent()
+	checkSampler := newCheckSampler(1, true, true, 1*time.Second, true, store, checkid.ID("hello:world:1234"), taggerComponent)
+
+	tagmatcher := filterlistimpl.NewNoopTagMatcher()
+	bucket := &metrics.DistributionBucket{
+		Name:       "my.distribution.bucket",
+		Count:      4,
+		LowerBound: 10,
+		UpperBound: 20,
+		Tags:       []string{"foo", "bar"},
+		Timestamp:  12345.0,
+	}
+
+	checkSampler.addDistributionBucket(bucket, tagmatcher)
+	matcher := strings.NewMatcher([]string{}, false)
+	checkSampler.commit(12349.0, &matcher)
+
+	_, sketches := checkSampler.flush()
+	require.Len(t, sketches, 1)
+
+	expSketch := &quantile.Sketch{}
+	expSketch.InsertMany(quantile.Default(), []float64{10, 10, 10, 10})
+
+	metrics.AssertSketchSeriesEqual(t, &metrics.SketchSeries{
+		Name: "my.distribution.bucket",
+		Tags: tagset.CompositeTagsFromSlice([]string{"foo", "bar"}),
+		Points: []metrics.SketchPoint{
+			{Ts: 12345.0, Sketch: expSketch},
+		},
+		ContextKey: generateContextKey(bucket),
+	}, sketches[0])
+}
+
+func TestCheckDistributionBucket(t *testing.T) {
+	testWithTagsStore(t, testCheckDistributionBucket)
+}
+
+func testCheckDistributionBucketInfinityBounds(t *testing.T, store *tags.Store) {
+	taggerComponent := nooptagger.NewComponent()
+	checkSampler := newCheckSampler(1, true, true, 1*time.Second, true, store, checkid.ID("hello:world:1234"), taggerComponent)
+
+	tagmatcher := filterlistimpl.NewNoopTagMatcher()
+	matcher := strings.NewMatcher([]string{}, false)
+
+	upperInf := &metrics.DistributionBucket{
+		Name:       "dist.upper.inf",
+		Count:      3,
+		LowerBound: 9,
+		UpperBound: math.Inf(1),
+		Timestamp:  12345,
+	}
+	lowerInf := &metrics.DistributionBucket{
+		Name:       "dist.lower.inf",
+		Count:      2,
+		LowerBound: math.Inf(-1),
+		UpperBound: 7,
+		Timestamp:  12346,
+	}
+
+	checkSampler.addDistributionBucket(upperInf, tagmatcher)
+	checkSampler.addDistributionBucket(lowerInf, tagmatcher)
+
+	checkSampler.commit(12350, &matcher)
+	_, sketches := checkSampler.flush()
+	require.Len(t, sketches, 2)
+
+	metrics.AssertSketchSeriesEqual(t, &metrics.SketchSeries{
+		Name:       "dist.upper.inf",
+		ContextKey: generateContextKey(upperInf),
+		Points: []metrics.SketchPoint{
+			{Ts: 12345, Sketch: sketchForValue(9, 3)},
+		},
+	}, sketches[0])
+	metrics.AssertSketchSeriesEqual(t, &metrics.SketchSeries{
+		Name:       "dist.lower.inf",
+		ContextKey: generateContextKey(lowerInf),
+		Points: []metrics.SketchPoint{
+			{Ts: 12346, Sketch: sketchForValue(7, 2)},
+		},
+	}, sketches[1])
+}
+
+func TestCheckDistributionBucketInfinityBounds(t *testing.T) {
+	testWithTagsStore(t, testCheckDistributionBucketInfinityBounds)
+}
+
+func testCheckDistributionBucketInvalid(t *testing.T, store *tags.Store) {
+	taggerComponent := nooptagger.NewComponent()
+	checkSampler := newCheckSampler(1, true, true, 1*time.Second, true, store, checkid.ID("hello:world:1234"), taggerComponent)
+
+	tagmatcher := filterlistimpl.NewNoopTagMatcher()
+	matcher := strings.NewMatcher([]string{}, false)
+
+	checkSampler.addDistributionBucket(&metrics.DistributionBucket{
+		Name:       "invalid.zero.count",
+		Count:      0,
+		LowerBound: 1,
+		UpperBound: 2,
+		Timestamp:  12345,
+	}, tagmatcher)
+	checkSampler.addDistributionBucket(&metrics.DistributionBucket{
+		Name:       "invalid.nan",
+		Count:      1,
+		LowerBound: math.NaN(),
+		UpperBound: 2,
+		Timestamp:  12345,
+	}, tagmatcher)
+	checkSampler.addDistributionBucket(&metrics.DistributionBucket{
+		Name:       "invalid.order",
+		Count:      1,
+		LowerBound: 3,
+		UpperBound: 2,
+		Timestamp:  12345,
+	}, tagmatcher)
+	checkSampler.addDistributionBucket(&metrics.DistributionBucket{
+		Name:       "invalid.unbounded",
+		Count:      1,
+		LowerBound: math.Inf(-1),
+		UpperBound: math.Inf(1),
+		Timestamp:  12345,
+	}, tagmatcher)
+
+	checkSampler.commit(12349, &matcher)
+	_, sketches := checkSampler.flush()
+	assert.Empty(t, sketches)
+}
+
+func TestCheckDistributionBucketInvalid(t *testing.T) {
+	testWithTagsStore(t, testCheckDistributionBucketInvalid)
 }
 
 func testFilteredMetrics(t *testing.T, store *tags.Store) {

--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -55,6 +55,12 @@ func (m *MockSender) AssertHistogramBucket(t *testing.T, method string, metric s
 	return m.Mock.AssertCalled(t, method, metric, value, lowerBound, upperBound, monotonic, hostname, tags, flushFirstValue)
 }
 
+// AssertDistributionBucket allows to assert a distribution bucket was emitted with given parameters.
+// Additional tags over the ones specified don't make it fail.
+func (m *MockSender) AssertDistributionBucket(t *testing.T, method string, metric string, count int64, lowerBound float64, upperBound float64, hostname string, tags []string) bool {
+	return m.Mock.AssertCalled(t, method, metric, count, lowerBound, upperBound, hostname, tags)
+}
+
 // AssertMetricInRange allows to assert a metric was emitted with given parameters, with a value in a given range.
 // Additional tags over the ones specified don't make it fail
 func (m *MockSender) AssertMetricInRange(t *testing.T, method string, metric string, min float64, max float64, hostname string, tags []string) bool {

--- a/pkg/aggregator/mocksender/mocked_methods.go
+++ b/pkg/aggregator/mocksender/mocked_methods.go
@@ -68,6 +68,11 @@ func (m *MockSender) Distribution(metric string, value float64, hostname string,
 	m.Called(metric, value, hostname, m.tagsWithCheckTags(tags))
 }
 
+// DistributionBucket adds a distribution bucket call to the mock calls.
+func (m *MockSender) DistributionBucket(metric string, count int64, lowerBound, upperBound float64, hostname string, tags []string) {
+	m.Called(metric, count, lowerBound, upperBound, hostname, m.tagsWithCheckTags(tags))
+}
+
 // GaugeNoIndex adds a gauge type to the mock calls that is not indexed.
 func (m *MockSender) GaugeNoIndex(metric string, value float64, hostname string, tags []string) {
 	m.Called(metric, value, hostname, m.tagsWithCheckTags(tags))

--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -125,6 +125,14 @@ func (m *MockSender) SetupAcceptAll() {
 		mock.AnythingOfType("[]string"), // tags
 		mock.AnythingOfType("bool"),     // FlushFirstValue
 	).Return()
+	m.On("DistributionBucket",
+		mock.AnythingOfType("string"),   // metric name
+		mock.AnythingOfType("int64"),    // count
+		mock.AnythingOfType("float64"),  // lower bound
+		mock.AnythingOfType("float64"),  // upper bound
+		mock.AnythingOfType("string"),   // hostname
+		mock.AnythingOfType("[]string"), // tags
+	).Return()
 	m.On("GetSenderStats", mock.AnythingOfType("stats.SenderStats")).Return()
 	m.On("DisableDefaultHostname", mock.AnythingOfType("bool")).Return()
 	m.On("SetCheckCustomTags", mock.AnythingOfType("[]string")).Return()

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -70,6 +70,15 @@ func (s *senderHistogramBucket) handle(agg *BufferedAggregator) {
 	agg.handleSenderBucket(*s)
 }
 
+type senderDistributionBucket struct {
+	id     checkid.ID
+	bucket *metrics.DistributionBucket
+}
+
+func (s *senderDistributionBucket) handle(agg *BufferedAggregator) {
+	agg.handleSenderDistributionBucket(*s)
+}
+
 type senderEventPlatformEvent struct {
 	id        checkid.ID
 	rawEvent  []byte
@@ -308,6 +317,55 @@ func (s *checkSender) Historate(metric string, value float64, hostname string, t
 
 func (s *checkSender) Distribution(metric string, value float64, hostname string, tags []string) {
 	s.sendMetricSample(metric, value, hostname, tags, metrics.DistributionType, false, false, 0)
+}
+
+// DistributionBucket submits an explicit bucket into the distribution sketch path.
+//
+// Arguments:
+//   - metric: metric name
+//   - count: number of samples represented by this bucket; must be > 0
+//   - lowerBound: lower bound of the caller-provided bucket
+//   - upperBound: upper bound of the caller-provided bucket; must be >= lowerBound
+//   - hostname: optional host override
+//   - tags: metric tags
+//
+// Use this instead of HistogramBucket when explicit caller-provided buckets
+// should remain a single weighted insert in the sketch. HistogramBucket is meant
+// for Prometheus/OpenMetrics histogram buckets and interpolates counts across the
+// sketch's internal bins, which changes the caller-provided bucket shape.
+func (s *checkSender) DistributionBucket(metric string, count int64, lowerBound, upperBound float64, hostname string, tags []string) {
+	tags = append(tags, s.checkTags...)
+
+	log.Tracef(
+		"Distribution Bucket %s submitted: %v [%f-%f] for host %s tags: %v",
+		metric,
+		count,
+		lowerBound,
+		upperBound,
+		hostname,
+		tags,
+	)
+
+	distributionBucket := &metrics.DistributionBucket{
+		Name:       metric,
+		Count:      count,
+		LowerBound: lowerBound,
+		UpperBound: upperBound,
+		Host:       hostname,
+		Tags:       tags,
+		Timestamp:  timeNowNano(),
+		Source:     metrics.CheckNameToMetricSource(checkid.IDToCheckName(s.id)),
+	}
+
+	if hostname == "" && !s.defaultHostnameDisabled {
+		distributionBucket.Host = s.defaultHostname
+	}
+
+	s.itemsOut <- &senderDistributionBucket{s.id, distributionBucket}
+
+	s.statsLock.Lock()
+	s.metricStats.DistributionBuckets++
+	s.statsLock.Unlock()
 }
 
 // GaugeWithTimestamp reports a new gauge value to the intake with the given timestamp.

--- a/pkg/aggregator/sender/sender.go
+++ b/pkg/aggregator/sender/sender.go
@@ -27,6 +27,20 @@ type Sender interface {
 	Histogram(metric string, value float64, hostname string, tags []string)
 	Historate(metric string, value float64, hostname string, tags []string)
 	Distribution(metric string, value float64, hostname string, tags []string)
+	// DistributionBucket submits an explicit bucket into the distribution sketch path.
+	//
+	// Arguments:
+	//   - metric: metric name
+	//   - count: number of samples represented by this bucket; must be > 0
+	//   - lowerBound: lower bound of the caller-provided bucket
+	//   - upperBound: upper bound of the caller-provided bucket; must be >= lowerBound
+	//   - hostname: optional host override
+	//   - tags: metric tags
+	//
+	// Use this instead of HistogramBucket when the caller wants explicit bucket
+	// counts to map to one weighted sketch value, rather than being spread across
+	// multiple internal sketch bins by interpolation.
+	DistributionBucket(metric string, count int64, lowerBound, upperBound float64, hostname string, tags []string)
 	ServiceCheck(checkName string, status servicecheck.ServiceCheckStatus, hostname string, tags []string, message string)
 	HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool)
 	// GaugeWithTimestamp reports a new gauge value to the intake with the given timestamp.

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -48,7 +48,7 @@ type senderWithChans struct {
 }
 
 func initSender(id checkid.ID, defaultHostname string) (s senderWithChans) {
-	s.itemChan = make(chan senderItem, 10)
+	s.itemChan = make(chan senderItem, 16)
 	s.serviceCheckChan = make(chan servicecheck.ServiceCheck, 10)
 	s.eventChan = make(chan event.Event, 10)
 	s.orchestratorChan = make(chan senderOrchestratorMetadata, 10)
@@ -514,6 +514,31 @@ func TestGetSenderAddCheckCustomTagsHistogramBucket(t *testing.T) {
 	assert.Equal(t, append(checkTags, customTags...), bucketSample.bucket.Tags)
 }
 
+func TestGetSenderAddCheckCustomTagsDistributionBucket(t *testing.T) {
+	s := initSender(checkID1, "")
+
+	s.sender.DistributionBucket("my.distribution_bucket", 42, 1.0, 2.0, "my-hostname", nil)
+	bucketSample := (<-s.itemChan).(*senderDistributionBucket)
+	assert.Nil(t, bucketSample.bucket.Tags)
+
+	checkTags := []string{"check:tag1", "check:tag2"}
+	s.sender.DistributionBucket("my.distribution_bucket", 42, 1.0, 2.0, "my-hostname", checkTags)
+	bucketSample = (<-s.itemChan).(*senderDistributionBucket)
+	assert.Equal(t, checkTags, bucketSample.bucket.Tags)
+
+	customTags := []string{"custom:tag1", "custom:tag2"}
+	s.sender.SetCheckCustomTags(customTags)
+	assert.Len(t, s.sender.checkTags, 2)
+
+	s.sender.DistributionBucket("my.distribution_bucket", 42, 1.0, 2.0, "my-hostname", nil)
+	bucketSample = (<-s.itemChan).(*senderDistributionBucket)
+	assert.Equal(t, customTags, bucketSample.bucket.Tags)
+
+	s.sender.DistributionBucket("my.distribution_bucket", 42, 1.0, 2.0, "my-hostname", checkTags)
+	bucketSample = (<-s.itemChan).(*senderDistributionBucket)
+	assert.Equal(t, append(checkTags, customTags...), bucketSample.bucket.Tags)
+}
+
 func TestCheckSenderInterface(t *testing.T) {
 	// this test not using anything global
 	// -
@@ -528,6 +553,7 @@ func TestCheckSenderInterface(t *testing.T) {
 	s.sender.Histogram("my.histo_metric", 3.0, "my-hostname", []string{"foo", "bar"})
 	s.sender.HistogramBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", []string{"foo", "bar"}, true)
 	s.sender.Distribution("my.distribution", 43.0, "my-hostname", []string{"foo", "bar"})
+	s.sender.DistributionBucket("my.distribution_bucket", 44, 5.0, 7.0, "my-hostname", []string{"foo", "bar"})
 	s.sender.Commit()
 	s.sender.ServiceCheck("my_service.can_connect", servicecheck.ServiceCheckOK, "my-hostname", []string{"foo", "bar"}, "message")
 	s.sender.EventPlatformEvent([]byte("raw-event"), "dbm-sample")
@@ -595,6 +621,14 @@ func TestCheckSenderInterface(t *testing.T) {
 	assert.EqualValues(t, checkID1, distributionSample.id)
 	assert.Equal(t, metrics.DistributionType, distributionSample.metricSample.Mtype)
 	assert.Equal(t, false, distributionSample.commit)
+
+	distributionBucket := (<-s.itemChan).(*senderDistributionBucket)
+	assert.Equal(t, "my.distribution_bucket", distributionBucket.bucket.Name)
+	assert.Equal(t, int64(44), distributionBucket.bucket.Count)
+	assert.Equal(t, 5.0, distributionBucket.bucket.LowerBound)
+	assert.Equal(t, 7.0, distributionBucket.bucket.UpperBound)
+	assert.Equal(t, "my-hostname", distributionBucket.bucket.Host)
+	assert.Equal(t, []string{"foo", "bar"}, distributionBucket.bucket.Tags)
 
 	commitSenderSample := (<-s.itemChan).(*senderMetricSample)
 	assert.EqualValues(t, checkID1, commitSenderSample.id)

--- a/pkg/aggregator/sketch_map.go
+++ b/pkg/aggregator/sketch_map.go
@@ -35,6 +35,15 @@ func (m sketchMap) insert(ts int64, ck ckey.ContextKey, v float64, sampleRate fl
 	return true
 }
 
+func (m sketchMap) insertN(ts int64, ck ckey.ContextKey, v float64, count uint) bool {
+	if count == 0 || math.IsInf(v, 0) || math.IsNaN(v) {
+		return false
+	}
+
+	m.getOrCreate(ts, ck).InsertN(v, count)
+	return true
+}
+
 func (m sketchMap) insertInterp(ts int64, ck ckey.ContextKey, lower float64, upper float64, count uint) bool {
 	if math.IsInf(lower, 0) || math.IsNaN(lower) {
 		return false

--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -72,6 +72,8 @@ var (
 		[]string{"check_name"}, "Service checks count")
 	tlmHistogramBuckets = telemetryimpl.GetCompatComponent().NewCounter("checks", "histogram_buckets",
 		[]string{"check_name"}, "Histogram buckets count")
+	tlmDistributionBuckets = telemetryimpl.GetCompatComponent().NewCounter("checks", "distribution_buckets",
+		[]string{"check_name"}, "Distribution buckets count")
 	tlmExecutionTime = telemetryimpl.GetCompatComponent().NewGauge("checks", "execution_time",
 		[]string{"check_name", "check_loader"}, "Check execution time")
 	tlmCheckDelay = telemetryimpl.GetCompatComponent().NewGauge("checks",
@@ -89,10 +91,11 @@ var (
 
 // SenderStats contains statistics showing the count of various types of telemetry sent by a check sender
 type SenderStats struct {
-	MetricSamples    int64
-	Events           int64
-	ServiceChecks    int64
-	HistogramBuckets int64
+	MetricSamples       int64
+	Events              int64
+	ServiceChecks       int64
+	HistogramBuckets    int64
+	DistributionBuckets int64
 	// EventPlatformEvents tracks the number of events submitted for each eventType
 	EventPlatformEvents map[string]int64
 	// LongRunningCheck is a field that is only set for long running checks
@@ -134,10 +137,12 @@ type Stats struct {
 	Events                   int64
 	ServiceChecks            int64
 	HistogramBuckets         int64
+	DistributionBuckets      int64
 	TotalMetricSamples       uint64
 	TotalEvents              uint64
 	TotalServiceChecks       uint64
 	TotalHistogramBuckets    uint64
+	TotalDistributionBuckets uint64
 	EventPlatformEvents      map[string]int64
 	TotalEventPlatformEvents map[string]int64
 	ExecutionTimes           [32]int64     // circular buffer of recent run durations, most recent at [(TotalRuns+31) % 32]
@@ -280,6 +285,13 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats S
 		cs.TotalHistogramBuckets += uint64(metricStats.HistogramBuckets)
 		if cs.Telemetry {
 			tlmHistogramBuckets.Add(float64(metricStats.HistogramBuckets), cs.CheckName)
+		}
+	}
+	if metricStats.DistributionBuckets > 0 {
+		cs.DistributionBuckets = metricStats.DistributionBuckets
+		cs.TotalDistributionBuckets += uint64(metricStats.DistributionBuckets)
+		if cs.Telemetry {
+			tlmDistributionBuckets.Add(float64(metricStats.DistributionBuckets), cs.CheckName)
 		}
 	}
 	for k, v := range metricStats.EventPlatformEvents {

--- a/pkg/collector/corechecks/safesender.go
+++ b/pkg/collector/corechecks/safesender.go
@@ -89,6 +89,11 @@ func (ss *safeSender) HistogramBucket(metric string, value int64, lowerBound, up
 	ss.Sender.HistogramBucket(metric, value, lowerBound, upperBound, monotonic, hostname, cloneTags(tags), flushFirstValue)
 }
 
+// DistributionBucket implements sender.Sender#DistributionBucket.
+func (ss *safeSender) DistributionBucket(metric string, count int64, lowerBound, upperBound float64, hostname string, tags []string) {
+	ss.Sender.DistributionBucket(metric, count, lowerBound, upperBound, hostname, cloneTags(tags))
+}
+
 // SetCheckCustomTags implements sender.Sender#SetCheckCustomTags.
 func (ss *safeSender) SetCheckCustomTags(tags []string) {
 	ss.Sender.SetCheckCustomTags(cloneTags(tags))

--- a/pkg/metrics/distribution_bucket.go
+++ b/pkg/metrics/distribution_bucket.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	"github.com/DataDog/datadog-agent/pkg/tagset"
+)
+
+// DistributionBucket represents an explicit bucket that should be inserted into
+// a distribution sketch as a weighted value, without interpolation.
+type DistributionBucket struct {
+	Name       string
+	Count      int64
+	LowerBound float64
+	UpperBound float64
+	Tags       []string
+	Host       string
+	Timestamp  float64
+	Source     MetricSource
+}
+
+// GetName returns the bucket name.
+func (m *DistributionBucket) GetName() string {
+	return m.Name
+}
+
+// GetHost returns the bucket host.
+func (m *DistributionBucket) GetHost() string {
+	return m.Host
+}
+
+// GetTags returns the bucket tags.
+func (m *DistributionBucket) GetTags(_, metricBuffer tagset.TagsAccumulator, _ tagger.Component) {
+	// DistributionBucket currently only comes from checks, so returning the
+	// metric tags directly is enough for context tracking.
+	metricBuffer.Append(m.Tags...)
+}
+
+// GetMetricType implements MetricSampleContext#GetMetricType.
+func (m *DistributionBucket) GetMetricType() MetricType {
+	return DistributionType
+}
+
+// IsNoIndex returns if the metric must not be indexed.
+func (m *DistributionBucket) IsNoIndex() bool {
+	return false
+}
+
+// GetSource returns the currently set MetricSource.
+func (m *DistributionBucket) GetSource() MetricSource {
+	return m.Source
+}

--- a/pkg/status/types.go
+++ b/pkg/status/types.go
@@ -19,20 +19,22 @@ type CLCChecks struct {
 
 // CLCStats is used to unmarshall the stats needed from the runner expvar payload
 type CLCStats struct {
-	AverageExecutionTime int    `json:"AverageExecutionTime"`
-	MetricSamples        int    `json:"MetricSamples"`
-	HistogramBuckets     int    `json:"HistogramBuckets"`
-	Events               int    `json:"Events"`
-	ServiceChecks        int    `json:"ServiceChecks"`
-	LastExecFailed       bool   `json:"LastExecFailed"`
-	LastError            string `json:"LastError"`
-	TotalRuns            uint64 `json:"TotalRuns"`
-	TotalErrors          uint64 `json:"TotalErrors"`
-	TotalMetricSamples   uint64 `json:"TotalMetricSamples"`
-	TotalEvents          uint64 `json:"TotalEvents"`
-	TotalServiceChecks   uint64 `json:"TotalServiceChecks"`
-	LastSuccessDate      int64  `json:"LastSuccessDate"`
-	LastExecutionDate    int64  `json:"LastExecutionDate"`
+	AverageExecutionTime     int    `json:"AverageExecutionTime"`
+	MetricSamples            int    `json:"MetricSamples"`
+	HistogramBuckets         int    `json:"HistogramBuckets"`
+	DistributionBuckets      int    `json:"DistributionBuckets"`
+	Events                   int    `json:"Events"`
+	ServiceChecks            int    `json:"ServiceChecks"`
+	LastExecFailed           bool   `json:"LastExecFailed"`
+	LastError                string `json:"LastError"`
+	TotalRuns                uint64 `json:"TotalRuns"`
+	TotalErrors              uint64 `json:"TotalErrors"`
+	TotalMetricSamples       uint64 `json:"TotalMetricSamples"`
+	TotalDistributionBuckets uint64 `json:"TotalDistributionBuckets"`
+	TotalEvents              uint64 `json:"TotalEvents"`
+	TotalServiceChecks       uint64 `json:"TotalServiceChecks"`
+	LastSuccessDate          int64  `json:"LastSuccessDate"`
+	LastExecutionDate        int64  `json:"LastExecutionDate"`
 }
 
 // Workers is used to unmarshall the workers info needed from the runner expvar payload
@@ -55,6 +57,7 @@ func (d *CLCStats) UnmarshalJSON(data []byte) error {
 	d.AverageExecutionTime = int(stats.AverageExecutionTime)
 	d.MetricSamples = int(stats.MetricSamples)
 	d.HistogramBuckets = int(stats.HistogramBuckets)
+	d.DistributionBuckets = int(stats.DistributionBuckets)
 	d.Events = int(stats.Events)
 	d.ServiceChecks = int(stats.ServiceChecks)
 	d.LastError = stats.LastError
@@ -62,6 +65,7 @@ func (d *CLCStats) UnmarshalJSON(data []byte) error {
 	d.TotalRuns = stats.TotalRuns
 	d.TotalErrors = stats.TotalErrors
 	d.TotalMetricSamples = stats.TotalMetricSamples
+	d.TotalDistributionBuckets = stats.TotalDistributionBuckets
 	d.TotalEvents = stats.TotalEvents
 	d.TotalServiceChecks = stats.TotalServiceChecks
 	d.LastSuccessDate = stats.LastSuccessDate

--- a/pkg/util/quantile/agent.go
+++ b/pkg/util/quantile/agent.go
@@ -89,6 +89,26 @@ func (a *Agent) Insert(v float64, sampleRate float64) {
 	a.flush()
 }
 
+// InsertN inserts the same value into the sketch count times.
+func (a *Agent) InsertN(v float64, count uint) {
+	if count == 0 {
+		return
+	}
+
+	k := agentConfig.key(v)
+	a.Sketch.Basic.InsertN(v, float64(count))
+	a.CountBuf = append(a.CountBuf, KeyCount{
+		k: k,
+		n: count,
+	})
+
+	if len(a.CountBuf) < agentBufCap {
+		return
+	}
+
+	a.flush()
+}
+
 // InsertInterpolate linearly interpolates a count from the given lower to upper bounds
 func (a *Agent) InsertInterpolate(lower float64, upper float64, count uint) error {
 	keys := make([]Key, 0)

--- a/pkg/util/quantile/agent_test.go
+++ b/pkg/util/quantile/agent_test.go
@@ -190,3 +190,29 @@ func TestAgentInterpolation(t *testing.T) {
 		check(t, tt)
 	}
 }
+
+func TestAgentInsertN(t *testing.T) {
+	a := &Agent{}
+
+	a.InsertN(42.0, 3)
+	require.Len(t, a.CountBuf, 1)
+	require.Equal(t, uint(3), a.CountBuf[0].n)
+	require.Equal(t, int64(3), a.Sketch.Basic.Cnt)
+	require.Equal(t, 42.0, a.Sketch.Basic.Min)
+	require.Equal(t, 42.0, a.Sketch.Basic.Max)
+	require.Equal(t, 126.0, a.Sketch.Basic.Sum)
+	require.Equal(t, 42.0, a.Sketch.Basic.Avg)
+
+	sketch := a.Finish()
+	require.NotNil(t, sketch)
+	require.Equal(t, int64(3), sketch.Basic.Cnt)
+	require.Equal(t, 42.0, sketch.Basic.Min)
+	require.Equal(t, 42.0, sketch.Basic.Max)
+	require.Equal(t, 126.0, sketch.Basic.Sum)
+	require.Equal(t, 42.0, sketch.Basic.Avg)
+
+	keys, counts := sketch.Cols()
+	require.Len(t, keys, 1)
+	require.Len(t, counts, 1)
+	require.Equal(t, uint32(3), counts[0])
+}


### PR DESCRIPTION
### What does this PR do?
Adds a `DistributionBucket` sender API that submits explicit bucket counts into the distribution sketch path without interpolating them across internal sketch bins.

### Motivation
`HistogramBucket` is designed for Prometheus/OpenMetrics buckets and spreads counts across the sketch range. This change adds a sender API for callers that already have explicit bucket counts and need them recorded as weighted sketch inserts instead.

### Describe how you validated your changes
`dda inv test --targets=./pkg/aggregator --verbose`

### Additional Notes