### PR TITLE
Remove `bazel` disk cache entries from GH/GL cache transfers

### DIFF
--- a/.github/actions/bazel-cache/action.yml
+++ b/.github/actions/bazel-cache/action.yml
@@ -19,7 +19,6 @@ runs:
         key: bazel-${{ hashFiles('.go-version', '.python-version') }}
         path: |
           .cache/bazel/*/cache
-          .cache/bazel/disk-cache
           .cache/go
           .cache/ms-go
           .cache/pip

--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -27,7 +27,6 @@
         files: [ .go-version, .python-version ]
       paths:
         - .cache/bazel/*/cache
-        - .cache/bazel/disk-cache
         - .cache/go
         - .cache/ms-go
         - .cache/pip


### PR DESCRIPTION
### What does this PR do?
Remove `bazel` disk cache entries from caches stored by GitHub (actions) & GitLab to S3.

### Motivation
We're currently capping `bazel` disk cache size to 5GB and found out it's not enough, so we're about to increase that limit:
- #50287.

Given the characteristics of the underlying storage (S3 buckets, slow), transferring the cache from/to GH/GL will therefore take an insane amount of time, which will defeat one of its main purpose (overall execution time).