### PR TITLE
Migrate bpf_maps_generator codegen to Bazel

### DIFF
--- a/bazel/rules/cws_codegen/defs.bzl
+++ b/bazel/rules/cws_codegen/defs.bzl
@@ -32,3 +32,34 @@ operators = macro(
         "output": attr.string(mandatory = True, configurable = False, doc = "Name of the generated .go file (e.g. eval_operators.go)."),
     },
 )
+
+def _bpf_maps_generator_impl(name, header, output, package_name, visibility):
+    gen = "{}_gen".format(name)
+    run_binary(
+        name = gen,
+        srcs = [header],
+        args = [
+            "-runtime-path=$(execpath {})".format(header),
+            "-output=$(execpath {}/{})".format(name, output),
+            "-pkg-name={}".format(package_name),
+        ],
+        outs = ["{}/{}".format(name, output)],
+        tool = "//pkg/security/secl/model/bpf_maps_generator",
+    )
+    native.exports_files([output], visibility)
+    write_source_file(
+        name = name,
+        in_file = ":{}".format(gen),
+        out_file = output,
+        check_that_out_file_exists = False,
+    )
+
+bpf_maps_generator = macro(
+    implementation = _bpf_maps_generator_impl,
+    doc = "Scan a BPF maps header file and generate the matching []string of map names via //pkg/security/secl/model/bpf_maps_generator.",
+    attrs = {
+        "header": attr.label(mandatory = True, configurable = False, allow_single_file = [".h"], doc = "Label of the BPF maps header file to scan (e.g. //pkg/security/ebpf/c/include:maps.h)."),
+        "output": attr.string(mandatory = True, configurable = False, doc = "Name of the generated .go file (e.g. consts_map_names_linux.go)."),
+        "package_name": attr.string(mandatory = True, configurable = False, doc = "Go package name to write into the generated file."),
+    },
+)

--- a/pkg/security/ebpf/c/include/BUILD.bazel
+++ b/pkg/security/ebpf/c/include/BUILD.bazel
@@ -14,3 +14,9 @@ filegroup(
     srcs = _SECURITY_HDRS,
     visibility = ["//visibility:public"],
 )
+
+# bpf_maps_generator (//bazel/rules/cws_codegen:defs.bzl) consumes maps.h directly.
+exports_files(
+    ["maps.h"],
+    visibility = ["//pkg/security/secl/model:__pkg__"],
+)

--- a/pkg/security/secl/model/BUILD.bazel
+++ b/pkg/security/secl/model/BUILD.bazel
@@ -1,10 +1,14 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("//bazel/rules/cws_codegen:defs.bzl", "bpf_maps_generator")
 load("//bazel/rules/go_stringer:defs.bzl", "go_stringer")
 
 exports_files(
     glob(
         ["*.go"],
-        exclude = ["model_string.go"],
+        exclude = [
+            "consts_map_names_linux.go",
+            "model_string.go",
+        ],
     ),
     visibility = ["//pkg/security/seclwin/model:__pkg__"],
 )
@@ -15,6 +19,18 @@ go_stringer(
     linecomment = True,
     output = "model_string.go",
     types = ["HashState"],
+)
+
+# TODO(ABLD-420): hand-wired because the matching //go:generate directive lives
+# in pkg/security/ebpf/map.go, which is currently gazelle-excluded. Once
+# pkg/security/ebpf is gazelle-managed, teach the //bazel/rules/cws_codegen
+# extension to parse this directive (and either emit the rule here, or move the
+# directive into this package) and drop this manual call.
+bpf_maps_generator(
+    name = "consts_map_names_linux",
+    package_name = "model",
+    header = "//pkg/security/ebpf/c/include:maps.h",
+    output = "consts_map_names_linux.go",
 )
 
 go_library(

--- a/pkg/security/secl/model/bpf_maps_generator/bpf_maps_generator.go
+++ b/pkg/security/secl/model/bpf_maps_generator/bpf_maps_generator.go
@@ -8,11 +8,12 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	_ "embed"
 	"flag"
 	"fmt"
+	"go/format"
 	"os"
-	"os/exec"
 	"regexp"
 	"sort"
 	"text/template" //nolint:depguard
@@ -96,24 +97,20 @@ func main() {
 		panic(err)
 	}
 
-	outputFile, err := os.Create(outputPath)
-	if err != nil {
-		panic(err)
-	}
-
-	if err := tmpl.Execute(outputFile, tmplContext{
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, tmplContext{
 		PackageName: packageName,
 		Entries:     entries,
 	}); err != nil {
 		panic(err)
 	}
 
-	if err := outputFile.Close(); err != nil {
+	formatted, err := format.Source(buf.Bytes())
+	if err != nil {
 		panic(err)
 	}
 
-	cmd := exec.Command("gofmt", "-s", "-w", outputPath)
-	if err := cmd.Run(); err != nil {
+	if err := os.WriteFile(outputPath, formatted, 0644); err != nil {
 		panic(err)
 	}
 }

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -525,16 +525,17 @@ def cws_go_generate(ctx, verbose=False):
     ctx.run("go install github.com/mailru/easyjson/easyjson")
     ctx.run("go install github.com/DataDog/datadog-agent/pkg/security/generators/accessors")
     ctx.run("go install github.com/DataDog/datadog-agent/pkg/security/generators/event_deep_copy")
-    # operators codegen is driven by Bazel via //bazel/rules/cws_codegen:defs.bzl%operators.
-    # Run it first so eval_operators.go is fresh for subsequent generators, then skip
-    # the //go:generate directive in `go generate` calls below. See ABLD-420.
+    # CWS codegens migrated to Bazel keep their //go:generate directives so a future
+    # Gazelle extension can pick them up; we just skip them in `go generate` here.
+    # See ABLD-420.
     bazel(ctx, "run", "//pkg/security/secl/compiler/eval:eval_operators")
+    bazel(ctx, "run", "//pkg/security/secl/model:consts_map_names_linux")
     with ctx.cd("./pkg/security/secl"):
         if sys.platform == "linux":
             ctx.run("GOOS=windows go generate -run=-tag.+windows ./...")
         elif is_windows:
             ctx.run('set "GOOS=linux" && go generate -run=-tag.+unix ./...')
-        cmd = "go generate -skip=operators"
+        cmd = "go generate -skip='operators|bpf_maps_generator'"
         if verbose:
             cmd += " -v"
         ctx.run(cmd + " ./...")
@@ -547,7 +548,7 @@ def cws_go_generate(ctx, verbose=False):
 
     ctx.run("go generate ./pkg/security/probe/remediations_linux.go")
     ctx.run("go generate ./pkg/security/probe/custom_events.go")
-    ctx.run("go generate -skip=operators -tags=linux_bpf,cws_go_generate ./pkg/security/...")
+    ctx.run("go generate -skip='operators|bpf_maps_generator' -tags=linux_bpf,cws_go_generate ./pkg/security/...")
 
     # synchronize the seclwin package from the secl package
     bazel(ctx, "run", "//pkg/security/seclwin:sync")


### PR DESCRIPTION
### What does this PR do?

Wraps the `bpf_maps_generator` Go binary in a hermetic Bazel macro (`//bazel/rules/cws_codegen:defs.bzl%bpf_maps_generator`) and uses `write_source_file` to keep `pkg/security/secl/model/consts_map_names_linux.go` in lockstep with `pkg/security/ebpf/c/include/maps.h`.

The generator no longer shells out to `gofmt` — it formats via the standard library's `go/format` package — so the action is self-contained and reproducible under Bazel.

The `//go:generate` directive in `pkg/security/ebpf/map.go` is intentionally kept, so a future Gazelle extension can adopt this rule once `pkg/security/ebpf` becomes Gazelle-managed. In the meantime, `cws_go_generate` skips it via `-skip='operators|bpf_maps_generator'` and gains an explicit `bazel run //pkg/security/secl/model:consts_map_names_linux` so manual invocations stay in sync with Bazel.

### Motivation

Refs [ABLD-420](https://datadoghq.atlassian.net/browse/ABLD-420). Continues the migration of CWS code generators from \`go generate\` shell-outs to hermetic, cacheable Bazel rules. Predecessor: #49977 (operators).

### Describe how you validated your changes

- `bazel run //pkg/security/secl/model:consts_map_names_linux` produces a byte-identical `consts_map_names_linux.go` to the file currently checked in (no working-tree diff after the run).
- `bazel test //pkg/security/secl/model:consts_map_names_linux_test` (the diff_test produced by `write_source_file`) passes.
- `bazel build //pkg/security/secl/model:model` and `bazel test //pkg/security/secl/model:model_test` still build/pass.

### Additional Notes

`consts_map_names_linux.go` is now excluded from the package-level `exports_files` glob (alongside `model_string.go`) so the macro can own its visibility, mirroring the pattern already used for `go_stringer`.

[ABLD-420]: https://datadoghq.atlassian.net/browse/ABLD-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ