### PR TITLE
[CWS] Fix and improve event retry queue: extTagsCb bug, metrics, larger default

### DIFF
--- a/pkg/config/schema/system-probe_schema.yaml
+++ b/pkg/config/schema/system-probe_schema.yaml
@@ -1459,7 +1459,7 @@ properties:
       event_retry_queue_threshold:
         node_type: setting
         type: number
-        default: 30
+        default: 512
       event_sampling:
         node_type: section
         type: object

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -34,7 +34,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.event_server.burst", 40)
 	cfg.BindEnvAndSetDefault("runtime_security_config.event_server.retention", "6s")
 	cfg.BindEnvAndSetDefault("runtime_security_config.event_server.rate", 10)
-	cfg.BindEnvAndSetDefault("runtime_security_config.event_retry_queue_threshold", 30)
+	cfg.BindEnvAndSetDefault("runtime_security_config.event_retry_queue_threshold", 512)
 	cfg.BindEnvAndSetDefault("runtime_security_config.cookie_cache_size", 100)
 	cfg.BindEnvAndSetDefault("runtime_security_config.internal_monitoring.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.log_patterns", []string{})

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -23,6 +23,18 @@ var (
 	// security-agent was not processing them fast enough
 	// Tags: rule_id
 	MetricEventServerExpired = newRuntimeMetric(".rules.event_server.expired")
+	// MetricEventServerRetry counts how many times a queued event was scheduled for retry
+	// Tags: -
+	MetricEventServerRetry = newRuntimeMetric(".rules.event_server.retry")
+	// MetricEventServerSkippedRetry counts retries that were skipped because the queue was at capacity
+	// Tags: -
+	MetricEventServerSkippedRetry = newRuntimeMetric(".rules.event_server.skipped_retry")
+	// MetricEventServerMissingTags counts events that were sent with missing container tags
+	// Tags: -
+	MetricEventServerMissingTags = newRuntimeMetric(".rules.event_server.missing_tags")
+	// MetricEventServerQueueSize is the current number of events waiting in the retry queue
+	// Tags: -
+	MetricEventServerQueueSize = newRuntimeMetric(".rules.event_server.queue_size")
 
 	// Rate limiter metrics
 

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -35,6 +35,9 @@ var (
 	// MetricEventServerQueueSize is the current number of events waiting in the retry queue
 	// Tags: -
 	MetricEventServerQueueSize = newRuntimeMetric(".rules.event_server.queue_size")
+	// MetricEventServerRetriesBeforeSend is a distribution of the number of retries an event required before being sent
+	// Tags: -
+	MetricEventServerRetriesBeforeSend = newRuntimeMetric(".rules.event_server.retries_before_send")
 
 	// Rate limiter metrics
 

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -86,6 +86,28 @@ func (p *pendingMsg) getMaxRetry() int {
 	return maxRetry
 }
 
+// tryResolve collects external tags and checks whether the message is ready to be
+// sent. Returns false when the message should be retried later.
+func (p *pendingMsg) tryResolve(isRetryAllowed bool) bool {
+	if p.extTagsCb != nil {
+		tags, retryable := p.extTagsCb()
+		if len(tags) == 0 && isRetryAllowed && retryable && p.retry < p.getMaxRetry() {
+			return false
+		}
+		for _, tag := range tags {
+			if !slices.Contains(p.tags, tag) {
+				p.tags = append(p.tags, tag)
+			}
+		}
+	}
+
+	if !p.isResolved() && isRetryAllowed && p.retry < p.getMaxRetry() {
+		return false
+	}
+
+	return true
+}
+
 func (p *pendingMsg) isResolved() bool {
 	for _, report := range p.actionReports {
 		if err := report.IsResolved(); err != nil {
@@ -254,7 +276,7 @@ func (a *APIServer) enqueue(msg *pendingMsg) {
 	a.queueLock.Unlock()
 }
 
-func (a *APIServer) dequeue(now time.Time, cb func(msg *pendingMsg, retry bool) bool) {
+func (a *APIServer) dequeue(now time.Time, sendCallback func(msg *pendingMsg, retry bool) bool) {
 	a.queueLock.Lock()
 	defer a.queueLock.Unlock()
 
@@ -268,7 +290,7 @@ func (a *APIServer) dequeue(now time.Time, cb func(msg *pendingMsg, retry bool) 
 			return false
 		}
 
-		if cb(msg, queueSize < a.cfg.EventRetryQueueThreshold) {
+		if sendCallback(msg, queueSize < a.cfg.EventRetryQueueThreshold) {
 			queueSize--
 			return true
 		}
@@ -352,7 +374,7 @@ func SendCustomEventKillAction(probe *sprobe.Probe, tags []string, actionReports
 }
 
 func (a *APIServer) start(ctx context.Context) {
-	ticker := time.NewTicker(200 * time.Millisecond)
+	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 
 	for {
@@ -363,22 +385,7 @@ func (a *APIServer) start(ctx context.Context) {
 					seclog.Debugf("queue limit reached: %d, sending event anyway", len(a.queue))
 				}
 
-				if msg.extTagsCb != nil && isRetryAllowed {
-					tags, retryable := msg.extTagsCb()
-					if len(tags) == 0 && retryable && msg.retry < msg.getMaxRetry() {
-						return false
-					}
-
-					// dedup
-					for _, tag := range tags {
-						if !slices.Contains(msg.tags, tag) {
-							msg.tags = append(msg.tags, tag)
-						}
-					}
-				}
-
-				// not fully resolved, retry
-				if !msg.isResolved() && isRetryAllowed && msg.retry < msg.getMaxRetry() {
+				if !msg.tryResolve(isRetryAllowed) {
 					return false
 				}
 

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -54,10 +54,10 @@ import (
 
 const (
 	// defaultMaxRetry is the default maximum number of retries for a pending message
-	defaultMaxRetry = 5
+	defaultMaxRetry = 25
 
 	// retryDelay is the delay between retries, changing this value may impact the retry logic.
-	retryDelay = time.Second
+	retryDelay = 200 * time.Millisecond
 )
 
 type pendingMsg struct {
@@ -90,20 +90,27 @@ func (p *pendingMsg) getMaxRetry() int {
 // sent. Returns false when the message should be retried later. Increments server
 // counters for skipped retries and missing tags.
 func (a *APIServer) tryResolve(msg *pendingMsg, isRetryAllowed bool) bool {
+	var (
+		skippedRetry bool
+		missingTags  bool
+	)
+
 	if msg.extTagsCb != nil {
 		tags, retryable := msg.extTagsCb()
-		if len(tags) == 0 && retryable && msg.retry < msg.getMaxRetry() {
-			if isRetryAllowed {
+		if len(tags) == 0 {
+			if isRetryAllowed && retryable && msg.retry < msg.getMaxRetry() {
 				return false
 			}
-			a.skippedRetryCount.Inc()
-		}
-		if len(tags) == 0 {
-			a.missingTagsCount.Inc()
-		}
-		for _, tag := range tags {
-			if !slices.Contains(msg.tags, tag) {
-				msg.tags = append(msg.tags, tag)
+			missingTags = true
+			// skippedRetry only when queue pressure forced us past a retryable miss
+			if !isRetryAllowed && retryable && msg.retry < msg.getMaxRetry() {
+				skippedRetry = true
+			}
+		} else {
+			for _, tag := range tags {
+				if !slices.Contains(msg.tags, tag) {
+					msg.tags = append(msg.tags, tag)
+				}
 			}
 		}
 	}
@@ -113,8 +120,15 @@ func (a *APIServer) tryResolve(msg *pendingMsg, isRetryAllowed bool) bool {
 			return false
 		}
 		if !isRetryAllowed && msg.retry < msg.getMaxRetry() {
-			a.skippedRetryCount.Inc()
+			skippedRetry = true
 		}
+	}
+
+	if skippedRetry {
+		a.skippedRetryCount.Inc()
+	}
+	if missingTags {
+		a.missingTagsCount.Inc()
 	}
 
 	return true

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -87,22 +87,34 @@ func (p *pendingMsg) getMaxRetry() int {
 }
 
 // tryResolve collects external tags and checks whether the message is ready to be
-// sent. Returns false when the message should be retried later.
-func (p *pendingMsg) tryResolve(isRetryAllowed bool) bool {
-	if p.extTagsCb != nil {
-		tags, retryable := p.extTagsCb()
-		if len(tags) == 0 && isRetryAllowed && retryable && p.retry < p.getMaxRetry() {
-			return false
+// sent. Returns false when the message should be retried later. Increments server
+// counters for skipped retries and missing tags.
+func (a *APIServer) tryResolve(msg *pendingMsg, isRetryAllowed bool) bool {
+	if msg.extTagsCb != nil {
+		tags, retryable := msg.extTagsCb()
+		if len(tags) == 0 && retryable && msg.retry < msg.getMaxRetry() {
+			if isRetryAllowed {
+				return false
+			}
+			a.skippedRetryCount.Inc()
+		}
+		if len(tags) == 0 {
+			a.missingTagsCount.Inc()
 		}
 		for _, tag := range tags {
-			if !slices.Contains(p.tags, tag) {
-				p.tags = append(p.tags, tag)
+			if !slices.Contains(msg.tags, tag) {
+				msg.tags = append(msg.tags, tag)
 			}
 		}
 	}
 
-	if !p.isResolved() && isRetryAllowed && p.retry < p.getMaxRetry() {
-		return false
+	if !msg.isResolved() {
+		if isRetryAllowed && msg.retry < msg.getMaxRetry() {
+			return false
+		}
+		if !isRetryAllowed && msg.retry < msg.getMaxRetry() {
+			a.skippedRetryCount.Inc()
+		}
 	}
 
 	return true
@@ -206,6 +218,11 @@ type APIServer struct {
 	envAsTags          []string
 	containerFilter    workloadfilter.FilterBundle
 
+	// retry queue metrics counters
+	retryCount        atomic.Int64
+	skippedRetryCount atomic.Int64
+	missingTagsCount  atomic.Int64
+
 	// os release data
 	kernelVersion string
 	distribution  string
@@ -305,6 +322,7 @@ func (a *APIServer) dequeue(now time.Time, sendCallback func(msg *pendingMsg, re
 		seclog.Debugf("failed to send event for rule `%s`, retry %d/%d, queue size: %d", msg.ruleID, msg.retry, msgMaxRetry, len(a.queue))
 
 		msg.sendAfter = now.Add(retryDelay)
+		a.retryCount.Inc()
 		msg.retry++
 
 		return false
@@ -385,7 +403,7 @@ func (a *APIServer) start(ctx context.Context) {
 					seclog.Debugf("queue limit reached: %d, sending event anyway", len(a.queue))
 				}
 
-				if !msg.tryResolve(isRetryAllowed) {
+				if !a.tryResolve(msg, isRetryAllowed) {
 					return false
 				}
 
@@ -633,6 +651,31 @@ func (a *APIServer) SendStats() error {
 				return err
 			}
 		}
+	}
+
+	// retry queue counters (delta since last call)
+	if val := a.retryCount.Swap(0); val > 0 {
+		if err := a.statsdClient.Count(metrics.MetricEventServerRetry, val, []string{}, 1.0); err != nil {
+			return err
+		}
+	}
+	if val := a.skippedRetryCount.Swap(0); val > 0 {
+		if err := a.statsdClient.Count(metrics.MetricEventServerSkippedRetry, val, []string{}, 1.0); err != nil {
+			return err
+		}
+	}
+	if val := a.missingTagsCount.Swap(0); val > 0 {
+		if err := a.statsdClient.Count(metrics.MetricEventServerMissingTags, val, []string{}, 1.0); err != nil {
+			return err
+		}
+	}
+
+	// current queue depth
+	a.queueLock.Lock()
+	queueSize := int64(len(a.queue))
+	a.queueLock.Unlock()
+	if err := a.statsdClient.Gauge(metrics.MetricEventServerQueueSize, float64(queueSize), []string{}, 1.0); err != nil {
+		return err
 	}
 
 	// telemetry for msg senders

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -449,6 +449,10 @@ func (a *APIServer) start(ctx context.Context) {
 				}
 				a.updateMsgService(m)
 
+				if err := a.statsdClient.Distribution(metrics.MetricEventServerRetriesBeforeSend, float64(msg.retry), []string{}, 1.0); err != nil {
+					seclog.Tracef("failed to send retries_before_send metric: %v", err)
+				}
+
 				a.msgSender.Send(m, a.expireEvent)
 
 				return true

--- a/pkg/security/module/server_test.go
+++ b/pkg/security/module/server_test.go
@@ -240,7 +240,7 @@ func TestExtTagsCbCalledWhenQueueFull(t *testing.T) {
 	}
 	server.queue = []*pendingMsg{msg}
 
-	server.dequeue(now, (*pendingMsg).tryResolve)
+	server.dequeue(now, server.tryResolve)
 
 	if !cbCalled {
 		t.Fatal("expected extTagsCb to be called even when queue is full")
@@ -250,6 +250,13 @@ func TestExtTagsCbCalledWhenQueueFull(t *testing.T) {
 	}
 	if len(server.queue) != 0 {
 		t.Fatalf("expected message to be sent (removed from queue), got size %d", len(server.queue))
+	}
+	// tags were present, so no missing-tags or skipped-retry counter should fire
+	if v := server.missingTagsCount.Load(); v != 0 {
+		t.Fatalf("expected missingTagsCount=0, got %d", v)
+	}
+	if v := server.skippedRetryCount.Load(); v != 0 {
+		t.Fatalf("expected skippedRetryCount=0, got %d", v)
 	}
 }
 
@@ -269,7 +276,7 @@ func TestExtTagsCbRetriesWhenEmptyAndRetryAllowed(t *testing.T) {
 	}
 	server.queue = []*pendingMsg{msg}
 
-	server.dequeue(now, (*pendingMsg).tryResolve)
+	server.dequeue(now, server.tryResolve)
 
 	if cbCallCount != 1 {
 		t.Fatalf("expected extTagsCb called once, got %d", cbCallCount)
@@ -280,6 +287,16 @@ func TestExtTagsCbRetriesWhenEmptyAndRetryAllowed(t *testing.T) {
 	}
 	if msg.retry != 1 {
 		t.Fatalf("expected retry counter incremented to 1, got %d", msg.retry)
+	}
+	// a retry was scheduled → retryCount incremented; nothing sent so no missing-tags/skipped-retry
+	if v := server.retryCount.Load(); v != 1 {
+		t.Fatalf("expected retryCount=1, got %d", v)
+	}
+	if v := server.missingTagsCount.Load(); v != 0 {
+		t.Fatalf("expected missingTagsCount=0 (message not yet sent), got %d", v)
+	}
+	if v := server.skippedRetryCount.Load(); v != 0 {
+		t.Fatalf("expected skippedRetryCount=0, got %d", v)
 	}
 }
 
@@ -299,7 +316,7 @@ func TestExtTagsCbNoRetryWhenQueueFull(t *testing.T) {
 	}
 	server.queue = []*pendingMsg{msg}
 
-	server.dequeue(now, (*pendingMsg).tryResolve)
+	server.dequeue(now, server.tryResolve)
 
 	if cbCallCount != 1 {
 		t.Fatalf("expected extTagsCb called once, got %d", cbCallCount)
@@ -307,6 +324,13 @@ func TestExtTagsCbNoRetryWhenQueueFull(t *testing.T) {
 	// message must be sent despite empty tags because queue is full
 	if len(server.queue) != 0 {
 		t.Fatalf("expected message to be sent (empty queue), got size %d", len(server.queue))
+	}
+	// the forced send counts as one skipped retry and one missing-tags event
+	if v := server.skippedRetryCount.Load(); v != 1 {
+		t.Fatalf("expected skippedRetryCount=1, got %d", v)
+	}
+	if v := server.missingTagsCount.Load(); v != 1 {
+		t.Fatalf("expected missingTagsCount=1, got %d", v)
 	}
 }
 
@@ -324,9 +348,16 @@ func TestExtTagsCbNoRetryWhenNotRetryable(t *testing.T) {
 	}
 	server.queue = []*pendingMsg{msg}
 
-	server.dequeue(now, (*pendingMsg).tryResolve)
+	server.dequeue(now, server.tryResolve)
 
 	if len(server.queue) != 0 {
 		t.Fatalf("expected message to be sent when not retryable, got queue size %d", len(server.queue))
+	}
+	// not retryable → missing tags counted, but no skipped retry
+	if v := server.missingTagsCount.Load(); v != 1 {
+		t.Fatalf("expected missingTagsCount=1, got %d", v)
+	}
+	if v := server.skippedRetryCount.Load(); v != 0 {
+		t.Fatalf("expected skippedRetryCount=0 (not retryable, not a skipped retry), got %d", v)
 	}
 }

--- a/pkg/security/module/server_test.go
+++ b/pkg/security/module/server_test.go
@@ -1,0 +1,332 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package module
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+// mockActionReport implements model.ActionReport for testing
+type mockActionReport struct {
+	maxRetry  int
+	resolved  error
+	matchRule bool
+}
+
+func (m *mockActionReport) IsResolved() error                 { return m.resolved }
+func (m *mockActionReport) MaxRetry() int                     { return m.maxRetry }
+func (m *mockActionReport) ToJSON() ([]byte, error)           { return nil, nil }
+func (m *mockActionReport) IsMatchingRule(_ eval.RuleID) bool { return m.matchRule }
+
+var _ model.ActionReport = (*mockActionReport)(nil)
+
+func newTestAPIServer(threshold int) *APIServer {
+	return &APIServer{
+		cfg: &config.RuntimeSecurityConfig{
+			EventRetryQueueThreshold: threshold,
+		},
+	}
+}
+
+func TestSlicesDeleteUntilFalse(t *testing.T) {
+	t.Run("all true removes all", func(t *testing.T) {
+		msgs := []*pendingMsg{{ruleID: "a"}, {ruleID: "b"}, {ruleID: "c"}}
+		result := slicesDeleteUntilFalse(msgs, func(_ *pendingMsg) bool { return true })
+		if len(result) != 0 {
+			t.Fatalf("expected empty slice, got %d elements", len(result))
+		}
+	})
+
+	t.Run("stops at first false", func(t *testing.T) {
+		msgs := []*pendingMsg{{ruleID: "a"}, {ruleID: "b"}, {ruleID: "c"}}
+		result := slicesDeleteUntilFalse(msgs, func(msg *pendingMsg) bool {
+			return msg.ruleID == "a"
+		})
+		if len(result) != 2 || result[0].ruleID != "b" || result[1].ruleID != "c" {
+			t.Fatalf("expected [b, c], got %v", result)
+		}
+	})
+
+	t.Run("first false keeps all", func(t *testing.T) {
+		msgs := []*pendingMsg{{ruleID: "a"}, {ruleID: "b"}}
+		result := slicesDeleteUntilFalse(msgs, func(_ *pendingMsg) bool { return false })
+		if len(result) != 2 {
+			t.Fatalf("expected 2 elements, got %d", len(result))
+		}
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		result := slicesDeleteUntilFalse(nil, func(_ *pendingMsg) bool { return true })
+		if result != nil {
+			t.Fatalf("expected nil, got %v", result)
+		}
+	})
+}
+
+func TestPendingMsgGetMaxRetry(t *testing.T) {
+	t.Run("no action reports returns default", func(t *testing.T) {
+		msg := &pendingMsg{}
+		if got := msg.getMaxRetry(); got != defaultMaxRetry {
+			t.Fatalf("expected %d, got %d", defaultMaxRetry, got)
+		}
+	})
+
+	t.Run("action report above default is used", func(t *testing.T) {
+		msg := &pendingMsg{
+			actionReports: []model.ActionReport{
+				&mockActionReport{maxRetry: defaultMaxRetry + 5},
+			},
+		}
+		if got := msg.getMaxRetry(); got != defaultMaxRetry+5 {
+			t.Fatalf("expected %d, got %d", defaultMaxRetry+5, got)
+		}
+	})
+
+	t.Run("action report below default uses default", func(t *testing.T) {
+		msg := &pendingMsg{
+			actionReports: []model.ActionReport{
+				&mockActionReport{maxRetry: 1},
+			},
+		}
+		if got := msg.getMaxRetry(); got != defaultMaxRetry {
+			t.Fatalf("expected %d, got %d", defaultMaxRetry, got)
+		}
+	})
+
+	t.Run("takes max across multiple reports", func(t *testing.T) {
+		msg := &pendingMsg{
+			actionReports: []model.ActionReport{
+				&mockActionReport{maxRetry: defaultMaxRetry + 3},
+				&mockActionReport{maxRetry: defaultMaxRetry + 10},
+				&mockActionReport{maxRetry: defaultMaxRetry + 1},
+			},
+		}
+		if got := msg.getMaxRetry(); got != defaultMaxRetry+10 {
+			t.Fatalf("expected %d, got %d", defaultMaxRetry+10, got)
+		}
+	})
+}
+
+func TestDequeueRetryIncrement(t *testing.T) {
+	server := newTestAPIServer(100)
+	now := time.Now()
+	msg := &pendingMsg{
+		ruleID:    "test-rule",
+		sendAfter: now.Add(-time.Second),
+	}
+	server.queue = []*pendingMsg{msg}
+
+	callCount := 0
+	server.dequeue(now, func(_ *pendingMsg, _ bool) bool {
+		callCount++
+		return false // signal retry needed
+	})
+
+	if callCount != 1 {
+		t.Fatalf("expected callback called once, got %d", callCount)
+	}
+	if msg.retry != 1 {
+		t.Fatalf("expected retry=1, got %d", msg.retry)
+	}
+	if len(server.queue) != 1 {
+		t.Fatalf("expected message to remain in queue, got queue size %d", len(server.queue))
+	}
+	if !msg.sendAfter.After(now) {
+		t.Fatal("expected sendAfter to be updated to a future time")
+	}
+}
+
+func TestDequeueMaxRetryForcesRemoval(t *testing.T) {
+	server := newTestAPIServer(100)
+	now := time.Now()
+	msg := &pendingMsg{
+		ruleID:    "test-rule",
+		retry:     defaultMaxRetry, // already at max
+		sendAfter: now.Add(-time.Second),
+	}
+	server.queue = []*pendingMsg{msg}
+
+	callCount := 0
+	server.dequeue(now, func(_ *pendingMsg, _ bool) bool {
+		callCount++
+		return false // cb says retry, but max is reached
+	})
+
+	if callCount != 1 {
+		t.Fatalf("expected callback called once, got %d", callCount)
+	}
+	// message must be removed even though cb returned false
+	if len(server.queue) != 0 {
+		t.Fatalf("expected empty queue after max retry reached, got %d", len(server.queue))
+	}
+}
+
+func TestDequeueRespectsSendAfterWhenQueueSmall(t *testing.T) {
+	// sendAfter in future + queue below threshold → message is held, cb not called
+	server := newTestAPIServer(100)
+	now := time.Now()
+	msg := &pendingMsg{
+		ruleID:    "test-rule",
+		sendAfter: now.Add(time.Second),
+	}
+	server.queue = []*pendingMsg{msg}
+
+	callCount := 0
+	server.dequeue(now, func(_ *pendingMsg, _ bool) bool {
+		callCount++
+		return true
+	})
+
+	if callCount != 0 {
+		t.Fatalf("expected callback not called while message is delayed, got %d", callCount)
+	}
+	if len(server.queue) != 1 {
+		t.Fatalf("expected message to remain in queue, got %d", len(server.queue))
+	}
+}
+
+func TestDequeueBypassesDelayWhenQueueFull(t *testing.T) {
+	// queue size == threshold → delay is bypassed and isRetryAllowed=false
+	server := newTestAPIServer(1) // threshold=1, queue will have 1 item → full
+	now := time.Now()
+	msg := &pendingMsg{
+		ruleID:    "test-rule",
+		sendAfter: now.Add(time.Second), // would normally be delayed
+	}
+	server.queue = []*pendingMsg{msg}
+
+	var gotIsRetryAllowed bool
+	callCount := 0
+	server.dequeue(now, func(_ *pendingMsg, isRetryAllowed bool) bool {
+		callCount++
+		gotIsRetryAllowed = isRetryAllowed
+		return true
+	})
+
+	if callCount != 1 {
+		t.Fatalf("expected callback called once (delay bypassed), got %d", callCount)
+	}
+	if gotIsRetryAllowed {
+		t.Fatal("expected isRetryAllowed=false when queue is at threshold")
+	}
+	if len(server.queue) != 0 {
+		t.Fatalf("expected empty queue after message sent, got %d", len(server.queue))
+	}
+}
+
+func TestExtTagsCbCalledWhenQueueFull(t *testing.T) {
+	// The key fix: extTagsCb must be called even when the queue is full (isRetryAllowed=false).
+	// Previously the callback was guarded by isRetryAllowed, so tags were never collected.
+	server := newTestAPIServer(1) // threshold=1 → queue full with one item
+
+	now := time.Now()
+	cbCalled := false
+	msg := &pendingMsg{
+		ruleID:    "test-rule",
+		sendAfter: now.Add(-time.Second),
+		extTagsCb: func() ([]string, bool) {
+			cbCalled = true
+			return []string{"container:my-app"}, false
+		},
+	}
+	server.queue = []*pendingMsg{msg}
+
+	server.dequeue(now, (*pendingMsg).tryResolve)
+
+	if !cbCalled {
+		t.Fatal("expected extTagsCb to be called even when queue is full")
+	}
+	if !slices.Contains(msg.tags, "container:my-app") {
+		t.Fatalf("expected collected tag in message, got %v", msg.tags)
+	}
+	if len(server.queue) != 0 {
+		t.Fatalf("expected message to be sent (removed from queue), got size %d", len(server.queue))
+	}
+}
+
+func TestExtTagsCbRetriesWhenEmptyAndRetryAllowed(t *testing.T) {
+	// When extTagsCb returns empty tags + retryable=true + isRetryAllowed=true → retry
+	server := newTestAPIServer(100) // high threshold → retry allowed
+
+	now := time.Now()
+	cbCallCount := 0
+	msg := &pendingMsg{
+		ruleID:    "test-rule",
+		sendAfter: now.Add(-time.Second),
+		extTagsCb: func() ([]string, bool) {
+			cbCallCount++
+			return nil, true // empty but retryable
+		},
+	}
+	server.queue = []*pendingMsg{msg}
+
+	server.dequeue(now, (*pendingMsg).tryResolve)
+
+	if cbCallCount != 1 {
+		t.Fatalf("expected extTagsCb called once, got %d", cbCallCount)
+	}
+	// message must be kept for retry
+	if len(server.queue) != 1 {
+		t.Fatalf("expected message to be kept in queue for retry, got size %d", len(server.queue))
+	}
+	if msg.retry != 1 {
+		t.Fatalf("expected retry counter incremented to 1, got %d", msg.retry)
+	}
+}
+
+func TestExtTagsCbNoRetryWhenQueueFull(t *testing.T) {
+	// When extTagsCb returns empty tags + retryable=true but isRetryAllowed=false → send anyway
+	server := newTestAPIServer(1) // threshold=1 → queue full
+
+	now := time.Now()
+	cbCallCount := 0
+	msg := &pendingMsg{
+		ruleID:    "test-rule",
+		sendAfter: now.Add(-time.Second),
+		extTagsCb: func() ([]string, bool) {
+			cbCallCount++
+			return nil, true // empty but retryable — ignored because queue is full
+		},
+	}
+	server.queue = []*pendingMsg{msg}
+
+	server.dequeue(now, (*pendingMsg).tryResolve)
+
+	if cbCallCount != 1 {
+		t.Fatalf("expected extTagsCb called once, got %d", cbCallCount)
+	}
+	// message must be sent despite empty tags because queue is full
+	if len(server.queue) != 0 {
+		t.Fatalf("expected message to be sent (empty queue), got size %d", len(server.queue))
+	}
+}
+
+func TestExtTagsCbNoRetryWhenNotRetryable(t *testing.T) {
+	// When extTagsCb returns empty tags + retryable=false → send anyway regardless of queue state
+	server := newTestAPIServer(100) // retry would normally be allowed
+
+	now := time.Now()
+	msg := &pendingMsg{
+		ruleID:    "test-rule",
+		sendAfter: now.Add(-time.Second),
+		extTagsCb: func() ([]string, bool) {
+			return nil, false // not retryable
+		},
+	}
+	server.queue = []*pendingMsg{msg}
+
+	server.dequeue(now, (*pendingMsg).tryResolve)
+
+	if len(server.queue) != 0 {
+		t.Fatalf("expected message to be sent when not retryable, got queue size %d", len(server.queue))
+	}
+}

--- a/pkg/security/probe/actions_linux.go
+++ b/pkg/security/probe/actions_linux.go
@@ -27,9 +27,11 @@ const (
 	// HashTriggerProcessExit hash triggered on process exit
 	HashTriggerProcessExit = "process_exit"
 
-	// maxRetryForMsgWithHashAction is the maximum number of retries for a hash action
-	// the reports will be marked as resolved after MAX 5 sec (so it doesn't matter if this retry period lasts for longer)
-	maxRetryForMsgWithHashAction = 10
+	// maxRetryForMsgWithHashAction is the maximum number of retries for a hash action.
+	// Hash reports are resolved after at most defaultHashActionFlushDelay (5s). This value
+	// must be large enough that maxRetryForMsgWithHashAction * retryDelay (200ms) > 5s with
+	// a comfortable margin. 50 × 200ms = 10s.
+	maxRetryForMsgWithHashAction = 50
 )
 
 // HashActionReport defines a hash action reports


### PR DESCRIPTION
### What does this PR do?
                                                     
* When the retry queue reached its capacity threshold (isRetryAllowed=false), the external-tags callback (extTagsCb) was gated behind the same flag and never invoked. Container tags were silently dropped for any event that was force-sent due to a full queue. The fix calls extTagsCb unconditionally to collect available tags, while keeping the retry decision (return false) gated on isRetryAllowed. 
* Four new metrics
* Default queue size increased from 30 → 512

### Motivation

### Describe how you validated your changes

### Additional Notes
