### PR TITLE
[AGTMETRICS-433] Send unit value for timed metrics

### DIFF
--- a/comp/dogstatsd/server/enrich.go
+++ b/comp/dogstatsd/server/enrich.go
@@ -113,6 +113,15 @@ func enrichMetricType(dogstatsdMetricType metricType) metrics.MetricType {
 	return metrics.GaugeType
 }
 
+// unitFromMetricType returns the Datadog unit string for a dogstatsd metric type.
+// Only timingType carries an implicit unit ("millisecond"); all other types return an empty string.
+func unitFromMetricType(mt metricType) string {
+	if mt == timingType {
+		return metrics.UnitMilliseconds
+	}
+	return ""
+}
+
 func isExcluded(metricName, namespace string, excludedNamespaces []string) bool {
 	if namespace != "" {
 		for _, prefix := range excludedNamespaces {
@@ -155,6 +164,8 @@ func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSam
 	// if 'ddSample.values' contains values we're enriching a multi-value
 	// dogstatsd message and will create a MetricSample per value. If not
 	// we will use 'ddSample.value'and return a single MetricSample
+	unit := unitFromMetricType(ddSample.metricType)
+
 	if len(ddSample.values) > 0 {
 		for idx := range ddSample.values {
 			dest = append(dest,
@@ -170,6 +181,7 @@ func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSam
 					OriginInfo: extractedOrigin,
 					ListenerID: listenerID,
 					Source:     metricSource,
+					Unit:       unit,
 				})
 		}
 		return dest
@@ -188,6 +200,7 @@ func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSam
 		OriginInfo: extractedOrigin,
 		ListenerID: listenerID,
 		Source:     metricSource,
+		Unit:       unit,
 	})
 }
 

--- a/pkg/metrics/histogram.go
+++ b/pkg/metrics/histogram.go
@@ -34,6 +34,7 @@ type Histogram struct {
 	samples     weightSamples
 	sum         float64
 	count       int64
+	unit        string // unit carried by samples (e.g. "millisecond" for timing metrics)
 }
 
 const (
@@ -108,6 +109,10 @@ func (h *Histogram) addSample(sample *MetricSample, _ float64) {
 	h.samples = append(h.samples, weightSample{sample.Value, int64(1 / rate)}) // add value and its weight
 	h.sum += sample.Value * (1 / rate)
 	h.count += int64(1 / rate)
+
+	if h.unit == "" && sample.Unit != "" {
+		h.unit = sample.Unit
+	}
 }
 
 func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
@@ -154,6 +159,7 @@ func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 			Points:     []Point{{Ts: timestamp, Value: value}},
 			MType:      mType,
 			NameSuffix: "." + aggregate,
+			Unit:       h.unit,
 		})
 	}
 
@@ -173,6 +179,7 @@ func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 					Points:     []Point{{Ts: timestamp, Value: s.value}},
 					MType:      APIGaugeType,
 					NameSuffix: fmt.Sprintf(".%dpercentile", h.percentiles[idx]),
+					Unit:       h.unit,
 				})
 				idx++
 			}
@@ -186,6 +193,7 @@ func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 	h.samples = weightSamples{}
 	h.sum = 0
 	h.count = 0
+	h.unit = ""
 
 	return series, nil
 }

--- a/pkg/metrics/histogram_test.go
+++ b/pkg/metrics/histogram_test.go
@@ -356,3 +356,31 @@ func BenchmarkHistogram10000SampleRate02(b *testing.B) {
 func BenchmarkHistogram100000SampleRate02(b *testing.B) {
 	benchHistogram(b, 100000, 0.2)
 }
+
+func TestHistogramUnitPropagation(t *testing.T) {
+	aggregates := []string{"max", "avg", "count"}
+	percentiles := []int{95}
+
+	// Timing sample: unit must appear on every flushed serie.
+	h := &Histogram{interval: 10, aggregates: aggregates, percentiles: percentiles}
+	h.addSample(&MetricSample{Value: 100, SampleRate: 1, Unit: UnitMilliseconds}, 50)
+	h.addSample(&MetricSample{Value: 200, SampleRate: 1, Unit: UnitMilliseconds}, 51)
+
+	series, err := h.flush(60)
+	require.Nil(t, err)
+	require.NotEmpty(t, series)
+	for _, s := range series {
+		assert.Equal(t, UnitMilliseconds, s.Unit, "serie %s should carry unit", s.NameSuffix)
+	}
+
+	// Plain histogram sample (no unit): every flushed serie must have empty unit.
+	h2 := &Histogram{interval: 10, aggregates: aggregates, percentiles: percentiles}
+	h2.addSample(&MetricSample{Value: 100, SampleRate: 1}, 50)
+
+	series2, err := h2.flush(60)
+	require.Nil(t, err)
+	require.NotEmpty(t, series2)
+	for _, s := range series2 {
+		assert.Equal(t, "", s.Unit, "serie %s should have no unit", s.NameSuffix)
+	}
+}

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -91,6 +91,9 @@ type MetricSampleContext interface {
 	GetSource() MetricSource
 }
 
+// UnitMilliseconds is the unit string for timing metrics, as defined by the Datadog API.
+const UnitMilliseconds = "millisecond"
+
 // MetricSample represents a raw metric sample
 type MetricSample struct {
 	Name            string
@@ -106,6 +109,7 @@ type MetricSample struct {
 	ListenerID      string
 	NoIndex         bool
 	Source          MetricSource
+	Unit            string
 }
 
 // Implement the MetricSampleContext interface

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -55,6 +55,7 @@ type Serie struct {
 	MType          APIMetricType        `json:"type"`
 	Interval       int64                `json:"interval"`
 	SourceTypeName string               `json:"source_type_name,omitempty"`
+	Unit           string               `json:"unit,omitempty"`
 	ContextKey     ckey.ContextKey      `json:"-"`
 	NameSuffix     string               `json:"-"`
 	NoIndex        bool                 `json:"-"` // This is only used by api V2

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -243,6 +243,7 @@ func (pb *PayloadsBuilder) writeSerie(serie *metrics.Serie) error {
 	const seriesTags = 3
 	const seriesPoints = 4
 	const seriesType = 5
+	const seriesUnit = 6
 	const seriesSourceTypeName = 7
 	const seriesInterval = 8
 	const serieMetadata = 9
@@ -360,7 +361,12 @@ func (pb *PayloadsBuilder) writeSerie(serie *metrics.Serie) error {
 			return err
 		}
 
-		// (Unit is omitted)
+		if serie.Unit != "" {
+			err = ps.String(seriesUnit, serie.Unit)
+			if err != nil {
+				return err
+			}
+		}
 
 		for _, p := range serie.Points {
 			err = ps.Embedded(seriesPoints, func(ps *molecule.ProtoStream) error {
@@ -525,6 +531,12 @@ func encodeSerie(serie *metrics.Serie, stream *jsoniter.Stream) {
 		stream.WriteMore()
 		stream.WriteObjectField("source_type_name")
 		stream.WriteString(serie.SourceTypeName)
+	}
+
+	if serie.Unit != "" {
+		stream.WriteMore()
+		stream.WriteObjectField("unit")
+		stream.WriteString(serie.Unit)
 	}
 
 	stream.WriteObjectEnd()

--- a/releasenotes/notes/dogstatsd-timing-unit-propagation-b2ab8251020f13f9.yaml
+++ b/releasenotes/notes/dogstatsd-timing-unit-propagation-b2ab8251020f13f9.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    DogStatsD timing metrics (``t`` type) now include an explicit unit value
+    (``millisecond``) in the metric payload sent to Datadog, allowing the
+    Datadog UI to display the correct unit automatically.

--- a/test/new-e2e/tests/agent-metric-pipelines/dogstatsd-unit/docs.go
+++ b/test/new-e2e/tests/agent-metric-pipelines/dogstatsd-unit/docs.go
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package dogstatsdunit contains e2e tests verifying that DogStatsD timing (ms)
+// metrics carry a "millisecond" unit through the Agent pipeline, while plain
+// counter and histogram metrics do not.
+package dogstatsdunit

--- a/test/new-e2e/tests/agent-metric-pipelines/dogstatsd-unit/dogstatsd_unit_nix_test.go
+++ b/test/new-e2e/tests/agent-metric-pipelines/dogstatsd-unit/dogstatsd_unit_nix_test.go
@@ -1,0 +1,134 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package dogstatsdunit
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+)
+
+const (
+	// countMetric is a DogStatsD counter (|c|). Flushed as a rate; no unit expected.
+	countMetric = "e2e.metric.unit.count"
+
+	// histogramMetric is a DogStatsD histogram (|h|). Flushed as multiple aggregated
+	// series (e.g. .max, .avg); no unit expected.
+	histogramMetric    = "e2e.metric.unit.histogram"
+	histogramMaxSuffix = ".max"
+
+	// timingMetric is a DogStatsD timing (|ms|). Processed identically to a histogram
+	// but the Agent attaches unit "millisecond" to every flushed serie.
+	timingMetric    = "e2e.metric.unit.timing"
+	timingMaxSuffix = ".max"
+
+	// expectedTimingUnit is the Datadog API unit name for millisecond timing metrics.
+	expectedTimingUnit = "millisecond"
+)
+
+type dogstatsdUnitSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+// TestDogstatsdMetricUnit runs the DogStatsD unit e2e test on Linux.
+func TestDogstatsdMetricUnit(t *testing.T) {
+	t.Parallel()
+	e2e.Run(t, &dogstatsdUnitSuite{}, e2e.WithProvisioner(
+		awshost.Provisioner(
+			awshost.WithRunOptions(
+				scenec2.WithAgentOptions(
+					agentparams.WithAgentConfig(`
+histogram_aggregates:
+  - max
+  - avg
+  - count
+histogram_percentiles:
+  - "0.95"
+`),
+				),
+			),
+		),
+	))
+}
+
+// sendMetric sends a single DogStatsD metric over UDP to the local Agent.
+func (s *dogstatsdUnitSuite) sendMetric(name string, value float32, metricType string) {
+	cmd := fmt.Sprintf(`bash -c 'echo -n "%s:%f|%s" > /dev/udp/127.0.0.1/8125'`, name, value, metricType)
+	s.Env().RemoteHost.MustExecute(cmd)
+}
+
+// TestDogstatsdUnitOnlyOnTimingMetrics sends a counter, a histogram, and a timing
+// metric in parallel and verifies that only the timing metric carries a unit.
+func (s *dogstatsdUnitSuite) TestDogstatsdUnitOnlyOnTimingMetrics() {
+	// Phase 1: keep sending all three metrics until at least one flushed serie for
+	// each has reached fakeintake.
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go func() { defer wg.Done(); s.sendMetric(countMetric, 1, "c") }()
+		go func() { defer wg.Done(); s.sendMetric(histogramMetric, 100, "h") }()
+		go func() {
+			defer wg.Done()
+			s.sendMetric(timingMetric, 100, "ms")
+			s.sendMetric(timingMetric, 0.2, "ms")
+			s.sendMetric(timingMetric, 3000, "ms")
+		}()
+		wg.Wait()
+
+		_, err := s.Env().FakeIntake.Client().FilterMetrics(countMetric)
+		assert.NoError(c, err)
+
+		histoSeries, err := s.Env().FakeIntake.Client().FilterMetrics(histogramMetric + histogramMaxSuffix)
+		assert.NoError(c, err)
+		assert.NotEmpty(c, histoSeries, "histogram .max serie must reach fakeintake")
+
+		timingSeries, err := s.Env().FakeIntake.Client().FilterMetrics(timingMetric + timingMaxSuffix)
+		assert.NoError(c, err)
+		assert.NotEmpty(c, timingSeries, "timing .max serie must reach fakeintake")
+	}, 2*time.Minute, 5*time.Second, "timed out waiting for all metric types to reach fakeintake")
+
+	// Phase 2: assert unit fields on each metric type.
+
+	// Counter: unit must be empty.
+	countSeries, err := s.Env().FakeIntake.Client().FilterMetrics(countMetric)
+	require.NoError(s.T(), err)
+	require.NotEmpty(s.T(), countSeries)
+	for _, m := range countSeries {
+		assert.Empty(s.T(), m.Unit,
+			"counter metric %q must not carry a unit, got %q", m.Metric, m.Unit)
+		fmt.Printf("metric %q does not carry a unit\n", m.Metric)
+	}
+
+	// Histogram .max: unit must be empty.
+	histoSeries, err := s.Env().FakeIntake.Client().FilterMetrics(histogramMetric + histogramMaxSuffix)
+	require.NoError(s.T(), err)
+	require.NotEmpty(s.T(), histoSeries)
+	for _, m := range histoSeries {
+		assert.Empty(s.T(), m.Unit,
+			"histogram metric %q must not carry a unit, got %q", m.Metric, m.Unit)
+		fmt.Printf("metric %q does not carry a unit\n", m.Metric)
+	}
+
+	// Timing .max: unit must be "millisecond".
+	timingSeries, err := s.Env().FakeIntake.Client().FilterMetrics(timingMetric + timingMaxSuffix)
+	require.NoError(s.T(), err)
+	require.NotEmpty(s.T(), timingSeries)
+	for _, m := range timingSeries {
+		assert.Equal(s.T(), expectedTimingUnit, m.Unit,
+			"timing metric %q must carry unit %q, got %q", m.Metric, expectedTimingUnit, m.Unit)
+		fmt.Printf("metric %q carries unit %q\n", m.Metric, m.Unit)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds a `Unit` field to `MetricSample`, `Histogram`, and `Serie`. When a DogStatsD
timing metric (`|ms|`) is enriched, `unitFromMetricType` sets `Unit = "millisecond"`
before `timingType` is erased into `HistogramType`. The unit flows through
aggregation and is serialized in both the protobuf v2 (field 6, previously skipped
with `// (Unit is omitted)`) and JSON v1 wire formats.

### Motivation

Timing metrics were silently losing their unit during enrichment. The backend had
no way to distinguish abstract histogram values from wall-clock millisecond timings.

### Describe how you validated your changes

1. Added `TestHistogramUnitPropagation` verifying that timing samples produce series
   with `Unit = "millisecond"` and plain histogram samples produce series with no unit.
2. Added `dogstatsdunit` e2e test to verify that timed metrics send unit information,
   while others don't.

### Additional notes