### PR TITLE
[CWS] propagate VariableOpts through scoped variable constructors and support full opts in test data

### DIFF
--- a/pkg/security/clihelpers/eval.go
+++ b/pkg/security/clihelpers/eval.go
@@ -223,24 +223,63 @@ func eventFromTestData(testData TestData) (eval.Event, error) {
 	return event, nil
 }
 
+// variableEntry is the new-format entry: a JSON object with a required "value"
+// field plus all eval.VariableOpts fields inlined.
+type variableEntry struct {
+	Value any `json:"value"`
+	eval.VariableOpts
+}
+
+// parseVariableEntry accepts both the old format (a direct value) and the new
+// format (a JSON object with a required "value" field and optional VariableOpts
+// fields).  It returns the unwrapped value and the VariableOpts decoded from
+// the entry.
+func parseVariableEntry(raw any) (any, eval.VariableOpts, error) {
+	opts := eval.VariableOpts{TTL: 10000000}
+
+	if _, ok := raw.(map[string]any); !ok {
+		// Old format: the entry itself is the variable value.
+		return raw, opts, nil
+	}
+
+	// New format: re-encode to JSON then unmarshal into the typed struct so
+	// that all VariableOpts fields are populated in a single, extensible step.
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, opts, fmt.Errorf("failed to marshal variable entry: %w", err)
+	}
+
+	var entry variableEntry
+	entry.VariableOpts = opts // carry the default TTL
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, opts, fmt.Errorf("failed to unmarshal variable entry: %w", err)
+	}
+
+	if entry.Value == nil {
+		return nil, opts, fmt.Errorf("variable entry is missing required 'value' field")
+	}
+
+	return entry.Value, entry.VariableOpts, nil
+}
+
 func variablesFromTestData(testData TestData) (map[string]eval.SECLVariable, error) {
 	variables := make(map[string]eval.SECLVariable)
 
 	// copy the embedded variables
 	maps.Copy(variables, model.SECLVariables)
 
-	varOpts := eval.VariableOpts{
-		TTL: 10000000,
-	}
-
 	// add the variables from the test data
-	for k, v := range testData.Variables {
+	for k, raw := range testData.Variables {
+		v, varOpts, err := parseVariableEntry(raw)
+		if err != nil {
+			return nil, fmt.Errorf("variable %s: %w", k, err)
+		}
 		switch v := v.(type) {
 		case string:
 			if rules.IsScopeVariable(k) {
 				variables[k] = eval.NewScopedStringVariable(func(_ *eval.Context, _ bool) (string, bool) {
 					return v, true
-				}, nil)
+				}, nil, varOpts)
 			} else {
 				variables[k] = eval.NewStringVariable(v, varOpts)
 			}
@@ -254,7 +293,7 @@ func variablesFromTestData(testData TestData) (map[string]eval.SECLVariable, err
 				if rules.IsScopeVariable(k) {
 					variables[k] = eval.NewScopedStringArrayVariable(func(_ *eval.Context, _ bool) ([]string, bool) {
 						return values, true
-					}, nil)
+					}, nil, varOpts)
 				} else {
 					variables[k] = eval.NewStringArrayVariable(values, varOpts)
 				}
@@ -271,7 +310,7 @@ func variablesFromTestData(testData TestData) (map[string]eval.SECLVariable, err
 				if rules.IsScopeVariable(k) {
 					variables[k] = eval.NewScopedIntArrayVariable(func(_ *eval.Context, _ bool) ([]int, bool) {
 						return values, true
-					}, nil)
+					}, nil, varOpts)
 				} else {
 					variables[k] = eval.NewIntArrayVariable(values, varOpts)
 				}
@@ -286,7 +325,7 @@ func variablesFromTestData(testData TestData) (map[string]eval.SECLVariable, err
 			if rules.IsScopeVariable(k) {
 				variables[k] = eval.NewScopedIntVariable(func(_ *eval.Context, _ bool) (int, bool) {
 					return int(value), true
-				}, nil)
+				}, nil, varOpts)
 			} else {
 				variables[k] = eval.NewIntVariable(int(value), varOpts)
 			}
@@ -294,7 +333,7 @@ func variablesFromTestData(testData TestData) (map[string]eval.SECLVariable, err
 			if rules.IsScopeVariable(k) {
 				variables[k] = eval.NewScopedBoolVariable(func(_ *eval.Context, _ bool) (bool, bool) {
 					return v, true
-				}, nil)
+				}, nil, varOpts)
 			} else {
 				variables[k] = eval.NewBoolVariable(v, varOpts)
 			}

--- a/pkg/security/clihelpers/eval.go
+++ b/pkg/security/clihelpers/eval.go
@@ -10,6 +10,7 @@ package clihelpers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -256,7 +257,7 @@ func parseVariableEntry(raw any) (any, eval.VariableOpts, error) {
 	}
 
 	if entry.Value == nil {
-		return nil, opts, fmt.Errorf("variable entry is missing required 'value' field")
+		return nil, opts, errors.New("variable entry is missing required 'value' field")
 	}
 
 	return entry.Value, entry.VariableOpts, nil

--- a/pkg/security/clihelpers/eval_test.go
+++ b/pkg/security/clihelpers/eval_test.go
@@ -55,6 +55,54 @@ func (p *fakeProvider) Type() string {
 	return "fake"
 }
 
+func TestParseVariableEntry(t *testing.T) {
+	t.Run("old format direct value", func(t *testing.T) {
+		v, opts, err := parseVariableEntry("hello")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v != "hello" {
+			t.Fatalf("expected 'hello', got %v", v)
+		}
+		if opts.Private {
+			t.Fatal("expected private=false")
+		}
+	})
+
+	t.Run("new format value only", func(t *testing.T) {
+		v, opts, err := parseVariableEntry(map[string]any{"value": "hello"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v != "hello" {
+			t.Fatalf("expected 'hello', got %v", v)
+		}
+		if opts.Private {
+			t.Fatal("expected private=false")
+		}
+	})
+
+	t.Run("new format with private", func(t *testing.T) {
+		v, opts, err := parseVariableEntry(map[string]any{"value": "secret", "private": true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v != "secret" {
+			t.Fatalf("expected 'secret', got %v", v)
+		}
+		if !opts.Private {
+			t.Fatal("expected private=true")
+		}
+	})
+
+	t.Run("new format missing value", func(t *testing.T) {
+		_, _, err := parseVariableEntry(map[string]any{"private": true})
+		if err == nil {
+			t.Fatal("expected error for missing 'value' field")
+		}
+	})
+}
+
 func TestEvalRule(t *testing.T) {
 	var policy = `
 rules:
@@ -108,6 +156,35 @@ rules:
 			},
 			"variables": {
 				"imds_v1_usage_services": ["wget"]
+			}
+		}
+	`
+
+		decoder := json.NewDecoder(bytes.NewBufferString(testData))
+
+		report, err := evalRule(provider, decoder, EvalRuleParams{})
+		if err != nil {
+			t.Fatalf("error evaluating rule: %s", err)
+		}
+
+		if report.Succeeded {
+			t.Fatalf("expected rule to fail")
+		}
+	})
+
+	t.Run("new variable format with private", func(t *testing.T) {
+		var testData = `
+		{
+			"type": "imds",
+			"values": {
+				"imds.cloud_provider": "aws",
+				"process.file.name": "curl"
+			},
+			"variables": {
+				"imds_v1_usage_services": {
+					"value": ["curl"],
+					"private": true
+				}
 			}
 		}
 	`

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -32,10 +32,10 @@ func newOptsWithParams(constants map[string]interface{}, legacyFields map[Field]
 	variables := map[string]SECLVariable{
 		"pid": NewScopedIntVariable(func(_ *Context, _ bool) (int, bool) {
 			return os.Getpid(), true
-		}, nil),
+		}, nil, VariableOpts{}),
 		"str": NewScopedStringVariable(func(_ *Context, _ bool) (string, bool) {
 			return "aaa", true
-		}, nil),
+		}, nil, VariableOpts{}),
 	}
 
 	return opts.WithVariables(variables).WithMacroStore(&MacroStore{})
@@ -508,6 +508,7 @@ func TestPartial(t *testing.T) {
 		func(_ *Context, _ interface{}) error {
 			return nil
 		},
+		VariableOpts{},
 	)
 
 	tests := []struct {

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -126,13 +126,11 @@ func (i *ScopedIntVariable) GetValue(ctx *Context, noFollowInheritance bool) (in
 }
 
 // NewScopedIntVariable returns a new integer variable
-func NewScopedIntVariable(intFnc func(ctx *Context, noFollowInheritance bool) (int, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIntVariable {
+func NewScopedIntVariable(intFnc func(ctx *Context, noFollowInheritance bool) (int, bool), setFnc func(ctx *Context, value interface{}) error, opts VariableOpts) *ScopedIntVariable {
 	return &ScopedIntVariable{
 		settableVariable: settableVariable{
 			setFnc: setFnc,
-			opts: VariableOpts{
-				Private: false,
-			},
+			opts:   opts,
 		},
 		intFnc: intFnc,
 	}
@@ -161,14 +159,12 @@ func (s *ScopedStringVariable) GetValue(ctx *Context, noFollowInheritance bool) 
 }
 
 // NewScopedStringVariable returns a new scoped string variable
-func NewScopedStringVariable(strFnc func(ctx *Context, noFollowInheritance bool) (string, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedStringVariable {
+func NewScopedStringVariable(strFnc func(ctx *Context, noFollowInheritance bool) (string, bool), setFnc func(ctx *Context, value interface{}) error, opts VariableOpts) *ScopedStringVariable {
 	return &ScopedStringVariable{
 		strFnc: strFnc,
 		settableVariable: settableVariable{
 			setFnc: setFnc,
-			opts: VariableOpts{
-				Private: false,
-			},
+			opts:   opts,
 		},
 	}
 }
@@ -195,14 +191,12 @@ func (b *ScopedBoolVariable) GetValue(ctx *Context, noFollowInheritance bool) (i
 }
 
 // NewScopedBoolVariable returns a new boolean variable
-func NewScopedBoolVariable(boolFnc func(ctx *Context, noFollowInheritance bool) (bool, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedBoolVariable {
+func NewScopedBoolVariable(boolFnc func(ctx *Context, noFollowInheritance bool) (bool, bool), setFnc func(ctx *Context, value interface{}) error, opts VariableOpts) *ScopedBoolVariable {
 	return &ScopedBoolVariable{
 		boolFnc: boolFnc,
 		settableVariable: settableVariable{
 			setFnc: setFnc,
-			opts: VariableOpts{
-				Private: false,
-			},
+			opts:   opts,
 		},
 	}
 }
@@ -229,14 +223,12 @@ func (i *ScopedIPVariable) GetValue(ctx *Context, noFollowInheritance bool) (int
 }
 
 // NewScopedIPVariable returns a new scoped IP variable
-func NewScopedIPVariable(ipFnc func(ctx *Context, noFollowInheritance bool) (net.IPNet, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIPVariable {
+func NewScopedIPVariable(ipFnc func(ctx *Context, noFollowInheritance bool) (net.IPNet, bool), setFnc func(ctx *Context, value interface{}) error, opts VariableOpts) *ScopedIPVariable {
 	return &ScopedIPVariable{
 		ipFnc: ipFnc,
 		settableVariable: settableVariable{
 			setFnc: setFnc,
-			opts: VariableOpts{
-				Private: false,
-			},
+			opts:   opts,
 		},
 	}
 }
@@ -280,14 +272,12 @@ func (s *ScopedStringArrayVariable) Append(ctx *Context, value interface{}) erro
 }
 
 // NewScopedStringArrayVariable returns a new scoped string array variable
-func NewScopedStringArrayVariable(strFnc func(ctx *Context, noFollowInheritance bool) ([]string, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedStringArrayVariable {
+func NewScopedStringArrayVariable(strFnc func(ctx *Context, noFollowInheritance bool) ([]string, bool), setFnc func(ctx *Context, value interface{}) error, opts VariableOpts) *ScopedStringArrayVariable {
 	return &ScopedStringArrayVariable{
 		strFnc: strFnc,
 		settableVariable: settableVariable{
 			setFnc: setFnc,
-			opts: VariableOpts{
-				Private: false,
-			},
+			opts:   opts,
 		},
 	}
 }
@@ -331,14 +321,12 @@ func (v *ScopedIntArrayVariable) Append(ctx *Context, value interface{}) error {
 }
 
 // NewScopedIntArrayVariable returns a new integer array variable
-func NewScopedIntArrayVariable(intFnc func(ctx *Context, noFollowInheritance bool) ([]int, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIntArrayVariable {
+func NewScopedIntArrayVariable(intFnc func(ctx *Context, noFollowInheritance bool) ([]int, bool), setFnc func(ctx *Context, value interface{}) error, opts VariableOpts) *ScopedIntArrayVariable {
 	return &ScopedIntArrayVariable{
 		intFnc: intFnc,
 		settableVariable: settableVariable{
 			setFnc: setFnc,
-			opts: VariableOpts{
-				Private: false,
-			},
+			opts:   opts,
 		},
 	}
 }
@@ -382,14 +370,12 @@ func (i *ScopedIPArrayVariable) Append(ctx *Context, value interface{}) error {
 }
 
 // NewScopedIPArrayVariable returns a new IP array variable
-func NewScopedIPArrayVariable(ipFnc func(ctx *Context, noFollowInheritance bool) ([]net.IPNet, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIPArrayVariable {
+func NewScopedIPArrayVariable(ipFnc func(ctx *Context, noFollowInheritance bool) ([]net.IPNet, bool), setFnc func(ctx *Context, value interface{}) error, opts VariableOpts) *ScopedIPArrayVariable {
 	return &ScopedIPArrayVariable{
 		ipFnc: ipFnc,
 		settableVariable: settableVariable{
 			setFnc: setFnc,
-			opts: VariableOpts{
-				Private: false,
-			},
+			opts:   opts,
 		},
 	}
 }
@@ -984,11 +970,11 @@ type Variables struct {
 
 // VariableOpts holds the options of a variable set
 type VariableOpts struct {
-	Size      int
-	TTL       time.Duration
-	Private   bool // When a variable is marked as private, it will not be included in the serialized event
-	Inherited bool
-	Telemetry *Telemetry
+	Size      int           `json:"size"`
+	TTL       time.Duration `json:"ttl"`
+	Private   bool          `json:"private"` // When a variable is marked as private, it will not be included in the serialized event
+	Inherited bool          `json:"inherited"`
+	Telemetry *Telemetry    `json:"-"`
 }
 
 // NewVariables returns a new set of global variables
@@ -1190,7 +1176,7 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 				return value.(int), set
 			}
 			return 0, false
-		}, setVariable), nil
+		}, setVariable, VariableOpts{}), nil
 	case bool:
 		return NewScopedBoolVariable(func(ctx *Context, noFollowInheritance bool) (bool, bool) {
 			if v := getVariable(ctx, noFollowInheritance); v != nil {
@@ -1198,7 +1184,7 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 				return value.(bool), set
 			}
 			return false, false
-		}, setVariable), nil
+		}, setVariable, VariableOpts{}), nil
 	case string:
 		return NewScopedStringVariable(func(ctx *Context, noFollowInheritance bool) (string, bool) {
 			if v := getVariable(ctx, noFollowInheritance); v != nil {
@@ -1206,7 +1192,7 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 				return value.(string), set
 			}
 			return "", false
-		}, setVariable), nil
+		}, setVariable, VariableOpts{}), nil
 	case net.IPNet:
 		return NewScopedIPVariable(func(ctx *Context, noFollowInheritance bool) (net.IPNet, bool) {
 			if v := getVariable(ctx, noFollowInheritance); v != nil {
@@ -1214,7 +1200,7 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 				return value.(net.IPNet), set
 			}
 			return net.IPNet{}, false
-		}, setVariable), nil
+		}, setVariable, VariableOpts{}), nil
 	case []string:
 		return NewScopedStringArrayVariable(func(ctx *Context, noFollowInheritance bool) ([]string, bool) {
 			if v := getVariable(ctx, noFollowInheritance); v != nil {
@@ -1222,7 +1208,7 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 				return value.([]string), set
 			}
 			return nil, false
-		}, setVariable), nil
+		}, setVariable, VariableOpts{}), nil
 	case []int:
 		return NewScopedIntArrayVariable(func(ctx *Context, noFollowInheritance bool) ([]int, bool) {
 			if v := getVariable(ctx, noFollowInheritance); v != nil {
@@ -1231,7 +1217,7 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 			}
 			return nil, false
 
-		}, setVariable), nil
+		}, setVariable, VariableOpts{}), nil
 	case []net.IPNet:
 		return NewScopedIPArrayVariable(func(ctx *Context, noFollowInheritance bool) ([]net.IPNet, bool) {
 			if v := getVariable(ctx, noFollowInheritance); v != nil {
@@ -1239,7 +1225,7 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 				return value.([]net.IPNet), set
 			}
 			return nil, false
-		}, setVariable), nil
+		}, setVariable, VariableOpts{}), nil
 	default:
 		return nil, fmt.Errorf("unsupported variable type %s for '%s'", reflect.TypeOf(value), name)
 	}

--- a/pkg/security/secl/model/variables.go
+++ b/pkg/security/secl/model/variables.go
@@ -20,9 +20,9 @@ var (
 				return 0, false
 			}
 			return int(pc.Process.Pid), true
-		}, nil),
+		}, nil, eval.VariableOpts{}),
 		"builtins.uuid4": eval.NewScopedStringVariable(func(_ *eval.Context, _ bool) (string, bool) {
 			return uuid.New().String(), true
-		}, nil),
+		}, nil, eval.VariableOpts{}),
 	}
 )


### PR DESCRIPTION
- Add JSON tags to eval.VariableOpts so all fields (size, ttl, private, inherited) can be set via JSON; Telemetry is excluded with json:"-"
- All NewScoped*Variable constructors now accept an explicit VariableOpts parameter instead of hardcoding Private: false, making opts fully caller-controlled
- Add variableEntry struct in clihelpers that embeds eval.VariableOpts, so any VariableOpts field can be set directly in the test-data JSON object alongside the required "value" field
- Add parseVariableEntry helper that handles both the old format (direct value) and the new object format, using json.Marshal+Unmarshal for extensible opts decoding
- Add unit tests for parseVariableEntry and an integration test for the new variable format with private:true

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
