### PR TITLE
Add pod spec normalization to mutation webhooks

### DIFF
--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -36,6 +36,14 @@ func Mutate(rawPod []byte, ns string, mutationType string, m MutatorFunc, dc dyn
 		return nil, fmt.Errorf("failed to decode raw object: %v", err)
 	}
 
+	// In rare cases multiple mutation webhooks executed in sequence can cause the spec to be invalid. This was seen
+	// when the autoinstrumentation library injection webhook ran before and after GKE Autopilot webhooks.
+	// Normalize correctable issues before proceeding so downstream can assume the pod spec is valid.
+	if err := NormalizePodSpec(&pod); err != nil {
+		// TODO should we return early here?
+		log.Warnf("failed to normalize input spec for %s: %v - API Server is likely to reject due to invalid spec", PodString(&pod), err)
+	}
+
 	injected, err := m(&pod, ns, dc)
 	if err != nil {
 		metrics.MutationAttempts.Inc(mutationType, metrics.StatusError, strconv.FormatBool(false), err.Error())

--- a/pkg/clusteragent/admission/mutate/common/pod_spec_normalizer.go
+++ b/pkg/clusteragent/admission/mutate/common/pod_spec_normalizer.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package common
+
+import (
+	"reflect"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// NormalizePodSpec resolves any pod spec issues
+func NormalizePodSpec(pod *corev1.Pod) error {
+	normalizedVolumes, err := normalizeVolumes(pod.Spec.Volumes)
+	if err != nil {
+		return err
+	}
+
+	pod.Spec.Volumes = normalizedVolumes
+	return nil
+}
+
+func normalizeVolumes(volumes []corev1.Volume) ([]corev1.Volume, error) {
+	seen := make(map[string]int, len(volumes))
+	var duplicates []int // Track duplicates in ascending order
+
+	// Iterate over volumes and identify duplicates
+	for i, vol := range volumes {
+		if j, found := seen[vol.Name]; found {
+			// Check that the identified duplicate is an _exact_ match to the previous
+			if !reflect.DeepEqual(vol, volumes[j]) {
+				return nil, log.Errorf("detected multiple volumes with the name \"%s\" but some fields differ, cannot normalize", vol.Name)
+			}
+			log.Warnf("detected multiple entries for volume \"%s\", normalizing the pod spec", vol.Name)
+			duplicates = append(duplicates, i)
+		} else {
+			seen[vol.Name] = i
+		}
+	}
+
+	// Iterate in reverse (to avoid index shifting) and delete any duplicates
+	for i := len(duplicates) - 1; i >= 0; i-- {
+		volumes = slices.Delete(volumes, duplicates[i], duplicates[i]+1)
+	}
+
+	return volumes, nil
+}

--- a/pkg/clusteragent/admission/mutate/common/pod_spec_normalizer.go
+++ b/pkg/clusteragent/admission/mutate/common/pod_spec_normalizer.go
@@ -36,7 +36,7 @@ func normalizeVolumes(volumes []corev1.Volume) ([]corev1.Volume, error) {
 		if j, found := seen[vol.Name]; found {
 			// Check that the identified duplicate is an _exact_ match to the previous
 			if !reflect.DeepEqual(vol, volumes[j]) {
-				return nil, log.Errorf("detected multiple volumes with the name \"%s\" but some fields differ, cannot normalize", vol.Name)
+				return volumes, log.Errorf("detected multiple volumes with the name \"%s\" but some fields differ, cannot normalize", vol.Name)
 			}
 			log.Warnf("detected multiple entries for volume \"%s\", normalizing the pod spec", vol.Name)
 			duplicates = append(duplicates, i)

--- a/pkg/clusteragent/admission/mutate/common/pod_spec_normalizer_test.go
+++ b/pkg/clusteragent/admission/mutate/common/pod_spec_normalizer_test.go
@@ -88,11 +88,11 @@ func TestNormalizeVolumes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			volumes, err := normalizeVolumes(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Unexpected err: %q", err)
+				t.Errorf("unexpected err: %q", err)
 			}
 
 			// assert elements match as if there is an error normalizing the volumes, no changes should occur
-			assert.ElementsMatch(t, volumes, tt.expected, "Normalization failed, volumes do not match")
+			assert.ElementsMatch(t, volumes, tt.expected, "normalization failed, volumes do not match")
 		})
 	}
 }

--- a/pkg/clusteragent/admission/mutate/common/pod_spec_normalizer_test.go
+++ b/pkg/clusteragent/admission/mutate/common/pod_spec_normalizer_test.go
@@ -1,0 +1,98 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestNormalizeVolumes(t *testing.T) {
+	volA := corev1.Volume{
+		Name: "vol-a",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+	volB := corev1.Volume{
+		Name: "vol-b",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+	volADifferentSource := corev1.Volume{
+		Name: "vol-a",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{Path: "/tmp"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		input    []corev1.Volume
+		expected []corev1.Volume
+		wantErr  bool
+	}{
+		{
+			name:     "no volumes",
+			input:    nil,
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:     "single volume, no duplicates",
+			input:    []corev1.Volume{volA},
+			expected: []corev1.Volume{volA},
+			wantErr:  false,
+		},
+		{
+			name:     "multiple unique volumes",
+			input:    []corev1.Volume{volA, volB},
+			expected: []corev1.Volume{volA, volB},
+			wantErr:  false,
+		},
+		{
+			name:     "exact duplicate is removed",
+			input:    []corev1.Volume{volA, volA},
+			expected: []corev1.Volume{volA},
+			wantErr:  false,
+		},
+		{
+			name:     "multiple exact duplicates are removed",
+			input:    []corev1.Volume{volA, volB, volA, volB},
+			expected: []corev1.Volume{volA, volB},
+			wantErr:  false,
+		},
+		{
+			name:     "same name but different fields returns error",
+			input:    []corev1.Volume{volA, volADifferentSource},
+			expected: []corev1.Volume{volA, volADifferentSource},
+			wantErr:  true,
+		},
+		{
+			name:     "duplicate with unique volume preserved",
+			input:    []corev1.Volume{volA, volB, volA},
+			expected: []corev1.Volume{volA, volB},
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			volumes, err := normalizeVolumes(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Unexpected err: %q", err)
+			}
+
+			// assert elements match as if there is an error normalizing the volumes, no changes should occur
+			assert.ElementsMatch(t, volumes, tt.expected, "Normalization failed, volumes do not match")
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?
Adds a normalization step to the common webhook mutation function that deduplicates pod spec volumes.

### Motivation
Annotation APM library injection was failing on GKE Autopilot; there appears to be a bug on the GKE webhook/API Server side reconciling all of the pod spec patches.

The webhook flow is as follows:

1. Datadog inject config webhook
2. Datadog inject tags webhook
3. Datadog inject apm webhook <-- this webhook adds an init container
4. GKE Autopilot webhook(s) fire, triggered by the init container with no requests/limits
5. **Datadog inject config webhook <-- this webhook _received_ a pod spec with a duplicate volume**
6. Datadog inject tags webhook
7. Datadog inject apm webhook 
8. API Server reject due to invalid spec 

<img width="3628" height="422" alt="Screenshot 2026-04-28 at 12 49 42 PM (1)" src="https://github.com/user-attachments/assets/7c0ea8a9-91b6-4dc4-8feb-77faa0918358" />


### Describe how you validated your changes
Deployed a custom build and confirmed that the changes took affect:
```
2026-04-29 10:22:54 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/mutate/common/pod_spec_normalizer.go:41 in normalizeVolumes) | detected multiple entries for volume "datadog-auto-instrumentation-etc", normalizing the pod spec
```

### Additional Notes
N/A