### PR TITLE
Apply `testing/synctest` to `TestProcessLikePayloadResponseTimeout`

### DIFF
--- a/comp/forwarder/defaultforwarder/forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -708,27 +709,19 @@ func TestTransactionEventHandlersNotRetryable(t *testing.T) {
 }
 
 func TestProcessLikePayloadResponseTimeout(t *testing.T) {
-	requests := atomic.NewInt64(0)
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		requests.Inc()
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-	mockConfig := mock.New(t)
-	responseTimeout := defaultResponseTimeout
+	synctest.Test(t, syncTestProcessLikePayloadResponseTimeout)
+}
 
-	defaultResponseTimeout = 5 * time.Second
-	mockConfig.SetWithoutSource("dd_url", ts.URL)
+func syncTestProcessLikePayloadResponseTimeout(t *testing.T) {
+	mockConfig := mock.New(t)
 	mockConfig.SetWithoutSource("forwarder_num_workers", 0) // Set the number of workers to 0 so the txn goes nowhere
-	defer func() {
-		defaultResponseTimeout = responseTimeout
-	}()
 
 	log := logmock.New(t)
-	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{ts.URL: {configUtils.NewAPIKeys("path", "api_key1")}})
+	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{"http://test.invalid": {configUtils.NewAPIKeys("path", "api_key1")}})
 	require.NoError(t, err)
 	secrets := secretsmock.New(t)
 	options := NewOptionsWithResolvers(mockConfig, log, r)
+	options.DisableAPIKeyChecking = true // Disable API key checking so no health check goroutine is started
 	options.Secrets = secrets
 	f := NewDefaultForwarder(mockConfig, log, options)
 


### PR DESCRIPTION
### What does this PR do?
Refactor `TestProcessLikePayloadResponseTimeout` to use `testing/synctest`:
- replace the `httptest` server (which answered validation requests the test never asserted on) with `http://test.invalid` (RFC 2606 reserved TLD guaranteed to never resolve),
- remove the reponse timeout override, thus restoring it to the package default (`defaultResponseTimeout`, 30s) since the 5s override only existed to limit wall-clock cost,
- sets `DisableAPIKeyChecking` to suppress the health-check goroutine that would otherwise deadlock the `synctest` "bubble",
- wraps the test in `synctest.Test` so the fake clock fires the deadline instantly.

### Motivation
The test slept 5s waiting for the response timeout: the `synctest` "bubble" eliminates that wall-clock cost entirely.

Dropping the `httptest` server also removes infrastructure the test never verified and makes the intent explicit: with no worker present, the response channel is closed after the deadline, regardless of deadline duration.
Overall, the scope narrows to the timeout branch of `submitProcessLikePayload` specifically (channel closed when no response arrives) which matches what the test name and its single assertion always expressed.

### Describe how you validated your changes
Measured with:
```
    go test -tags test -v -count 10 \
        -run TestProcessLikePayloadResponseTimeout$ \
        ./comp/forwarder/defaultforwarder/
```
```
before (10 samples): 5.04 5.03 5.02 5.02 5.03 5.02 5.02 5.02 5.02 5.02 s
                     avg 5.02 s
```
```
after  (10 samples): 0.04 0.03 0.03 0.03 0.03 0.03 0.03 0.05 0.04 0.03 s
                     avg 0.03 s
```

### Additional Notes
https://go.dev/blog/synctest