### PR TITLE
Add remote cache eviction retry policy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,7 @@ common --@rules_python//python/config_settings:bootstrap_impl=script # https://g
 common --check_direct_dependencies=error # Escalate any bypassed `bazel_dep` to a resolution failure
 common --enable_platform_specific_config # Supported OS identifiers are linux, macos, windows, freebsd, and openbsd
 common --experimental_disk_cache_gc_max_size=5G # Cap applied whenever --disk_cache is also set, no-op otherwise
+common --experimental_remote_cache_eviction_retries=5 # To mitigate transient eviction errors due to the low value set right above
 common --experimental_proto_descriptor_sets_include_source_info # Preserve comments in generated pb.go
 common --experimental_strict_repo_env # Do not leak uncontrolled environment variables into repository rules
 common --experimental_ui_max_stdouterr_bytes=1073741819 # why?


### PR DESCRIPTION
### What does this PR do?

Sets `--experimental_remote_cache_eviction_retries=5` in the workspace `.bazelrc` so that Bazel automatically retries the build when an action fails with `REMOTE_CACHE_EVICTED` (exit code 39) — i.e., when a CAS blob referenced by an AC entry has been evicted from either the local `--disk_cache` or the remote buildbarn cache between the AC lookup and the CAS read.

### Motivation

We are observing intermittent build failures of two related shapes:

1. `WARNING: Remote Cache: ... NoSuchFileException: .../disk_cache/cas/...` followed by spawn failures. This is the local disk-cache GC (capped at 5 GB via `--experimental_disk_cache_gc_max_size=5G`) racing with active builds — Bazel's own source acknowledges this race and explicitly recommends retrying as the mitigation.
2. `ERROR: ... Lost inputs no longer available remotely: external/+http_archive+cpython/...` from the remote buildbarn cache evicting blobs that AC entries still reference.

Bazel's whole-build retry path (`BlazeCommandDispatcher` checking for `ExitCode.REMOTE_CACHE_EVICTED`) re-runs the failed actions in the same warm server, which re-uploads the missing blobs to the CAS. A bound of 5 mirrors the upstream default and is enough to absorb the eviction race without risking infinite loops.

### Describe how you validated your changes

No code change to validate — the option only takes effect when a build hits a `REMOTE_CACHE_EVICTED` failure, at which point Bazel will retry up to 5 times instead of failing immediately. Behavior is documented in `ExecutionOptions.java` and `BlazeCommandDispatcher.java` upstream.