### PR TITLE
[ABLD-387] Make `go_stringer` Gazelle extension manage updates

### DIFF
--- a/bazel/rules/go_stringer/_gazelle_extension.go
+++ b/bazel/rules/go_stringer/_gazelle_extension.go
@@ -37,8 +37,15 @@ func (*lang) Name() string {
 func (*lang) Kinds() map[string]rule.KindInfo {
 	return map[string]rule.KindInfo{
 		name: {
-			MatchAttrs:    []string{"output"},
-			NonEmptyAttrs: map[string]bool{"output": true, "src": true, "types": true},
+			MatchAttrs: []string{"output"},
+			MergeableAttrs: map[string]bool{ // always replicate //go:generate args
+				"build_tags":  true,
+				"linecomment": true,
+				"src":         true,
+				"trimprefix":  true,
+				"types":       true,
+			},
+			NonEmptyAttrs: map[string]bool{"src": true, "types": true},
 		},
 	}
 }
@@ -62,29 +69,33 @@ func (*lang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
 			}
 		}
 	}
-	var goFiles []string
+	var liveRules []*rule.Rule
 	for _, f := range args.RegularFiles {
-		if strings.HasSuffix(f, ".go") {
-			goFiles = append(goFiles, f)
+		if !strings.HasSuffix(f, ".go") {
+			continue
 		}
-	}
-	if len(goFiles) == 0 {
-		return language.GenerateResult{}
-	}
-	var rules []*rule.Rule
-	for _, f := range goFiles {
 		directives, err := readDirectives(filepath.Join(args.Dir, f))
 		if err != nil {
 			continue
 		}
-		rules = append(rules, directives...)
+		liveRules = append(liveRules, directives...)
 	}
-	if len(rules) == 0 {
-		return language.GenerateResult{}
+	liveOutputs := make(map[string]bool, len(liveRules))
+	for _, r := range liveRules {
+		liveOutputs[r.AttrString("output")] = true
+	}
+	var staleRules []*rule.Rule
+	if args.File != nil {
+		for _, r := range args.File.Rules {
+			if r.Kind() == name && !liveOutputs[r.AttrString("output")] {
+				staleRules = append(staleRules, rule.NewRule(name, r.Name()))
+			}
+		}
 	}
 	return language.GenerateResult{
-		Gen:     rules,
-		Imports: make([]interface{}, len(rules)),
+		Empty:   staleRules,
+		Gen:     liveRules,
+		Imports: make([]interface{}, len(liveRules)),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
- add `build_tags`, `linecomment`, `src`, `trimprefix`, `types` to `MergeableAttrs` so Gazelle keeps them in sync with their `//go:generate stringer` source directives,
- drop `output` from `NonEmptyAttrs`: it is the `MatchAttrs` key and is never cleared, so it prevented stale rules from being deleted,
- populate `Empty` in `GenerateResult` with name stubs for `go_stringer` rules whose directive was removed, so Gazelle deletes them.

### Motivation
https://github.com/DataDog/datadog-agent/pull/49831#discussion_r3154581585: stale or wrong values for `build_tags` (see discussion), `src`, `types`, `trimprefix`, and `linecomment` would survive `gazelle` updates unchanged!
=> `MergeableAttrs` governs which attributes Gazelle may rewrite in existing rules.

`output` in `NonEmptyAttrs` blocked deletion of stale rules via the `Empty` mechanism, since it is non-mergeable and always outlives a merge with an empty stub.

### Describe how you validated your changes
For each attribute, introduced a wrong value (or removed a required one) in `pkg/security/secl/model/BUILD.bazel` and confirmed `bazel run //:gazelle -- -mode=diff` produced the correct correction.
Also verified that removing the `//go:generate stringer` directive entirely causes Gazelle to emit a diff deleting the rule and its `load`.