### PR TITLE
fix(discovery): wait for unix socket to accept connections in test

### DIFF
--- a/pkg/discovery/module/impl_linux_test.go
+++ b/pkg/discovery/module/impl_linux_test.go
@@ -114,10 +114,17 @@ func setupRustDiscoveryModule(t *testing.T) *testDiscoveryModule {
 		_ = cmd.Wait()
 	})
 
+	// Dial rather than stat: the socket file becomes visible after bind(2) but
+	// before listen(2), so a stale poll can win that window and the subsequent
+	// HTTP request fails with ECONNREFUSED.
 	require.Eventually(t, func() bool {
-		_, err := os.Stat(socketPath)
-		return err == nil
-	}, 10*time.Second, 50*time.Millisecond, "system-probe-lite socket did not appear")
+		conn, err := net.Dial("unix", socketPath)
+		if err != nil {
+			return false
+		}
+		conn.Close()
+		return true
+	}, 10*time.Second, 50*time.Millisecond, "system-probe-lite socket did not become ready")
 
 	return &testDiscoveryModule{
 		url: "http://sysprobe",


### PR DESCRIPTION
### What does this PR do?

In `setupRustDiscoveryModule` (`pkg/discovery/module/impl_linux_test.go`), replace the `os.Stat` poll on the system-probe-lite unix socket file with a `net.Dial` poll. The Eventually loop now waits until the socket is actually accepting connections, not just until the inode appears.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-437

`TestDiscovery/rust/TestState` flaked once in CI with:

```
Get "http://sysprobe/discovery/state": dial unix /tmp/.../sysprobe.sock: connect: connection refused
```

`tokio::net::UnixListener::bind` runs through `mio::sys::unix::uds::listener::bind_addr`, which issues `bind(2)` and `listen(2)` as two separate syscalls. The kernel makes the socket inode visible to other processes as soon as `bind(2)` returns, but `connect(2)` returns `ECONNREFUSED` until `listen(2)` transitions the socket into LISTEN state. Tokio's single-threaded runtime can be preempted between those two syscalls, and on a loaded CI runner that gap can stretch past the test's 50 ms `os.Stat` poll, so the test sees the file and races into the gap.

I verified the diagnosis by replacing `setup_socket` with manual `socket()`/`bind()`/sleep/`listen()` calls on a single fd: with the original `os.Stat` probe, the test fails immediately (0.05s) with the exact CI error; with the new `net.Dial` probe, Eventually waits the gap out and the test passes. Reverted the rust experiment after confirmation.

### Describe how you validated your changes

- `dda inv -e system-probe.test -p ./pkg/discovery/module -r 'TestDiscovery/rust/TestState'` passes against the unmodified rust binary.
- Same command passes against an instrumented rust binary that artificially introduces a 2 s gap between `bind(2)` and `listen(2)`, where the previous probe fails instantly with the CI error string.