### PR TITLE
coord run-log (full) — 2026-04-28 14:57

### DIFF
--- a/comp/logs/agent/agentimpl/agent.go
+++ b/comp/logs/agent/agentimpl/agent.go
@@ -33,7 +33,6 @@ import (
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	integrationsimpl "github.com/DataDog/datadog-agent/comp/logs/integrations/impl"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
-	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -84,9 +83,8 @@ type dependencies struct {
 	Auditor            auditor.Component
 	WMeta              option.Option[workloadmeta.Component]
 	SchedulerProviders []schedulers.Scheduler `group:"log-agent-scheduler"`
-	Tagger             tagger.Component
-	Compression        logscompression.Component
-	Observer           option.Option[observer.Component]
+	Tagger      tagger.Component
+	Compression logscompression.Component
 }
 
 type provides struct {
@@ -123,8 +121,7 @@ type logAgent struct {
 	wmeta                     option.Option[workloadmeta.Component]
 	schedulerProviders        []schedulers.Scheduler
 	integrationsLogs          integrations.Component
-	compression               logscompression.Component
-	observerHandle            observer.Handle
+	compression logscompression.Component
 
 	// make sure this is done only once, when we're ready
 	prepareSchedulers sync.Once
@@ -149,12 +146,6 @@ func newLogsAgent(deps dependencies) provides {
 
 		integrationsLogs := integrationsimpl.NewLogsIntegration()
 
-		// Initialize observer handle if observer component is available
-		var observerHandle observer.Handle
-		if obs, ok := deps.Observer.Get(); ok {
-			observerHandle = obs.GetHandle("logs")
-		}
-
 		logsAgent := &logAgent{
 			log:                deps.Log,
 			config:             deps.Config,
@@ -169,9 +160,8 @@ func newLogsAgent(deps dependencies) provides {
 			wmeta:              deps.WMeta,
 			schedulerProviders: deps.SchedulerProviders,
 			integrationsLogs:   integrationsLogs,
-			tagger:             deps.Tagger,
-			compression:        deps.Compression,
-			observerHandle:     observerHandle,
+			tagger:      deps.Tagger,
+			compression: deps.Compression,
 		}
 		deps.Lc.Append(fx.Hook{
 			OnStart: logsAgent.start,

--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -115,7 +115,6 @@ func buildPipelineProvider(a *logAgent, processingRules []*config.ProcessingRule
 		a.compression,
 		a.config.GetBool("logs_config.disable_distributed_senders"), // legacy
 		false, // serverless
-		a.observerHandle,
 	)
 	return pipelineProvider
 }

--- a/comp/logs/agent/agentimpl/agent_serverless_init.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init.go
@@ -57,7 +57,6 @@ func (a *logAgent) SetupPipeline(
 		a.compression,
 		true, // disable distributed sending for serverless
 		true, // serverless
-		nil,  // no observer in serverless
 	)
 
 	lnchrs := launchers.NewLaunchers(a.sources, pipelineProvider, a.auditor, a.tracker)

--- a/comp/observer/README.md
+++ b/comp/observer/README.md
@@ -283,6 +283,16 @@ observer:
   # Main switches
   analysis:
     enabled: true                    # Enable the anomaly detection pipeline
+  ingest_metrics:
+    enabled: true                    # When false, drops externally-ingested
+                                     # metrics (DogStatsD, check samplers,
+                                     # HF runners) at the handle factory.
+                                     # Logs and log-derived virtual metrics
+                                     # produced inside the engine by
+                                     # LogMetricsExtractors are unaffected,
+                                     # so the log -> metric detector path
+                                     # keeps working when external metric
+                                     # ingestion is disabled.
 
   # Agent internal log capture
   capture_agent_internal_logs:

--- a/comp/observer/bundle.go
+++ b/comp/observer/bundle.go
@@ -8,6 +8,7 @@ package observer
 
 import (
 	observerfx "github.com/DataDog/datadog-agent/comp/observer/fx"
+	logssourcefx "github.com/DataDog/datadog-agent/comp/observer/logssource/fx"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -17,5 +18,6 @@ import (
 func Bundle() fxutil.BundleOptions {
 	return fxutil.Bundle(
 		observerfx.Module(),
+		logssourcefx.Module(),
 	)
 }

--- a/comp/observer/impl/ingest_metrics_disabled_test.go
+++ b/comp/observer/impl/ingest_metrics_disabled_test.go
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// TestObserverDropsMetricsWhenIngestMetricsDisabled verifies that when
+// observer.ingest_metrics.enabled is false, the handle drops external
+// ObserveMetric calls while logs and log-derived virtual metrics still
+// reach the engine.
+func TestObserverDropsMetricsWhenIngestMetricsDisabled(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	extractor := NewLogMetricsExtractor(DefaultLogMetricsExtractorConfig())
+	eng := newEngine(engineConfig{
+		storage:    storage,
+		extractors: []observerdef.LogMetricsExtractor{extractor},
+	})
+
+	th := newTelemetryHandler(noopsimpl.GetCompatComponent())
+	obs := &observerImpl{
+		engine:               eng,
+		obsCh:                make(chan observation, 16),
+		telemetryHandler:     th,
+		dropCounter:          th.telemetryCounters[telemetryObsChannelDropped],
+		ingestMetricsEnabled: false,
+	}
+	obs.handleFunc = obs.innerHandle
+
+	var (
+		wg        sync.WaitGroup
+		closeOnce sync.Once
+	)
+	stopFn := func() {
+		// close is idempotent via Once; wg.Wait() is safe to call multiple times.
+		closeOnce.Do(func() { close(obs.obsCh) })
+		wg.Wait()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		obs.run()
+	}()
+	// Guarantee cleanup even if an assertion calls t.Fatal before stopFn().
+	t.Cleanup(stopFn)
+
+	h := obs.GetHandle("all-metrics")
+
+	drop, ok := h.(*metricDropHandle)
+	require.Truef(t, ok, `GetHandle("all-metrics") returned %T, want *metricDropHandle`, h)
+
+	assert.False(t, drop.ObserveMetricAndReportDrop(&metricObs{
+		name:      "system.cpu.user",
+		value:     50,
+		timestamp: 1000,
+	}), "ObserveMetricAndReportDrop should report false when dropped by configuration")
+
+	drop.ObserveMetric(&metricObs{
+		name:      "system.mem.used",
+		value:     1024,
+		timestamp: 1000,
+	})
+
+	drop.ObserveLog(&logObs{
+		content:     []byte("Request completed in 45ms"),
+		status:      "info",
+		tags:        []string{"service:web"},
+		timestampMs: 1_000_000,
+	})
+
+	// Flush: close signals EOF; run() drains all buffered items before returning,
+	// so the ObserveLog above is guaranteed to be processed before we assert storage.
+	stopFn()
+
+	allMetricsSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: "all-metrics"})
+	assert.Empty(t, allMetricsSeries,
+		"external metrics must not be stored when observer.ingest_metrics.enabled=false")
+
+	extractorSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: extractor.Name()})
+	require.NotEmpty(t, extractorSeries,
+		"log-extractor virtual metrics must keep flowing into storage even when observer.ingest_metrics.enabled=false")
+}
+
+// TestMetricDropHandle covers the wrapper in isolation, mirroring
+// the pattern used in system_filter_test.go for hfFilteredHandle.
+func TestMetricDropHandle(t *testing.T) {
+	inner := &countingHandle{}
+	wrap := &metricDropHandle{inner: inner}
+
+	wrap.ObserveMetric(&sampleNoSource{name: "any.metric"})
+	wrap.ObserveTrace(nil)
+	wrap.ObserveTraceStats(nil)
+	assert.Equal(t, 0, inner.received,
+		"metricDropHandle: inner.received = %d, want 0 (ObserveMetric/Trace/TraceStats must be dropped)", inner.received)
+	assert.False(t, wrap.ObserveMetricAndReportDrop(&sampleNoSource{name: "any.metric"}),
+		"ObserveMetricAndReportDrop reports false (config drop, not channel-full)")
+
+	wrap.ObserveLog(&logObs{content: []byte("hi"), timestampMs: 1})
+	assert.Equal(t, 1, inner.logReceived,
+		"metricDropHandle: inner.logReceived = %d, want 1 (ObserveLog must forward to inner)", inner.logReceived)
+
+	wrap.ObserveProfile(nil)
+	assert.Equal(t, 1, inner.profileReceived,
+		"metricDropHandle: inner.profileReceived = %d, want 1 (ObserveProfile must forward to inner)", inner.profileReceived)
+}

--- a/comp/observer/impl/ingest_metrics_disabled_test.go
+++ b/comp/observer/impl/ingest_metrics_disabled_test.go
@@ -60,11 +60,11 @@ func TestObserverDropsMetricsWhenIngestMetricsDisabled(t *testing.T) {
 	drop, ok := h.(*metricDropHandle)
 	require.Truef(t, ok, `GetHandle("all-metrics") returned %T, want *metricDropHandle`, h)
 
-	assert.False(t, drop.ObserveMetricAndReportDrop(&metricObs{
+	assert.True(t, drop.ObserveMetricAndReportDrop(&metricObs{
 		name:      "system.cpu.user",
 		value:     50,
 		timestamp: 1000,
-	}), "ObserveMetricAndReportDrop should report false when dropped by configuration")
+	}), "ObserveMetricAndReportDrop should report true when dropped by configuration (signals recorder to write Dropped=true)")
 
 	drop.ObserveMetric(&metricObs{
 		name:      "system.mem.used",
@@ -103,8 +103,8 @@ func TestMetricDropHandle(t *testing.T) {
 	wrap.ObserveTraceStats(nil)
 	assert.Equal(t, 0, inner.received,
 		"metricDropHandle: inner.received = %d, want 0 (ObserveMetric/Trace/TraceStats must be dropped)", inner.received)
-	assert.False(t, wrap.ObserveMetricAndReportDrop(&sampleNoSource{name: "any.metric"}),
-		"ObserveMetricAndReportDrop reports false (config drop, not channel-full)")
+	assert.True(t, wrap.ObserveMetricAndReportDrop(&sampleNoSource{name: "any.metric"}),
+		"ObserveMetricAndReportDrop reports true (config drop) so recordingHandle writes Dropped=true")
 
 	wrap.ObserveLog(&logObs{content: []byte("hi"), timestampMs: 1})
 	assert.Equal(t, 1, inner.logReceived,

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -235,12 +235,17 @@ func NewComponent(deps Requires) Provides {
 	hfFilterSources := make(map[metrics.MetricSource]struct{})
 
 	obs := &observerImpl{
-		engine:             eng,
-		obsCh:              make(chan observation, 1000),
-		telemetryHandler:   th,
-		dropCounter:        th.telemetryCounters[telemetryObsChannelDropped],
-		hfContainerEnabled: hfContainerEnabled,
-		hfFilterSources:    hfFilterSources,
+		engine:               eng,
+		obsCh:                make(chan observation, 1000),
+		telemetryHandler:     th,
+		dropCounter:          th.telemetryCounters[telemetryObsChannelDropped],
+		hfContainerEnabled:   hfContainerEnabled,
+		hfFilterSources:      hfFilterSources,
+		ingestMetricsEnabled: cfg.GetBool("observer.ingest_metrics.enabled"),
+	}
+
+	if !obs.ingestMetricsEnabled {
+		pkglog.Warn("[observer] observer.ingest_metrics.enabled=false: externally-ingested metrics will be dropped at the handle factory")
 	}
 
 	// Set up handle function based on recording and analysis configuration.
@@ -510,6 +515,13 @@ type observerImpl struct {
 
 	// hfContainerEnabled is true when high-frequency container check collection is active.
 	hfContainerEnabled bool
+
+	// ingestMetricsEnabled gates externally-ingested metrics at the handle
+	// factory. When false, "all-metrics" and HF handles return a wrapper
+	// that drops ObserveMetric calls. Logs and profiles still pass through,
+	// and log-derived virtual metrics produced inside the engine by
+	// LogMetricsExtractors are unaffected because they bypass the handle.
+	ingestMetricsEnabled bool
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
@@ -677,13 +689,20 @@ func (o *observerImpl) GetHandle(name string) observerdef.Handle {
 // When any HF check collection is enabled, the "all-metrics" handle is wrapped
 // with hfFilteredHandle to suppress 15s samples for checks that have a 1s HF
 // counterpart active — the scorer should only see the higher-resolution stream.
+// When observer.ingest_metrics.enabled=false, the resulting handle is further
+// wrapped with metricDropHandle so external metrics are dropped at the edge,
+// while ObserveLog/ObserveProfile pass through.
 func (o *observerImpl) innerHandle(name string) observerdef.Handle {
 	h := &handle{ch: o.obsCh, source: name, dropCounter: o.dropCounter}
 	o.engine.registerHandle(h)
+	var out observerdef.Handle = h
 	if len(o.hfFilterSources) > 0 && name == "all-metrics" {
-		return &hfFilteredHandle{inner: h, sources: o.hfFilterSources}
+		out = &hfFilteredHandle{inner: h, sources: o.hfFilterSources}
 	}
-	return h
+	if !o.ingestMetricsEnabled {
+		out = &metricDropHandle{inner: out}
+	}
+	return out
 }
 
 // sourceProvider is a structural interface satisfied by *metrics.MetricSample,
@@ -752,6 +771,25 @@ func (f *hfFilteredHandle) ObserveLog(msg observerdef.LogView)             { f.i
 func (f *hfFilteredHandle) ObserveTrace(_ observerdef.TraceView)           {}
 func (f *hfFilteredHandle) ObserveTraceStats(_ observerdef.TraceStatsView) {}
 func (f *hfFilteredHandle) ObserveProfile(p observerdef.ProfileView)       { f.inner.ObserveProfile(p) }
+
+// metricDropHandle drops every ObserveMetric call but lets logs and
+// profiles through. Used when observer.ingest_metrics.enabled=false so
+// external metric sources (DogStatsD, check samplers, HF runners) do not
+// feed the engine. Virtual metrics produced by LogMetricsExtractors
+// during engine.IngestLog are unaffected because they bypass this handle
+// path entirely (they are written directly to storage from the engine).
+type metricDropHandle struct{ inner observerdef.Handle }
+
+var _ observerdef.Handle = (*metricDropHandle)(nil)
+
+func (m *metricDropHandle) ObserveMetric(_ observerdef.MetricView) {}
+func (m *metricDropHandle) ObserveMetricAndReportDrop(_ observerdef.MetricView) bool {
+	return false
+}
+func (m *metricDropHandle) ObserveLog(msg observerdef.LogView)             { m.inner.ObserveLog(msg) }
+func (m *metricDropHandle) ObserveTrace(_ observerdef.TraceView)           {}
+func (m *metricDropHandle) ObserveTraceStats(_ observerdef.TraceStatsView) {}
+func (m *metricDropHandle) ObserveProfile(p observerdef.ProfileView)       { m.inner.ObserveProfile(p) }
 
 // noopHandle returns a handle that discards all observations.
 // Used when analysis is disabled so the analysis pipeline is not started.

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -784,7 +784,7 @@ var _ observerdef.Handle = (*metricDropHandle)(nil)
 
 func (m *metricDropHandle) ObserveMetric(_ observerdef.MetricView) {}
 func (m *metricDropHandle) ObserveMetricAndReportDrop(_ observerdef.MetricView) bool {
-	return false
+	return true
 }
 func (m *metricDropHandle) ObserveLog(msg observerdef.LogView)             { m.inner.ObserveLog(msg) }
 func (m *metricDropHandle) ObserveTrace(_ observerdef.TraceView)           {}

--- a/comp/observer/impl/system_filter_test.go
+++ b/comp/observer/impl/system_filter_test.go
@@ -34,16 +34,18 @@ func (s *sampleNoSource) GetRawTags() []string    { return nil }
 func (s *sampleNoSource) GetTimestampUnix() int64 { return 0 }
 func (s *sampleNoSource) GetSampleRate() float64  { return 1 }
 
-// countingHandle records how many MetricView observations it receives.
+// countingHandle records how many MetricView, LogView, and ProfileView observations it receives.
 type countingHandle struct {
-	received int
+	received        int
+	logReceived     int
+	profileReceived int
 }
 
 func (h *countingHandle) ObserveMetric(_ observerdef.MetricView)         { h.received++ }
-func (h *countingHandle) ObserveLog(_ observerdef.LogView)               {}
+func (h *countingHandle) ObserveLog(_ observerdef.LogView)               { h.logReceived++ }
 func (h *countingHandle) ObserveTrace(_ observerdef.TraceView)           {}
 func (h *countingHandle) ObserveTraceStats(_ observerdef.TraceStatsView) {}
-func (h *countingHandle) ObserveProfile(_ observerdef.ProfileView)       {}
+func (h *countingHandle) ObserveProfile(_ observerdef.ProfileView)       { h.profileReceived++ }
 
 func makeHFHandle(sources map[metrics.MetricSource]struct{}) *hfFilteredHandle {
 	return &hfFilteredHandle{inner: &countingHandle{}, sources: sources}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -699,12 +699,13 @@ func (tb *TestBench) rerunDetectorsLocked() {
 		tb.handleTelemetry([]observerdef.ObserverTelemetry{t}, detName, dataTime)
 	}
 
-	// Populate tb.logAnomalies from AnomalyTypeLog anomalies produced by detectors.
-	// These are distinct from metric anomalies and are served via /api/log-anomalies.
+	// Populate tb.logAnomalies: direct log anomalies (AnomalyTypeLog) and
+	// metric detector anomalies on log-derived series (isLogDerivedAnomaly),
+	// mirroring the live observer's notify.go classification logic.
 	tb.logAnomalies = []observerdef.Anomaly{}
 	tb.logAnomaliesByDetector = make(map[string][]observerdef.Anomaly)
 	for _, a := range result.anomalies {
-		if a.Type == observerdef.AnomalyTypeLog {
+		if a.Type == observerdef.AnomalyTypeLog || isLogDerivedAnomaly(a) {
 			tb.logAnomalies = append(tb.logAnomalies, a)
 			tb.logAnomaliesByDetector[a.DetectorName] = append(tb.logAnomaliesByDetector[a.DetectorName], a)
 		}

--- a/comp/observer/logssource/def/component.go
+++ b/comp/observer/logssource/def/component.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package logssource provides a component that feeds container logs into the
+// observer without requiring the logs agent to be enabled.
+package logssource
+
+// team: q-branch
+
+// Component is the component type.
+type Component interface{}

--- a/comp/observer/logssource/fx/fx.go
+++ b/comp/observer/logssource/fx/fx.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package fx defines the fx options for the logssource component.
+package fx
+
+import (
+	"go.uber.org/fx"
+
+	logssource "github.com/DataDog/datadog-agent/comp/observer/logssource/def"
+	logssourceimpl "github.com/DataDog/datadog-agent/comp/observer/logssource/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			logssourceimpl.NewComponent,
+		),
+		fx.Invoke(func(_ logssource.Component) {}),
+	)
+}

--- a/comp/observer/logssource/impl/component.go
+++ b/comp/observer/logssource/impl/component.go
@@ -1,0 +1,159 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package logssourceimpl implements the logssource component.
+package logssourceimpl
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/fx"
+
+	config "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/comp/logs/agent/flare"
+	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+	logssource "github.com/DataDog/datadog-agent/comp/observer/logssource/def"
+	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
+	containerLauncher "github.com/DataDog/datadog-agent/pkg/logs/launchers/container"
+	filelauncher "github.com/DataDog/datadog-agent/pkg/logs/launchers/file"
+	journaldlauncher "github.com/DataDog/datadog-agent/pkg/logs/launchers/journald"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
+	fileTailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/file"
+	"github.com/DataDog/datadog-agent/pkg/logs/types"
+	"github.com/DataDog/datadog-agent/pkg/logs/util/opener"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+// Requires defines the dependencies for the logssource component.
+type Requires struct {
+	compdef.In
+
+	Lc          fx.Lifecycle
+	Log         log.Component
+	Config      config.Component
+	Hostname    hostname.Component
+	WMeta       option.Option[workloadmeta.Component]
+	Tagger      tagger.Component
+	Auditor     auditor.Component
+	Observer    option.Option[observer.Component]
+	FilterStore option.Option[workloadfilter.Component]
+}
+
+// Provides defines the output of the logssource component.
+type Provides struct {
+	compdef.Out
+	Comp logssource.Component
+}
+
+type logssourceComponent struct{}
+
+// NewComponent creates the logssource component.
+//
+// The component is a no-op when any of these are true:
+//   - the observer is unavailable
+//   - workloadmeta is unavailable
+//
+// The component itself has no build-tag constraints. Capability differences
+// across builds are handled transparently by the underlying launchers:
+//   - container logs require the kubelet or docker build tag (no-op otherwise)
+//   - journald logs (incl. the kubelet.service source) require the systemd
+//     build tag (no-op otherwise)
+//   - file logs are always supported
+func NewComponent(deps Requires) (Provides, error) {
+	obs, obsOk := deps.Observer.Get()
+	wmeta, wmetaOk := deps.WMeta.Get()
+
+	analysisEnabled := deps.Config.GetBool("observer.analysis.enabled")
+	recordingEnabled := deps.Config.GetBool("observer.recording.enabled")
+	if !obsOk || !wmetaOk || (!analysisEnabled && !recordingEnabled) {
+		return Provides{Comp: &logssourceComponent{}}, nil
+	}
+
+	observerHandle := obs.GetHandle("logs")
+
+	processingRules, err := logsconfig.GlobalProcessingRules(deps.Config)
+	if err != nil {
+		deps.Log.Warnf("observer logssource: invalid global processing rules, proceeding without them: %v", err)
+		processingRules = nil
+	}
+
+	var pauseFilter workloadfilter.FilterBundle
+	if fs, ok := deps.FilterStore.Get(); ok {
+		pauseFilter = fs.GetContainerPausedFilters()
+	}
+
+	pipeline := newObserverPipeline(deps.Config, processingRules, deps.Hostname, observerHandle)
+	logSources := sources.NewLogSources()
+	tracker := tailers.NewTailerTracker()
+
+	fingerprintCfg, err := logsconfig.GlobalFingerprintConfig(deps.Config)
+	if err != nil {
+		deps.Log.Warnf("observer logssource: invalid fingerprint config, proceeding with defaults: %v", err)
+		fingerprintCfg = &types.FingerprintConfig{}
+	}
+	fileOpener := opener.NewFileOpener()
+	fileLauncher := filelauncher.NewLauncher(
+		deps.Config.GetInt("logs_config.open_files_limit"),
+		filelauncher.DefaultSleepDuration,
+		deps.Config.GetBool("logs_config.validate_pod_container_id"),
+		time.Duration(deps.Config.GetFloat64("logs_config.file_scan_period")*float64(time.Second)),
+		deps.Config.GetString("logs_config.file_wildcard_selection_mode"),
+		flare.NewFlareController(),
+		deps.Tagger,
+		fileOpener,
+		fileTailer.NewFingerprinter(*fingerprintCfg, fileOpener),
+	)
+
+	launcher := containerLauncher.NewLauncher(logSources, option.New(wmeta), deps.Tagger)
+	launchersMgr := launchers.NewLaunchers(logSources, pipeline, deps.Auditor, tracker)
+	launchersMgr.AddLauncher(fileLauncher)
+	launchersMgr.AddLauncher(launcher)
+	launchersMgr.AddLauncher(journaldlauncher.NewLauncher(flare.NewFlareController(), deps.Tagger))
+
+	registerKubeletJournaldSource(logSources, deps.Log)
+
+	sp := newSourceProvider(wmeta, logSources, pauseFilter)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	deps.Lc.Append(fx.Hook{
+		OnStart: func(_ context.Context) error {
+			deps.Log.Infof("[observer/logssource] starting container log pipeline")
+			pipeline.start()
+			launchersMgr.Start()
+			sp.run(ctx)
+			return nil
+		},
+		OnStop: func(_ context.Context) error {
+			// Shutdown ordering is load-bearing — do NOT reorder.
+			// 1. Signal the source provider to stop, then wait for it to fully exit.
+			//    Without the wait, handleSet could call AddSource on an unbuffered channel
+			//    after the launcher has stopped reading — deadlock.
+			cancel()
+			sp.wait()
+			// 2. Stop all tailers; blocks until the last message is written to inputChan.
+			launchersMgr.Stop()
+			// 3. Drain inputChan; proc writes surviving messages to outputChan then exits.
+			pipeline.proc.Stop()
+			// 4. Signal the drain goroutine to exit (safe: proc.Stop returned = no more writes).
+			close(pipeline.outputChan)
+			// 5. Wait for the drain goroutine to finish.
+			<-pipeline.drainDone
+			return nil
+		},
+	})
+
+	return Provides{Comp: &logssourceComponent{}}, nil
+}

--- a/comp/observer/logssource/impl/kubelet_source.go
+++ b/comp/observer/logssource/impl/kubelet_source.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet && systemd
+
+package logssourceimpl
+
+import (
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+)
+
+// registerKubeletJournaldSource registers a journald source that tails the
+// kubelet.service unit. Only built when kubelet support is compiled in and the
+// systemd build tag is set (journald requires systemd to actually tail logs).
+func registerKubeletJournaldSource(logSources *sources.LogSources, logger log.Component) {
+	src := sources.NewLogSource("kubelet", &logsconfig.LogsConfig{
+		Type:               logsconfig.JournaldType,
+		ConfigID:           "kubelet",
+		IncludeSystemUnits: logsconfig.StringSliceField{"kubelet.service"},
+		Tags:               logsconfig.StringSliceField{"source:kubelet"},
+	})
+	logSources.AddSource(src)
+	logger.Infof("[observer/logssource] registered kubelet journald source: config_id=%q include_units=%v tags=%v (expected tailer id=journald:%s)",
+		src.Config.ConfigID, src.Config.IncludeSystemUnits,
+		src.Config.Tags, src.Config.ConfigID)
+}

--- a/comp/observer/logssource/impl/kubelet_source_stub.go
+++ b/comp/observer/logssource/impl/kubelet_source_stub.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !kubelet || !systemd
+
+package logssourceimpl
+
+import (
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+)
+
+// registerKubeletJournaldSource is a no-op when either kubelet support or
+// systemd is not compiled in: the kubelet journald source can only do useful
+// work when both tags are set.
+func registerKubeletJournaldSource(_ *sources.LogSources, logger log.Component) {
+	logger.Debugf("[observer/logssource] kubelet journald source not registered: requires kubelet+systemd build tags")
+}

--- a/comp/observer/logssource/impl/pipeline.go
+++ b/comp/observer/logssource/impl/pipeline.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package logssourceimpl
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
+	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/processor"
+)
+
+// observerPipeline is a pipeline.Provider that forwards log messages to the
+// observer — no network sender.
+type observerPipeline struct {
+	proc           *processor.Processor
+	inputChan      chan *message.Message
+	outputChan     chan *message.Message
+	drainDone      chan struct{}
+	observerHandle observer.Handle
+}
+
+func newObserverPipeline(
+	cfg pkgconfigmodel.Reader,
+	processingRules []*logsconfig.ProcessingRule,
+	hostname hostnameinterface.Component,
+	observerHandle observer.Handle,
+) *observerPipeline {
+	chanSize := cfg.GetInt("logs_config.message_channel_size")
+	inputChan := make(chan *message.Message, chanSize)
+	outputChan := make(chan *message.Message, chanSize)
+	const pipelineID = "observer-logs-0"
+	pipelineMonitor := metrics.NewNoopPipelineMonitor(pipelineID)
+	proc := processor.New(
+		cfg,
+		inputChan,
+		outputChan,
+		processingRules,
+		processor.PassthroughEncoder,
+		diagnostic.NewBufferedMessageReceiver(nil, hostname),
+		hostname,
+		pipelineMonitor,
+		pipelineID,
+	)
+	return &observerPipeline{
+		proc:           proc,
+		inputChan:      inputChan,
+		outputChan:     outputChan,
+		drainDone:      make(chan struct{}),
+		observerHandle: observerHandle,
+	}
+}
+
+// start starts the processor and the output drain goroutine.
+// The drain goroutine MUST outlive proc.Stop() — see component.go OnStop for
+// the required shutdown sequence.
+func (p *observerPipeline) start() {
+	go func() {
+		defer close(p.drainDone)
+		for msg := range p.outputChan {
+			p.observerHandle.ObserveLog(msg)
+		}
+	}()
+	p.proc.Start()
+}
+
+// NextPipelineChan implements pipeline.Provider.
+func (p *observerPipeline) NextPipelineChan() chan *message.Message {
+	return p.inputChan
+}
+
+// NextPipelineChanWithMonitor implements pipeline.Provider.
+func (p *observerPipeline) NextPipelineChanWithMonitor() (chan *message.Message, *metrics.CapacityMonitor) {
+	return p.inputChan, nil
+}
+
+// GetOutputChan implements pipeline.Provider.
+func (p *observerPipeline) GetOutputChan() chan *message.Message {
+	return p.outputChan
+}
+
+// Start implements pipeline.Provider — component.go calls start() directly instead.
+func (p *observerPipeline) Start() {}
+
+// Stop implements pipeline.Provider — component.go handles ordered shutdown.
+func (p *observerPipeline) Stop() {}
+
+// Flush implements pipeline.Provider.
+func (p *observerPipeline) Flush(ctx context.Context) {
+	p.proc.Flush(ctx)
+}

--- a/comp/observer/logssource/impl/source_provider.go
+++ b/comp/observer/logssource/impl/source_provider.go
@@ -1,0 +1,145 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package logssourceimpl
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	workloadfilterutil "github.com/DataDog/datadog-agent/comp/core/workloadfilter/util/workloadmeta"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// sourceProvider translates workloadmeta container events into LogSources,
+// publishing them to the provided LogSources instance.
+type sourceProvider struct {
+	wmeta       workloadmeta.Component
+	logSources  *sources.LogSources
+	pauseFilter workloadfilter.FilterBundle
+
+	mu            sync.Mutex
+	activeSources map[string]*sources.LogSource // keyed by container ID
+
+	stopped sync.WaitGroup
+}
+
+func newSourceProvider(wmeta workloadmeta.Component, logSources *sources.LogSources, pauseFilter workloadfilter.FilterBundle) *sourceProvider {
+	return &sourceProvider{
+		wmeta:         wmeta,
+		logSources:    logSources,
+		pauseFilter:   pauseFilter,
+		activeSources: make(map[string]*sources.LogSource),
+	}
+}
+
+// run subscribes to workloadmeta and processes container events until ctx is cancelled.
+// Call wait() after cancelling ctx to ensure no AddSource/RemoveSource calls are in
+// flight before stopping the launcher.
+func (sp *sourceProvider) run(ctx context.Context) {
+	filter := workloadmeta.NewFilterBuilder().
+		AddKind(workloadmeta.KindContainer).
+		Build()
+	ch := sp.wmeta.Subscribe("observer-logssource", workloadmeta.NormalPriority, filter)
+
+	sp.stopped.Add(1)
+	go func() {
+		defer sp.stopped.Done()
+		defer sp.wmeta.Unsubscribe(ch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case bundle, ok := <-ch:
+				if !ok {
+					return
+				}
+				bundle.Acknowledge()
+				for _, event := range bundle.Events {
+					container, ok := event.Entity.(*workloadmeta.Container)
+					if !ok {
+						continue
+					}
+					switch event.Type {
+					case workloadmeta.EventTypeSet:
+						sp.handleSet(container)
+					case workloadmeta.EventTypeUnset:
+						sp.handleUnset(container)
+					}
+				}
+			}
+		}
+	}()
+}
+
+func (sp *sourceProvider) handleSet(c *workloadmeta.Container) {
+	if !c.State.Running {
+		return
+	}
+	if sp.isPauseContainer(c) || isAgentContainer(c) {
+		return
+	}
+	// For containerd/non-Docker runtimes on Kubernetes, wait for kubelet
+	// enrichment before emitting a source. The containerd collector publishes
+	// container entities before the kubelet collector attaches the
+	// KubernetesPod owner; if we emit the source now, the container
+	// launcher's tailerfactory fails with "cannot find pod for container" in
+	// getPodAndContainer and has no retry. Workloadmeta re-notifies
+	// subscribers with the merged entity once kubelet enriches it, so
+	// skipping here is safe.
+	// Docker containers are tailed via the socket and have no pod owner, so
+	// this guard does not apply to them.
+	if c.Runtime != workloadmeta.ContainerRuntimeDocker {
+		if c.Owner == nil || c.Owner.Kind != workloadmeta.KindKubernetesPod {
+			return
+		}
+	}
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	if _, exists := sp.activeSources[c.EntityID.ID]; exists {
+		return // idempotent: already tracked
+	}
+	src := sources.NewLogSource(c.EntityID.ID, &logsconfig.LogsConfig{
+		Type:       string(c.Runtime),
+		Identifier: c.EntityID.ID,
+	})
+	sp.activeSources[c.EntityID.ID] = src
+	sp.logSources.AddSource(src)
+	log.Infof("[observer/logssource] added container source: %s (runtime=%s)", c.Image.ShortName, c.Runtime)
+}
+
+func (sp *sourceProvider) handleUnset(c *workloadmeta.Container) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	src, exists := sp.activeSources[c.EntityID.ID]
+	if !exists {
+		return
+	}
+	delete(sp.activeSources, c.EntityID.ID)
+	sp.logSources.RemoveSource(src)
+}
+
+// wait blocks until the event loop goroutine has fully exited.
+func (sp *sourceProvider) wait() {
+	sp.stopped.Wait()
+}
+
+// isPauseContainer uses the workloadfilter bundle when available, falling back
+// to an image-name heuristic for builds where the filter store is absent.
+func (sp *sourceProvider) isPauseContainer(c *workloadmeta.Container) bool {
+	if sp.pauseFilter != nil {
+		return sp.pauseFilter.IsExcluded(workloadfilterutil.CreateContainer(c, nil))
+	}
+	return strings.Contains(strings.ToLower(c.Image.ShortName), "pause")
+}
+
+func isAgentContainer(c *workloadmeta.Container) bool {
+	return strings.Contains(strings.ToLower(c.Image.ShortName), "agent")
+}

--- a/comp/observer/logssource/impl/source_provider_test.go
+++ b/comp/observer/logssource/impl/source_provider_test.go
@@ -1,0 +1,196 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package logssourceimpl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"go.uber.org/goleak"
+
+	compConfig "github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// --- filter function tests ---
+
+func TestIsPauseContainer(t *testing.T) {
+	sp, _ := newTestSourceProvider() // pauseFilter=nil → falls back to heuristic
+	cases := []struct {
+		image string
+		want  bool
+	}{
+		{"pause", true},
+		{"k8s.gcr.io/pause", true},
+		{"registry.k8s.io/pause:3.9", true},
+		{"PAUSE", true},
+		{"nginx", false},
+		{"my-pause-proxy", true}, // contains "pause" — acceptable false positive for fallback heuristic
+		{"", false},
+	}
+	for _, tc := range cases {
+		c := &workloadmeta.Container{
+			Image: workloadmeta.ContainerImage{ShortName: tc.image},
+		}
+		assert.Equal(t, tc.want, sp.isPauseContainer(c), "image=%q", tc.image)
+	}
+}
+
+func TestIsAgentContainer(t *testing.T) {
+	cases := []struct {
+		image string
+		want  bool
+	}{
+		{"datadog-agent", true},
+		{"gcr.io/datadoghq/datadog-agent", true},
+		{"dd-agent", true},
+		{"DD-AGENT", true},
+		{"nginx", false},
+		{"my-datadog-agent-sidecar", true},
+	}
+	for _, tc := range cases {
+		c := &workloadmeta.Container{
+			Image: workloadmeta.ContainerImage{ShortName: tc.image},
+		}
+		assert.Equal(t, tc.want, isAgentContainer(c), "image=%q", tc.image)
+	}
+}
+
+// --- sourceProvider handle method tests ---
+
+func newTestSourceProvider() (*sourceProvider, *sources.LogSources) {
+	ls := sources.NewLogSources()
+	sp := newSourceProvider(nil, ls, nil) // wmeta/pauseFilter not needed for direct handle tests
+	return sp, ls
+}
+
+func runningContainer(id, image string) *workloadmeta.Container {
+	return &workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainer, ID: id},
+		Image:    workloadmeta.ContainerImage{ShortName: image},
+		Runtime:  workloadmeta.ContainerRuntimeContainerd,
+		State:    workloadmeta.ContainerState{Running: true},
+		Owner: &workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesPod,
+			ID:   "test-pod-uid",
+		},
+	}
+}
+
+func runningDockerContainer(id, image string) *workloadmeta.Container {
+	return &workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainer, ID: id},
+		Image:    workloadmeta.ContainerImage{ShortName: image},
+		Runtime:  workloadmeta.ContainerRuntimeDocker,
+		State:    workloadmeta.ContainerState{Running: true},
+	}
+}
+
+func TestHandleSet_AddsRunningContainer(t *testing.T) {
+	sp, ls := newTestSourceProvider()
+	sp.handleSet(runningContainer("abc", "nginx"))
+	assert.Len(t, ls.GetSources(), 1)
+}
+
+func TestHandleSet_SkipsNonRunning(t *testing.T) {
+	sp, ls := newTestSourceProvider()
+	c := runningContainer("abc", "nginx")
+	c.State.Running = false
+	sp.handleSet(c)
+	assert.Empty(t, ls.GetSources())
+}
+
+func TestHandleSet_SkipsPauseImage(t *testing.T) {
+	sp, ls := newTestSourceProvider()
+	sp.handleSet(runningContainer("abc", "pause"))
+	assert.Empty(t, ls.GetSources())
+}
+
+func TestHandleSet_SkipsAgentImage(t *testing.T) {
+	sp, ls := newTestSourceProvider()
+	sp.handleSet(runningContainer("abc", "datadog-agent"))
+	assert.Empty(t, ls.GetSources())
+}
+
+func TestHandleSet_DockerContainerNoPodOwner(t *testing.T) {
+	sp, ls := newTestSourceProvider()
+	sp.handleSet(runningDockerContainer("abc", "nginx"))
+	assert.Len(t, ls.GetSources(), 1, "Docker containers need no pod owner")
+}
+
+func TestHandleSet_ContainerdContainerNoPodOwner(t *testing.T) {
+	sp, ls := newTestSourceProvider()
+	c := runningContainer("abc", "nginx")
+	c.Owner = nil
+	sp.handleSet(c)
+	assert.Empty(t, ls.GetSources(), "containerd containers without a pod owner must wait for kubelet enrichment")
+}
+
+func TestHandleSet_Idempotent(t *testing.T) {
+	sp, ls := newTestSourceProvider()
+	c := runningContainer("abc", "nginx")
+	sp.handleSet(c)
+	sp.handleSet(c) // second Set for same container ID
+	assert.Len(t, ls.GetSources(), 1, "duplicate Set must not add a second LogSource")
+}
+
+func TestHandleUnset_RemovesSource(t *testing.T) {
+	sp, ls := newTestSourceProvider()
+	c := runningContainer("abc", "nginx")
+	sp.handleSet(c)
+	require.Len(t, ls.GetSources(), 1)
+	sp.handleUnset(c)
+	assert.Empty(t, ls.GetSources())
+}
+
+func TestHandleUnset_UnknownContainerIsNoop(t *testing.T) {
+	sp, ls := newTestSourceProvider()
+	sp.handleUnset(runningContainer("unknown", "nginx")) // should not panic
+	assert.Empty(t, ls.GetSources())
+}
+
+func TestHandleUnset_AllowsReAdd(t *testing.T) {
+	sp, ls := newTestSourceProvider()
+	c := runningContainer("abc", "nginx")
+	sp.handleSet(c)
+	sp.handleUnset(c)
+	sp.handleSet(c) // re-add after removal must work
+	assert.Len(t, ls.GetSources(), 1)
+}
+
+// --- goroutine lifecycle test ---
+
+func newWMetaMock(t *testing.T) workloadmetamock.Mock {
+	t.Helper()
+	return fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		fx.Provide(func() log.Component { return logmock.New(t) }),
+		fx.Provide(func() compConfig.Component { return compConfig.NewMock(t) }),
+		fx.Supply(context.Background()),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+}
+
+func TestSourceProvider_GoRoutineExitsCleanly(t *testing.T) {
+	wmeta := newWMetaMock(t)
+	// Snapshot after wmeta starts its own goroutines so only ours are checked.
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	ls := sources.NewLogSources()
+	sp := newSourceProvider(wmeta, ls, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sp.run(ctx)
+	cancel()
+	sp.wait() // must not hang
+}

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent.go
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent.go
@@ -218,7 +218,6 @@ func (a *Agent) SetupPipeline(
 		a.compression,
 		a.config.GetBool("logs_config.disable_distributed_senders"),
 		false, // serverless
-		nil,   // observer handle (not integrated with otel-agent yet)
 	)
 
 	a.destinationsCtx = destinationsCtx

--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -51,7 +51,6 @@ func NewLogReporter(hostname string, sourceName, sourceType string, endpoints *c
 		compression,
 		cfg.GetBool("logs_config.disable_distributed_senders"),
 		false, // serverless
-		nil,   // observer handle
 	)
 	pipelineProvider.Start()
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -359,6 +359,12 @@ func InitConfig(config pkgconfigmodel.Setup) {
 
 	// Observer component configuration for anomaly detection
 	config.BindEnvAndSetDefault("observer.analysis.enabled", true)
+	// When false, the observer drops externally-ingested metrics
+	// (DogStatsD, check samplers, HF runners) at the handle factory.
+	// Logs are unaffected. Log-derived virtual metrics produced inside
+	// the engine by LogMetricsExtractors continue to flow into storage,
+	// so log-only anomaly detection keeps working.
+	config.BindEnvAndSetDefault("observer.ingest_metrics.enabled", true)
 	config.BindEnvAndSetDefault("observer.traces.fetch_interval", 5*time.Second)
 	config.BindEnvAndSetDefault("observer.traces.max_fetch_batch", 100)
 	config.BindEnvAndSetDefault("observer.profiles.fetch_interval", 10*time.Second)

--- a/pkg/logs/launchers/container/tailerfactory/factory.go
+++ b/pkg/logs/launchers/container/tailerfactory/factory.go
@@ -119,7 +119,11 @@ func (tf *factory) makeTailer(
 		}
 		source.Messages.AddMessage("socketTailerError", "The socket tailer could not be made, falling back to file")
 		log.Warnf("Could not make socket tailer for source %s (falling back to file): %v", source.Name, err)
-		return makeFileTailer(source)
+		t, err = makeFileTailer(source)
+		if err != nil {
+			log.Warnf("Could not make file tailer for source %s (socket fallback also failed): %v", source.Name, err)
+		}
+		return t, err
 	}
 	return nil, nil // unreachable
 }

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
-	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
@@ -42,7 +41,6 @@ func NewPipeline(
 	cfg pkgconfigmodel.Reader,
 	compression logscompression.Component,
 	instanceID string,
-	observerHandle observer.Handle,
 ) *Pipeline {
 	strategyInput := make(chan *message.Message, cfg.GetInt("logs_config.message_channel_size"))
 	flushChan := make(chan struct{})
@@ -62,7 +60,7 @@ func NewPipeline(
 	inputChan := make(chan *message.Message, cfg.GetInt("logs_config.message_channel_size"))
 
 	processor := processor.New(cfg, inputChan, strategyInput, processingRules,
-		encoder, diagnosticMessageReceiver, hostname, senderImpl.PipelineMonitor(), instanceID, observerHandle)
+		encoder, diagnosticMessageReceiver, hostname, senderImpl.PipelineMonitor(), instanceID)
 
 	return &Pipeline{
 		InputChan:       inputChan,

--- a/pkg/logs/pipeline/processor_only_provider.go
+++ b/pkg/logs/pipeline/processor_only_provider.go
@@ -34,7 +34,7 @@ func NewProcessorOnlyProvider(diagnosticMessageReceiver diagnostic.MessageReceiv
 	pipelineID := "0"
 	pipelineMonitor := metrics.NewNoopPipelineMonitor(pipelineID)
 	processor := processor.New(nil, inputChan, outputChan, processingRules,
-		encoder, diagnosticMessageReceiver, hostname, pipelineMonitor, pipelineID, nil)
+		encoder, diagnosticMessageReceiver, hostname, pipelineMonitor, pipelineID)
 
 	p := &processorOnlyProvider{
 		processor:       processor,

--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
-	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -67,10 +66,9 @@ type provider struct {
 	currentPipelineIndex *atomic.Uint32
 	serverlessMeta       sender.ServerlessMeta
 
-	hostname       hostnameinterface.Component
-	cfg            pkgconfigmodel.Reader
-	compression    logscompression.Component
-	observerHandle observer.Handle
+	hostname    hostnameinterface.Component
+	cfg         pkgconfigmodel.Reader
+	compression logscompression.Component
 
 	failoverEnabled    bool
 	routerChannels     []chan *message.Message
@@ -92,7 +90,6 @@ func NewProvider(
 	compression logscompression.Component,
 	legacyMode bool,
 	serverless bool,
-	observerHandle observer.Handle,
 ) Provider {
 	var senderImpl sender.PipelineComponent
 	serverlessMeta := sender.NewServerlessMeta(serverless)
@@ -113,7 +110,6 @@ func NewProvider(
 		compression,
 		serverlessMeta,
 		senderImpl,
-		observerHandle,
 	)
 }
 
@@ -221,7 +217,6 @@ func newProvider(
 	compression logscompression.Component,
 	serverlessMeta sender.ServerlessMeta,
 	senderImpl sender.PipelineComponent,
-	observerHandle observer.Handle,
 ) Provider {
 	return &provider{
 		numberOfPipelines:         numberOfPipelines,
@@ -235,7 +230,6 @@ func newProvider(
 		hostname:                  hostname,
 		cfg:                       cfg,
 		compression:               compression,
-		observerHandle:            observerHandle,
 
 		failoverEnabled:    cfg.GetBool("logs_config.pipeline_failover.enabled"),
 		currentRouterIndex: atomic.NewUint32(0),
@@ -260,7 +254,6 @@ func (p *provider) Start() {
 			p.cfg,
 			p.compression,
 			strconv.Itoa(i),
-			p.observerHandle,
 		)
 		pipeline.Start()
 		p.pipelines = append(p.pipelines, pipeline)

--- a/pkg/logs/processor/passthrough.go
+++ b/pkg/logs/processor/passthrough.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package processor
+
+import "github.com/DataDog/datadog-agent/pkg/logs/message"
+
+// PassthroughEncoder is an encoder that preserves the rendered log line in
+// GetContent() unchanged. Use this when the consumer reads GetContent()
+// directly (e.g. the observer) to avoid wrapping the content in a JSON
+// transport envelope.
+var PassthroughEncoder Encoder = &passthroughEncoder{}
+
+type passthroughEncoder struct{}
+
+func (p *passthroughEncoder) Encode(msg *message.Message, _ string) error {
+	msg.SetEncoded(msg.GetContent())
+	return nil
+}

--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
-	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -49,9 +48,8 @@ type Processor struct {
 	mu                        sync.Mutex
 	hostname                  hostnameinterface.Component
 	config                    pkgconfigmodel.Reader
-	configChan                chan failoverConfig
-	failoverConfig            failoverConfig
-	observerHandle            observer.Handle
+	configChan     chan failoverConfig
+	failoverConfig failoverConfig
 
 	// Telemetry
 	pipelineMonitor metrics.PipelineMonitor
@@ -62,7 +60,7 @@ type Processor struct {
 // New returns an initialized Processor with config support for failover notifications.
 func New(config pkgconfigmodel.Reader, inputChan, outputChan chan *message.Message, processingRules []*config.ProcessingRule,
 	encoder Encoder, diagnosticMessageReceiver diagnostic.MessageReceiver, hostname hostnameinterface.Component,
-	pipelineMonitor metrics.PipelineMonitor, instanceID string, observerHandle observer.Handle) *Processor {
+	pipelineMonitor metrics.PipelineMonitor, instanceID string) *Processor {
 
 	p := &Processor{
 		config:                    config,
@@ -77,7 +75,6 @@ func New(config pkgconfigmodel.Reader, inputChan, outputChan chan *message.Messa
 		pipelineMonitor:           pipelineMonitor,
 		utilization:               pipelineMonitor.MakeUtilizationMonitor(metrics.ProcessorTlmName, instanceID),
 		instanceID:                instanceID,
-		observerHandle:            observerHandle,
 	}
 
 	// Initialize cached failover config
@@ -206,11 +203,6 @@ func (p *Processor) processMessage(msg *message.Message) {
 
 		// report this message to diagnostic receivers (e.g. `stream-logs` command)
 		p.diagnosticMessageReceiver.HandleMessage(msg, rendered, "")
-
-		// report to observer if available
-		if p.observerHandle != nil {
-			p.observerHandle.ObserveLog(msg)
-		}
 
 		if p.failoverConfig.isFailoverActive {
 			p.filterMRFMessages(msg)

--- a/pkg/security/reporter/reporter.go
+++ b/pkg/security/reporter/reporter.go
@@ -60,7 +60,6 @@ func newReporter(hostname string, stopper startstop.Stopper, sourceName, sourceT
 		compression,
 		cfg.GetBool("logs_config.disable_distributed_senders"),
 		false, // serverless
-		nil,   // observer handle (not integrated with security-agent yet)
 	)
 	pipelineProvider.Start()
 	stopper.Add(pipelineProvider)

--- a/tasks/e2e_framework/aws/__init__.py
+++ b/tasks/e2e_framework/aws/__init__.py
@@ -5,6 +5,7 @@ from tasks.e2e_framework.aws.ecs import create_ecs, destroy_ecs
 from tasks.e2e_framework.aws.eks import create_eks, destroy_eks
 from tasks.e2e_framework.aws.gensim_eks import (
     destroy_gensim_eks,
+    list_episodes_gensim_eks,
     status_gensim_eks,
     stop_all_gensim_eks,
     submit_gensim_eks,
@@ -24,6 +25,7 @@ _gensim_eks_coll.add_task(status_gensim_eks, name="status")
 _gensim_eks_coll.add_task(destroy_gensim_eks, name="destroy")
 _gensim_eks_coll.add_task(stop_all_gensim_eks, name="stop-all")
 _gensim_eks_coll.add_task(update_manifest_shas_gensim_eks, name="update-manifest-shas")
+_gensim_eks_coll.add_task(list_episodes_gensim_eks, name="list-episodes")
 _eks_coll = Collection("eks")
 _eks_coll.add_collection(_gensim_eks_coll)
 collection.add_collection(_eks_coll)

--- a/tasks/e2e_framework/aws/gensim_eks.py
+++ b/tasks/e2e_framework/aws/gensim_eks.py
@@ -680,7 +680,7 @@ def _get_gensim_repo_path() -> Path:
 
 
 # Episode subdirectories to search within the gensim-episodes repo.
-_EPISODE_SUBDIRS = ["postmortems", "synthetics"]
+_EPISODE_SUBDIRS = ["agent-q-branch", "postmortems", "synthetics"]
 
 
 def _find_episode_dir(repo_path: Path, ep_name: str) -> Path:

--- a/tasks/e2e_framework/aws/gensim_eks.py
+++ b/tasks/e2e_framework/aws/gensim_eks.py
@@ -188,12 +188,10 @@ def submit_gensim_eks(
     for ep_name, scen_name, pinned_sha in episode_pairs:
         ep_dir = _find_episode_dir(gensim_repo_path, ep_name)
         chart_dir = ep_dir / "chart"
-        scenario_file = ep_dir / "episodes" / f"{scen_name}.yaml"
 
         if not chart_dir.exists():
             raise Exit(f"Chart directory not found: {chart_dir}")
-        if not scenario_file.exists():
-            raise Exit(f"Scenario file not found: {scenario_file}")
+        _resolve_scenario_file(ep_dir, scen_name)
 
         if pinned_sha:
             rel_path = ep_dir.relative_to(gensim_repo_path)
@@ -635,6 +633,37 @@ def update_manifest_shas_gensim_eks(ctx: Context) -> None:
     tool.info(f"\nUpdated {updated} SHA(s) in {_EVAL_MANIFEST_PATH}. Review and commit the changes.")
 
 
+@task(
+    help={
+        "match": "Only show episode:scenario pairs whose full id contains this substring (case-insensitive)",
+    }
+)
+def list_episodes_gensim_eks(_ctx: Context, match: str = "") -> None:
+    """
+    List all episode:scenario pairs discoverable in the local gensim-episodes checkout.
+
+    Each line is suitable for --episodes (e.g. authcore-pgbouncer:pool-saturation).
+
+    Examples:
+        inv aws.eks.gensim.list-episodes
+        inv aws.eks.gensim.list-episodes --match=pgbouncer
+    """
+    repo_path = _get_gensim_repo_path()
+    pairs = _discover_episode_scenario_pairs(repo_path)
+    needle = match.strip().lower()
+    shown = 0
+    for ep_name, scen_name in pairs:
+        line = f"{ep_name}:{scen_name}"
+        if needle and needle not in line.lower():
+            continue
+        tool.info(line)
+        shown += 1
+    if not pairs:
+        tool.warn(f"No episodes found under {repo_path}.")
+    elif shown == 0 and needle:
+        tool.warn(f"No episode:scenario pairs matched {match!r}.")
+
+
 # -- Helpers -------------------------------------------------------------------
 
 
@@ -681,6 +710,45 @@ def _get_gensim_repo_path() -> Path:
 
 # Episode subdirectories to search within the gensim-episodes repo.
 _EPISODE_SUBDIRS = ["agent-q-branch", "postmortems", "synthetics"]
+_EPISODE_SUBDIR_SET = frozenset(_EPISODE_SUBDIRS)
+
+
+def _resolve_scenario_file(ep_dir: Path, scen_name: str) -> Path:
+    """Return episodes/<scenario>.yaml or .yml, preferring .yaml if both exist (matches submit / Pulumi)."""
+    episodes_dir = ep_dir / "episodes"
+    for ext in (".yaml", ".yml"):
+        candidate = episodes_dir / f"{scen_name}{ext}"
+        if candidate.is_file():
+            return candidate
+    raise Exit(f"Scenario file not found for {scen_name!r} under {episodes_dir} (tried .yaml and .yml).")
+
+
+def _discover_episode_scenario_pairs(repo_path: Path) -> list[tuple[str, str]]:
+    """Return sorted unique (episode_name, scenario_stem) pairs from episodes/*.yaml and *.yml."""
+    pairs: set[tuple[str, str]] = set()
+
+    def add_from_episode_dir(ep_dir: Path) -> None:
+        scen_dir = ep_dir / "episodes"
+        if not scen_dir.is_dir():
+            return
+        for pattern in ("*.yaml", "*.yml"):
+            for yml in scen_dir.glob(pattern):
+                pairs.add((ep_dir.name, yml.stem))
+
+    try:
+        for child in sorted(repo_path.iterdir()):
+            if not child.is_dir() or child.name.startswith("."):
+                continue
+            if child.name in _EPISODE_SUBDIR_SET:
+                for ep_dir in sorted(child.iterdir()):
+                    if ep_dir.is_dir() and not ep_dir.name.startswith("."):
+                        add_from_episode_dir(ep_dir)
+            else:
+                add_from_episode_dir(child)
+    except OSError as e:
+        raise Exit(f"Could not scan gensim-episodes repo {repo_path}: {e}") from e
+
+    return sorted(pairs)
 
 
 def _find_episode_dir(repo_path: Path, ep_name: str) -> Path:

--- a/tasks/e2e_framework/aws/gensim_eks.py
+++ b/tasks/e2e_framework/aws/gensim_eks.py
@@ -100,6 +100,12 @@ _VALID_MODES = ("record-parquet", "live-anomaly-detection", "live-and-record")
         "skip_build": "Skip episode image building (use cached ECR images from a previous run)",
         "send_dd_event": "Send a Datadog event when the run is submitted (default: true)",
         "disable_logs_agent": "Disable log collection in the Helm values for the gensim Datadog Agent (default: false)",
+        "disable_metrics_ingestion": (
+            "Disable observer ingestion of externally-ingested metrics (DogStatsD, "
+            "check samplers, HF runners). Logs and log-derived virtual metrics keep "
+            "flowing through the engine, so log-only anomaly detection still works "
+            "(default: false)"
+        ),
     }
 )
 def submit_gensim_eks(
@@ -117,6 +123,7 @@ def submit_gensim_eks(
     skip_build: bool = False,
     send_dd_event: bool = True,
     disable_logs_agent: bool = False,
+    disable_metrics_ingestion: bool = False,
 ) -> None:
     """
     Submit a gensim evaluation run to an EKS cluster.
@@ -134,6 +141,7 @@ def submit_gensim_eks(
         inv aws.eks.gensim.submit --image=... --episode-manifest=./gensim-eval-scenarios.json
         inv aws.eks.gensim.submit --image=... --episodes=... --mode=live-anomaly-detection
         inv aws.eks.gensim.submit --image=... --episodes=... --disable-logs-agent
+        inv aws.eks.gensim.submit --image=... --episodes=... --mode=live-anomaly-detection --disable-metrics-ingestion
     """
     from pydantic_core._pydantic_core import ValidationError
 
@@ -334,6 +342,7 @@ def submit_gensim_eks(
         "gensim:episodeDataDir": str(gensim_repo_path),
         "gensim:mode": mode,
         "gensim:disableLogsAgent": disable_logs_agent,
+        "gensim:disableMetricsIngestion": disable_metrics_ingestion,
         # Datadog keys -- must be explicit since install_agent=False
         "ddagent:apiKey": _get_api_key(local_config),
         "ddagent:appKey": _get_app_key(local_config),

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -404,7 +404,9 @@ def eval_combinations(
         build_testbench(ctx)
         build_scorer(ctx)
 
-    if seed is None:
+    if seed is not None:
+        seed = int(seed)
+    else:
         seed = random.randint(0, 2**32 - 1)
 
     force_enable_list = [c.strip() for c in force_enable.split(",") if c.strip()]
@@ -655,7 +657,9 @@ def eval_bayesian(
         print(color_message(f"Error: locked components not in active set: {', '.join(sorted(not_active))}", Color.RED))
         return
 
-    if seed is None:
+    if seed is not None:
+        seed = int(seed)
+    else:
         seed = random.randint(0, 2**32 - 1)
 
     if not _prepare_eval_output_dir(output_dir, overwrite=overwrite):
@@ -973,7 +977,9 @@ def eval_pipeline(
     if not _prepare_eval_output_dir(output_dir, overwrite=overwrite):
         return
 
-    if seed is None:
+    if seed is not None:
+        seed = int(seed)
+    else:
         seed = random.randint(0, 2**32 - 1)
 
     rng = random.Random(seed)
@@ -1305,7 +1311,9 @@ def eval_component(
         print(color_message(f"Error: cannot force-disable the evaluated component '{component}'", Color.RED))
         return
 
-    if seed is None:
+    if seed is not None:
+        seed = int(seed)
+    else:
         seed = random.randint(0, 2**32 - 1)
 
     # --- deterministic seed derivation ---

--- a/test/e2e-framework/scenarios/aws/gensim-eks/agent-values.yaml.tmpl
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/agent-values.yaml.tmpl
@@ -41,6 +41,10 @@ datadog:
     - name: DD_OBSERVER_EVENT_REPORTER_SENDING_ENABLED
       value: "true"
 {{- end}}
+{{- if not .MetricsIngestionEnabled}}
+    - name: DD_OBSERVER_INGEST_METRICS_ENABLED
+      value: "false"
+{{- end}}
     - name: DD_OBSERVER_HIGH_FREQUENCY_INTERVAL
       value: "1s"
 
@@ -54,6 +58,10 @@ agents:
   useConfigMap: true
   customAgentConfig:
     observer:
+{{- if not .MetricsIngestionEnabled}}
+      ingest_metrics:
+        enabled: false
+{{- end}}
 {{- if eq .Mode "record-parquet"}}
       recording:
         enabled: true

--- a/test/e2e-framework/scenarios/aws/gensim-eks/agent-values.yaml.tmpl
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/agent-values.yaml.tmpl
@@ -55,6 +55,47 @@ agents:
     tag: {{.ImageTag}}
     doNotCheckTag: true
     pullPolicy: Always
+{{- if not .LogsEnabled}}
+  # When the legacy logs agent is OFF (logs_enabled=false), the chart does not
+  # auto-mount /var/log/pods or /var/log/containers — but the observer
+  # logssource component still needs them so the file launcher can tail
+  # container stdout/stderr. /etc/machine-id is required by sd_journal, and
+  # the journal paths are needed by the kubelet journald source.
+  # When the legacy logs agent is ON, the chart adds these mounts itself
+  # (with the same names), so adding them here would duplicate-collide.
+  volumes:
+    - name: logpodpath
+      hostPath:
+        path: /var/log/pods
+    - name: logcontainerpath
+      hostPath:
+        path: /var/log/containers
+    - name: hostmachineid
+      hostPath:
+        path: /etc/machine-id
+    - name: host-var-log-journal
+      hostPath:
+        path: /var/log/journal
+    - name: host-run-log-journal
+      hostPath:
+        path: /run/log/journal
+  volumeMounts:
+    - name: logpodpath
+      mountPath: /var/log/pods
+      readOnly: true
+    - name: logcontainerpath
+      mountPath: /var/log/containers
+      readOnly: true
+    - name: hostmachineid
+      mountPath: /etc/machine-id
+      readOnly: true
+    - name: host-var-log-journal
+      mountPath: /var/log/journal
+      readOnly: true
+    - name: host-run-log-journal
+      mountPath: /run/log/journal
+      readOnly: true
+{{- end}}
   useConfigMap: true
   customAgentConfig:
     observer:

--- a/test/e2e-framework/scenarios/aws/gensim-eks/run.go
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/run.go
@@ -57,7 +57,7 @@ import (
 
 // episodeSubdirs lists the subdirectories within the gensim-episodes repo
 // that may contain episode directories.
-var episodeSubdirs = []string{"postmortems", "synthetics"}
+var episodeSubdirs = []string{"agent-q-branch", "postmortems", "synthetics"}
 
 // findEpisodeDir locates an episode directory by searching known subdirectories
 // within the gensim-episodes repo root. Also supports legacy episodeDataDir

--- a/test/e2e-framework/scenarios/aws/gensim-eks/run.go
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/run.go
@@ -77,6 +77,23 @@ func findEpisodeDir(repoRoot, episodeName string) (string, error) {
 	return "", fmt.Errorf("episode %q not found in %v under %s", episodeName, episodeSubdirs, repoRoot)
 }
 
+// readScenarioFile loads episodes/<scenario>.yaml or episodes/<scenario>.yml from an episode directory.
+// It prefers .yaml when both exist. The orchestrator and ConfigMap always use the key <scenario>.yaml.
+func readScenarioFile(epDir, scenario string) ([]byte, error) {
+	episodesDir := filepath.Join(epDir, "episodes")
+	for _, ext := range []string{".yaml", ".yml"} {
+		p := filepath.Join(episodesDir, scenario+ext)
+		b, err := os.ReadFile(p)
+		if err == nil {
+			return b, nil
+		}
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("reading scenario file %q: %w", p, err)
+		}
+	}
+	return nil, fmt.Errorf("scenario file not found for %q in %s (tried .yaml and .yml)", scenario, episodesDir)
+}
+
 // Run is the Pulumi entry point for the aws/gensim-eks scenario.
 // It is registered in registry/scenarios.go and invoked by the e2e-framework runner.
 func Run(ctx *pulumi.Context) error {
@@ -332,7 +349,7 @@ func deployOrchestratorJob(
 		if err != nil {
 			return fmt.Errorf("reading play-episode.sh for episode %q: %w", ep.episode, err)
 		}
-		scenarioContent, err := os.ReadFile(filepath.Join(epDir, "episodes", ep.scenario+".yaml"))
+		scenarioContent, err := readScenarioFile(epDir, ep.scenario)
 		if err != nil {
 			return fmt.Errorf("reading scenario %q for episode %q: %w", ep.scenario, ep.episode, err)
 		}

--- a/test/e2e-framework/scenarios/aws/gensim-eks/run.go
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/run.go
@@ -139,6 +139,14 @@ func Run(ctx *pulumi.Context) error {
 	}
 	logsEnabled := !disableLogsAgent
 
+	disableMetricsIngestion := false
+	if v := strings.TrimSpace(cfg.Get("disableMetricsIngestion")); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			disableMetricsIngestion = b
+		}
+	}
+	metricsIngestionEnabled := !disableMetricsIngestion
+
 	// If no episodes are specified, stop here — cluster-only mode.
 	if episodes == "" {
 		return nil
@@ -221,7 +229,7 @@ func Run(ctx *pulumi.Context) error {
 	if err := deployOrchestratorJob(
 		ctx, &awsEnv, kubeProvider, sa, ddSecret,
 		episodes, agentImage, gensimSha, namespace, s3Bucket, imageRegistry, episodeDataDir, mode,
-		logsEnabled,
+		logsEnabled, metricsIngestionEnabled,
 	); err != nil {
 		return err
 	}
@@ -313,6 +321,7 @@ func deployOrchestratorJob(
 	episodeDataDir string,
 	mode string,
 	logsEnabled bool,
+	metricsIngestionEnabled bool,
 ) error {
 	kubeOpts := []pulumi.ResourceOption{pulumi.Provider(kubeProvider)}
 
@@ -439,7 +448,7 @@ func deployOrchestratorJob(
 	}
 
 	// ── Agent values ConfigMap ───────────────────────────────────────────────
-	renderedValues, err := renderAgentValues(agentImage, mode, logsEnabled)
+	renderedValues, err := renderAgentValues(agentImage, mode, logsEnabled, metricsIngestionEnabled)
 	if err != nil {
 		return err
 	}
@@ -555,9 +564,13 @@ var orchestratorScript string
 //go:embed agent-values.yaml.tmpl
 var agentValuesTmpl string
 
-// renderAgentValues renders the agent Helm values template with the given image and mode.
+// renderAgentValues renders the agent Helm values template with the given
+// image, mode, and feature toggles. metricsIngestionEnabled=false makes the
+// observer drop externally-ingested metrics (DogStatsD, check samplers, HF
+// runners) at the handle factory; logs and log-derived virtual metrics
+// produced inside the engine by LogMetricsExtractors keep flowing.
 // mode is one of "record-parquet" or "live-anomaly-detection".
-func renderAgentValues(agentImage, mode string, logsEnabled bool) (string, error) {
+func renderAgentValues(agentImage, mode string, logsEnabled, metricsIngestionEnabled bool) (string, error) {
 	idx := strings.LastIndex(agentImage, ":")
 	if idx < 0 {
 		return "", fmt.Errorf("invalid image reference %q: expected format repo:tag (e.g. docker.io/datadog/agent-dev:latest)", agentImage)
@@ -574,7 +587,8 @@ func renderAgentValues(agentImage, mode string, logsEnabled bool) (string, error
 	err = tmpl.Execute(&buf, struct {
 		ImageRepo, ImageTag, Mode string
 		LogsEnabled               bool
-	}{repo, tag, mode, logsEnabled})
+		MetricsIngestionEnabled   bool
+	}{repo, tag, mode, logsEnabled, metricsIngestionEnabled})
 	if err != nil {
 		return "", fmt.Errorf("rendering agent-values template: %w", err)
 	}

--- a/test/e2e-framework/scenarios/aws/gensim-eks/run_test.go
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/run_test.go
@@ -16,20 +16,40 @@ func TestRenderAgentValues_LogsEnabled(t *testing.T) {
 	image := "docker.io/datadog/agent-dev:my-tag"
 	mode := "record-parquet"
 
-	out, err := renderAgentValues(image, mode, true)
+	out, err := renderAgentValues(image, mode, true, true)
 	require.NoError(t, err)
 	require.Contains(t, out, "logs:")
 	require.Contains(t, out, "enabled: true")
 	require.Contains(t, out, "containerCollectAll: true")
 
-	out, err = renderAgentValues(image, mode, false)
+	out, err = renderAgentValues(image, mode, false, true)
 	require.NoError(t, err)
 	require.Contains(t, out, "enabled: false")
 	require.NotContains(t, out, "containerCollectAll")
 }
 
+func TestRenderAgentValues_MetricsIngestion(t *testing.T) {
+	image := "docker.io/datadog/agent-dev:my-tag"
+	mode := "live-anomaly-detection"
+
+	// Default: metric ingestion stays enabled, no override emitted.
+	out, err := renderAgentValues(image, mode, true, true)
+	require.NoError(t, err)
+	require.NotContains(t, out, "DD_OBSERVER_INGEST_METRICS_ENABLED")
+	require.NotContains(t, out, "ingest_metrics:")
+
+	// Disabled: emit both the env var and the customAgentConfig override
+	// so the observer drops external metrics at the handle factory.
+	out, err = renderAgentValues(image, mode, true, false)
+	require.NoError(t, err)
+	require.Contains(t, out, "DD_OBSERVER_INGEST_METRICS_ENABLED")
+	require.Contains(t, out, `value: "false"`)
+	require.Contains(t, out, "ingest_metrics:")
+	require.Contains(t, out, "enabled: false")
+}
+
 func TestRenderAgentValues_InvalidImage(t *testing.T) {
-	_, err := renderAgentValues("notag", "record-parquet", true)
+	_, err := renderAgentValues("notag", "record-parquet", true, true)
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "invalid image reference"))
 }


### PR DESCRIPTION
Coordinator harness run-log.

seed correlators

- Mode: `full`
- Scratch branch: `claude/observer-full-20260428T1457`
- PR base: `ella/claude-coordinator-harness` (harness + observer; PR diff = ships only)
- Upstream merge source: `q-branch-observer`
- Started: 2026-04-28T14:57:53

_This PR is the bidirectional control channel: status comments posted by the coordinator; steering comments by the operator. Each shipped candidate becomes one commit on this branch, making the run a self-contained eval-matrix entry diffable against `ella/claude-coordinator-harness`._
