### PR TITLE
[PROF-14315] Replace go compilation with dda in the build container for local testing

### DIFF
--- a/tools/host-profiler/Dockerfile
+++ b/tools/host-profiler/Dockerfile
@@ -1,3 +1,15 @@
+FROM debian:trixie-slim AS dda
+ARG DDA_VERSION=v0.29.0
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then DDA_ARCH="x86_64"; \
+    elif [ "$ARCH" = "arm64" ]; then DDA_ARCH="aarch64"; fi && \
+    curl -fsSL --retry 4 "https://github.com/DataDog/datadog-agent-dev/releases/download/${DDA_VERSION}/dda-${DDA_ARCH}-unknown-linux-gnu.tar.gz" \
+    | tar -xzf - -C /usr/local/bin && \
+    chmod +x /usr/local/bin/dda
+
 FROM golang:1.25.9-trixie
 
 RUN cross_debian_arch=$(uname -m | sed -e 's/aarch64/amd64/'  -e 's/x86_64/arm64/'); \
@@ -11,6 +23,9 @@ RUN cross_debian_arch=$(uname -m | sed -e 's/aarch64/amd64/'  -e 's/x86_64/arm64
     apt-get clean autoclean && \
     apt-get autoremove --yes
 
+COPY --from=dda /usr/local/bin/dda /usr/local/bin/dda
+ENV DDA_INTERACTIVE=false
+
 ARG UID
 ARG GID
 
@@ -22,6 +37,8 @@ RUN chown -R build:build /go
 ENV GOTOOLCHAIN=auto
 
 USER build
+
+RUN dda self dep sync -f legacy-tasks
 
 WORKDIR /app
 

--- a/tools/host-profiler/build_and_launch.sh
+++ b/tools/host-profiler/build_and_launch.sh
@@ -6,10 +6,6 @@ if [ "${DO_NOT_START_PROFILER}" = "1" ]; then
     echo "To start the profiler, run: launch.sh"
     sleep infinity
 else
-    mkdir -p bin/host-profiler
-    go build -tags "remove_all_sd docker kubelet" -ldflags="-X github.com/DataDog/datadog-agent/pkg/version.AgentVersion=docker-dev" \
-      -o bin/host-profiler/host-profiler ./cmd/host-profiler
-
-    # Launch the profiler
+    dda inv host-profiler.build
     exec ./tools/host-profiler/launch.sh
 fi


### PR DESCRIPTION
### What does this PR do?

Replace go compilation with dda in the build container for local testing following https://github.com/DataDog/datadog-agent/blob/c50d9eac9cb88e56b84855fe5665afe89e062f6b/Dockerfiles/agent-ddot/Dockerfile.agent-otel#L103

### Motivation

We recently added some compilation tags but had to keep track of them in multiple places. We want to rely on dda for compilation to prevent this.

### Describe how you validated your changes
- Tested locally with `docker-compose up --build -d`

### Additional Notes
