### PR TITLE
Add Depot attribution token to CI defaults

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,6 +150,10 @@ default:
   retry:
     max: 1 # Retry everything once on failure
     when: always
+  id_tokens:
+    # https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/6599641753/CI+Identity+Attribution+for+Depot+Requests
+    DEPOT_ATTRIBUTION_ID_TOKEN:
+      aud: depot
 
 stages:
   - .pre

--- a/.gitlab/.pre/common/shared.yml
+++ b/.gitlab/.pre/common/shared.yml
@@ -5,6 +5,9 @@
   id_tokens:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts
+    # https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/6599641753/CI+Identity+Attribution+for+Depot+Requests
+    DEPOT_ATTRIBUTION_ID_TOKEN:
+      aud: depot
 
 # GitHub token setup scripts - use with !reference in before_script
 # Example: - !reference [.setup_github_token_comment_pr]

--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -3,6 +3,9 @@
   id_tokens:
     BUILDBARN_ID_TOKEN:
       aud: buildbarn.us1.ddbuild.io
+    # https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/6599641753/CI+Identity+Attribution+for+Depot+Requests
+    DEPOT_ATTRIBUTION_ID_TOKEN:
+      aud: depot
   variables:
     BAZELISK_HOME: "$XDG_CACHE_HOME/bazelisk" # not all bazelisk versions may honor $XDG_CACHE_HOME
 


### PR DESCRIPTION
### What does this PR do?

Adds a `DEPOT_ATTRIBUTION_ID_TOKEN` (with `aud: depot`) to the GitLab CI default `id_tokens` and to the Linux/Bazel templates that override `id_tokens` (since overrides supersede the default). Windows and macOS overrides are intentionally left untouched.

### Motivation

Begin attributing depot dependency downloads to GitLab CI jobs by exposing a GitLab ID token by default to all jobs in datadog-agent.

Once this PR is merged and the [feature flag](https://mosaic.us1.ddbuild.io/feature-flags/ci.gitlab-runner.enable-depot-envoy-proxy) is enabled for datadog-agent, depot dependency downloads in CI will be routed to a sidecar network proxy on the GitLab runner pod. The proxy injects the ID token as a header into all requests to depot.
- This currently affects the following domains: `depot-read-api-python.us1.ddbuild.io`, `depot-read-api-go.us1.ddbuild.io`, `depot-read-api-npm.us1.ddbuild.io`, and `depot-read-api-rust.us1.ddbuild.io`

For more details, see https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/6599641753/CI+Identity+Attribution+for+Depot+Requests

### Describe how you validated your changes

- Enabled proxy injection for this branch and verified CI passes on this PR.

### Additional Notes

Files updated:
- `.gitlab-ci.yml` — added `id_tokens.DEPOT_ATTRIBUTION_ID_TOKEN` under `default` (no prior `default.id_tokens` block existed).
- `.gitlab/.pre/common/shared.yml` — `.dd_octo_sts` template.
- `.gitlab/build/bazel/defs.yml` — `.bazel:defs` template.