### PR TITLE
[ACTP] retry PAR enrollment on server failures

### DIFF
--- a/pkg/privateactionrunner/autoconnections/client.go
+++ b/pkg/privateactionrunner/autoconnections/client.go
@@ -15,9 +15,19 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+	parutil "github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/jsonapi"
+)
+
+const (
+	createConnectionInitialBackoff = 1 * time.Second
+	createConnectionMaxBackoff     = 30 * time.Second
+	// Bounded so a flaky API can't block startup indefinitely: connection
+	// creation is best-effort (callers log-and-continue on failure), and we
+	// don't want a single bad connection to delay the rest of the loop.
+	createConnectionMaxElapsed = 5 * time.Minute
 )
 
 // ConnectionsClient is an HTTP client for creating connections via the Datadog API.
@@ -26,6 +36,7 @@ type ConnectionsClient struct {
 	baseUrl    string
 	apiKey     string
 	appKey     string
+	retryOpts  parutil.RetryHTTPOptions
 }
 
 func NewConnectionsAPIClient(cfg model.Reader, ddSite, apiKey, appKey string) (*ConnectionsClient, error) {
@@ -42,6 +53,11 @@ func NewConnectionsAPIClient(cfg model.Reader, ddSite, apiKey, appKey string) (*
 		baseUrl:    baseUrl,
 		apiKey:     apiKey,
 		appKey:     appKey,
+		retryOpts: parutil.RetryHTTPOptions{
+			InitialInterval: createConnectionInitialBackoff,
+			MaxInterval:     createConnectionMaxBackoff,
+			MaxElapsedTime:  createConnectionMaxElapsed,
+		},
 	}, nil
 }
 
@@ -94,9 +110,20 @@ func (c *ConnectionsClient) CreateConnection(ctx context.Context, definition Con
 
 	url := c.baseUrl + createConnectionEndpoint
 
+	_, err = parutil.RetryHTTPRequest(ctx, func() (struct{}, int, error) {
+		statusCode, sendErr := c.sendCreateConnection(ctx, url, body)
+		return struct{}{}, statusCode, sendErr
+	}, c.retryOpts)
+	return err
+}
+
+// sendCreateConnection performs a single connection-create POST and returns
+// the HTTP status code along with any error. The status code is 0 for
+// transport-level failures.
+func (c *ConnectionsClient) sendCreateConnection(ctx context.Context, url string, body []byte) (int, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return 0, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	httpReq.Header.Set(apiKeyHeader, c.apiKey)
@@ -106,18 +133,18 @@ func (c *ConnectionsClient) CreateConnection(ctx context.Context, definition Con
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return 0, fmt.Errorf("request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("failed to read response: %w", err)
+		return resp.StatusCode, fmt.Errorf("failed to read response: %w", err)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("API request failed: %d - %s", resp.StatusCode, string(respBody))
+		return resp.StatusCode, fmt.Errorf("API request failed: %d - %s", resp.StatusCode, string(respBody))
 	}
 
-	return nil
+	return resp.StatusCode, nil
 }

--- a/pkg/privateactionrunner/autoconnections/client_test.go
+++ b/pkg/privateactionrunner/autoconnections/client_test.go
@@ -10,14 +10,32 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config/mock"
+	parutil "github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
 	"github.com/DataDog/jsonapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// newTestClient builds a ConnectionsClient with retry intervals tight enough
+// that 5xx tests don't waste real time before exhausting MaxElapsedTime.
+func newTestClient(baseUrl string) *ConnectionsClient {
+	return &ConnectionsClient{
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		baseUrl:    baseUrl,
+		apiKey:     "test-api-key",
+		appKey:     "test-app-key",
+		retryOpts: parutil.RetryHTTPOptions{
+			InitialInterval: 1 * time.Millisecond,
+			MaxInterval:     2 * time.Millisecond,
+			MaxElapsedTime:  20 * time.Millisecond,
+		},
+	}
+}
 
 // mockTagsProvider is a test double for TagsProvider
 type mockTagsProvider struct {
@@ -125,12 +143,7 @@ func TestCreateConnection_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &ConnectionsClient{
-		httpClient: &http.Client{Timeout: 10 * time.Second},
-		baseUrl:    server.URL,
-		apiKey:     "test-api-key",
-		appKey:     "test-app-key",
-	}
+	client := newTestClient(server.URL)
 
 	httpDef := ConnectionDefinition{
 		FQNPrefix:       "com.datadoghq.http",
@@ -159,12 +172,8 @@ func TestCreateConnection_Success(t *testing.T) {
 }
 
 func TestCreateConnection_MissingAppKey(t *testing.T) {
-	client := &ConnectionsClient{
-		httpClient: &http.Client{Timeout: 10 * time.Second},
-		baseUrl:    "http://localhost",
-		apiKey:     "test-api-key",
-		appKey:     "",
-	}
+	client := newTestClient("http://localhost")
+	client.appKey = ""
 
 	httpDef := ConnectionDefinition{
 		FQNPrefix:       "com.datadoghq.http",
@@ -216,12 +225,7 @@ func TestCreateConnection_ErrorResponses(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := &ConnectionsClient{
-				httpClient: &http.Client{Timeout: 10 * time.Second},
-				baseUrl:    server.URL,
-				apiKey:     "test-api-key",
-				appKey:     "test-app-key",
-			}
+			client := newTestClient(server.URL)
 
 			httpDef := ConnectionDefinition{
 				FQNPrefix:       "com.datadoghq.http",
@@ -241,6 +245,87 @@ func TestCreateConnection_ErrorResponses(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.responseBody)
 		})
 	}
+}
+
+func TestCreateConnection_RetriesOn5xxThenSucceeds(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"errors": ["temporary"]}`))
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data": {"id": "conn-123"}}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	// Give this test a longer budget than the default helper since we expect
+	// real retries to occur.
+	client.retryOpts.MaxElapsedTime = 1 * time.Second
+
+	httpDef := ConnectionDefinition{
+		FQNPrefix:       "com.datadoghq.http",
+		IntegrationType: "HTTP",
+		Credentials:     CredentialConfig{Type: "HTTPNoAuth"},
+	}
+
+	err := client.CreateConnection(context.Background(), httpDef, "runner-id-123", "runner-name", []string{"tag:1"})
+
+	require.NoError(t, err)
+	assert.EqualValues(t, 3, atomic.LoadInt32(&hits), "should have retried until success")
+}
+
+func TestCreateConnection_NoRetryOn4xx(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"errors": ["forbidden"]}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+
+	httpDef := ConnectionDefinition{
+		FQNPrefix:       "com.datadoghq.http",
+		IntegrationType: "HTTP",
+		Credentials:     CredentialConfig{Type: "HTTPNoAuth"},
+	}
+
+	err := client.CreateConnection(context.Background(), httpDef, "runner-id-123", "runner-name", []string{"tag:1"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+	assert.EqualValues(t, 1, atomic.LoadInt32(&hits), "4xx must not be retried")
+}
+
+func TestCreateConnection_5xxExhaustsBudgetThenFails(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"errors": ["broken"]}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+
+	httpDef := ConnectionDefinition{
+		FQNPrefix:       "com.datadoghq.http",
+		IntegrationType: "HTTP",
+		Credentials:     CredentialConfig{Type: "HTTPNoAuth"},
+	}
+
+	start := time.Now()
+	err := client.CreateConnection(context.Background(), httpDef, "runner-id-123", "runner-name", []string{"tag:1"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+	assert.Greater(t, atomic.LoadInt32(&hits), int32(1), "5xx should retry at least once")
+	assert.Less(t, time.Since(start), 1*time.Second, "should bail within MaxElapsedTime budget")
 }
 
 func TestBuildConnectionRequest_KubernetesNoIntegrationFields(t *testing.T) {

--- a/pkg/privateactionrunner/autoconnections/connections_creator_test.go
+++ b/pkg/privateactionrunner/autoconnections/connections_creator_test.go
@@ -40,12 +40,8 @@ func TestCreateConnection_CorrectHTTPRequest(t *testing.T) {
 	defer server.Close()
 
 	// Create client with mock server endpoint
-	client := &ConnectionsClient{
-		httpClient: &http.Client{},
-		baseUrl:    server.URL,
-		apiKey:     "test-api-key",
-		appKey:     "test-app-key",
-	}
+	client := newTestClient(server.URL)
+	client.httpClient = &http.Client{}
 
 	definition := supportedConnections["kubernetes"]
 
@@ -112,12 +108,8 @@ func TestCreateConnection_StatusCodeHandling(t *testing.T) {
 			defer server.Close()
 
 			// Create client with mock server endpoint
-			client := &ConnectionsClient{
-				httpClient: &http.Client{},
-				baseUrl:    server.URL,
-				apiKey:     "test-api-key",
-				appKey:     "test-app-key",
-			}
+			client := newTestClient(server.URL)
+			client.httpClient = &http.Client{}
 
 			definition := supportedConnections["kubernetes"]
 
@@ -152,12 +144,8 @@ func TestAutoCreateConnections_AllBundlesSuccess(t *testing.T) {
 	actionsAllowlist := []string{"com.datadoghq.http.request", "com.datadoghq.kubernetes.core.getPods", "com.datadoghq.script.runPredefinedScipt"}
 
 	// Use server's client which is pre-configured for TLS
-	testClient := &ConnectionsClient{
-		httpClient: server.Client(),
-		baseUrl:    server.URL,
-		apiKey:     "test-api-key",
-		appKey:     "test-app-key",
-	}
+	testClient := newTestClient(server.URL)
+	testClient.httpClient = server.Client()
 
 	provider := &mockTagsProvider{}
 
@@ -181,20 +169,22 @@ func TestAutoCreateConnections_AllBundlesSuccess(t *testing.T) {
 }
 
 func TestAutoCreateConnections_PartialFailures(t *testing.T) {
-	requestCount := 0
+	var k8sAttempts, scriptAttempts int
 
-	// Mock HTTPS server - fail HTTP, succeed others
+	// Mock HTTPS server - fail Kubernetes, succeed others. Kubernetes will be
+	// retried until the client's MaxElapsedTime budget is exhausted, then
+	// AutoCreateConnections moves on to the next connection.
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
 		body, _ := io.ReadAll(r.Body)
 
-		// Fail if it's the Kubernetes
 		if strings.Contains(string(body), `"name":"Kubernetes (runner-abc123)"`) {
+			k8sAttempts++
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(`{"errors": ["internal error"]}`))
 			return
 		}
 
+		scriptAttempts++
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(`{"data": {"id": "conn-123"}}`))
 	}))
@@ -203,12 +193,8 @@ func TestAutoCreateConnections_PartialFailures(t *testing.T) {
 	actionsAllowlist := []string{"com.datadoghq.http.request", "com.datadoghq.kubernetes.core.getPods", "com.datadoghq.script.runPredefinedScipt"}
 
 	// Use server's client which is pre-configured for TLS
-	testClient := &ConnectionsClient{
-		httpClient: server.Client(),
-		baseUrl:    server.URL,
-		apiKey:     "test-api-key",
-		appKey:     "test-app-key",
-	}
+	testClient := newTestClient(server.URL)
+	testClient.httpClient = server.Client()
 
 	provider := &mockTagsProvider{}
 
@@ -224,7 +210,8 @@ func TestAutoCreateConnections_PartialFailures(t *testing.T) {
 
 	// Should return nil even with failures (non-blocking)
 	require.NoError(t, err, "AutoCreateConnections should not propagate errors")
-	assert.Equal(t, 2, requestCount, "Should attempt to create all 2 connections")
+	assert.GreaterOrEqual(t, k8sAttempts, 1, "Kubernetes should be attempted")
+	assert.Equal(t, 1, scriptAttempts, "Script should be created exactly once after k8s retries are exhausted")
 }
 
 func TestAutoCreateConnections_NoRelevantBundles(t *testing.T) {
@@ -241,12 +228,8 @@ func TestAutoCreateConnections_NoRelevantBundles(t *testing.T) {
 	actionsAllowlist := []string{"com.datadoghq.gitlab.issues.getIssue"}
 
 	// Use server's client which is pre-configured for TLS
-	testClient := &ConnectionsClient{
-		httpClient: server.Client(),
-		baseUrl:    server.URL,
-		apiKey:     "test-api-key",
-		appKey:     "test-app-key",
-	}
+	testClient := newTestClient(server.URL)
+	testClient.httpClient = server.Client()
 
 	provider := &mockTagsProvider{}
 
@@ -280,12 +263,8 @@ func TestAutoCreateConnections_PartialAllowlist(t *testing.T) {
 	actionsAllowlist := []string{"com.datadoghq.script.runPredefinedScipt"}
 
 	// Use server's client which is pre-configured for TLS
-	testClient := &ConnectionsClient{
-		httpClient: server.Client(),
-		baseUrl:    server.URL,
-		apiKey:     "test-api-key",
-		appKey:     "test-app-key",
-	}
+	testClient := newTestClient(server.URL)
+	testClient.httpClient = server.Client()
 
 	provider := &mockTagsProvider{}
 

--- a/pkg/privateactionrunner/opms/public_opms.go
+++ b/pkg/privateactionrunner/opms/public_opms.go
@@ -26,6 +26,9 @@ import (
 
 const (
 	createPARPath = "/api/unstable/on_prem_runners"
+
+	enrollmentInitialBackoff = 1 * time.Second
+	enrollmentMaxBackoff     = 30 * time.Second
 )
 
 // PublicClient exposes endpoint that don't require JWT authentication
@@ -94,9 +97,42 @@ func (p *publicClient) EnrollWithApiKey(
 		return nil, fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", createRunnerUrl.String(), strings.NewReader(string(requestBodyJSON)))
+	respBody, err := p.doEnrollRequestWithRetry(ctx, createRunnerUrl.String(), requestBodyJSON, apiKey, appKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build runner creation request: %w", err)
+		return nil, err
+	}
+
+	createRunnerResponse := new(par.CreateRunnerResponse)
+	err = jsonapi.Unmarshal(respBody, createRunnerResponse)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal runner creation response: %w", err)
+	}
+	return createRunnerResponse, nil
+}
+
+// doEnrollRequestWithRetry sends the enrollment POST and retries on transport
+// errors or HTTP 5xx responses with exponential backoff. 4xx responses are
+// returned immediately. Retries are unbounded; the caller's context
+// cancellation is the only exit other than success or a permanent (4xx)
+// failure. Enrollment is required for the runner to function, so we keep
+// trying rather than crashing the agent.
+func (p *publicClient) doEnrollRequestWithRetry(ctx context.Context, url string, body []byte, apiKey, appKey string) ([]byte, error) {
+	return util.RetryHTTPRequest(ctx, func() ([]byte, int, error) {
+		return p.doEnrollRequest(ctx, url, body, apiKey, appKey)
+	}, util.RetryHTTPOptions{
+		InitialInterval: enrollmentInitialBackoff,
+		MaxInterval:     enrollmentMaxBackoff,
+		// MaxElapsedTime: 0 — retry forever until ctx is cancelled.
+	})
+}
+
+// doEnrollRequest sends a single enrollment POST. Returns the response body on
+// success. On non-2xx responses, returns the status code so the caller can
+// decide whether to retry.
+func (p *publicClient) doEnrollRequest(ctx context.Context, url string, body []byte, apiKey, appKey string) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(string(body)))
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to build runner creation request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/vnd.api+json")
@@ -109,28 +145,22 @@ func (p *publicClient) EnrollWithApiKey(
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send runner creation request: %w", err)
+		return nil, 0, fmt.Errorf("failed to send runner creation request: %w", err)
 	}
 	defer func() {
-		err = resp.Body.Close()
-		if err != nil {
-			log.Error("error closing runner creation response body", log.ErrorField(err))
+		if cerr := resp.Body.Close(); cerr != nil {
+			log.Error("error closing runner creation response body", log.ErrorField(cerr))
 		}
 	}()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("runner creation failed with HTTP status code %d and failed to read HTTP response with error %w", resp.StatusCode, err)
+		return nil, resp.StatusCode, fmt.Errorf("runner creation failed with HTTP status code %d and failed to read HTTP response with error %w", resp.StatusCode, err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("runner creation failed with HTTP status code %d and response %s", resp.StatusCode, string(respBody))
+		return nil, resp.StatusCode, fmt.Errorf("runner creation failed with HTTP status code %d and response %s", resp.StatusCode, string(respBody))
 	}
 
-	createRunnerResponse := new(par.CreateRunnerResponse)
-	err = jsonapi.Unmarshal(respBody, createRunnerResponse)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal runner creation response: %w", err)
-	}
-	return createRunnerResponse, nil
+	return respBody, resp.StatusCode, nil
 }

--- a/pkg/privateactionrunner/util/BUILD.bazel
+++ b/pkg/privateactionrunner/util/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "circuit_breaker.go",
         "context.go",
         "error.go",
+        "http_retry.go",
         "jwt.go",
         "keys.go",
         "response_parser.go",
@@ -16,6 +17,7 @@ go_library(
     deps = [
         "//pkg/privateactionrunner/adapters/logging",
         "//pkg/proto/pbgo/privateactionrunner/errorcode",
+        "@com_github_cenkalti_backoff_v5//:backoff",
         "@com_github_go_jose_go_jose_v4//:go-jose",
         "@com_github_golang_jwt_jwt_v5//:jwt",
     ],
@@ -23,7 +25,10 @@ go_library(
 
 go_test(
     name = "util_test",
-    srcs = ["keys_test.go"],
+    srcs = [
+        "http_retry_test.go",
+        "keys_test.go",
+    ],
     embed = [":util"],
     gotags = ["test"],
     deps = ["@com_github_stretchr_testify//assert"],

--- a/pkg/privateactionrunner/util/BUILD.bazel
+++ b/pkg/privateactionrunner/util/BUILD.bazel
@@ -31,5 +31,8 @@ go_test(
     ],
     embed = [":util"],
     gotags = ["test"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/privateactionrunner/util/http_retry.go
+++ b/pkg/privateactionrunner/util/http_retry.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package util
+
+import (
+	"context"
+	"time"
+
+	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
+	"github.com/cenkalti/backoff/v5"
+)
+
+// RetryHTTPOptions controls the retry policy for RetryHTTPRequest.
+//
+// MaxElapsedTime == 0 disables the elapsed-time cap, meaning retries continue
+// until the request succeeds, hits a permanent failure (4xx), or the caller's
+// context is cancelled.
+type RetryHTTPOptions struct {
+	InitialInterval time.Duration
+	MaxInterval     time.Duration
+	MaxElapsedTime  time.Duration
+}
+
+// RetryHTTPRequest runs op with exponential backoff. op returns
+// (result, statusCode, err); statusCode should be 0 for transport-level errors
+// where no HTTP response was received.
+//
+// 4xx responses are treated as permanent (no retry) since they typically
+// indicate a non-transient client problem (bad credentials, malformed payload).
+// Transport errors and 5xx responses are retried.
+func RetryHTTPRequest[T any](ctx context.Context, op func() (T, int, error), opts RetryHTTPOptions) (T, error) {
+	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.InitialInterval = opts.InitialInterval
+	expBackoff.MaxInterval = opts.MaxInterval
+
+	return backoff.Retry(ctx, func() (T, error) {
+		result, statusCode, err := op()
+		if err == nil {
+			return result, nil
+		}
+		if statusCode >= 400 && statusCode < 500 {
+			return result, backoff.Permanent(err)
+		}
+		log.FromContext(ctx).Warnf("HTTP request failed, will retry: %v", err)
+		return result, err
+	},
+		backoff.WithBackOff(expBackoff),
+		backoff.WithMaxElapsedTime(opts.MaxElapsedTime),
+	)
+}

--- a/pkg/privateactionrunner/util/http_retry_test.go
+++ b/pkg/privateactionrunner/util/http_retry_test.go
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package util
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fastTestOpts uses sub-millisecond intervals so tests don't spend real time waiting.
+func fastTestOpts(maxElapsed time.Duration) RetryHTTPOptions {
+	return RetryHTTPOptions{
+		InitialInterval: 1 * time.Millisecond,
+		MaxInterval:     2 * time.Millisecond,
+		MaxElapsedTime:  maxElapsed,
+	}
+}
+
+func TestRetryHTTPRequest_SuccessFirstTry(t *testing.T) {
+	var calls int32
+	result, err := RetryHTTPRequest(context.Background(), func() (string, int, error) {
+		atomic.AddInt32(&calls, 1)
+		return "ok", 200, nil
+	}, fastTestOpts(0))
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&calls))
+}
+
+func TestRetryHTTPRequest_RetriesOn5xxThenSucceeds(t *testing.T) {
+	var calls int32
+	result, err := RetryHTTPRequest(context.Background(), func() (string, int, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			return "", 503, errors.New("service unavailable")
+		}
+		return "ok", 200, nil
+	}, fastTestOpts(0))
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result)
+	assert.EqualValues(t, 3, atomic.LoadInt32(&calls))
+}
+
+func TestRetryHTTPRequest_RetriesOnTransportErrorThenSucceeds(t *testing.T) {
+	var calls int32
+	result, err := RetryHTTPRequest(context.Background(), func() (string, int, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 2 {
+			return "", 0, errors.New("dial tcp: connection refused")
+		}
+		return "ok", 200, nil
+	}, fastTestOpts(0))
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result)
+	assert.EqualValues(t, 2, atomic.LoadInt32(&calls))
+}
+
+func TestRetryHTTPRequest_NoRetryOn4xx(t *testing.T) {
+	var calls int32
+	originalErr := errors.New("bad credentials")
+	_, err := RetryHTTPRequest(context.Background(), func() (string, int, error) {
+		atomic.AddInt32(&calls, 1)
+		return "", 401, originalErr
+	}, fastTestOpts(0))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, originalErr)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&calls), "4xx should not retry")
+}
+
+func TestRetryHTTPRequest_StopsAtMaxElapsedTime(t *testing.T) {
+	var calls int32
+	originalErr := errors.New("server error")
+	start := time.Now()
+	_, err := RetryHTTPRequest(context.Background(), func() (string, int, error) {
+		atomic.AddInt32(&calls, 1)
+		return "", 500, originalErr
+	}, fastTestOpts(50*time.Millisecond))
+
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, originalErr)
+	assert.Greater(t, atomic.LoadInt32(&calls), int32(1), "should retry at least once")
+	assert.Less(t, elapsed, 1*time.Second, "should stop within MaxElapsedTime budget")
+}
+
+func TestRetryHTTPRequest_StopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls int32
+	go func() {
+		// Cancel after a few attempts.
+		for atomic.LoadInt32(&calls) < 2 {
+			time.Sleep(1 * time.Millisecond)
+		}
+		cancel()
+	}()
+
+	_, err := RetryHTTPRequest(ctx, func() (string, int, error) {
+		atomic.AddInt32(&calls, 1)
+		return "", 500, errors.New("transient")
+	}, fastTestOpts(0)) // unbounded, only ctx exits
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/releasenotes/notes/par-retry-enrollment-and-connections-2ef02634543a7d81.yaml
+++ b/releasenotes/notes/par-retry-enrollment-and-connections-2ef02634543a7d81.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    The Private Action Runner now retries self-enrollment and auto-connection
+    creation requests when the Datadog API returns a transient ``5xx``
+    response.


### PR DESCRIPTION
### What does this PR do?

Retry runner enrollment endpoint with exponential backoff on server error

### Motivation

Provide better resiliency. Currently k8s deployment will CLB while host deployment will stop and never restart.
By continuously retrying to enroll we get a behavior closer to other agent components and it should integrate well with initiatives like agent health.


### Describe how you validated your changes

Ran locally

### Additional Notes

Note : we don't retry on what is considered terminal failures (4xx) 
