### PR TITLE
[CONTP-1646] Fix SNMP listener worker injection race in tests

### DIFF
--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -62,6 +62,7 @@ type SNMPListener struct {
 	services       map[string]*SNMPService
 	deviceDeduper  devicededuper.DeviceDeduper
 	sessionFactory snmpSessionFactory
+	workerFunc     snmpWorkerFunc
 }
 
 // SNMPService implements and store results from the Service interface for the SNMP listener
@@ -93,6 +94,8 @@ type snmpJob struct {
 	currentIP net.IP
 }
 
+type snmpWorkerFunc func(l *SNMPListener, jobs <-chan snmpJob)
+
 type deviceCache struct {
 	IP        net.IP `json:"ip"`
 	AuthIndex int    `json:"auth_index"`
@@ -111,6 +114,7 @@ func NewSNMPListener(ServiceListernerDeps) (ServiceListener, error) {
 		config:         snmpConfig,
 		deviceDeduper:  devicededuper.NewDeviceDeduper(snmpConfig),
 		sessionFactory: newGosnmpSession,
+		workerFunc:     defaultWorker,
 	}, nil
 }
 
@@ -198,8 +202,7 @@ func (l *SNMPListener) writeCache(subnet *snmpSubnet) {
 	}
 }
 
-// Don't make it a method, to be overridden in tests
-var worker = func(l *SNMPListener, jobs <-chan snmpJob) {
+var defaultWorker snmpWorkerFunc = func(l *SNMPListener, jobs <-chan snmpJob) {
 	for {
 		select {
 		case <-l.stop:
@@ -426,7 +429,12 @@ func (l *SNMPListener) checkDevices() {
 
 	jobs := make(chan snmpJob)
 	for w := 0; w < l.config.Workers; w++ {
-		go worker(l, jobs)
+		workerFunc := l.workerFunc
+		if workerFunc == nil {
+			// Fallback to defaultWorker if l.workerFunc isn't set
+			workerFunc = defaultWorker
+		}
+		go workerFunc(l, jobs)
 	}
 
 	discoveryTicker := time.NewTicker(time.Duration(l.config.DiscoveryInterval) * time.Second)

--- a/comp/core/autodiscovery/listeners/snmp_test.go
+++ b/comp/core/autodiscovery/listeners/snmp_test.go
@@ -51,16 +51,16 @@ func TestSNMPListener(t *testing.T) {
 	mockConfig.SetWithoutSource("network_devices.autodiscovery.configs", []interface{}{snmpConfig})
 	mockConfig.SetWithoutSource("network_devices.autodiscovery.workers", 1)
 
-	worker = func(_ *SNMPListener, jobs <-chan snmpJob) {
+	l, err := NewSNMPListener(ServiceListernerDeps{})
+	assert.Equal(t, nil, err)
+	snmpListener := l.(*SNMPListener)
+	snmpListener.workerFunc = func(_ *SNMPListener, jobs <-chan snmpJob) {
 		for {
 			job := <-jobs
 			testChan <- job
 		}
 	}
-
-	l, err := NewSNMPListener(ServiceListernerDeps{})
-	assert.Equal(t, nil, err)
-	l.Listen(newSvc, delSvc)
+	snmpListener.Listen(newSvc, delSvc)
 
 	job := <-testChan
 
@@ -98,7 +98,7 @@ func TestSNMPListenerSubnets(t *testing.T) {
 	mockConfig.SetWithoutSource("network_devices.autodiscovery.configs", configs)
 	mockConfig.SetWithoutSource("network_devices.autodiscovery.workers", 10)
 
-	worker = func(_ *SNMPListener, jobs <-chan snmpJob) {
+	testWorker := func(_ *SNMPListener, jobs <-chan snmpJob) {
 		for {
 			job := <-jobs
 			testChan <- job
@@ -114,6 +114,7 @@ func TestSNMPListenerSubnets(t *testing.T) {
 		stop:           make(chan struct{}),
 		config:         snmpListenerConfig,
 		sessionFactory: newGosnmpSession,
+		workerFunc:     testWorker,
 	}
 
 	l.Listen(newSvc, delSvc)
@@ -147,16 +148,16 @@ func TestSNMPListenerIgnoredAdresses(t *testing.T) {
 	mockConfig.SetWithoutSource("network_devices.autodiscovery.configs", []interface{}{snmpConfig})
 	mockConfig.SetWithoutSource("network_devices.autodiscovery.workers", 1)
 
-	worker = func(_ *SNMPListener, jobs <-chan snmpJob) {
+	l, err := NewSNMPListener(ServiceListernerDeps{})
+	assert.Equal(t, nil, err)
+	snmpListener := l.(*SNMPListener)
+	snmpListener.workerFunc = func(_ *SNMPListener, jobs <-chan snmpJob) {
 		for {
 			job := <-jobs
 			testChan <- job
 		}
 	}
-
-	l, err := NewSNMPListener(ServiceListernerDeps{})
-	assert.Equal(t, nil, err)
-	l.Listen(newSvc, delSvc)
+	snmpListener.Listen(newSvc, delSvc)
 
 	job := <-testChan
 
@@ -748,13 +749,8 @@ func TestMigrateCache(t *testing.T) {
 // Integration tests: device discovery flow with fake SNMP sessions
 // ===========================================================================
 
-var defaultWorkerFunc = worker
-
 func setupTestListener(t *testing.T, configs []interface{}, extraOpts map[string]interface{}) (*SNMPListener, *testSessionFactory) {
 	t.Helper()
-
-	// Restore worker to the default in case a previous test overrode it
-	worker = defaultWorkerFunc
 
 	testDir := t.TempDir()
 	mockConfig := configmock.New(t)
@@ -776,6 +772,7 @@ func setupTestListener(t *testing.T, configs []interface{}, extraOpts map[string
 		config:         listenerConfig,
 		deviceDeduper:  devicededuper.NewDeviceDeduper(listenerConfig),
 		sessionFactory: factory.build,
+		workerFunc:     defaultWorker,
 	}
 	return l, factory
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a race in SNMP listener tests by moving the worker function override from package-level state to a per-listener field.

### Motivation

`TestListenDeduplication` could race with a goroutine from `TestListenUnreachable` because tests were mutating the global `worker` function while listener goroutines could still read it.

See [CI Flaky view](https://app.datadoghq.com/ci/test/flaky?sort=-pipelines_failed&sp=%5B%7B%22p%22%3A%7B%22fingerprintFqn%22%3A%22f80950f234c6d3ad%22%2C%22activeTab%22%3A%22occurrences%22%7D%2C%22i%22%3A%22test-optimization-flaky-management-history%22%7D%5D&viewMode=flaky)

### Describe how you validated your changes

Ran:

- `dda inv test --targets=./comp/core/autodiscovery/listeners`
- `dda inv test --targets=./comp/core/autodiscovery/listeners --race`