### PR TITLE
Avoid goroutine leak in `logmock`'s cleanup

### DIFF
--- a/comp/core/log/mock/mock.go
+++ b/comp/core/log/mock/mock.go
@@ -39,7 +39,7 @@ func New(t testing.TB) log.Component {
 
 	t.Cleanup(func() {
 		// stop using the logger to avoid a race condition
-		pkglog.SetupLogger(pkglog.Default(), pkglog.DebugStr)
+		pkglog.SetupLogger(pkglog.Disabled(), pkglog.DebugStr)
 		iface.Close()
 	})
 


### PR DESCRIPTION
### What does this PR do?
Replaces `pkglog.Default()` with `pkglog.Disabled()` in the `t.Cleanup` registered by `logmock.New`.

### Motivation
Prevent a gorouting leak in general, hindering `synctest` in particular (https://github.com/DataDog/datadog-agent/pull/50009#discussion_r3155087301):
- general case: `pkglog.Default()` creates an `Async` slog handler, spawning a goroutine for no practical purpose (test being torn down),
- `synctest` case: when `logmock.New` is called inside a "bubble" (which passes its own inner `*testing.T`), `t.Cleanup` fires inside that bubble, the goroutine outlives it and causes a deadlock.

`pkglog.Disabled()` is goroutine-free, making `logmock.New` safe to call anywhere, including inside a `synctest` bubble.

### Describe how you validated your changes
Existing `comp/core/log/mock` tests and dependent ones pass unchanged.

### Additional Notes
`synctest`'s [Bubble lifetime](https://go.dev/blog/synctest#bubble-lifetime).