### PR TITLE
feat(opw): add mTLS support for agent -> opw logs forwarding

### DIFF
--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -20,6 +20,7 @@ import (
 	pkgconfigutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/logs/types"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 )
 
 // ErrEmptyFingerprintConfig is returned when a fingerprint config is empty
@@ -372,6 +373,15 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 		main.Host = host
 		main.Port = port
 		main.useSSL = useSSL
+		// Apply OPW-specific TLS transport options so only the OPW main endpoint uses them;
+		// additional Datadog endpoints on this pipeline are unaffected.
+		if certFile := coreConfig.GetString(logsConfig.getObsPipelineConfigKey("observability_pipelines_worker", "tls.cert_file")); certFile != "" {
+			keyFile := coreConfig.GetString(logsConfig.getObsPipelineConfigKey("observability_pipelines_worker", "tls.key_file"))
+			main.TransportOptions = append(main.TransportOptions, httputils.WithTLSClientCert(certFile, keyFile))
+		}
+		if caFile := coreConfig.GetString(logsConfig.getObsPipelineConfigKey("observability_pipelines_worker", "tls.ca_file")); caFile != "" {
+			main.TransportOptions = append(main.TransportOptions, httputils.WithCustomRootCA(caFile))
+		}
 	} else if logsDDURL, logsDDURLDefined := logsConfig.logsDDURL(); logsDDURLDefined {
 		host, port, pathPrefix, useSSL, err := parseAddressWithScheme(logsDDURL, defaultNoSSL, parseAddress)
 		if err != nil {

--- a/comp/logs/agent/config/endpoints.go
+++ b/comp/logs/agent/config/endpoints.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"go.uber.org/atomic"
@@ -89,6 +90,11 @@ type Endpoint struct {
 	Origin    IntakeOrigin
 
 	ExtraHTTPHeaders map[string]string
+
+	// TransportOptions holds optional per-endpoint HTTP transport modifiers. Set when the
+	// endpoint requires non-default TLS behaviour (e.g. OPW with a private CA or client cert).
+	// Fields in the transport func slice are applied after the shared transport defaults.
+	TransportOptions []func(*http.Transport)
 }
 
 // unmarshalEndpoint is used to load additional endpoints from the configuration which stored as JSON/mapstructure.

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1857,6 +1857,9 @@ func vector(config pkgconfigmodel.Setup) {
 func bindVectorOptions(config pkgconfigmodel.Setup, datatype string) {
 	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.enabled", datatype), false)
 	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.url", datatype), "")
+	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.tls.ca_file", datatype), "")
+	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.tls.cert_file", datatype), "")
+	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.tls.key_file", datatype), "")
 
 	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.enabled", datatype), false)
 	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.url", datatype), "")

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -161,7 +161,7 @@ func newDestination(endpoint config.Endpoint,
 		url:                 buildURL(endpoint),
 		endpoint:            endpoint,
 		contentType:         contentType,
-		client:              httputils.NewResetClient(endpoint.ConnectionResetInterval, httpClientFactory(cfg, timeoutOverride)),
+		client:              httputils.NewResetClient(endpoint.ConnectionResetInterval, httpClientFactory(cfg, timeoutOverride, endpoint.TransportOptions...)),
 		destinationsContext: destinationsContext,
 		workerPool:          workerPool,
 		wg:                  sync.WaitGroup{},
@@ -433,7 +433,7 @@ func (d *Destination) updateRetryState(err error, isRetrying chan bool) bool {
 	return false
 }
 
-func httpClientFactory(cfg pkgconfigmodel.Reader, timeoutOverride time.Duration) func() *http.Client {
+func httpClientFactory(cfg pkgconfigmodel.Reader, timeoutOverride time.Duration, extraOpts ...func(*http.Transport)) func() *http.Client {
 	var transport *http.Transport
 
 	transportConfig := cfg.Get("logs_config.http_protocol")
@@ -446,7 +446,7 @@ func httpClientFactory(cfg pkgconfigmodel.Reader, timeoutOverride time.Duration)
 	switch transportConfig {
 	case "http1":
 		// Use default ALPN auto-negotiation to negotiate up to http/1.1
-		transport = httputils.CreateHTTPTransport(cfg)
+		transport = httputils.CreateHTTPTransport(cfg, extraOpts...)
 	case "auto":
 		fallthrough
 	default:
@@ -454,7 +454,8 @@ func httpClientFactory(cfg pkgconfigmodel.Reader, timeoutOverride time.Duration)
 			log.Warnf("Invalid http_protocol '%v', falling back to 'auto'", transportConfig)
 		}
 		// Use default ALPN auto-negotiation and negotiate to HTTP/2 if possible, if not it will automatically fallback to best available protocol
-		transport = httputils.CreateHTTPTransport(cfg, httputils.WithHTTP2())
+		opts := append([]func(*http.Transport){httputils.WithHTTP2()}, extraOpts...)
+		transport = httputils.CreateHTTPTransport(cfg, opts...)
 	}
 
 	return func() *http.Client {

--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -7,6 +7,7 @@ package http
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
@@ -245,5 +246,52 @@ func WithHTTP2() func(*http.Transport) {
 func MaxConnsPerHost(maxConns int) func(*http.Transport) {
 	return func(transport *http.Transport) {
 		transport.MaxConnsPerHost = maxConns
+	}
+}
+
+// WithTLSClientCert returns a transport option that presents a client certificate during TLS
+// handshakes (mTLS). The certificate is reloaded from disk on each handshake, enabling cert
+// rotation without an agent restart. The callback only fires when the server sends a
+// CertificateRequest, so configuring this on a transport used against servers that don't require
+// client certs is harmless.
+func WithTLSClientCert(certFile, keyFile string) func(*http.Transport) {
+	return func(t *http.Transport) {
+		if t.TLSClientConfig == nil {
+			t.TLSClientConfig = &tls.Config{}
+		}
+		t.TLSClientConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load TLS client certificate: %w", err)
+			}
+			return &cert, nil
+		}
+	}
+}
+
+// WithCustomRootCA returns a transport option that appends a PEM-encoded CA certificate to the
+// system cert pool. The system pool is used as the base so existing connections to public
+// endpoints (e.g. Datadog intake) continue to work. This is used when connecting to a server
+// whose cert is signed by a private CA not present in the OS trust store.
+func WithCustomRootCA(caFile string) func(*http.Transport) {
+	return func(t *http.Transport) {
+		caPEM, err := os.ReadFile(caFile)
+		if err != nil {
+			log.Warnf("failed to read CA file %s: %v", caFile, err)
+			return
+		}
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			log.Warnf("failed to load system cert pool, falling back to empty pool: %v", err)
+			pool = x509.NewCertPool()
+		}
+		if !pool.AppendCertsFromPEM(caPEM) {
+			log.Warnf("no certificates were parsed from CA file %s", caFile)
+			return
+		}
+		if t.TLSClientConfig == nil {
+			t.TLSClientConfig = &tls.Config{}
+		}
+		t.TLSClientConfig.RootCAs = pool
 	}
 }


### PR DESCRIPTION
Adds WithTLSClientCert and WithCustomRootCA transport option helpers to pkg/util/http, threads them through the logs HTTP destination via a new Endpoint.TransportOptions field, and wires them up from the OPW logs config keys (observability_pipelines_worker.logs.tls.*).

The custom transport is scoped to the OPW main endpoint only; additional Datadog intake endpoints are constructed fresh and do not inherit TransportOptions, so the Datadog intake transport is unaffected.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
