### PR TITLE
[CWS] Fix races in the test event handler

### DIFF
--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -87,10 +87,11 @@ func (s *stringSlice) Set(value string) error {
 
 func (tm *testModule) HandleEvent(event *model.Event) {
 	tm.eventHandlers.RLock()
-	defer tm.eventHandlers.RUnlock()
+	onProbeEvent := tm.eventHandlers.onProbeEvent
+	tm.eventHandlers.RUnlock()
 
-	if tm.eventHandlers.onProbeEvent != nil {
-		tm.eventHandlers.onProbeEvent(event)
+	if onProbeEvent != nil {
+		onProbeEvent(event)
 	}
 }
 
@@ -98,7 +99,9 @@ func (tm *testModule) HandleCustomEvent(_ *rules.Rule, _ *events.CustomEvent) {}
 
 func (tm *testModule) SendEvent(rule *rules.Rule, event events.Event, extTagsCb func() ([]string, bool), service string) {
 	tm.eventHandlers.RLock()
-	defer tm.eventHandlers.RUnlock()
+	onCustom := tm.eventHandlers.onCustomSendEvent
+	onSendEvent := tm.eventHandlers.onSendEvent
+	tm.eventHandlers.RUnlock()
 
 	// forward to the API server
 	if tm.cws != nil {
@@ -107,12 +110,12 @@ func (tm *testModule) SendEvent(rule *rules.Rule, event events.Event, extTagsCb 
 
 	switch ev := event.(type) {
 	case *events.CustomEvent:
-		if tm.eventHandlers.onCustomSendEvent != nil {
-			tm.eventHandlers.onCustomSendEvent(rule, ev)
+		if onCustom != nil {
+			onCustom(rule, ev)
 		}
 	case *model.Event:
-		if tm.eventHandlers.onSendEvent != nil {
-			tm.eventHandlers.onSendEvent(rule, ev)
+		if onSendEvent != nil {
+			onSendEvent(rule, ev)
 		}
 	}
 }

--- a/pkg/security/tests/move_mount_test.go
+++ b/pkg/security/tests/move_mount_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -292,6 +293,11 @@ func TestMoveMountRecursivePropagation(t *testing.T) {
 	defer test.Close()
 
 	t.Run("moved-recursive-with-propagation", func(t *testing.T) {
+		// allMounts is written from the probe event handler goroutine and read
+		// from the test goroutine after GetProbeEvent returns. GetProbeEvent
+		// does not wait for in-flight callbacks on timeout, so we need our own
+		// synchronization to avoid a data race.
+		var allMountsMu sync.Mutex
 		allMounts := map[uint32]uint32{}
 
 		te, err := newTestEnvironment(false, t.TempDir())
@@ -330,14 +336,22 @@ func TestMoveMountRecursivePropagation(t *testing.T) {
 				return false
 			}
 			assert.NotEqual(t, 0, event.Mount.NamespaceInode, "Namespace inode not captured")
+			allMountsMu.Lock()
 			allMounts[event.Mount.MountID]++
+			allMountsMu.Unlock()
 			return false
 		}, 5*time.Second, model.FileMoveMountEventType)
 
+		allMountsMu.Lock()
 		assert.GreaterOrEqual(t, len(allMounts), 3, "Not all mount events were obtained")
+		mountIDs := make([]uint32, 0, len(allMounts))
+		for id := range allMounts {
+			mountIDs = append(mountIDs, id)
+		}
+		allMountsMu.Unlock()
 
 		p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
-		for i := range allMounts {
+		for _, i := range mountIDs {
 			path, _, _, _ := p.Resolvers.MountResolver.ResolveMountPath(i, 0)
 
 			if len(path) == 0 || !strings.Contains(path, "tmp1") && !strings.Contains(path, "tmp2") {


### PR DESCRIPTION
### What does this PR do?
The fix snapshots the handler callbacks in testModule.SendEvent under eventHandlers.RLock(), then releases the lock before calling APIServer.SendEvent or invoking any handler. This avoids holding a read lock across a potentially blocking external call, which was the root cause of the lock cycle.
We do the same for testModule.HandleEvent even if it was not part of the deadlock we saw to prevent any other issue in the future. 
Fix another race in a mount test that appeared after the first fix.

### Motivation
Fixes a 3-way deadlock between testModule.SendEvent, APIServer.dequeue, and RegisterRuleEventHandler that caused TestActionKillWithSignature (and potentially other tests using WaitSignalFromRule) to hang for the full 55-minute package timeout.

This is only a test fix and should not affect the agent.