### PR TITLE
Apply `testing/synctest` to `TestDomainForwarderHAPreFailover`

### DIFF
--- a/comp/forwarder/defaultforwarder/domain_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder_test.go
@@ -9,6 +9,7 @@ package defaultforwarder
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -121,6 +122,10 @@ func TestDomainForwarderSendHTTPTransactions(t *testing.T) {
 }
 
 func TestDomainForwarderHAPreFailover(t *testing.T) {
+	synctest.Test(t, syncTestDomainForwarderHAPreFailover)
+}
+
+func syncTestDomainForwarderHAPreFailover(t *testing.T) {
 	mockConfig := mock.New(t)
 	mockConfig.SetWithoutSource("multi_region_failover.enabled", "true")
 	mockConfig.SetWithoutSource("multi_region_failover.failover_metrics", "false")


### PR DESCRIPTION
### What does this PR do?
Extracts the test body into `syncTestDomainForwarderHAPreFailover`, taking `log` as a parameter so it can be created outside the `synctest` bubble, and replaces the original `TestDomainForwarderHAPreFailover` with a `synctest.Test` wrapper.

### Motivation
The test waited 1s on a `time.After(time.Second)` select to confirm a transaction was not queued.
The `synctest` bubble fires that timer instantly.

### Describe how you validated your changes
Measured with:
```
    go test -tags test -v -count 10 \
        -run TestDomainForwarderHAPreFailover$ \
        ./comp/forwarder/defaultforwarder/
```
```
before (10 samples): 1.03 1.03 1.03 1.02 1.02 1.02 1.02 1.03 1.02 1.02 s
                     avg 1.02 s
```
```
after  (10 samples): 0.04 0.03 0.03 0.03 0.04 0.03 0.03 0.03 0.04 0.03 s
                     avg 0.03 s
```

### Additional Notes
https://go.dev/blog/synctest