### PR TITLE
upgrade goflow2 to fix netflow parser issue (#49888)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -284,7 +284,7 @@ require (
 	github.com/miekg/dns v1.1.69
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/netsampler/goflow2 v1.3.3
+	github.com/netsampler/goflow2 v1.3.8-0.20260412031118-ad727784ae6f
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852
 	github.com/open-policy-agent/opa v1.7.1
@@ -656,7 +656,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-syslog/v4 v4.3.0 // indirect
 	github.com/leodido/ragel-machinery v0.0.0-20190525184631-5f46317e436b // indirect
-	github.com/libp2p/go-reuseport v0.2.0 // indirect
+	github.com/libp2p/go-reuseport v0.3.0 // indirect
 	github.com/lightstep/go-expohisto v1.0.0 // indirect
 	github.com/linode/go-metadata v0.2.4 // indirect
 	github.com/linode/linodego v1.63.0 // indirect

--- a/releasenotes/notes/netflow-fix-packet-parsing-72c15b929c5e832a.yaml
+++ b/releasenotes/notes/netflow-fix-packet-parsing-72c15b929c5e832a.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes an issue with the NetFlow collector where certain packets would be dropped, producing
+    error logs and lost data. The issue was caused when a packet had trailing padding
+    which was not properly handled.


### PR DESCRIPTION
This PR integrates the change from this PR https://github.com/netsampler/goflow2/pull/503 to fix an issue we are seeing in some customer environments when parsing incoming packets.

Addresses an issue reported by a customer

* Replayed packets from a pcap to validate that they are now parsed as expected


(cherry picked from commit 6d6e5fb70f921a1996ded0e1fd746f0769a16d31)
