### PR TITLE
Add lazy Python artifact materialization PoC

### DIFF
--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -68,6 +68,7 @@ use_repo(
     "com_github_containerd_containerd",
     "com_github_containerd_containerd_api",
     "com_github_containerd_errdefs",
+    "com_github_containerd_stargz_snapshotter_estargz",
     "com_github_containerd_typeurl_v2",
     "com_github_containernetworking_cni",
     "com_github_coreos_go_semver",

--- a/go.mod
+++ b/go.mod
@@ -206,6 +206,7 @@ require (
 	github.com/containerd/containerd v1.7.30
 	github.com/containerd/containerd/api v1.9.0
 	github.com/containerd/errdefs v1.0.0
+	github.com/containerd/stargz-snapshotter/estargz v0.18.1
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.2.3
 	github.com/coreos/go-semver v0.3.1
@@ -542,7 +543,6 @@ require (
 	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.1 // indirect
-	github.com/containerd/stargz-snapshotter/estargz v0.18.1 // indirect
 	github.com/containerd/ttrpc v1.2.7 // indirect
 	github.com/containernetworking/plugins v1.4.1 // indirect
 	github.com/dennwc/varint v1.0.0 // indirect

--- a/pkg/collector/python/lazyartifacts/BUILD.bazel
+++ b/pkg/collector/python/lazyartifacts/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "lazyartifacts",
+    srcs = ["resolver.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/collector/python/lazyartifacts",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/config/setup",
+        "@com_github_containerd_stargz_snapshotter_estargz//:estargz",
+        "@com_github_google_go_containerregistry//pkg/authn:authn",
+        "@com_github_google_go_containerregistry//pkg/name:name",
+        "@com_github_google_go_containerregistry//pkg/v1:pkg",
+        "@com_github_google_go_containerregistry//pkg/v1/remote:remote",
+        "@com_github_google_go_containerregistry//pkg/v1/remote/transport:transport",
+        "@com_github_opencontainers_go_digest//:go-digest",
+    ],
+)
+
+go_test(
+    name = "lazyartifacts_test",
+    srcs = ["resolver_test.go"],
+    embed = [":lazyartifacts"],
+)

--- a/pkg/collector/python/lazyartifacts/resolver.go
+++ b/pkg/collector/python/lazyartifacts/resolver.go
@@ -1,0 +1,729 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package lazyartifacts materializes Python integrations from registry-hosted
+// eStargz Agent images on demand.
+package lazyartifacts
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/containerd/stargz-snapshotter/estargz"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/opencontainers/go-digest"
+
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+const (
+	defaultPlatform      = "linux/amd64"
+	embeddedSitePackages = "opt/datadog-agent/embedded/lib"
+	pythonCheckPrefix    = "python-check"
+	cacheLockStaleAfter  = 30 * time.Minute
+)
+
+// Result describes a lazily materialized capability.
+type Result struct {
+	Capability  string
+	CacheDir    string
+	ImportPath  string
+	CacheHit    bool
+	ImageDigest string
+	Stats       Stats
+}
+
+// Stats reports how much compressed registry data was fetched while resolving
+// the capability.
+type Stats struct {
+	RangeRequests int   `json:"range_requests"`
+	RangeBytes    int64 `json:"range_bytes"`
+	LayersOpened  int   `json:"layers_opened"`
+}
+
+type materializedFile struct {
+	Path   string `json:"path"`
+	Type   string `json:"type"`
+	Size   int64  `json:"size,omitempty"`
+	Layer  string `json:"layer"`
+	Digest string `json:"digest,omitempty"`
+}
+
+type marker struct {
+	Image       string             `json:"image"`
+	ImageDigest string             `json:"image_digest"`
+	Capability  string             `json:"capability"`
+	ImportPath  string             `json:"import_path"`
+	CreatedAt   time.Time          `json:"created_at"`
+	Files       []materializedFile `json:"files"`
+	Stats       Stats              `json:"stats"`
+}
+
+// EnsurePythonCheck materializes the Python integration named checkName from an
+// eStargz Agent image and returns a site-packages directory that can be added to
+// sys.path. This is an experimental PoC path and is intentionally disabled by
+// default.
+func EnsurePythonCheck(ctx context.Context, checkName string) (*Result, error) {
+	cfg := pkgconfigsetup.Datadog()
+	if !cfg.GetBool("python_lazy_artifacts.enabled") {
+		return nil, errors.New("python lazy artifacts are disabled")
+	}
+
+	sourceImage := cfg.GetString("python_lazy_artifacts.source_image")
+	if sourceImage == "" {
+		return nil, errors.New("python_lazy_artifacts.source_image must be set")
+	}
+
+	cacheDir := cfg.GetString("python_lazy_artifacts.cache_dir")
+	if cacheDir == "" {
+		return nil, errors.New("python_lazy_artifacts.cache_dir must be set")
+	}
+
+	platform := cfg.GetString("python_lazy_artifacts.platform")
+	if platform == "" {
+		platform = defaultPlatform
+	}
+
+	resolver, err := newResolver(ctx, sourceImage, platform)
+	if err != nil {
+		return nil, err
+	}
+
+	return resolver.ensurePythonCheck(ctx, checkName, cacheDir)
+}
+
+type resolver struct {
+	ref         name.Reference
+	repo        name.Repository
+	client      *http.Client
+	imageDigest string
+	layers      []v1.Descriptor
+	layerCache  map[string]*layerReader
+	stats       Stats
+}
+
+func newResolver(ctx context.Context, imageRef string, platform string) (*resolver, error) {
+	parsedPlatform, err := parsePlatform(platform)
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	desc, err := remote.Get(ref, remote.WithContext(ctx), remote.WithPlatform(parsedPlatform), remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return nil, err
+	}
+
+	img, err := desc.Image()
+	if err != nil {
+		return nil, err
+	}
+
+	manifest, err := img.Manifest()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := registryClient(ctx, ref.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	return &resolver{
+		ref:         ref,
+		repo:        ref.Context(),
+		client:      client,
+		imageDigest: desc.Digest.String(),
+		layers:      manifest.Layers,
+		layerCache:  map[string]*layerReader{},
+	}, nil
+}
+
+func parsePlatform(rawPlatform string) (v1.Platform, error) {
+	parts := strings.Split(rawPlatform, "/")
+	if len(parts) != 2 {
+		return v1.Platform{}, fmt.Errorf("platform must be os/arch, got %q", rawPlatform)
+	}
+	return v1.Platform{OS: parts[0], Architecture: parts[1]}, nil
+}
+
+func registryClient(ctx context.Context, repo name.Repository) (*http.Client, error) {
+	auth, err := authn.Resolve(ctx, authn.DefaultKeychain, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	rt, err := transport.NewWithContext(ctx, repo.Registry, auth, remote.DefaultTransport, []string{repo.Scope(transport.PullScope)})
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Client{Transport: rt}, nil
+}
+
+func (r *resolver) ensurePythonCheck(ctx context.Context, checkName string, cacheDir string) (*Result, error) {
+	capability := capabilityNameForPythonCheck(checkName)
+	cacheKey := cacheKey(r.imageDigest, capability)
+	finalDir := filepath.Join(cacheDir, cacheKey)
+	markerPath := filepath.Join(finalDir, ".complete.json")
+
+	if cached, err := readMarker(markerPath); err == nil {
+		return &Result{
+			Capability:  capability,
+			CacheDir:    finalDir,
+			ImportPath:  cached.ImportPath,
+			CacheHit:    true,
+			ImageDigest: cached.ImageDigest,
+			Stats:       cached.Stats,
+		}, nil
+	}
+
+	unlock, err := lockCache(ctx, cacheDir, cacheKey)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	if cached, err := readMarker(markerPath); err == nil {
+		return &Result{
+			Capability:  capability,
+			CacheDir:    finalDir,
+			ImportPath:  cached.ImportPath,
+			CacheHit:    true,
+			ImageDigest: cached.ImageDigest,
+			Stats:       cached.Stats,
+		}, nil
+	}
+
+	layer, checkPath, ent, err := r.findPythonCheck(ctx, checkName)
+	if err != nil {
+		return nil, err
+	}
+
+	importPath, err := pythonCheckImportPath(finalDir, checkPath, checkName)
+	if err != nil {
+		return nil, err
+	}
+
+	tmpDir := finalDir + fmt.Sprintf(".tmp-%d", os.Getpid())
+	if err := os.RemoveAll(tmpDir); err != nil {
+		return nil, err
+	}
+	rootDir := filepath.Join(tmpDir, "root")
+	if err := os.MkdirAll(rootDir, 0o755); err != nil {
+		return nil, err
+	}
+
+	var files []materializedFile
+	if err := materializeEntry(layer, rootDir, checkPath, ent, &files); err != nil {
+		os.RemoveAll(tmpDir) //nolint:errcheck
+		return nil, err
+	}
+
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	stats := r.accumulateStats()
+	m := marker{
+		Image:       r.ref.String(),
+		ImageDigest: r.imageDigest,
+		Capability:  capability,
+		ImportPath:  importPath,
+		CreatedAt:   time.Now().UTC(),
+		Files:       files,
+		Stats:       stats,
+	}
+
+	markerBytes, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		os.RemoveAll(tmpDir) //nolint:errcheck
+		return nil, err
+	}
+
+	if err := os.WriteFile(filepath.Join(tmpDir, ".complete.json"), markerBytes, 0o644); err != nil {
+		os.RemoveAll(tmpDir) //nolint:errcheck
+		return nil, err
+	}
+
+	if err := os.RemoveAll(finalDir); err != nil {
+		os.RemoveAll(tmpDir) //nolint:errcheck
+		return nil, err
+	}
+	if err := os.Rename(tmpDir, finalDir); err != nil {
+		os.RemoveAll(tmpDir) //nolint:errcheck
+		return nil, err
+	}
+
+	return &Result{
+		Capability:  capability,
+		CacheDir:    finalDir,
+		ImportPath:  importPath,
+		CacheHit:    false,
+		ImageDigest: r.imageDigest,
+		Stats:       stats,
+	}, nil
+}
+
+func readMarker(markerPath string) (*marker, error) {
+	f, err := os.Open(markerPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var cached marker
+	if err := json.NewDecoder(f).Decode(&cached); err != nil {
+		return nil, err
+	}
+	if cached.ImportPath == "" || cached.ImageDigest == "" {
+		return nil, errors.New("incomplete lazy artifact marker")
+	}
+	return &cached, nil
+}
+
+func lockCache(ctx context.Context, cacheDir string, cacheKey string) (func(), error) {
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return nil, err
+	}
+
+	lockDir := filepath.Join(cacheDir, cacheKey+".lock")
+	for {
+		err := os.Mkdir(lockDir, 0o700)
+		if err == nil {
+			return func() {
+				os.Remove(lockDir) //nolint:errcheck
+			}, nil
+		}
+		if !os.IsExist(err) {
+			return nil, err
+		}
+
+		if info, statErr := os.Stat(lockDir); statErr == nil && time.Since(info.ModTime()) > cacheLockStaleAfter {
+			os.Remove(lockDir) //nolint:errcheck
+			continue
+		}
+
+		timer := time.NewTimer(200 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (r *resolver) findPythonCheck(ctx context.Context, checkName string) (*layerReader, string, *estargz.TOCEntry, error) {
+	for i := len(r.layers) - 1; i >= 0; i-- {
+		layer, err := r.openLayer(ctx, r.layers[i])
+		if err != nil {
+			return nil, "", nil, err
+		}
+
+		checkPath, ent, found := findPythonCheckInLayer(layer, checkName)
+		if found {
+			return layer, checkPath, ent, nil
+		}
+	}
+
+	return nil, "", nil, fmt.Errorf("python check %q not found in eStargz image", checkName)
+}
+
+func findPythonCheckInLayer(layer *layerReader, checkName string) (string, *estargz.TOCEntry, bool) {
+	lib, ok := layer.stargz.Lookup(embeddedSitePackages)
+	if !ok || lib.Type != "dir" {
+		return "", nil, false
+	}
+
+	var checkPath string
+	var checkEntry *estargz.TOCEntry
+	lib.ForeachChild(func(base string, child *estargz.TOCEntry) bool {
+		if child.Type != "dir" || !strings.HasPrefix(base, "python") {
+			return true
+		}
+
+		candidate := path.Join(embeddedSitePackages, base, "site-packages", "datadog_checks", checkName)
+		ent, ok := layer.stargz.Lookup(candidate)
+		if !ok || ent.Type != "dir" {
+			return true
+		}
+
+		checkPath = candidate
+		checkEntry = ent
+		return false
+	})
+
+	return checkPath, checkEntry, checkEntry != nil
+}
+
+type layerReader struct {
+	desc     v1.Descriptor
+	blob     *registryBlobReaderAt
+	stargz   *estargz.Reader
+	verifier estargz.TOCEntryVerifier
+}
+
+func (r *resolver) openLayer(ctx context.Context, desc v1.Descriptor) (*layerReader, error) {
+	key := desc.Digest.String()
+	if lr, ok := r.layerCache[key]; ok {
+		return lr, nil
+	}
+
+	blob := &registryBlobReaderAt{
+		ctx:    ctx,
+		client: r.client,
+		repo:   r.repo,
+		digest: desc.Digest,
+		size:   desc.Size,
+	}
+
+	reader, err := estargz.Open(io.NewSectionReader(blob, 0, desc.Size))
+	if err != nil {
+		return nil, fmt.Errorf("open eStargz layer %s: %w", desc.Digest, err)
+	}
+
+	tocDigestRaw := desc.Annotations[estargz.TOCJSONDigestAnnotation]
+	if tocDigestRaw == "" {
+		return nil, fmt.Errorf("layer %s is missing %s", desc.Digest, estargz.TOCJSONDigestAnnotation)
+	}
+	tocDigest, err := digest.Parse(tocDigestRaw)
+	if err != nil {
+		return nil, fmt.Errorf("parse TOC digest annotation for layer %s: %w", desc.Digest, err)
+	}
+
+	verifier, err := reader.VerifyTOC(tocDigest)
+	if err != nil {
+		return nil, fmt.Errorf("verify TOC for layer %s: %w", desc.Digest, err)
+	}
+
+	lr := &layerReader{desc: desc, blob: blob, stargz: reader, verifier: verifier}
+	r.layerCache[key] = lr
+	r.stats.LayersOpened++
+	return lr, nil
+}
+
+func (r *resolver) accumulateStats() Stats {
+	out := r.stats
+	for _, lr := range r.layerCache {
+		reqs, bytes := lr.blob.stats()
+		out.RangeRequests += reqs
+		out.RangeBytes += bytes
+	}
+	return out
+}
+
+type registryBlobReaderAt struct {
+	ctx    context.Context
+	client *http.Client
+	repo   name.Repository
+	digest v1.Hash
+	size   int64
+
+	mu            sync.Mutex
+	rangeRequests int
+	rangeBytes    int64
+}
+
+func (r *registryBlobReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if off < 0 || off >= r.size {
+		return 0, io.EOF
+	}
+
+	want := len(p)
+	end := off + int64(want) - 1
+	if end >= r.size {
+		end = r.size - 1
+		want = int(end - off + 1)
+		p = p[:want]
+	}
+
+	u := url.URL{
+		Scheme: r.repo.Registry.Scheme(),
+		Host:   r.repo.Registry.RegistryStr(),
+		Path:   fmt.Sprintf("/v2/%s/blobs/%s", r.repo.RepositoryStr(), r.digest.String()),
+	}
+	req, err := http.NewRequestWithContext(r.ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", off, end))
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPartialContent {
+		return 0, fmt.Errorf("range GET %s returned %s", u.String(), resp.Status)
+	}
+
+	n, err := io.ReadFull(resp.Body, p)
+	r.mu.Lock()
+	r.rangeRequests++
+	r.rangeBytes += int64(n)
+	r.mu.Unlock()
+	if err != nil {
+		return n, err
+	}
+	if n != want {
+		return n, io.ErrUnexpectedEOF
+	}
+	return n, nil
+}
+
+func (r *registryBlobReaderAt) stats() (int, int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.rangeRequests, r.rangeBytes
+}
+
+func materializeEntry(layer *layerReader, rootDir string, imagePath string, ent *estargz.TOCEntry, files *[]materializedFile) error {
+	switch ent.Type {
+	case "dir":
+		if err := mkdirSafe(rootDir, imagePath, os.FileMode(ent.Mode)&0o777); err != nil {
+			return err
+		}
+		*files = append(*files, materializedFile{Path: "/" + imagePath, Type: "dir", Layer: layer.desc.Digest.String()})
+
+		var walkErr error
+		ent.ForeachChild(func(base string, child *estargz.TOCEntry) bool {
+			walkErr = materializeEntry(layer, rootDir, path.Join(imagePath, base), child, files)
+			return walkErr == nil
+		})
+		return walkErr
+	case "reg":
+		return materializeRegularFile(layer, rootDir, imagePath, ent, files)
+	case "symlink":
+		return materializeSymlink(layer, rootDir, imagePath, ent, files)
+	default:
+		return fmt.Errorf("unsupported entry type %q at %q", ent.Type, imagePath)
+	}
+}
+
+func materializeRegularFile(layer *layerReader, rootDir string, imagePath string, ent *estargz.TOCEntry, files *[]materializedFile) error {
+	dest, err := safeDest(rootDir, imagePath)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+
+	tmp := dest + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, fileMode(ent.Mode))
+	if err != nil {
+		return err
+	}
+
+	h := sha256.New()
+	n, copyErr := copyVerifiedChunks(layer, imagePath, ent, io.MultiWriter(out, h))
+	closeErr := out.Close()
+	if copyErr != nil {
+		os.Remove(tmp) //nolint:errcheck
+		return copyErr
+	}
+	if closeErr != nil {
+		os.Remove(tmp) //nolint:errcheck
+		return closeErr
+	}
+	if n != ent.Size {
+		os.Remove(tmp) //nolint:errcheck
+		return fmt.Errorf("short materialization for %q: copied %d bytes, expected %d", imagePath, n, ent.Size)
+	}
+
+	actualDigest := "sha256:" + hex.EncodeToString(h.Sum(nil))
+	if ent.Digest != "" && actualDigest != ent.Digest {
+		os.Remove(tmp) //nolint:errcheck
+		return fmt.Errorf("file digest mismatch for %q: got %s, want %s", imagePath, actualDigest, ent.Digest)
+	}
+
+	if err := os.Chmod(tmp, fileMode(ent.Mode)); err != nil {
+		os.Remove(tmp) //nolint:errcheck
+		return err
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		os.Remove(tmp) //nolint:errcheck
+		return err
+	}
+
+	*files = append(*files, materializedFile{
+		Path:   "/" + imagePath,
+		Type:   "reg",
+		Size:   ent.Size,
+		Layer:  layer.desc.Digest.String(),
+		Digest: actualDigest,
+	})
+	return nil
+}
+
+func copyVerifiedChunks(layer *layerReader, imagePath string, ent *estargz.TOCEntry, out io.Writer) (int64, error) {
+	src, err := layer.stargz.OpenFile(imagePath)
+	if err != nil {
+		return 0, err
+	}
+
+	var copied int64
+	for copied < ent.Size {
+		chunk, ok := layer.stargz.ChunkEntryForOffset(imagePath, copied)
+		if !ok {
+			return copied, fmt.Errorf("no chunk for %q at offset %d", imagePath, copied)
+		}
+
+		size := chunk.ChunkSize
+		if size <= 0 || copied+size > ent.Size {
+			size = ent.Size - copied
+		}
+		buf := make([]byte, size)
+
+		n, readErr := src.ReadAt(buf, copied)
+		if n > 0 {
+			if err := verifyChunk(layer, chunk, buf[:n]); err != nil {
+				return copied, err
+			}
+			written, writeErr := out.Write(buf[:n])
+			copied += int64(written)
+			if writeErr != nil {
+				return copied, writeErr
+			}
+			if written != n {
+				return copied, io.ErrShortWrite
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF && copied == ent.Size {
+				break
+			}
+			return copied, readErr
+		}
+	}
+
+	return copied, nil
+}
+
+func verifyChunk(layer *layerReader, chunk *estargz.TOCEntry, data []byte) error {
+	v, err := layer.verifier.Verifier(chunk)
+	if err != nil {
+		return fmt.Errorf("chunk verifier for offset %d: %w", chunk.Offset, err)
+	}
+	if _, err := v.Write(data); err != nil {
+		return fmt.Errorf("write chunk verifier for offset %d: %w", chunk.Offset, err)
+	}
+	if !v.Verified() {
+		return fmt.Errorf("chunk digest mismatch at offset %d", chunk.Offset)
+	}
+	return nil
+}
+
+func materializeSymlink(layer *layerReader, rootDir string, imagePath string, ent *estargz.TOCEntry, files *[]materializedFile) error {
+	if filepath.IsAbs(ent.LinkName) || strings.Contains(filepath.Clean(ent.LinkName), "..") {
+		return fmt.Errorf("unsafe symlink %q -> %q", imagePath, ent.LinkName)
+	}
+
+	dest, err := safeDest(rootDir, imagePath)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dest); err != nil {
+		return err
+	}
+	if err := os.Symlink(ent.LinkName, dest); err != nil {
+		return err
+	}
+
+	*files = append(*files, materializedFile{Path: "/" + imagePath, Type: "symlink", Layer: layer.desc.Digest.String()})
+	return nil
+}
+
+func mkdirSafe(rootDir string, imagePath string, mode os.FileMode) error {
+	dest, err := safeDest(rootDir, imagePath)
+	if err != nil {
+		return err
+	}
+	if mode == 0 {
+		mode = 0o755
+	}
+	return os.MkdirAll(dest, mode)
+}
+
+func safeDest(rootDir string, imagePath string) (string, error) {
+	clean := cleanImagePath(imagePath)
+	if clean == "." || clean == "" {
+		return "", errors.New("refusing to materialize root")
+	}
+
+	dest := filepath.Join(rootDir, filepath.FromSlash(clean))
+	rel, err := filepath.Rel(rootDir, dest)
+	if err != nil {
+		return "", err
+	}
+	if rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return "", fmt.Errorf("path escapes root: %q", imagePath)
+	}
+	return dest, nil
+}
+
+func cleanImagePath(p string) string {
+	return strings.TrimPrefix(path.Clean("/"+p), "/")
+}
+
+func fileMode(mode int64) os.FileMode {
+	m := os.FileMode(mode) & 0o777
+	if m == 0 {
+		return 0o644
+	}
+	return m
+}
+
+func pythonCheckImportPath(finalDir string, checkPath string, checkName string) (string, error) {
+	suffix := path.Join("datadog_checks", checkName)
+	if !strings.HasSuffix(checkPath, suffix) {
+		return "", fmt.Errorf("python check path %q does not end with %q", checkPath, suffix)
+	}
+
+	sitePackages := strings.TrimSuffix(checkPath, suffix)
+	sitePackages = strings.TrimSuffix(sitePackages, "/")
+	if sitePackages == "" {
+		return "", fmt.Errorf("unable to derive site-packages path from %q", checkPath)
+	}
+
+	return filepath.Join(finalDir, "root", filepath.FromSlash(sitePackages)), nil
+}
+
+func capabilityNameForPythonCheck(checkName string) string {
+	return pythonCheckPrefix + ":" + checkName
+}
+
+func cacheKey(imageDigest string, capabilityName string) string {
+	sum := sha256.Sum256([]byte(imageDigest + "\x00" + capabilityName))
+	safeCap := strings.NewReplacer("/", "_", ":", "_").Replace(capabilityName)
+	return safeCap + "-" + hex.EncodeToString(sum[:])[:16]
+}

--- a/pkg/collector/python/lazyartifacts/resolver_test.go
+++ b/pkg/collector/python/lazyartifacts/resolver_test.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package lazyartifacts
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParsePlatform(t *testing.T) {
+	platform, err := parsePlatform("linux/arm64")
+	if err != nil {
+		t.Fatalf("parsePlatform returned an error: %v", err)
+	}
+	if platform.OS != "linux" || platform.Architecture != "arm64" {
+		t.Fatalf("unexpected platform: %+v", platform)
+	}
+
+	if _, err := parsePlatform("linux"); err == nil {
+		t.Fatal("expected invalid platform to return an error")
+	}
+}
+
+func TestPythonCheckImportPath(t *testing.T) {
+	cacheDir := filepath.Join("cache", "python-check-mongo")
+	checkPath := "opt/datadog-agent/embedded/lib/python3.13/site-packages/datadog_checks/mongo"
+
+	importPath, err := pythonCheckImportPath(cacheDir, checkPath, "mongo")
+	if err != nil {
+		t.Fatalf("pythonCheckImportPath returned an error: %v", err)
+	}
+
+	expected := filepath.Join(cacheDir, "root", "opt", "datadog-agent", "embedded", "lib", "python3.13", "site-packages")
+	if importPath != expected {
+		t.Fatalf("unexpected import path: got %q want %q", importPath, expected)
+	}
+}
+
+func TestPythonCheckImportPathRejectsUnexpectedPath(t *testing.T) {
+	_, err := pythonCheckImportPath("cache", "opt/datadog-agent/embedded/lib/python3.13/site-packages/foo/mongo", "mongo")
+	if err == nil {
+		t.Fatal("expected invalid check path to return an error")
+	}
+}
+
+func TestCacheKey(t *testing.T) {
+	key := cacheKey("sha256:abc", "python-check:mongo")
+	if strings.ContainsAny(key, "/:") {
+		t.Fatalf("cache key contains a path separator or colon: %q", key)
+	}
+	if !strings.HasPrefix(key, "python-check_mongo-") {
+		t.Fatalf("unexpected cache key prefix: %q", key)
+	}
+}

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -8,6 +8,8 @@
 package python
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"expvar"
 	"fmt"
@@ -28,6 +30,7 @@ import (
 	collectoraggregator "github.com/DataDog/datadog-agent/pkg/collector/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
+	"github.com/DataDog/datadog-agent/pkg/collector/python/lazyartifacts"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
@@ -58,6 +61,7 @@ var (
 	linterLock       sync.Mutex
 	agentVersionTags []string
 	pythonOnce       sync.Once
+	lazyPythonPaths  sync.Map
 )
 
 const (
@@ -160,36 +164,35 @@ func (cl *PythonCheckLoader) Load(senderManager sender.SenderManager, config int
 
 	// Looking for wheels first
 	modules := []string{fmt.Sprintf("%s.%s", wheelNamespace, moduleName), moduleName}
-	var loadedAsWheel bool
+	loadResult := loadPythonCheckClass(modules)
+	if loadResult.checkModule == nil || loadResult.checkClass == nil {
+		if result, err := ensureLazyPythonCheck(context.Background(), moduleName); err == nil {
+			if err := addLazyPythonPath(result.ImportPath); err == nil {
+				log.Infof(
+					"Materialized lazy Python check %s from %s into %s (cache_hit=%t, range_requests=%d, range_bytes=%d)",
+					moduleName,
+					pkgconfigsetup.Datadog().GetString("python_lazy_artifacts.source_image"),
+					result.CacheDir,
+					result.CacheHit,
+					result.Stats.RangeRequests,
+					result.Stats.RangeBytes,
+				)
 
-	loadedName := ""
-	var checkModule *C.rtloader_pyobject_t
-	var checkClass *C.rtloader_pyobject_t
-	var loadErrors []string // store errors for each module
-
-	for _, name := range modules {
-		// TrackedCStrings untracked by memory tracker currently
-		moduleName := TrackedCString(name)
-		defer C.call_free(unsafe.Pointer(moduleName))
-		if res := C.get_class(rtloader, moduleName, &checkModule, &checkClass); res != 0 {
-			if strings.HasPrefix(name, wheelNamespace+".") {
-				loadedAsWheel = true
+				retryLoadResult := loadPythonCheckClass(modules)
+				if retryLoadResult.checkModule == nil || retryLoadResult.checkClass == nil {
+					retryLoadResult.loadErrors = append(loadResult.loadErrors, retryLoadResult.loadErrors...)
+				}
+				loadResult = retryLoadResult
+			} else {
+				log.Debugf("Unable to add lazy Python import path %s for check %s: %v", result.ImportPath, moduleName, err)
 			}
-			loadedName = name
-			break
-		}
-
-		if err := getRtLoaderError(); err != nil {
-			log.Debugf("Unable to load python module - %s: %v", name, err)
-			loadErrors = append(loadErrors, fmt.Sprintf("unable to load python module %s: %v", name, err))
-		} else {
-			log.Debugf("Unable to load python module - %s", name)
-			loadErrors = append(loadErrors, "unable to load python module "+name)
+		} else if pkgconfigsetup.Datadog().GetBool("python_lazy_artifacts.enabled") {
+			log.Debugf("Unable to materialize lazy Python check %s: %v", moduleName, err)
 		}
 	}
 
-	if checkModule == nil || checkClass == nil {
-		errMsg := strings.Join(loadErrors, ", ")
+	if loadResult.checkModule == nil || loadResult.checkClass == nil {
+		errMsg := strings.Join(loadResult.loadErrors, ", ")
 		log.Debugf("Unable to load check %s: %s", moduleName, errMsg)
 		return nil, fmt.Errorf("unable to load check %s: %s", moduleName, errMsg)
 	}
@@ -202,14 +205,14 @@ func (cl *PythonCheckLoader) Load(senderManager sender.SenderManager, config int
 	versionAttr := TrackedCString("__version__")
 	defer C.call_free(unsafe.Pointer(versionAttr))
 	// get_attr_string allocation tracked by memory tracker
-	if res := C.get_attr_string(rtloader, checkModule, versionAttr, &version); res != 0 {
+	if res := C.get_attr_string(rtloader, loadResult.checkModule, versionAttr, &version); res != 0 {
 		wheelVersion = C.GoString(version)
 		C.rtloader_free(rtloader, unsafe.Pointer(version))
 	} else {
 		log.Debugf("python check '%s' doesn't have a '__version__' attribute: %s", config.Name, getRtLoaderError())
 	}
 
-	if !pkgconfigsetup.Datadog().GetBool("disable_py3_validation") && !loadedAsWheel {
+	if !pkgconfigsetup.Datadog().GetBool("disable_py3_validation") && !loadResult.loadedAsWheel {
 		// Customers, though unlikely might version their custom checks.
 		// Let's use the module namespace to try to decide if this was a
 		// custom check, check for py3 compatibility
@@ -219,7 +222,7 @@ func (cl *PythonCheckLoader) Load(senderManager sender.SenderManager, config int
 		fileAttr := TrackedCString("__file__")
 		defer C.call_free(unsafe.Pointer(fileAttr))
 		// get_attr_string allocation tracked by memory tracker
-		if res := C.get_attr_string(rtloader, checkModule, fileAttr, &checkFilePath); res != 0 {
+		if res := C.get_attr_string(rtloader, loadResult.checkModule, fileAttr, &checkFilePath); res != 0 {
 			goCheckFilePath = C.GoString(checkFilePath)
 			C.rtloader_free(rtloader, unsafe.Pointer(checkFilePath))
 		} else {
@@ -227,10 +230,10 @@ func (cl *PythonCheckLoader) Load(senderManager sender.SenderManager, config int
 		}
 
 		// Ensure we never emit an empty check_name tag
-		if loadedName == "" {
-			loadedName = moduleName // config.Name (the original check name)
+		if loadResult.loadedName == "" {
+			loadResult.loadedName = moduleName // config.Name (the original check name)
 		}
-		go reportPy3Warnings(loadedName, goCheckFilePath)
+		go reportPy3Warnings(loadResult.loadedName, goCheckFilePath)
 	}
 
 	var goHASupported bool
@@ -239,14 +242,14 @@ func (cl *PythonCheckLoader) Load(senderManager sender.SenderManager, config int
 
 		haSupportedAttr := TrackedCString("HA_SUPPORTED")
 		defer C.call_free(unsafe.Pointer(haSupportedAttr))
-		if res := C.get_attr_bool(rtloader, checkClass, haSupportedAttr, &haSupported); res != 0 {
+		if res := C.get_attr_bool(rtloader, loadResult.checkClass, haSupportedAttr, &haSupported); res != 0 {
 			goHASupported = haSupported == C.bool(true)
 		} else {
 			log.Debugf("Could not query the HA_SUPPORTED attribute for check %s: %s", moduleName, getRtLoaderError())
 		}
 	}
 
-	c, err := NewPythonCheck(senderManager, moduleName, checkClass, goHASupported)
+	c, err := NewPythonCheck(senderManager, moduleName, loadResult.checkClass, goHASupported)
 	if err != nil {
 		return c, err
 	}
@@ -257,8 +260,8 @@ func (cl *PythonCheckLoader) Load(senderManager sender.SenderManager, config int
 	}
 	// The GIL should be unlocked at this point, `check.Configure` uses its own stickyLock and stickyLocks must not be nested
 	if err := c.Configure(senderManager, configDigest, instance, config.InitConfig, configSource, config.Provider); err != nil {
-		C.rtloader_decref(rtloader, checkClass)
-		C.rtloader_decref(rtloader, checkModule)
+		C.rtloader_decref(rtloader, loadResult.checkClass)
+		C.rtloader_decref(rtloader, loadResult.checkModule)
 
 		if errors.Is(err, check.ErrSkipCheckInstance) {
 			return nil, err
@@ -274,11 +277,82 @@ func (cl *PythonCheckLoader) Load(senderManager sender.SenderManager, config int
 	}
 
 	c.version = wheelVersion
-	C.rtloader_decref(rtloader, checkClass)
-	C.rtloader_decref(rtloader, checkModule)
+	C.rtloader_decref(rtloader, loadResult.checkClass)
+	C.rtloader_decref(rtloader, loadResult.checkModule)
 
 	log.Debugf("python loader: done loading check %s (version %s)", moduleName, wheelVersion)
 	return c, nil
+}
+
+type pythonCheckClassLoadResult struct {
+	loadedName    string
+	loadedAsWheel bool
+	checkModule   *C.rtloader_pyobject_t
+	checkClass    *C.rtloader_pyobject_t
+	loadErrors    []string
+}
+
+func loadPythonCheckClass(modules []string) pythonCheckClassLoadResult {
+	var result pythonCheckClassLoadResult
+
+	for _, name := range modules {
+		// TrackedCStrings untracked by memory tracker currently
+		moduleName := TrackedCString(name)
+		defer C.call_free(unsafe.Pointer(moduleName))
+		if res := C.get_class(rtloader, moduleName, &result.checkModule, &result.checkClass); res != 0 {
+			if strings.HasPrefix(name, wheelNamespace+".") {
+				result.loadedAsWheel = true
+			}
+			result.loadedName = name
+			break
+		}
+
+		if err := getRtLoaderError(); err != nil {
+			log.Debugf("Unable to load python module - %s: %v", name, err)
+			result.loadErrors = append(result.loadErrors, fmt.Sprintf("unable to load python module %s: %v", name, err))
+		} else {
+			log.Debugf("Unable to load python module - %s", name)
+			result.loadErrors = append(result.loadErrors, "unable to load python module "+name)
+		}
+	}
+
+	return result
+}
+
+func ensureLazyPythonCheck(ctx context.Context, moduleName string) (*lazyartifacts.Result, error) {
+	if !pkgconfigsetup.Datadog().GetBool("python_lazy_artifacts.enabled") {
+		return nil, errors.New("python lazy artifacts are disabled")
+	}
+	return lazyartifacts.EnsurePythonCheck(ctx, moduleName)
+}
+
+func addLazyPythonPath(importPath string) error {
+	if importPath == "" {
+		return errors.New("empty Python import path")
+	}
+	if _, loaded := lazyPythonPaths.Load(importPath); loaded {
+		return nil
+	}
+
+	pythonPathLiteral, err := json.Marshal(importPath)
+	if err != nil {
+		return err
+	}
+	code := fmt.Sprintf(
+		"import importlib, os, sys\np = %s\nsys.path.append(p) if p not in sys.path else None\npkg = sys.modules.get('datadog_checks')\npkg_path = os.path.join(p, 'datadog_checks')\npkg.__path__.append(pkg_path) if pkg is not None and hasattr(pkg, '__path__') and pkg_path not in pkg.__path__ else None\nimportlib.invalidate_caches()\n",
+		pythonPathLiteral,
+	)
+	cCode := TrackedCString(code)
+	defer C.call_free(unsafe.Pointer(cCode))
+	if res := C.run_simple_string(rtloader, cCode); res == 0 {
+		if err := getRtLoaderError(); err != nil {
+			return err
+		}
+		return errors.New("failed to update Python sys.path")
+	}
+
+	lazyPythonPaths.Store(importPath, struct{}{})
+	return nil
 }
 
 func (cl *PythonCheckLoader) String() string {

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -63,6 +63,13 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	// Otherwise, Python is loaded when the collector is initialized.
 	config.BindEnvAndSetDefault("python_lazy_loading", true)
 
+	// Experimental PoC: materialize missing bundled Python integrations from an
+	// eStargz Agent image at runtime.
+	config.BindEnvAndSetDefault("python_lazy_artifacts.enabled", false)
+	config.BindEnvAndSetDefault("python_lazy_artifacts.source_image", "")
+	config.BindEnvAndSetDefault("python_lazy_artifacts.cache_dir", filepath.Join(defaultRunPath, "lazy-artifacts"))
+	config.BindEnvAndSetDefault("python_lazy_artifacts.platform", "linux/amd64")
+
 	// If true, then the go loader will be prioritized over the python loader.
 	config.BindEnvAndSetDefault("prioritize_go_check_loader", true)
 

--- a/test/e2e-framework/components/kubernetes/kind-cluster.yaml
+++ b/test/e2e-framework/components/kubernetes/kind-cluster.yaml
@@ -48,7 +48,7 @@ containerdConfigPatches:
 {{- end }}
 networking:
   apiServerAddress: "0.0.0.0"
-  apiServerPort: 8443
+  apiServerPort: {{ if .APIServerPort }}{{ .APIServerPort }}{{ else }}8443{{ end }}
 {{- if .KubeProxyReplacement }}
   disableDefaultCNI: true
   kubeProxyMode: "none"

--- a/test/e2e-framework/components/kubernetes/kind.go
+++ b/test/e2e-framework/components/kubernetes/kind.go
@@ -252,7 +252,14 @@ func NewLocalKindClusterWithConfig(env config.Env, name string, kubeVersion stri
 			return err
 		}
 
-		clusterComp.KubeConfig = kubeConfigCmd.StdoutOutput()
+		// Pulumi's Helm provider performs its own API discovery. With the local
+		// kind config bound to 0.0.0.0, that discovery can reject the generated
+		// API server certificate even though the Kubernetes provider can create
+		// resources with the same kubeconfig. Match the remote kind path above and
+		// disable TLS verification for this local-only test cluster kubeconfig.
+		clusterComp.KubeConfig = kubeConfigCmd.StdoutOutput().ApplyT(func(kubeConfig string) string {
+			return regexp.MustCompile("certificate-authority-data:.+").ReplaceAllString(kubeConfig, "insecure-skip-tls-verify: true")
+		}).(pulumi.StringOutput)
 		clusterComp.ClusterName = kindClusterName.ToStringOutput()
 
 		return nil

--- a/test/e2e-framework/components/kubernetes/kind_versions.go
+++ b/test/e2e-framework/components/kubernetes/kind_versions.go
@@ -30,6 +30,7 @@ type KindConfigFlags struct {
 	NewContainerdRegistryConfig bool             // whether to use the new containerd registry mirror config format (for containerd >= 2.2, used in kubernetes >= v1.32)
 	KubeProxyReplacement        bool             // whether to set kubeProxyMode to "none" in the kind config
 	WorkerNodes                 []KindWorkerNode // additional worker nodes beyond the control-plane
+	APIServerPort               int              // optional host port for the Kubernetes API server
 }
 
 // KindWorkerNode describes a kind worker node.

--- a/test/e2e-framework/testing/provisioners/local/kubernetes/kind.go
+++ b/test/e2e-framework/testing/provisioners/local/kubernetes/kind.go
@@ -47,6 +47,7 @@ type ProvisionerParams struct {
 	standaloneAgentFunc StandaloneAgentDeployFunc
 	workerNodes         []kubeComp.KindWorkerNode
 	imagesToLoad        []string
+	apiServerPort       int
 }
 
 func newProvisionerParams() *ProvisionerParams {
@@ -165,6 +166,14 @@ func WithKindLoadImage(image string) ProvisionerOption {
 	}
 }
 
+// WithKindAPIServerPort sets the local host port for the kind API server.
+func WithKindAPIServerPort(port int) ProvisionerOption {
+	return func(params *ProvisionerParams) error {
+		params.apiServerPort = port
+		return nil
+	}
+}
+
 // Provisioner creates a new provisioner
 func Provisioner(opts ...ProvisionerOption) provisioners.TypedProvisioner[environments.Kubernetes] {
 	// We ALWAYS need to make a deep copy of `params`, as the provisioner can be called multiple times.
@@ -193,7 +202,8 @@ func KindRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *Prov
 	}
 
 	kindCluster, err := kubeComp.NewLocalKindClusterWithConfig(&localEnv, params.name, localEnv.KubernetesVersion(), kubeComp.KindConfigFlags{
-		WorkerNodes: params.workerNodes,
+		WorkerNodes:   params.workerNodes,
+		APIServerPort: params.apiServerPort,
 	})
 	if err != nil {
 		return err

--- a/test/new-e2e/tests/lazyartifacts/BUILD.bazel
+++ b/test/new-e2e/tests/lazyartifacts/BUILD.bazel
@@ -1,0 +1,1 @@
+# gazelle:ignore

--- a/test/new-e2e/tests/lazyartifacts/python_kind_test.go
+++ b/test/new-e2e/tests/lazyartifacts/python_kind_test.go
@@ -1,0 +1,179 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package lazyartifacts
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/redis"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
+	kubecomp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	localkubernetes "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/local/kubernetes"
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+)
+
+const (
+	lazySourceImage = "docker.io/alidatadog/agent-latest-full-estargz-poc@sha256:3d4c01e9511a86f4c9fc05cb2cca1ce53f1325107e6e9b8720716d07da8e7bff"
+	lazyCacheDir    = "/var/lib/datadog-agent/lazy-artifacts"
+)
+
+const lazyPythonHelmValues = `
+datadog:
+  logLevel: DEBUG
+  admissionController:
+    enabled: false
+  apm:
+    instrumentation:
+      enabled: false
+  autoscaling:
+    workload:
+      enabled: false
+  clusterChecks:
+    enabled: false
+  helmCheck:
+    enabled: false
+  kubeStateMetricsCore:
+    enabled: false
+  prometheusScrape:
+    enabled: false
+  sbom:
+    containerImage:
+      enabled: false
+    host:
+      enabled: false
+clusterAgent:
+  enabled: false
+  admissionController:
+    enabled: false
+    agentSidecarInjection:
+      enabled: false
+  metricsProvider:
+    enabled: false
+clusterChecksRunner:
+  enabled: false
+agents:
+  image:
+    pullPolicy: Never
+  volumes:
+    - name: lazy-artifacts-cache
+      emptyDir: {}
+  volumeMounts:
+    - name: lazy-artifacts-cache
+      mountPath: /var/lib/datadog-agent/lazy-artifacts
+  containers:
+    agent:
+      env:
+        - name: DD_PYTHON_LAZY_ARTIFACTS_ENABLED
+          value: "true"
+        - name: DD_PYTHON_LAZY_ARTIFACTS_SOURCE_IMAGE
+          value: "` + lazySourceImage + `"
+        - name: DD_PYTHON_LAZY_ARTIFACTS_PLATFORM
+          value: "linux/amd64"
+        - name: DD_PYTHON_LAZY_ARTIFACTS_CACHE_DIR
+          value: "` + lazyCacheDir + `"
+`
+
+type lazyPythonKindSuite struct {
+	e2e.BaseSuite[environments.Kubernetes]
+}
+
+func TestLazyPythonArtifactsLocalKind(t *testing.T) {
+	agentImage := os.Getenv("DD_TEST_LAZY_AGENT_IMAGE")
+	if agentImage == "" {
+		t.Skip("DD_TEST_LAZY_AGENT_IMAGE not set; skipping local kind lazy artifact e2e")
+	}
+
+	e2e.Run(t, &lazyPythonKindSuite{}, e2e.WithProvisioner(
+		localkubernetes.Provisioner(
+			localkubernetes.WithName("lazy-artifacts"),
+			localkubernetes.WithKindAPIServerPort(18443),
+			localkubernetes.WithKindLoadImage(agentImage),
+			localkubernetes.WithAgentOptions(
+				kubernetesagentparams.WithAgentFullImagePath(agentImage),
+				kubernetesagentparams.WithHelmValues(lazyPythonHelmValues),
+			),
+			localkubernetes.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*kubecomp.Workload, error) {
+				return redis.K8sAppDefinition(e, kubeProvider, "workload-redis", false, nil)
+			}),
+		),
+	))
+}
+
+func (s *lazyPythonKindSuite) TestRedisCheckMaterializedFromLazySourceImage() {
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		metrics, err := s.Env().FakeIntake.Client().FilterMetrics(
+			"redis.net.instantaneous_ops_per_sec",
+			fakeintake.WithMatchingTags[*aggregator.MetricSeries]([]*regexp.Regexp{
+				regexp.MustCompile(`^kube_namespace:workload-redis$`),
+			}),
+		)
+		assert.NoError(c, err)
+		assert.NotEmpty(c, metrics, "redisdb metrics were not received yet")
+	}, 5*time.Minute, 10*time.Second)
+
+	agentPod := getAgentPod(s.T(), s.Env().KubernetesCluster.Client())
+
+	stdout, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
+		agentPod.Namespace,
+		agentPod.Name,
+		"agent",
+		[]string{"bash", "-c", "test ! -d /opt/datadog-agent/embedded/lib/python3.13/site-packages/datadog_checks/redisdb"},
+	)
+	assert.NoError(s.T(), err)
+	assert.Empty(s.T(), stdout)
+	assert.Empty(s.T(), stderr)
+
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		stdout, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
+			agentPod.Namespace,
+			agentPod.Name,
+			"agent",
+			[]string{"bash", "-c", "marker=$(find " + lazyCacheDir + " -name .complete.json -print -quit); test -n \"$marker\" && cat \"$marker\""},
+		)
+		assert.NoError(c, err)
+		assert.Empty(c, stderr)
+
+		var marker struct {
+			Image      string `json:"image"`
+			Capability string `json:"capability"`
+			Stats      struct {
+				RangeRequests int   `json:"range_requests"`
+				RangeBytes    int64 `json:"range_bytes"`
+			} `json:"stats"`
+		}
+		if assert.NoError(c, json.Unmarshal([]byte(stdout), &marker)) {
+			assert.Equal(c, lazySourceImage, marker.Image)
+			assert.Equal(c, "python-check:redisdb", marker.Capability)
+			assert.Greater(c, marker.Stats.RangeRequests, 0)
+			assert.Less(c, marker.Stats.RangeBytes, int64(5*1024*1024))
+		}
+	}, 2*time.Minute, 5*time.Second)
+}
+
+func getAgentPod(t assert.TestingT, client kubeclient.Interface) corev1.Pod {
+	pods, err := client.CoreV1().Pods("datadog").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app=dda-linux-datadog",
+	})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, pods.Items)
+
+	return pods.Items[0]
+}


### PR DESCRIPTION
## Summary

This PR adds an experimental PoC for capability-based lazy materialization of Python integrations from a registry-hosted eStargz Agent image.

The Agent behavior is gated behind `python_lazy_artifacts.enabled` and is off by default. When a Python check import fails, the loader can:

- resolve `python_lazy_artifacts.source_image` as an OCI/eStargz image
- discover the requested `datadog_checks/<check>` directory from the eStargz TOC instead of using a manual manifest
- materialize only that directory into `python_lazy_artifacts.cache_dir`
- add the materialized `site-packages` path to the live Python interpreter and retry the import once

PoC image used for smoke testing:

`docker.io/alidatadog/agent-latest-full-estargz-poc@sha256:3d4c01e9511a86f4c9fc05cb2cca1ce53f1325107e6e9b8720716d07da8e7bff`

The platform manifest has the expected eStargz TOC annotation on layer `sha256:27c1100d66ca7f1b7487991687b2d59621f0cbc0c36b6f2565edf85c40114097`.

## Notes

- This is intentionally a PoC and does not add signature verification yet.
- No range coalescing yet.
- No overlay/whiteout support; this targets flattened Agent full images for now.
- The source image should be pinned by digest for reproducible cache keys.

## Testing

- `dda inv test --targets=./pkg/collector/python/lazyartifacts`
- `bazel test //pkg/collector/python/lazyartifacts:lazyartifacts_test`
- `dda inv linter.go --targets=./pkg/collector/python/lazyartifacts,./pkg/collector/python`
- Docker Hub smoke test materialized `python-check:mongo` from the PoC image: 41 range requests, 1,173,490 compressed bytes, 47 entries; second run hit the persistent cache.

Local `dda inv test --targets=./pkg/collector/python` and pre-push `go-test` are blocked in this worktree by missing `rtloader/build/rtloader/libdatadog-agent-rtloader`; the new package test passes independently.