### PR TITLE
fix(par): surface rshell sandbox warnings via dedicated output field

### DIFF
--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"slices"
@@ -123,10 +124,17 @@ type RunCommandInputs struct {
 }
 
 // RunCommandOutputs defines the outputs for the runCommand action.
+//
+// SandboxWarnings carries non-fatal diagnostic messages emitted by rshell
+// during runner construction (e.g. an AllowedPaths entry that does not
+// exist on the host). Empty when the sandbox configuration is clean. These
+// messages indicate misconfiguration, not command failure: they are
+// independent of ExitCode.
 type RunCommandOutputs struct {
-	ExitCode int    `json:"exitCode"`
-	Stdout   string `json:"stdout"`
-	Stderr   string `json:"stderr"`
+	ExitCode        int      `json:"exitCode"`
+	Stdout          string   `json:"stdout"`
+	Stderr          string   `json:"stderr"`
+	SandboxWarnings []string `json:"sandboxWarnings,omitempty"`
 }
 
 // Run executes the command through the rshell restricted interpreter.
@@ -161,8 +169,12 @@ func (h *RunCommandHandler) Run(
 		}
 	}
 	var stdout, stderr bytes.Buffer
+	// Route sandbox diagnostics to a dedicated sink so they do not leak
+	// into the action's stderr field. We discard the streaming output and
+	// read the messages back via runner.Warnings() into SandboxWarnings.
 	runner, err := interp.New(
 		interp.StdIO(nil, &stdout, &stderr),
+		interp.WarningsWriter(io.Discard),
 		interp.AllowedPaths(effectiveAllowedPaths),
 		interp.ProcPath(resolveProcPath()),
 		interp.AllowedCommands(effectiveAllowedCommands),
@@ -185,9 +197,10 @@ func (h *RunCommandHandler) Run(
 	}
 
 	return &RunCommandOutputs{
-		ExitCode: exitCode,
-		Stdout:   stdout.String(),
-		Stderr:   stderr.String(),
+		ExitCode:        exitCode,
+		Stdout:          stdout.String(),
+		Stderr:          stderr.String(),
+		SandboxWarnings: runner.Warnings(),
 	}, nil
 }
 

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -486,6 +486,56 @@ func TestRunCommandBackendAllowedPathsRestrictsAccess(t *testing.T) {
 		"expected cat to fail because /var/log is not in the backend list")
 }
 
+func TestRunCommandSandboxWarningsKeepStderrClean(t *testing.T) {
+	// AllowedPaths includes one valid + one missing entry. The rshell
+	// library emits a "skipping" diagnostic for the missing one. The
+	// handler must surface that diagnostic in SandboxWarnings, not in
+	// Stderr — so callers inspecting Stderr to detect command failure
+	// don't see false positives. ExitCode and Stdout are independent of
+	// the sandbox configuration noise. The missing path is chosen so it
+	// does not share a prefix with the temp dir; otherwise
+	// reducePathListToBroadest collapses them and rshell never sees the
+	// missing one.
+	dir := t.TempDir()
+	missing := "/__rshell_sandbox_warnings_test_missing__"
+	handler := NewRunCommandHandler([]string{setup.RShellPathAllowAll}, []string{"rshell:echo"})
+
+	task := makeTaskWithPaths("echo hello",
+		[]string{"rshell:echo"},
+		map[string][]string{setup.RShellPathAllowMapDefaultKey: {dir, missing}})
+
+	out, err := handler.Run(context.Background(), task, nil)
+
+	require.NoError(t, err)
+	result := out.(*RunCommandOutputs)
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Equal(t, "hello\n", result.Stdout)
+	assert.Empty(t, result.Stderr,
+		"sandbox warnings must not leak into the command's stderr field")
+	require.Len(t, result.SandboxWarnings, 1,
+		"the missing path should produce exactly one warning")
+	assert.Contains(t, result.SandboxWarnings[0], "AllowedPaths: skipping")
+}
+
+func TestRunCommandSandboxWarningsNilWhenCleanConfig(t *testing.T) {
+	// All configured paths exist — SandboxWarnings must be nil so the
+	// JSON wire output omits the field entirely (omitempty).
+	dir := t.TempDir()
+	handler := NewRunCommandHandler([]string{setup.RShellPathAllowAll}, []string{"rshell:echo"})
+
+	task := makeTaskWithPaths("echo hi",
+		[]string{"rshell:echo"},
+		map[string][]string{setup.RShellPathAllowMapDefaultKey: {dir}})
+
+	out, err := handler.Run(context.Background(), task, nil)
+
+	require.NoError(t, err)
+	result := out.(*RunCommandOutputs)
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Nil(t, result.SandboxWarnings,
+		"a clean sandbox configuration must produce no warnings")
+}
+
 func mockStatFn(existing map[string]bool) func(string) (os.FileInfo, error) {
 	return func(path string) (os.FileInfo, error) {
 		if existing[path] {

--- a/releasenotes/notes/par-rshell-sandbox-warnings-928404b5babdf16c.yaml
+++ b/releasenotes/notes/par-rshell-sandbox-warnings-928404b5babdf16c.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Private Action Runner ``runCommand`` action no longer leaks
+    ``AllowedPaths`` skip diagnostics into the action's ``stderr`` field
+    when a configured path is missing on the host (e.g. a Unix-shaped
+    path on Windows). Diagnostics are now surfaced in a new
+    ``sandboxWarnings`` output field, leaving ``stderr`` reserved for
+    actual command output.

--- a/releasenotes/notes/par-rshell-sandbox-warnings-928404b5babdf16c.yaml
+++ b/releasenotes/notes/par-rshell-sandbox-warnings-928404b5babdf16c.yaml
@@ -1,9 +1,0 @@
----
-fixes:
-  - |
-    Private Action Runner ``runCommand`` action no longer leaks
-    ``AllowedPaths`` skip diagnostics into the action's ``stderr`` field
-    when a configured path is missing on the host (e.g. a Unix-shaped
-    path on Windows). Diagnostics are now surfaced in a new
-    ``sandboxWarnings`` output field, leaving ``stderr`` reserved for
-    actual command output.


### PR DESCRIPTION
### What does this PR do?

- Adds an optional `sandboxWarnings: string[]` field to `RunCommandOutputs` for the Private Action Runner `runCommand` action.
- Routes rshell sandbox diagnostics into that field instead of the action's `stderr`, by passing `interp.WarningsWriter(io.Discard)` and reading `runner.Warnings()` after `interp.New(...)`.

### Motivation

When `AllowedPaths` for `runCommand` contains a path that does not exist on the host (e.g. `/var/log` on Windows, `C:\var\log` on Linux), rshell emits a non-fatal `AllowedPaths: skipping ...` diagnostic during runner construction. Up to v0.0.13 the library flushed those diagnostics onto the runner's stderr writer, which the handler surfaced in `RunCommandOutputs.Stderr` — making every script execution look like a failure (non-empty stderr) even though `ExitCode == 0`.

[DataDog/rshell#200](https://github.com/DataDog/rshell/pull/200) (in v0.0.14) decoupled sandbox diagnostics from the runner's stderr writer behind an opt-in `WarningsWriter` option and a `Runner.Warnings()` accessor. This PR adopts both.

Closes [DataDog/rshell#191](https://github.com/DataDog/rshell/issues/191) on the agent side. The matching contract change in dd-source — additive `sandboxWarnings?: string[]` on `RunCommandOutputs` — is in [DataDog/dd-source#423305](https://github.com/DataDog/dd-source/pull/423305).

### Describe how you validated your changes

- `go build ./pkg/privateactionrunner/...` — clean.
- `go test -count=1 ./pkg/privateactionrunner/bundles/remoteaction/rshell/...` — all tests pass, including two new ones:
  - `TestRunCommandSandboxWarningsKeepStderrClean`: configures one valid + one missing `AllowedPaths` entry, runs `echo hello`, asserts `Stderr` is empty (no sandbox diagnostic leakage), and `SandboxWarnings` carries one `AllowedPaths: skipping ...` entry naming the missing path.
  - `TestRunCommandSandboxWarningsNilWhenCleanConfig`: a clean configuration must produce `nil` `SandboxWarnings` so the field is omitted from the JSON wire output.

### Additional Notes

- `SandboxWarnings` uses `json:"sandboxWarnings,omitempty"`. Old PAR consumers that don't know about the field continue to deserialize the response unchanged.
- `interp.WarningsWriter(io.Discard)` is the right choice here because we read messages back via the accessor — there's no value in also writing them to the runner's stderr buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)