### PR TITLE
Fix race conditions on sequenceID in Viper

### DIFF
--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -129,12 +129,13 @@ func (c *safeConfig) Set(key string, newValue interface{}, source model.Source) 
 	}
 	// Increment the sequence ID only if the value has changed
 	c.sequenceID++
+	sequenceID := c.sequenceID
 	c.Unlock()
 
 	// notifying all receiver about the updated setting
 	for _, receiver := range receivers {
 		log.Debugf("notifying %s about configuration change for '%s'", getCallerLocation(1), key)
-		receiver(key, source, oldValue, latestValue, c.sequenceID)
+		receiver(key, source, oldValue, latestValue, sequenceID)
 	}
 }
 
@@ -171,11 +172,12 @@ func (c *safeConfig) UnsetForSource(key string, source model.Source) {
 		receivers = slices.Clone(c.notificationReceivers)
 		c.sequenceID++
 	}
+	sequenceID := c.sequenceID
 	c.Unlock()
 
 	// notifying all receiver about the updated setting
 	for _, receiver := range receivers {
-		receiver(key, source, previousValue, newValue, c.sequenceID)
+		receiver(key, source, previousValue, newValue, sequenceID)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes race conditions in Viper by copying sequenceID in a lock, before sending updates to observers.

This imitates the same fix made in nodetreemodel: https://github.com/DataDog/datadog-agent/pull/49641

### Motivation

Avoid race conditions.

### Describe how you validated your changes

### Additional Notes
