### PR TITLE
Avoid truncating multiline logs aggregated by auto multiline detection

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -165,19 +165,27 @@ func TestTagTruncatedLogs(t *testing.T) {
 	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[0].ParsingExtra.Tags)
 	assertMessageContent(t, msgs[0], "...TRUNCATED...12345")
 
-	// "1234" + "5678" fits (8 < 10) but adding "90" overflows
-	require.Empty(t, processMsg(ag, newMessage("1234"), startGroup))
-	require.Empty(t, processMsg(ag, newMessage("5678"), aggregate))
+	// "12\\n34" fits (6 < 10), but adding "567" would overflow (11 >= 10).
+	// The aggregator should abandon multiline aggregation and emit standalone events.
+	require.Empty(t, processMsg(ag, newMessage("12"), startGroup))
+	require.Empty(t, processMsg(ag, newMessage("34"), aggregate))
 
-	msgs = processMsg(ag, newMessage("90"), aggregate)
-	require.Len(t, msgs, 2)
-	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
-	assert.Equal(t, []string{message.TruncatedReasonTag("auto_multiline")}, msgs[0].ParsingExtra.Tags)
-	assertMessageContent(t, msgs[0], "1234\\n5678...TRUNCATED...")
+	msgs = processMsg(ag, newMessage("567"), aggregate)
+	require.Len(t, msgs, 3)
+	assert.False(t, msgs[0].ParsingExtra.IsMultiLine)
+	assert.False(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[0].ParsingExtra.Tags)
+	assertMessageContent(t, msgs[0], "12")
 
-	assert.True(t, msgs[1].ParsingExtra.IsTruncated)
-	assert.Equal(t, []string{message.TruncatedReasonTag("auto_multiline")}, msgs[1].ParsingExtra.Tags)
-	assertTrailingMultiline(t, msgs[1], "...TRUNCATED...90")
+	assert.False(t, msgs[1].ParsingExtra.IsMultiLine)
+	assert.False(t, msgs[1].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[1].ParsingExtra.Tags)
+	assertMessageContent(t, msgs[1], "34")
+
+	assert.False(t, msgs[2].ParsingExtra.IsMultiLine)
+	assert.False(t, msgs[2].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[2].ParsingExtra.Tags)
+	assertMessageContent(t, msgs[2], "567")
 
 	// noAggregate resets truncation carry; "00" should not be truncated
 	msgs = processMsg(ag, newMessage("00"), noAggregate)
@@ -187,21 +195,37 @@ func TestTagTruncatedLogs(t *testing.T) {
 	assertMessageContent(t, msgs[0], "00")
 }
 
-func TestSingleGroupIsTruncatedAsMultilineLog(t *testing.T) {
-	ag := NewCombiningAggregator(5, true, false, status.NewInfoRegistry())
+func TestSingleGroupOverflowStopsAggregation(t *testing.T) {
+	ag := NewCombiningAggregator(8, true, false, status.NewInfoRegistry())
 
 	require.Empty(t, processMsg(ag, newMessage("123"), startGroup))
 
-	// "123" + "456" overflows (3+3=6 >= 5)
+	// "123\\n456" would overflow (3+2+3=8 >= 8), so the lines stay separate.
 	msgs := processMsg(ag, newMessage("456"), aggregate)
 	require.Len(t, msgs, 2)
-	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
-	assert.Equal(t, []string{message.TruncatedReasonTag("auto_multiline")}, msgs[0].ParsingExtra.Tags)
-	assertTrailingMultiline(t, msgs[0], "123...TRUNCATED...")
+	assert.False(t, msgs[0].ParsingExtra.IsMultiLine)
+	assert.False(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[0].ParsingExtra.Tags)
+	assertMessageContent(t, msgs[0], "123")
 
-	assert.True(t, msgs[1].ParsingExtra.IsTruncated)
-	assert.Equal(t, []string{message.TruncatedReasonTag("auto_multiline")}, msgs[1].ParsingExtra.Tags)
-	assertTrailingMultiline(t, msgs[1], "...TRUNCATED...456")
+	assert.False(t, msgs[1].ParsingExtra.IsMultiLine)
+	assert.False(t, msgs[1].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[1].ParsingExtra.Tags)
+	assertMessageContent(t, msgs[1], "456")
+}
+
+func TestOverflowedGroupEmitsOriginalTokens(t *testing.T) {
+	ag := NewCombiningAggregator(8, false, false, status.NewInfoRegistry())
+
+	firstTokens := []Token{1, 2}
+	secondTokens := []Token{3, 4}
+
+	require.Empty(t, ag.Process(newMessage("123"), startGroup, firstTokens))
+
+	completed := ag.Process(newMessage("456"), aggregate, secondTokens)
+	require.Len(t, completed, 2)
+	assert.Equal(t, firstTokens, completed[0].Tokens)
+	assert.Equal(t, secondTokens, completed[1].Tokens)
 }
 
 func TestSingleLineTruncatedLogIsTaggedSingleLine(t *testing.T) {
@@ -222,23 +246,28 @@ func TestSingleLineTruncatedLogIsTaggedSingleLine(t *testing.T) {
 }
 
 func TestTagMultiLineLogs(t *testing.T) {
-	ag := NewCombiningAggregator(10, false, true, status.NewInfoRegistry())
+	ag := NewCombiningAggregator(12, false, true, status.NewInfoRegistry())
 
-	require.Empty(t, processMsg(ag, newMessage("12345"), startGroup))
-	require.Empty(t, processMsg(ag, newMessage("6789"), aggregate))
+	require.Empty(t, processMsg(ag, newMessage("1234"), startGroup))
+	require.Empty(t, processMsg(ag, newMessage("5678"), aggregate))
 
-	// "12345\n6789" (11 bytes) + "1" (1) overflows at 12 >= 10
-	msgs := processMsg(ag, newMessage("1"), aggregate)
-	require.Len(t, msgs, 2)
-	assert.True(t, msgs[0].ParsingExtra.IsMultiLine)
-	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
-	assert.Equal(t, []string{message.MultiLineSourceTag("auto_multiline")}, msgs[0].ParsingExtra.Tags)
-	assertMessageContent(t, msgs[0], "12345\\n6789...TRUNCATED...")
+	// "1234\\n5678" fits (10 < 12), but adding "90" would overflow (14 >= 12).
+	msgs := processMsg(ag, newMessage("90"), aggregate)
+	require.Len(t, msgs, 3)
+	assert.False(t, msgs[0].ParsingExtra.IsMultiLine)
+	assert.False(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[0].ParsingExtra.Tags)
+	assertMessageContent(t, msgs[0], "1234")
 
-	assert.True(t, msgs[1].ParsingExtra.IsMultiLine)
-	assert.True(t, msgs[1].ParsingExtra.IsTruncated)
-	assert.Equal(t, []string{message.MultiLineSourceTag("auto_multiline")}, msgs[1].ParsingExtra.Tags)
-	assertTrailingMultiline(t, msgs[1], "...TRUNCATED...1")
+	assert.False(t, msgs[1].ParsingExtra.IsMultiLine)
+	assert.False(t, msgs[1].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[1].ParsingExtra.Tags)
+	assertMessageContent(t, msgs[1], "5678")
+
+	assert.False(t, msgs[2].ParsingExtra.IsMultiLine)
+	assert.False(t, msgs[2].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[2].ParsingExtra.Tags)
+	assertMessageContent(t, msgs[2], "90")
 
 	msgs = processMsg(ag, newMessage("2"), noAggregate)
 	require.Len(t, msgs, 1)
@@ -251,14 +280,12 @@ func TestTagMultiLineLogs(t *testing.T) {
 func TestSingleLineTooLongTruncation(t *testing.T) {
 	ag := NewCombiningAggregator(5, false, true, status.NewInfoRegistry())
 
-	// Phase 1: multi-line log where messages overflow
-	require.Empty(t, processMsg(ag, newMessage("123"), startGroup))
-
-	// "123"(3) + "456"(3) = 6 >= 5 → overflow, emits 2 messages
-	msgs := processMsg(ag, newMessage("456"), aggregate)
+	// Phase 1: aggregation overflow should emit intact standalone lines and not start truncation carry.
+	require.Empty(t, processMsg(ag, newMessage("12"), startGroup))
+	msgs := processMsg(ag, newMessage("3"), aggregate)
 	require.Len(t, msgs, 2)
-	assertTrailingMultiline(t, msgs[0], "123...TRUNCATED...")
-	assertTrailingMultiline(t, msgs[1], "...TRUNCATED...456")
+	assertMessageContent(t, msgs[0], "12")
+	assertMessageContent(t, msgs[1], "3")
 
 	// bucket empty, add "123456" → immediately flushed (6 >= 5)
 	msgs = processMsg(ag, newMessage("123456"), aggregate)
@@ -680,26 +707,26 @@ func TestDetectingAggregator_COATTelemetry_NoCombineForStandaloneAggregates(t *t
 	assert.Equal(t, float64(0), truncAfter-truncBefore)
 }
 
-func TestDetectingAggregator_COATTelemetry_WouldTruncate(t *testing.T) {
-	// maxContentSize=20 so combining will overflow
+func TestDetectingAggregator_COATTelemetry_OverflowingGroupsAreNotCombined(t *testing.T) {
+	// maxContentSize=20 so combining would overflow and be abandoned
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 20, false, true)
 
 	truncBefore := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
 
-	// startGroup(10 bytes content) + aggregate(15 bytes content) → 15 + 10 = 25 >= 20 → truncation
+	// startGroup(10 bytes) + aggregate(15 bytes) would overflow once the escaped
+	// newline separator is added, so combining mode would abandon aggregation.
 	ag.Process(newMessage("1234567890"), startGroup, nil)     // 10 bytes content
-	ag.Process(newMessage("123456789012345"), aggregate, nil) // 15 bytes, RawDataLen=15, 15+10>=20 → truncate
+	ag.Process(newMessage("123456789012345"), aggregate, nil) // 10+2+15 >= 20 → do not combine
 
 	truncAfter := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 	totalAfter := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineAfter := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
 
-	// Both lines (startGroup + overflowing aggregate) belong to the truncated group
-	assert.Equal(t, float64(2), truncAfter-truncBefore)
+	assert.Equal(t, float64(0), truncAfter-truncBefore)
 	assert.Equal(t, float64(2), totalAfter-totalBefore)
-	assert.Equal(t, float64(2), combineAfter-combineBefore)
+	assert.Equal(t, float64(0), combineAfter-combineBefore)
 }
 
 func TestDetectingAggregator_COATTelemetry_NoTruncateForOversizedSingleLine(t *testing.T) {
@@ -741,8 +768,8 @@ func TestDetectingAggregator_COATTelemetry_NoCountsWhenNotDefaultPath(t *testing
 	assert.Equal(t, float64(0), truncAfter-truncBefore)
 }
 
-func TestDetectingAggregator_COATTelemetry_MultiGroupWithTruncation(t *testing.T) {
-	// maxContentSize=15 to make the second group truncate
+func TestDetectingAggregator_COATTelemetry_MultiGroupWithOverflow(t *testing.T) {
+	// maxContentSize=15 to make the second group overflow and be abandoned
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 15, false, true)
 
 	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
@@ -751,12 +778,12 @@ func TestDetectingAggregator_COATTelemetry_MultiGroupWithTruncation(t *testing.T
 
 	// Group 1: fits (5 content + 2 LF + 3 content = 10 < 15)
 	ag.Process(newMessage("12345"), startGroup, nil) // 5 bytes
-	ag.Process(newMessage("678"), aggregate, nil)    // RawDataLen=3, 3+5=8 < 15 → ok, bufLen = 5+2+3 = 10
+	ag.Process(newMessage("678"), aggregate, nil)    // 5+2+3 = 10 < 15 → combine
 
-	// Group 2: will truncate (10 content + RawDataLen=10 → 10+10=20 >= 15)
+	// Group 2: would overflow (10+2+10 = 22 >= 15), so it is not counted as combined.
 	ag.Process(newMessage("1234567890"), startGroup, nil) // 10 bytes, starts new group
-	ag.Process(newMessage("1234567890"), aggregate, nil)  // RawDataLen=10, 10+10>=15 → truncate
-	ag.Process(newMessage("123"), aggregate, nil)         // Aggregate out of a startGroup should not count as would-combine
+	ag.Process(newMessage("1234567890"), aggregate, nil)  // 10+2+10 >= 15 → abandon aggregation
+	ag.Process(newMessage("123"), aggregate, nil)         // Aggregate out of a group should not count as would-combine
 
 	// noAggregate standalone
 	ag.Process(newMessage("standalone"), noAggregate, nil)
@@ -766,6 +793,6 @@ func TestDetectingAggregator_COATTelemetry_MultiGroupWithTruncation(t *testing.T
 	truncAfter := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 
 	assert.Equal(t, float64(6), totalAfter-totalBefore)
-	assert.Equal(t, float64(4), combineAfter-combineBefore) // group 1: startGroup + aggregate, group 2: startGroup + aggregate
-	assert.Equal(t, float64(2), truncAfter-truncBefore)     // group 2 (2 lines) would truncate
+	assert.Equal(t, float64(2), combineAfter-combineBefore) // only group 1 is combined
+	assert.Equal(t, float64(0), truncAfter-truncBefore)
 }

--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -672,6 +672,7 @@ func TestDetectingAggregator_COATTelemetry_WouldCombine(t *testing.T) {
 	ag.Process(newMessage("timestamp line"), startGroup, nil)
 	ag.Process(newMessage("  continuation 1"), aggregate, nil)
 	ag.Process(newMessage("  continuation 2"), aggregate, nil)
+	ag.Flush()
 
 	totalAfter := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineAfter := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
@@ -721,6 +722,29 @@ func TestDetectingAggregator_COATTelemetry_OverflowingGroupsAreNotCombined(t *te
 	assert.Equal(t, float64(0), truncAfter-truncBefore)
 	assert.Equal(t, float64(2), totalAfter-totalBefore)
 	assert.Equal(t, float64(0), combineAfter-combineBefore)
+}
+
+func TestDetectingAggregator_COATTelemetry_LateOverflowDropsWholeGroup(t *testing.T) {
+	// The first three lines fit together, but the fourth would overflow and cause
+	// combining mode to abandon aggregation for the whole group.
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 15, false, true)
+
+	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+	truncBefore := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
+
+	ag.Process(newMessage("1234"), startGroup, nil) // 4
+	ag.Process(newMessage("12"), aggregate, nil)    // 4+2+2 = 8
+	ag.Process(newMessage("12"), aggregate, nil)    // 8+2+2 = 12
+	ag.Process(newMessage("12"), aggregate, nil)    // 12+2+2 = 16 >= 15, abandon group
+
+	totalAfter := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
+	combineAfter := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
+	truncAfter := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
+
+	assert.Equal(t, float64(4), totalAfter-totalBefore)
+	assert.Equal(t, float64(0), combineAfter-combineBefore)
+	assert.Equal(t, float64(0), truncAfter-truncBefore)
 }
 
 func TestDetectingAggregator_COATTelemetry_NoTruncateForOversizedSingleLine(t *testing.T) {

--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -32,12 +32,6 @@ func assertMessageContent(t *testing.T, m *message.Message, content string) {
 	assert.Equal(t, m.IsMultiLine, isMultiLine)
 }
 
-func assertTrailingMultiline(t *testing.T, m *message.Message, content string) {
-	t.Helper()
-	assert.Equal(t, content, string(m.GetContent()))
-	assert.Equal(t, m.IsMultiLine, true)
-}
-
 // processMsg calls Process with nil tokens and returns only the messages, for tests that
 // don't need to inspect token propagation.
 func processMsg(ag Aggregator, msg *message.Message, label Label) []*message.Message {

--- a/pkg/logs/internal/decoder/preprocessor/combining_aggregator.go
+++ b/pkg/logs/internal/decoder/preprocessor/combining_aggregator.go
@@ -22,8 +22,8 @@ type bucket struct {
 	originalDataLen int
 	contentLen      int
 	lines           []AggregatedMessageWithTokens
-	// shouldTruncate only tracks single-line truncation carry between emitted frames of
-	// one oversized log line. Multiline aggregation no longer sets this state.
+	// shouldTruncate carries truncation state between emitted frames of one oversized
+	// single-line log.
 	shouldTruncate bool
 }
 
@@ -97,12 +97,9 @@ func (b *bucket) flush() AggregatedMessageWithTokens {
 		truncatedReason = "auto_multiline"
 	}
 
-	// A multiline bucket is never truncated because of aggregation. If appending
-	// another aggregate line would make the bucket reach the limit, Process explodes the
-	// bucket back into individual events before that line is added. That means the only
-	// truncation that can happen here is the single-line case: this event is already at
-	// the size limit on its own, or it is the remainder of a previously split oversized
-	// single-line log carried by shouldTruncate.
+	// Process flushes multiline buckets before an additional aggregate line can push the
+	// combined content over the limit. Truncation in this path therefore comes from a
+	// single oversized line or a continuation frame tracked by shouldTruncate.
 	content, isTruncated := b.applyTruncation(msg, content, b.contentLen >= b.maxContentSize, truncatedReason)
 	msg.SetContent(content)
 	msg.RawDataLen = b.originalDataLen
@@ -127,11 +124,9 @@ func (b *bucket) flush() AggregatedMessageWithTokens {
 func (b *bucket) emitSingle(msg *message.Message, tokens []Token) AggregatedMessageWithTokens {
 	content := bytes.TrimSpace(msg.GetContent())
 
-	// Once a bucket is exploded, each emitted event is treated like a standalone line.
-	// Since multiline aggregation no longer causes truncation, the only truncation that
-	// can happen here is the normal single-line case: this specific line is oversized on
-	// its own, or the decoder already marked it truncated because it is one chunk of a
-	// split oversized line.
+	// Once a bucket is exploded, each emitted event follows the normal single-line
+	// truncation path. This specific line may be oversized on its own, or it may
+	// already be marked truncated because it is one chunk of a split oversized line.
 	content, _ = b.applyTruncation(msg, content, len(content) > b.maxContentSize || msg.ParsingExtra.IsTruncated, "single_line")
 	msg.SetContent(content)
 	return AggregatedMessageWithTokens{Msg: msg, Tokens: tokens}
@@ -177,9 +172,8 @@ func NewCombiningAggregator(maxContentSize int, tagTruncatedLogs bool, tagMultiL
 }
 
 func (a *combiningAggregator) wouldOverflowBucket(msg *message.Message) bool {
-	// This is only an aggregation guard. Crossing this boundary no longer truncates
-	// the combined message; it forces us to abandon aggregation and emit the original
-	// lines individually instead.
+	// This guard decides when to abandon aggregation and emit the buffered lines
+	// individually.
 	projectedLen := a.bucket.contentLen + len(msg.GetContent())
 	if a.bucket.originalDataLen > 0 {
 		projectedLen += len(message.EscapedLineFeed)
@@ -247,7 +241,7 @@ func (a *combiningAggregator) Process(msg *message.Message, label Label, tokens 
 
 	// If appending the current aggregate line would make the combined message too large,
 	// emit all buffered lines as standalone messages and emit the current line on its
-	// own instead of truncating because of multiline aggregation.
+	// own on the normal single-line path.
 	if a.wouldOverflowBucket(msg) {
 		a.explodeBucketToCollected()
 		a.emitSingleToCollected(msg, tokens)

--- a/pkg/logs/internal/decoder/preprocessor/combining_aggregator.go
+++ b/pkg/logs/internal/decoder/preprocessor/combining_aggregator.go
@@ -19,26 +19,21 @@ type bucket struct {
 	tagMultiLineLogs bool
 	maxContentSize   int
 
-	message         *message.Message
-	firstLineTokens []Token
 	originalDataLen int
-	buffer          *bytes.Buffer
-	lineCount       int
-	shouldTruncate  bool
-	needsTruncation bool
+	contentLen      int
+	lines           []AggregatedMessageWithTokens
+	// shouldTruncate only tracks single-line truncation carry between emitted frames of
+	// one oversized log line. Multiline aggregation no longer sets this state.
+	shouldTruncate bool
 }
 
 func (b *bucket) add(msg *message.Message, tokens []Token) {
-	if b.message == nil {
-		b.message = msg
-		b.firstLineTokens = tokens
-	}
 	if b.originalDataLen > 0 {
-		b.buffer.Write(message.EscapedLineFeed)
+		b.contentLen += len(message.EscapedLineFeed)
 	}
-	b.buffer.Write(msg.GetContent())
+	b.contentLen += len(msg.GetContent())
+	b.lines = append(b.lines, AggregatedMessageWithTokens{Msg: msg, Tokens: tokens})
 	b.originalDataLen += msg.RawDataLen
-	b.lineCount++
 }
 
 func (b *bucket) isEmpty() bool {
@@ -46,43 +41,74 @@ func (b *bucket) isEmpty() bool {
 }
 
 func (b *bucket) reset() {
-	b.buffer.Reset()
-	b.message = nil
-	b.firstLineTokens = nil
-	b.lineCount = 0
+	b.lines = nil
+	b.contentLen = 0
 	b.originalDataLen = 0
-	b.needsTruncation = false
+}
+
+// applyTruncation applies the shared single-line truncation behavior used by both
+// direct emission and bucket flushes. Callers decide whether the current event is
+// independently oversized; this helper only adds the carry-over markers and tags.
+func (b *bucket) applyTruncation(msg *message.Message, content []byte, shouldTruncate bool, truncatedReason string) ([]byte, bool) {
+	lastWasTruncated := b.shouldTruncate
+	b.shouldTruncate = shouldTruncate
+
+	if lastWasTruncated {
+		// The previous emitted event was truncated because it was already too large on its
+		// own, so this event is the continuation of that same oversized single-line log.
+		content = append(message.TruncatedFlag, content...)
+	}
+
+	if b.shouldTruncate {
+		// The current event is already too large on its own (or was already marked truncated
+		// upstream), so we keep the single-line truncation marker on the emitted event.
+		content = append(content, message.TruncatedFlag...)
+		metrics.LogsTruncated.Add(1)
+	}
+
+	if lastWasTruncated || b.shouldTruncate {
+		msg.ParsingExtra.IsTruncated = true
+		if b.tagTruncatedLogs {
+			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedReasonTag(truncatedReason))
+		}
+	}
+
+	return content, msg.ParsingExtra.IsTruncated
 }
 
 func (b *bucket) flush() AggregatedMessageWithTokens {
 	defer b.reset()
 
-	lastWasTruncated := b.shouldTruncate
-	b.shouldTruncate = b.buffer.Len() >= b.maxContentSize || b.needsTruncation
+	content := make([]byte, 0, b.contentLen)
+	accumulatedRawDataLen := 0
+	for i, line := range b.lines {
+		if i > 0 && accumulatedRawDataLen > 0 {
+			content = append(content, message.EscapedLineFeed...)
+		}
+		content = append(content, line.Msg.GetContent()...)
+		accumulatedRawDataLen += line.Msg.RawDataLen
+	}
+	content = bytes.TrimSpace(content)
 
-	data := bytes.TrimSpace(b.buffer.Bytes())
-	content := make([]byte, len(data))
-	copy(content, data)
-
-	if lastWasTruncated {
-		// The previous line has been truncated because it was too long,
-		// the new line is just the remainder. Add the truncated flag at
-		// the beginning of the content.
-		content = append(message.TruncatedFlag, content...)
+	msg := b.lines[0].Msg
+	lineCount := len(b.lines)
+	truncatedReason := "single_line"
+	if lineCount > 1 {
+		truncatedReason = "auto_multiline"
 	}
 
-	if b.shouldTruncate {
-		// The current line is too long. Mark it truncated at the end.
-		content = append(content, message.TruncatedFlag...)
-		metrics.LogsTruncated.Add(1)
-	}
-
-	msg := b.message
+	// A multiline bucket is never truncated because of aggregation. If appending
+	// another aggregate line would make the bucket reach the limit, Process explodes the
+	// bucket back into individual events before that line is added. That means the only
+	// truncation that can happen here is the single-line case: this event is already at
+	// the size limit on its own, or it is the remainder of a previously split oversized
+	// single-line log carried by shouldTruncate.
+	content, isTruncated := b.applyTruncation(msg, content, b.contentLen >= b.maxContentSize, truncatedReason)
 	msg.SetContent(content)
 	msg.RawDataLen = b.originalDataLen
 	tlmTags := []string{"false", "single_line"}
 
-	if b.lineCount > 1 {
+	if lineCount > 1 {
 		msg.ParsingExtra.IsMultiLine = true
 		tlmTags[1] = "auto_multi_line"
 		if b.tagMultiLineLogs {
@@ -90,20 +116,35 @@ func (b *bucket) flush() AggregatedMessageWithTokens {
 		}
 	}
 
-	if lastWasTruncated || b.shouldTruncate {
-		msg.ParsingExtra.IsTruncated = true
+	if isTruncated {
 		tlmTags[0] = "true"
-		if b.tagTruncatedLogs {
-			if b.lineCount > 1 {
-				msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedReasonTag("auto_multiline"))
-			} else {
-				msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
-			}
-		}
 	}
 
 	metrics.TlmAutoMultilineAggregatorFlush.Inc(tlmTags...)
-	return AggregatedMessageWithTokens{Msg: msg, Tokens: b.firstLineTokens}
+	return AggregatedMessageWithTokens{Msg: msg, Tokens: b.lines[0].Tokens}
+}
+
+func (b *bucket) emitSingle(msg *message.Message, tokens []Token) AggregatedMessageWithTokens {
+	content := bytes.TrimSpace(msg.GetContent())
+
+	// Once a bucket is exploded, each emitted event is treated like a standalone line.
+	// Since multiline aggregation no longer causes truncation, the only truncation that
+	// can happen here is the normal single-line case: this specific line is oversized on
+	// its own, or the decoder already marked it truncated because it is one chunk of a
+	// split oversized line.
+	content, _ = b.applyTruncation(msg, content, len(content) > b.maxContentSize || msg.ParsingExtra.IsTruncated, "single_line")
+	msg.SetContent(content)
+	return AggregatedMessageWithTokens{Msg: msg, Tokens: tokens}
+}
+
+func (b *bucket) explode() []AggregatedMessageWithTokens {
+	defer b.reset()
+
+	collected := make([]AggregatedMessageWithTokens, 0, len(b.lines))
+	for _, line := range b.lines {
+		collected = append(collected, b.emitSingle(line.Msg, line.Tokens))
+	}
+	return collected
 }
 
 // combiningAggregator aggregates multiline logs with a given label.
@@ -124,18 +165,26 @@ func NewCombiningAggregator(maxContentSize int, tagTruncatedLogs bool, tagMultiL
 
 	return &combiningAggregator{
 		bucket: &bucket{
-			buffer:           bytes.NewBuffer(nil),
 			tagTruncatedLogs: tagTruncatedLogs,
 			tagMultiLineLogs: tagMultiLineLogs,
 			maxContentSize:   maxContentSize,
-			lineCount:        0,
 			shouldTruncate:   false,
-			needsTruncation:  false,
 		},
 		maxContentSize:     maxContentSize,
 		multiLineMatchInfo: multiLineMatchInfo,
 		linesCombinedInfo:  linesCombinedInfo,
 	}
+}
+
+func (a *combiningAggregator) wouldOverflowBucket(msg *message.Message) bool {
+	// This is only an aggregation guard. Crossing this boundary no longer truncates
+	// the combined message; it forces us to abandon aggregation and emit the original
+	// lines individually instead.
+	projectedLen := a.bucket.contentLen + len(msg.GetContent())
+	if a.bucket.originalDataLen > 0 {
+		projectedLen += len(message.EscapedLineFeed)
+	}
+	return projectedLen >= a.maxContentSize
 }
 
 // flushToCollected appends the flushed bucket message (if any) to a.collected.
@@ -144,7 +193,22 @@ func (a *combiningAggregator) flushToCollected() {
 		a.bucket.reset()
 		return
 	}
+	if len(a.bucket.lines) > 1 {
+		a.linesCombinedInfo.Add(int64(len(a.bucket.lines) - 1))
+	}
 	a.collected = append(a.collected, a.bucket.flush())
+}
+
+func (a *combiningAggregator) emitSingleToCollected(msg *message.Message, tokens []Token) {
+	a.collected = append(a.collected, a.bucket.emitSingle(msg, tokens))
+}
+
+func (a *combiningAggregator) explodeBucketToCollected() {
+	if a.bucket.isEmpty() {
+		a.bucket.reset()
+		return
+	}
+	a.collected = append(a.collected, a.bucket.explode()...)
 }
 
 // Process processes a multiline log using a label and returns any completed messages.
@@ -173,30 +237,25 @@ func (a *combiningAggregator) Process(msg *message.Message, label Label, tokens 
 		a.multiLineMatchInfo.Add(1)
 		a.bucket.add(msg, tokens)
 		if msg.RawDataLen >= a.maxContentSize {
-			// Start group is too big to append anything to, flush it and reset.
+			// A startGroup can still truncate, but only because this individual line is
+			// already at the limit on its own. That's the remaining single-line truncation
+			// case in this codepath; it is not caused by multiline aggregation.
 			a.flushToCollected()
 		}
 		return a.collected
 	}
 
-	// Check for a total buffer size larger than the limit. This should only be reachable by an aggregate label
-	// following a smaller than max-size start group label, and will result in the reset (flush) of the entire bucket.
-	// This reset will intentionally break multi-line detection and aggregation for logs larger than the limit, because
-	// doing so is safer than assuming we will correctly get a new startGroup for subsequent single line logs.
-	if msg.RawDataLen+a.bucket.buffer.Len() >= a.maxContentSize {
-		a.bucket.needsTruncation = true
-		a.bucket.lineCount++ // Account for the current (not yet processed) message being part of the same log
-		a.flushToCollected()
-
-		a.bucket.lineCount++ // Account for the previous (now flushed) message being part of the same log
-		a.bucket.add(msg, tokens)
-		a.flushToCollected()
+	// If appending the current aggregate line would make the combined message too large,
+	// emit all buffered lines as standalone messages and emit the current line on its
+	// own instead of truncating because of multiline aggregation.
+	if a.wouldOverflowBucket(msg) {
+		a.explodeBucketToCollected()
+		a.emitSingleToCollected(msg, tokens)
 		return a.collected
 	}
 
 	// We're an aggregate label within a startGroup and within the maxContentSize. Append new multiline
-	a.linesCombinedInfo.Add(1)
-	a.bucket.add(msg, nil) // continuation lines don't need tokens
+	a.bucket.add(msg, tokens)
 	return a.collected
 }
 

--- a/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
+++ b/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
@@ -18,7 +18,7 @@ import (
 //
 // When isDefaultPath is true, it also collects COAT telemetry that simulates what the
 // combining aggregator would do, tracking lines that would be combined and groups that
-// would be truncated if auto multiline were enabled by default.
+// would overflow if auto multiline were enabled by default.
 type detectingAggregator struct {
 	collected             []AggregatedMessageWithTokens
 	previousMsg           *message.Message
@@ -36,8 +36,8 @@ type detectingAggregator struct {
 }
 
 // NewDetectingAggregator creates a new detecting aggregator.
-// maxContentSize is used both for truncation handling and to simulate truncation
-// detection for COAT telemetry.
+// maxContentSize is used both for truncation handling and to simulate multiline
+// overflow detection for COAT telemetry.
 func NewDetectingAggregator(tailerInfo *status.InfoRegistry, maxContentSize int, tagTruncatedLogs bool, isDefaultPath bool) Aggregator {
 	multiLineMatchInfo := status.NewCountInfo("MultiLine matches")
 	tailerInfo.Register(multiLineMatchInfo)
@@ -160,24 +160,23 @@ func (d *detectingAggregator) processSimulatedAggregate(msg *message.Message) {
 		return
 	}
 
-	// This line would be combined in combining mode
-	metrics.TlmAutoMultilineWouldCombine.Inc()
-
-	// When the first aggregate arrives, also count the startGroup line that anchors this group
-	if d.linesInCurrentGroup == 1 {
-		metrics.TlmAutoMultilineWouldCombine.Inc()
-	}
-
-	// Simulate the combining aggregator's overflow check:
-	// if msg.RawDataLen + bucket.buffer.Len() >= maxContentSize → truncation
-	if msg.RawDataLen+d.simulatedBufLen >= d.maxContentSize {
-		truncatedLines := float64(d.linesInCurrentGroup + 1)
-		metrics.TlmAutoMultilineWouldTruncate.Add(truncatedLines)
+	// Simulate the combining aggregator's overflow check, including the escaped
+	// newline separator that would be inserted between lines. If the group would
+	// overflow, the combining aggregator abandons multiline aggregation instead of
+	// truncating the combined message.
+	if d.simulatedBufLen+len(message.EscapedLineFeed)+len(msg.GetContent()) >= d.maxContentSize {
 		d.resetSimulatedGroup()
 		return
 	}
 
-	// len(EscapedLineFeed) == 2
+	// This line would be combined in combining mode.
+	metrics.TlmAutoMultilineWouldCombine.Inc()
+
+	// When the first aggregate arrives, also count the startGroup line that anchors this group.
+	if d.linesInCurrentGroup == 1 {
+		metrics.TlmAutoMultilineWouldCombine.Inc()
+	}
+
 	d.simulatedBufLen += len(message.EscapedLineFeed) + len(msg.GetContent())
 	d.linesInCurrentGroup++
 }

--- a/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
+++ b/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
@@ -92,7 +92,7 @@ func (d *detectingAggregator) Process(msg *message.Message, label Label, tokens 
 			d.previousWasStartGroup = false
 		}
 		d.emit(msg, tokens)
-		d.resetSimulatedGroup()
+		d.finalizeSimulatedGroup()
 		return d.collected
 	}
 
@@ -121,7 +121,7 @@ func (d *detectingAggregator) Flush() []AggregatedMessageWithTokens {
 		d.previousMsgTokens = nil
 		d.previousWasStartGroup = false
 	}
-	d.resetSimulatedGroup()
+	d.finalizeSimulatedGroup()
 	return d.collected
 }
 
@@ -135,8 +135,8 @@ func (d *detectingAggregator) processSimulatedStartGroup(msg *message.Message) {
 	if !d.isDefaultPath {
 		return
 	}
-	// Finalize any previous group (no truncation on normal finalize)
-	d.resetSimulatedGroup()
+	// Finalize any previous group before starting a new candidate.
+	d.finalizeSimulatedGroup()
 
 	// A startGroup that is already >= maxContentSize would be flushed immediately
 	// by the combining aggregator. That's a single oversized line -- excluded from
@@ -169,16 +169,20 @@ func (d *detectingAggregator) processSimulatedAggregate(msg *message.Message) {
 		return
 	}
 
-	// This line would be combined in combining mode.
-	metrics.TlmAutoMultilineWouldCombine.Inc()
-
-	// When the first aggregate arrives, also count the startGroup line that anchors this group.
-	if d.linesInCurrentGroup == 1 {
-		metrics.TlmAutoMultilineWouldCombine.Inc()
-	}
-
 	d.simulatedBufLen += len(message.EscapedLineFeed) + len(msg.GetContent())
 	d.linesInCurrentGroup++
+}
+
+// finalizeSimulatedGroup reports a simulated multiline group that would survive
+// aggregation without overflowing the size limit.
+func (d *detectingAggregator) finalizeSimulatedGroup() {
+	if !d.inGroup {
+		return
+	}
+	if d.linesInCurrentGroup > 1 {
+		metrics.TlmAutoMultilineWouldCombine.Add(float64(d.linesInCurrentGroup))
+	}
+	d.resetSimulatedGroup()
 }
 
 // resetSimulatedGroup resets the COAT simulation state.

--- a/pkg/logs/tailers/file/tailer_test.go
+++ b/pkg/logs/tailers/file/tailer_test.go
@@ -399,20 +399,24 @@ func (suite *TailerTestSuite) TestTruncatedTagAutoMultilineHandler() {
 	_, err = suite.testFile.WriteString("2024-01-01 10:00:01 [INFO] Next log\n")
 	suite.Nil(err)
 
-	// First message should be the aggregated multiline log with truncation
+	// The overflowed multiline group should fall back to standalone messages.
 	msg := <-suite.outputChan
 	tags := msg.Tags()
-
-	// Check for truncation tag with "auto_multiline" reason
-	suite.Contains(tags, message.TruncatedReasonTag("auto_multiline"))
-
-	// The content should contain the truncation flag
 	content := string(msg.GetContent())
-	suite.Contains(content, "...TRUNCATED...")
+	suite.Equal("2024-01-01 10:00:00 [ERROR] First line of multiline log message", content)
+	suite.NotContains(tags, message.TruncatedReasonTag("auto_multiline"))
+	suite.NotContains(tags, message.MultiLineSourceTag("auto_multiline"))
 
-	// Second message should be the single-line log
 	msg2 := <-suite.outputChan
-	suite.NotNil(msg2)
+	tags2 := msg2.Tags()
+	content2 := string(msg2.GetContent())
+	suite.Equal("continuation line that should be aggregated here", content2)
+	suite.NotContains(tags2, message.TruncatedReasonTag("auto_multiline"))
+	suite.NotContains(tags2, message.MultiLineSourceTag("auto_multiline"))
+
+	// Third message should be the next single-line log.
+	msg3 := <-suite.outputChan
+	suite.Equal("2024-01-01 10:00:01 [INFO] Next log", string(msg3.GetContent()))
 }
 
 func (suite *TailerTestSuite) TestTruncatedTagSingleLineHandler() {

--- a/releasenotes/notes/auto-multiline-overflow-fallback-5a062d3ce7074565.yaml
+++ b/releasenotes/notes/auto-multiline-overflow-fallback-5a062d3ce7074565.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Logs collected with automatic multiline detection now fall back to individual
+    events when combining lines would exceed ``logs_config.max_message_size_bytes``.
+    Oversized single log lines continue to use the normal truncation path, and
+    multiline logs that fit within the limit are still aggregated.


### PR DESCRIPTION
### What does this PR do?

Updates auto-multiline aggregation so logs are no longer truncated just because combining lines would push the message over `logs_config.max_message_size_bytes`.

When an aggregate line would make the current multiline bucket overflow, the bucket is now exploded back into its original per-line events and each line is emitted individually. The single-line truncation path is preserved for logs that are oversized on their own, and the bucket implementation was cleaned up to share truncation handling in one helper and avoid storing the buffered message content twice.

### Motivation

Jira: [AGNTLOG-625](https://datadoghq.atlassian.net/browse/AGNTLOG-625)

Today, auto multiline can cause a log to be truncated purely because aggregation made the combined payload exceed the max message size. That loses signal even when the underlying individual lines would have fit under the limit on their own. This change makes overflowed multiline groups fall back to standalone events instead.

### Describe how you validated your changes

- Ran unit tests: `dda inv test --targets=./pkg/logs/internal/decoder/preprocessor`
- Rebuilt the agent and ran an end-to-end local QA flow against a mock HTTP intake with `logs_config.max_message_size_bytes: 100`
- Enabled `auto_multi_line_detection: true` on a file source and confirmed:
  - oversized single-line logs are still split and tagged with `truncated:single_line`
  - multiline logs under the limit are still aggregated and tagged with `multiline:auto_multiline`
  - multiline logs that would exceed the limit are emitted as individual events with no multiline/truncation tag added by aggregation
  - the single-line behavior matches with auto multiline disabled

Observed examples:

```text
single line, auto multiline enabled:
CASE1_SINGLE_LONG XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...TRUNCATED...
...TRUNCATED...XXXXXXXXXXXXXXXXXXXXXXXXXXXX CASE1_SINGLE_LONG_TAIL

multiline under limit:
2024-01-01 10:00:00 [INFO] CASE2 under-limit first line\n  CASE2 under-limit continuation

multiline over limit:
2024-01-01 10:00:02 [INFO] CASE3 overflow first line with filler 1234567890 1234
CASE3 overflow continuation that pushes the combined payload above limit
```

### Additional Notes

- The detecting aggregator’s COAT simulation was updated to match the new behavior: overflowed groups are no longer counted as "would truncate" due to aggregation.
- Continuation lines from an exploded bucket are emitted through the normal single-line path, so they keep the existing single-line trimming behavior.


[AGNTLOG-625]: https://datadoghq.atlassian.net/browse/AGNTLOG-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ