### PR TITLE
Fix deadlock in orchestrator check TerminatedResourceBundle.Disable

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
@@ -65,12 +65,43 @@ func (tb *TerminatedResourceBundle) Add(k8sCollector collectors.K8sCollector, ob
 	tb.terminatedResources[k8sCollector] = append(tb.terminatedResources[k8sCollector], resource)
 }
 
-// Run sends all buffered terminated resources
+// Run sends all buffered terminated resources.
 func (tb *TerminatedResourceBundle) Run() {
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
+	tb.flush(true)
+}
 
-	// do not send terminated resources if the bundle is not enabled
+// Enable enables the TerminatedResourceBundle to start buffering terminated resources.
+func (tb *TerminatedResourceBundle) Enable() {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	tb.enabled = true
+}
+
+// Disable flushes any buffered terminated resources and then disables the bundle
+// from accepting new terminated resources.
+// Manifests are sent directly via the sender (bypassing the ManifestBuffer)
+// because the buffer goroutine may already be stopped when Disable is called.
+func (tb *TerminatedResourceBundle) Disable() {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	if !tb.enabled {
+		return
+	}
+
+	tb.flush(false)
+	tb.enabled = false
+}
+
+// flush processes and sends all buffered terminated resources.
+// Must be called with tb.mu held.
+// When useBuffer is true, manifest messages for collectors that support
+// buffering are sent through the ManifestBuffer channel (only safe while the
+// ManifestBuffer goroutine is running). When false, all manifests are sent
+// directly via the sender.
+func (tb *TerminatedResourceBundle) flush(useBuffer bool) {
 	if !tb.enabled {
 		return
 	}
@@ -97,11 +128,11 @@ func (tb *TerminatedResourceBundle) Run() {
 		nt := collector.Metadata().NodeType
 		orchestrator.SetCacheStats(result.ResourcesListed, len(result.Result.MetadataMessages), nt)
 
-		if collector.Metadata().IsMetadataProducer { // for CR and CRD we don't have metadata but only manifests
+		if collector.Metadata().IsMetadataProducer {
 			orchSender.OrchestratorMetadata(result.Result.MetadataMessages, tb.runCfg.ClusterID, int(nt))
 		}
 
-		if collector.Metadata().SupportsManifestBuffering {
+		if useBuffer && collector.Metadata().SupportsManifestBuffering {
 			BufferManifestProcessResult(result.Result.ManifestMessages, tb.manifestBuffer)
 		} else {
 			orchSender.OrchestratorManifest(result.Result.ManifestMessages, tb.runCfg.ClusterID)
@@ -109,24 +140,6 @@ func (tb *TerminatedResourceBundle) Run() {
 
 		tb.terminatedResources[collector] = make([]interface{}, 0, tb.runCfg.Config.MaxPerMessage)
 	}
-}
-
-// Enable enables the TerminatedResourceBundle to start buffering terminated resources.
-func (tb *TerminatedResourceBundle) Enable() {
-	tb.mu.Lock()
-	defer tb.mu.Unlock()
-	tb.enabled = true
-}
-
-// Disable flushes any buffered terminated resources and then disables the bundle
-// from accepting new terminated resources.
-func (tb *TerminatedResourceBundle) Disable() {
-	// send all buffered terminated resources
-	tb.Run()
-
-	tb.mu.Lock()
-	defer tb.mu.Unlock()
-	tb.enabled = false
 }
 
 func toTypedSlice(k8sCollector collectors.K8sCollector, list []interface{}) interface{} {

--- a/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle_test.go
@@ -10,7 +10,9 @@ package orchestrator
 
 import (
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,8 +20,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator"
+	orchcfg "github.com/DataDog/datadog-agent/pkg/orchestrator/config"
 	pkgorchestratormodel "github.com/DataDog/datadog-agent/pkg/orchestrator/model"
 )
 
@@ -179,4 +189,98 @@ func TestGetResource(t *testing.T) {
 			require.Equal(t, tt.wantOk, err == nil)
 		})
 	}
+}
+
+// fakeK8sCollector is a minimal K8sCollector whose Process returns a
+// fixed result containing manifest messages.
+type fakeK8sCollector struct {
+	metadata      *collectors.CollectorMetadata
+	processResult *collectors.CollectorRunResult
+}
+
+func (f *fakeK8sCollector) Init(*collectors.CollectorRunConfig) {}
+func (f *fakeK8sCollector) Metadata() *collectors.CollectorMetadata {
+	return f.metadata
+}
+func (f *fakeK8sCollector) Run(*collectors.CollectorRunConfig) (*collectors.CollectorRunResult, error) {
+	return f.processResult, nil
+}
+func (f *fakeK8sCollector) Process(*collectors.CollectorRunConfig, interface{}) (*collectors.CollectorRunResult, error) {
+	return f.processResult, nil
+}
+func (f *fakeK8sCollector) Informer() cache.SharedInformer { return nil }
+
+// TestDisableDoesNotBlockWithStoppedManifestBuffer proves that Disable
+// completes even when the ManifestBuffer goroutine is not running.
+//
+// Before the fix, Disable → Run → BufferManifestProcessResult would send
+// on the unbuffered ManifestChan with no reader, blocking forever while
+// holding tb.mu.
+func TestDisableDoesNotBlockWithStoppedManifestBuffer(t *testing.T) {
+	checkBase := core.NewCheckBase("test-orchestrator")
+	mockSender := mocksender.NewMockSender(checkBase.ID())
+	mockSender.On("OrchestratorManifest", mock.Anything, mock.Anything).Return()
+	mockSender.On("OrchestratorMetadata", mock.Anything, mock.Anything, mock.Anything).Return()
+
+	orchCheck := &OrchestratorCheck{CheckBase: checkBase}
+	_ = orchCheck.CommonConfigure(mockSender.GetSenderManager(), nil, nil, "test", "provider")
+
+	runCfg := &collectors.CollectorRunConfig{
+		ClusterID: "test-cluster",
+		Config: &orchcfg.OrchestratorConfig{
+			MaxPerMessage:            100,
+			MaxWeightPerMessageBytes: 1000000,
+		},
+	}
+
+	manifestBuffer := &ManifestBuffer{
+		ManifestChan: make(chan interface{}),
+		stopCh:       make(chan struct{}),
+	}
+
+	collector := &fakeK8sCollector{
+		metadata: &collectors.CollectorMetadata{
+			Name:                      "fake-replicaset",
+			SupportsManifestBuffering: true,
+			IsMetadataProducer:        true,
+			NodeType:                  orchestrator.K8sReplicaSet,
+			Version:                   "v1",
+			Group:                     "apps",
+		},
+		processResult: &collectors.CollectorRunResult{
+			Result: processors.ProcessResult{
+				ManifestMessages: []model.MessageBody{
+					&model.CollectorManifest{
+						Manifests: []*model.Manifest{{Type: int32(1), Uid: "test-uid"}},
+					},
+				},
+			},
+			ResourcesListed:    1,
+			ResourcesProcessed: 1,
+		},
+	}
+
+	tb := NewTerminatedResourceBundle(orchCheck, runCfg, manifestBuffer)
+	tb.Enable()
+
+	tb.mu.Lock()
+	tb.terminatedResources[collector] = []interface{}{
+		&appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: "deleted-rs"}},
+	}
+	tb.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tb.Disable()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Disable() blocked: ManifestBuffer goroutine is not running but flush tried to send through ManifestChan")
+	}
+
+	require.False(t, tb.enabled)
+	mockSender.AssertCalled(t, "OrchestratorManifest", mock.Anything, mock.Anything)
 }

--- a/releasenotes-dca/notes/fix-orchestrator-terminated-resource-deadlock-b0db89c654a4eab7.yaml
+++ b/releasenotes-dca/notes/fix-orchestrator-terminated-resource-deadlock-b0db89c654a4eab7.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix a deadlock in the orchestrator check that caused ``Cancel`` to hang
+    indefinitely, leaking goroutines and preventing the check from being
+    rescheduled. The issue occurred when ``TerminatedResourceBundle.Disable``
+    tried to flush manifests through a channel whose consumer goroutine had
+    already stopped.


### PR DESCRIPTION
### What does this PR do?

Fixes a deadlock in `TerminatedResourceBundle.Disable()` that caused `OrchestratorCheck.Cancel()` to hang indefinitely, leaking goroutines and preventing the check from being rescheduled.

### Motivation

A goroutine dump from a production cluster-agent showed **9 permanently leaked goroutines** (stuck from 718 to 5,615 minutes), all with the same stack:

```
goroutine N [chan send, M minutes]:
  BufferManifestProcessResult(...)      manifest_buffer.go:162
  (*TerminatedResourceBundle).Run(...)  terminated_resource_bundle.go:105
  (*TerminatedResourceBundle).Disable() terminated_resource_bundle.go:125
  (*OrchestratorCheck).Cancel(...)      orchestrator.go:244
```

Plus one goroutine blocked on `sync.Mutex.Lock` in `Enable()`, preventing the new check instance from running.

**Root cause:** `Disable()` called `Run()`, which acquired `tb.mu` and then sent on `ManifestChan` (an unbuffered channel). The `ManifestBuffer` goroutine that reads from this channel only runs during `CollectorBundle.Run()` — by the time `Cancel()` is called, it has already stopped. The send blocks forever while holding the mutex, permanently leaking the goroutine and deadlocking any future `Enable()`/`Add()`/`Run()` call.

**Secondary issue:** The old `Disable()` released the mutex between `Run()` and the re-acquire to set `enabled = false`, creating a race window where `Add()` could sneak in terminated resources that would never be flushed.

### Fix

Refactored into a single `flush(useBuffer bool)` method:
- **`Run()`** calls `flush(true)` — uses the ManifestBuffer channel (safe during `CollectorBundle.Run()` when the buffer goroutine is active)
- **`Disable()`** calls `flush(false)` — sends manifests directly via the sender, bypassing the channel entirely. Also acquires the lock once for the entire operation, eliminating the race window.

### Describe how you validated your changes

- Code review and analysis of the goroutine dump confirming the deadlock chain
- The fix is a minimal refactor with no behavioral change to the happy path (`Run()` still uses the buffer)

### Additional Notes

Each time the check was rescheduled (e.g. leader election change), a new `Cancel()` goroutine got permanently stuck, accumulating leaked goroutines over time. The dump showed 9 such goroutines from ~4 days of uptime.

Made with [Cursor](https://cursor.com)