### PR TITLE
Fix orchestrator manifest buffer shutdown

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -427,7 +427,9 @@ func (cb *CollectorBundle) Run(sender sender.Sender) {
 
 		if cb.runCfg.Config.IsManifestCollectionEnabled {
 			if cb.manifestBuffer.Cfg.BufferedManifestEnabled && collector.Metadata().SupportsManifestBuffering {
-				BufferManifestProcessResult(result.Result.ManifestMessages, cb.manifestBuffer)
+				if !BufferManifestProcessResult(result.Result.ManifestMessages, cb.manifestBuffer) {
+					sender.OrchestratorManifest(result.Result.ManifestMessages, cb.check.clusterID)
+				}
 			} else {
 				sender.OrchestratorManifest(result.Result.ManifestMessages, cb.check.clusterID)
 			}

--- a/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go
@@ -63,6 +63,8 @@ type ManifestBuffer struct {
 	bufferedManifests []interface{}
 	stopCh            chan struct{}
 	wg                sync.WaitGroup
+	lifecycleMu       sync.RWMutex
+	running           bool
 }
 
 // NewManifestBuffer returns a new ManifestBuffer
@@ -121,7 +123,17 @@ func (cb *ManifestBuffer) appendManifest(m interface{}, sender sender.Sender) {
 // Start is to start a thread to buffer manifest and send them
 // It flushes manifests every defaultFlushManifestTime
 func (cb *ManifestBuffer) Start(sender sender.Sender) {
+	cb.lifecycleMu.Lock()
+	if cb.running {
+		cb.lifecycleMu.Unlock()
+		return
+	}
+
+	cb.ManifestChan = make(chan interface{})
+	cb.stopCh = make(chan struct{})
+	cb.running = true
 	cb.wg.Add(1)
+	cb.lifecycleMu.Unlock()
 
 	go func() {
 		ticker := time.NewTicker(cb.Cfg.ManifestBufferFlushInterval)
@@ -150,18 +162,37 @@ func (cb *ManifestBuffer) Start(sender sender.Sender) {
 
 // Stop is to kill the thread collecting manifest
 func (cb *ManifestBuffer) Stop() {
-	cb.stopCh <- struct{}{}
+	cb.lifecycleMu.Lock()
+	defer cb.lifecycleMu.Unlock()
+
+	if !cb.running {
+		return
+	}
+
+	close(cb.stopCh)
+	cb.running = false
 	cb.wg.Wait()
 }
 
-// BufferManifestProcessResult is to add process result to the buffer
-func BufferManifestProcessResult(messages []model.MessageBody, buffer *ManifestBuffer) {
+// BufferManifestProcessResult adds a process result to the buffer.
+// It returns false when the buffer is not running, allowing callers to send the
+// result directly instead of blocking forever on a stopped buffer.
+func BufferManifestProcessResult(messages []model.MessageBody, buffer *ManifestBuffer) bool {
+	buffer.lifecycleMu.RLock()
+	defer buffer.lifecycleMu.RUnlock()
+
+	if !buffer.running {
+		return false
+	}
+
 	for _, message := range messages {
 		m := message.(*model.CollectorManifest)
 		for _, manifest := range m.Manifests {
 			buffer.ManifestChan <- manifest
 		}
 	}
+
+	return true
 }
 
 func setManifestStats(manifests []interface{}) {

--- a/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer_test.go
@@ -62,7 +62,7 @@ func TestOrchestratorManifestBuffer(t *testing.T) {
 		Tags:        []string{"dropped:tag"},
 		ClusterName: "dropped-cluster",
 	}
-	BufferManifestProcessResult([]model.MessageBody{body}, mb)
+	assert.True(t, BufferManifestProcessResult([]model.MessageBody{body}, mb))
 	mb.Stop()
 
 	// Buffer size is 2, as we have 5 manifests, the buffer needs to be flushed 3 times
@@ -100,6 +100,32 @@ func TestOrchestratorManifestBuffer(t *testing.T) {
 	}, manifestToSend[2].Manifests)
 	assert.EqualValues(t, bufferCluster, manifestToSend[2].ClusterName)
 	assert.EqualValues(t, expectedTags, manifestToSend[2].Tags)
+}
+
+func TestBufferManifestProcessResultWhenBufferNotRunning(t *testing.T) {
+	mb := getManifestBuffer(t)
+
+	body := model.MessageBody(&model.CollectorManifest{
+		Manifests: []*model.Manifest{{Type: int32(1)}},
+	})
+
+	assert.False(t, BufferManifestProcessResult([]model.MessageBody{body}, mb))
+}
+
+func TestBufferManifestProcessResultWhenBufferStopped(t *testing.T) {
+	manifestToSend = []*model.CollectorManifest{}
+	mb := getManifestBuffer(t)
+	mb.Start(getSender(t))
+
+	body := model.MessageBody(&model.CollectorManifest{
+		Manifests: []*model.Manifest{{Type: int32(1)}},
+	})
+
+	assert.True(t, BufferManifestProcessResult([]model.MessageBody{body}, mb))
+	mb.Stop()
+
+	require.Len(t, manifestToSend, 1)
+	assert.False(t, BufferManifestProcessResult([]model.MessageBody{body}, mb))
 }
 
 func TestNewManifestBuffer(t *testing.T) {

--- a/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
@@ -102,7 +102,9 @@ func (tb *TerminatedResourceBundle) Run() {
 		}
 
 		if collector.Metadata().SupportsManifestBuffering {
-			BufferManifestProcessResult(result.Result.ManifestMessages, tb.manifestBuffer)
+			if !BufferManifestProcessResult(result.Result.ManifestMessages, tb.manifestBuffer) {
+				orchSender.OrchestratorManifest(result.Result.ManifestMessages, tb.runCfg.ClusterID)
+			}
 		} else {
 			orchSender.OrchestratorManifest(result.Result.ManifestMessages, tb.runCfg.ClusterID)
 		}


### PR DESCRIPTION
## What
Fix orchestrator manifest buffering so producers do not block forever after the buffer goroutine has stopped.

## Why
Cancelling the orchestrator check can flush terminated resources after CollectorBundle.Run has stopped the manifest buffer. The terminated resource flush then tried to send to an unbuffered channel with no receiver while holding the terminated bundle mutex, which also blocked the next scheduled run in Enable().

## Validation
- dda inv test --targets=./pkg/collector/corechecks/cluster/orchestrator