### PR TITLE
stop sslCertInfoMapCleaner on Stop

### DIFF
--- a/pkg/network/tracer/connection/ssl-uprobes/ebpf_ssl.go
+++ b/pkg/network/tracer/connection/ssl-uprobes/ebpf_ssl.go
@@ -269,6 +269,7 @@ func (p *SSLCertsProgram) Start() error {
 
 // Stop shuts down the attacher
 func (p *SSLCertsProgram) Stop() {
+	p.sslCertInfoMapCleaner.Stop()
 	p.handshakeStateMapCleaner.Stop()
 	p.attacher.Stop()
 }


### PR DESCRIPTION
### What does this PR do?

Stop the map cleaner for `ssl_cert_info` map on `Stop()`

### Motivation

Error `pkg/ebpf/map_cleaner.go:200: 2026-04-28 18:34:37.413 CDT | ERROR | error iterating map=Hash(ssl_cert_info)#-1: map batch lookup: bad file descriptor`

### Describe how you validated your changes

### Additional Notes
