### PR TITLE
Do not run cgo godefs/runtime compilation bundle tests on macos and windows

### DIFF
--- a/bazel/rules/ebpf/cgo_godefs.bzl
+++ b/bazel/rules/ebpf/cgo_godefs.bzl
@@ -156,16 +156,22 @@ _STD_LINUX_DEPS = [
 def _cgo_godefs_macro_impl(name, visibility, src, deps, hdrs, platform):
     all_deps = deps + (_STD_LINUX_DEPS if platform == "linux" else [])
 
+    # Applied to every target the macro creates so the diff_test stamped out by
+    # write_source_file is skipped on incompatible OSes — incompatibility-by-
+    # association does not propagate reliably when tests are named explicitly
+    # (e.g. via the verify_generated_files test_suite).
+    compat = select({
+        "@platforms//os:{}".format(platform): [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    })
+
     gen = name + "_gen"
     _cgo_godefs(
         name = gen,
         src = src,
         deps = all_deps,
         hdrs = hdrs,
-        target_compatible_with = select({
-            "@platforms//os:{}".format(platform): [],
-            "//conditions:default": ["@platforms//:incompatible"],
-        }),
+        target_compatible_with = compat,
     )
 
     base = src.name.removesuffix(".go")
@@ -175,6 +181,7 @@ def _cgo_godefs_macro_impl(name, visibility, src, deps, hdrs, platform):
         name = name + "_main_out",
         srcs = [":" + gen],
         output_group = "main",
+        target_compatible_with = compat,
     )
     write_source_file(
         name = name,
@@ -182,6 +189,7 @@ def _cgo_godefs_macro_impl(name, visibility, src, deps, hdrs, platform):
         in_file = ":" + name + "_main_out",
         out_file = main_file,
         check_that_out_file_exists = False,
+        target_compatible_with = compat,
     )
 
     if platform == "linux":
@@ -190,6 +198,7 @@ def _cgo_godefs_macro_impl(name, visibility, src, deps, hdrs, platform):
             name = name + "_test_out",
             srcs = [":" + gen],
             output_group = "test_file",
+            target_compatible_with = compat,
         )
         write_source_file(
             name = name + "_test_file",
@@ -197,6 +206,7 @@ def _cgo_godefs_macro_impl(name, visibility, src, deps, hdrs, platform):
             in_file = ":" + name + "_test_out",
             out_file = test_file,
             check_that_out_file_exists = False,
+            target_compatible_with = compat,
         )
 
 INTERNAL_FOR_TESTING = {"relpath": _relpath}

--- a/bazel/rules/ebpf/runtime_compilation.bzl
+++ b/bazel/rules/ebpf/runtime_compilation.bzl
@@ -62,6 +62,7 @@ def _runtime_compilation_bundle_impl(name, visibility, src_c, out_name, include_
             in_file = ":{}".format(gen_name),
             out_file = out_go_file,
             check_that_out_file_exists = False,
+            target_compatible_with = _LINUX_ONLY,
             # Out files are .gitignored; tag as manual so bazel test //... skips them.
             tags = ["manual"],
         )


### PR DESCRIPTION
### What does this PR do?
I have discovered that we were executing cgo godefs related tests (as well as runtime compilation) on macos even though they are ebpf specific, therefore, must only be executed on Linux.
