### PR TITLE
SNMP: try next metadata symbol when scalar value is empty

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -148,6 +148,15 @@ func computeInterfaceStatus(adminStatus devicemetadata.IfAdminStatus, operStatus
 	return devicemetadata.InterfaceStatusDown
 }
 
+// isEmptyMetadataScalarValue: polled scalar has no usable string (trim empty, ToString err); try next symbol.
+func isEmptyMetadataScalarValue(value valuestore.ResultValue) bool {
+	s, err := value.ToString()
+	if err != nil {
+		return true
+	}
+	return strings.TrimSpace(s) == ""
+}
+
 func buildMetadataStore(metadataConfigs profiledefinition.MetadataConfig, values *valuestore.ResultValueStore) *metadata.Store {
 	metadataStore := metadata.NewMetadataStore()
 	if values == nil {
@@ -172,6 +181,9 @@ func buildMetadataStore(metadataConfigs profiledefinition.MetadataConfig, values
 					value, err := getScalarValueFromSymbol(values, symbol)
 					if err != nil {
 						log.Debugf("error getting scalar value: %v", err)
+						continue
+					}
+					if isEmptyMetadataScalarValue(value) {
 						continue
 					}
 					metadataStore.AddScalarValue(fieldFullName, value)

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -1671,3 +1671,34 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaceTypeZero(t *test
 
 	sender.AssertEventPlatformEvent(t, compactEvent.Bytes(), "network-devices-metadata")
 }
+
+func Test_buildMetadataStore_scalar_skipsEmptyStringForNextSymbol(t *testing.T) {
+	meta := profiledefinition.MetadataConfig{
+		"device": {
+			Fields: map[string]profiledefinition.MetadataField{
+				"serial_number": {
+					Symbols: []profiledefinition.SymbolConfig{
+						{OID: "1.3.6.1.4.1.9.5.1.2.19.0", Name: "chassisSerialNumberString"},
+						{OID: "1.3.6.1.2.1.47.1.1.1.1.11.1000", Name: "entPhysicalSerialNum"},
+						{OID: "1.3.6.1.2.1.47.1.1.1.1.11.1", Name: "entPhysicalSerialNum"},
+					},
+				},
+			},
+		},
+	}
+	store := &valuestore.ResultValueStore{
+		ScalarValues: valuestore.ScalarResultValuesType{
+			"1.3.6.1.2.1.47.1.1.1.1.11.1000": {Value: ""},
+			"1.3.6.1.2.1.47.1.1.1.1.11.1":    {Value: "FOC2628YLVB.1"},
+		},
+	}
+	ms := buildMetadataStore(meta, store)
+	assert.Equal(t, "FOC2628YLVB.1", ms.GetScalarAsString("device.serial_number"))
+}
+
+func Test_isEmptyMetadataScalarValue(t *testing.T) {
+	assert.True(t, isEmptyMetadataScalarValue(valuestore.ResultValue{Value: ""}))
+	assert.True(t, isEmptyMetadataScalarValue(valuestore.ResultValue{Value: "   \t"}))
+	assert.True(t, isEmptyMetadataScalarValue(valuestore.ResultValue{Value: []byte{}}))
+	assert.False(t, isEmptyMetadataScalarValue(valuestore.ResultValue{Value: "x"}))
+}

--- a/releasenotes/notes/snmp-metadata-skip-empty-scalar-symbols-e4b2a1c3d5e67890.yaml
+++ b/releasenotes/notes/snmp-metadata-skip-empty-scalar-symbols-e4b2a1c3d5e67890.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    SNMP network device metadata: when a profile lists multiple scalar ``symbols`` for the same
+    metadata field (for example ``serial_number``), the check now skips values that resolve to an
+    empty string (after trimming whitespace) and continues to the next symbol, matching the intended
+    fallback order when an OID exists but carries no usable serial.


### PR DESCRIPTION
### What does this PR do?

For SNMP **device metadata** scalar fields that list multiple `symbols:` (e.g. `device.serial_number`), `buildMetadataStore` now **skips** a candidate when the **polled SNMP value** has no usable string after decode (trimmed empty, or `ToString` error) and continues to the **next** symbol. Previously, an OID present in results with an **empty string** still called `AddScalarValue`, which set `ScalarFieldHasValue` and blocked later fallbacks.

### Motivation

- AGENT-16048:  If an intermediate OID exists but returns `""`, the agent should behave like a miss and try the next OID—matching operator expectations for Catalyst-style `symbols` lists.

### Describe how you validated your changes

```bash
go test -tags=test ./pkg/collector/corechecks/snmp/internal/report/ -run 'Test_buildMetadataStore_scalar_skipsEmptyStringForNextSymbol|Test_isEmptyMetadataScalarValue' -count=1 -v
```

I installed the dev build to verify.
- Before: missing serial_number - taken from empty string
  <img width="1310" height="532" alt="image" src="https://github.com/user-attachments/assets/b04a8f94-b442-4f50-8089-139fc147a710" />

- After: serial_number taken from next symbol
  <img width="1306" height="617" alt="image" src="https://github.com/user-attachments/assets/720d9147-9264-4350-8873-1c1629a44734" />


### Additional Notes

- Release note: `releasenotes/notes/snmp-metadata-skip-empty-scalar-symbols-e4b2a1c3d5e67890.yaml`
- Scope: scalar **device** metadata path in `report_device_metadata.go` only (non-scalar / column metadata unchanged).