### PR TITLE
[CWS] add utils_syscall_table_generator and generate_utils_syscall_table invoke task

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,6 +2,8 @@
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
 env_vars = use_repo_rule("//bazel/repo:env_vars.bzl", "env_vars")
 
 # Environment values available for packaging.
@@ -136,6 +138,22 @@ http_archive(
         "https://codeload.github.com/bazelbuild/buildtools/tar.gz/refs/tags/v8.5.1",
         "https://github.com/bazelbuild/buildtools/archive/refs/tags/v8.5.1.tar.gz",
     ],
+)
+
+# Upstream Linux kernel syscall tables, used by
+# //pkg/security/utils:utils_syscall_table to (re)generate
+# pkg/security/utils/syscalls.go. Bumping the kernel version requires updating
+# the URLs and sha256 of both files together.
+http_file(
+    name = "linux_v6_13_syscall_64_tbl",
+    sha256 = "a25d490b97e98fa2ad7912f229555e1c8f0e5ba70960f508ae4c324b2439aa04",
+    urls = ["https://raw.githubusercontent.com/torvalds/linux/v6.13/arch/x86/entry/syscalls/syscall_64.tbl"],
+)
+
+http_file(
+    name = "linux_v6_13_unistd_h",
+    sha256 = "53b1df8caee4a4c2ff37d0ec895e22663a0e61b188de61b98f025709ba6c8e18",
+    urls = ["https://raw.githubusercontent.com/torvalds/linux/v6.13/include/uapi/asm-generic/unistd.h"],
 )
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")

--- a/pkg/security/generators/utils_syscall_table_generator/BUILD.bazel
+++ b/pkg/security/generators/utils_syscall_table_generator/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "utils_syscall_table_generator_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/security/generators/utils_syscall_table_generator",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "utils_syscall_table_generator",
+    embed = [":utils_syscall_table_generator_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/security/generators/utils_syscall_table_generator/main.go
+++ b/pkg/security/generators/utils_syscall_table_generator/main.go
@@ -13,10 +13,9 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"net/http"
+	"go/format"
+	"io"
 	"os"
-	"os/exec"
-	"path"
 	"regexp"
 	"slices"
 	"strconv"
@@ -26,29 +25,29 @@ import (
 
 func main() {
 	var (
-		amd64TableURL string
-		arm64TableURL string
-		outputPath    string
+		amd64TablePath string
+		arm64TablePath string
+		outputPath     string
 	)
 
-	flag.StringVar(&amd64TableURL, "amd64-table-url", "", "URL of the x86_64 .tbl syscall table")
-	flag.StringVar(&arm64TableURL, "arm64-table-url", "", "URL of the arm64 unistd.h syscall table")
+	flag.StringVar(&amd64TablePath, "amd64-table", "", "Path to the x86_64 .tbl syscall table")
+	flag.StringVar(&arm64TablePath, "arm64-table", "", "Path to the arm64 unistd.h syscall table")
 	flag.StringVar(&outputPath, "output", "", "Output path of the generated Go file")
 	flag.Parse()
 
-	if amd64TableURL == "" || arm64TableURL == "" || outputPath == "" {
+	if amd64TablePath == "" || arm64TablePath == "" || outputPath == "" {
 		fmt.Fprintf(os.Stderr, "Please provide all required flags\n")
 		flag.Usage()
 		os.Exit(1)
 	}
 
-	amd64Syscalls, err := parseSyscallTable(amd64TableURL, []string{"common", "64"})
+	amd64Syscalls, err := parseFile(amd64TablePath, parseSyscallTableLine([]string{"common", "64"}))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to parse amd64 table: %v\n", err)
 		os.Exit(1)
 	}
 
-	arm64Syscalls, err := parseUnistdTable(arm64TableURL)
+	arm64Syscalls, err := parseFile(arm64TablePath, parseUnistdTableLine)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to parse arm64 table: %v\n", err)
 		os.Exit(1)
@@ -60,7 +59,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := writeFileAndFormat(outputPath, content); err != nil {
+	if err := os.WriteFile(outputPath, content, 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to write output: %v\n", err)
 		os.Exit(1)
 	}
@@ -72,14 +71,17 @@ type syscallEntry struct {
 	Name   string
 }
 
-func parseLinuxFile(url string, perLine func(string) (*syscallEntry, error)) ([]*syscallEntry, error) {
-	resp, err := http.Get(url)
+func parseFile(path string, perLine func(string) (*syscallEntry, error)) ([]*syscallEntry, error) {
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer f.Close()
+	return parseReader(f, perLine)
+}
 
-	scanner := bufio.NewScanner(resp.Body)
+func parseReader(r io.Reader, perLine func(string) (*syscallEntry, error)) ([]*syscallEntry, error) {
+	scanner := bufio.NewScanner(r)
 	var syscalls []*syscallEntry
 
 	for scanner.Scan() {
@@ -96,8 +98,8 @@ func parseLinuxFile(url string, perLine func(string) (*syscallEntry, error)) ([]
 	return syscalls, scanner.Err()
 }
 
-func parseSyscallTable(url string, abis []string) ([]*syscallEntry, error) {
-	return parseLinuxFile(url, func(line string) (*syscallEntry, error) {
+func parseSyscallTableLine(abis []string) func(string) (*syscallEntry, error) {
+	return func(line string) (*syscallEntry, error) {
 		if line == "" || strings.HasPrefix(line, "#") {
 			return nil, nil
 		}
@@ -118,23 +120,21 @@ func parseSyscallTable(url string, abis []string) ([]*syscallEntry, error) {
 			return &syscallEntry{Arch: "amd64", Number: int(number), Name: name}, nil
 		}
 		return nil, nil
-	})
+	}
 }
 
 var unistdDefinedRe = regexp.MustCompile(`#define __NR(3264)?_([0-9a-zA-Z_]+)\s+([0-9]+)`)
 
-func parseUnistdTable(url string) ([]*syscallEntry, error) {
-	return parseLinuxFile(url, func(line string) (*syscallEntry, error) {
-		subs := unistdDefinedRe.FindStringSubmatch(line)
-		if subs == nil {
-			return nil, nil
-		}
-		nr, err := strconv.ParseInt(subs[3], 10, 0)
-		if err != nil {
-			return nil, err
-		}
-		return &syscallEntry{Arch: "arm64", Number: int(nr), Name: subs[2]}, nil
-	})
+func parseUnistdTableLine(line string) (*syscallEntry, error) {
+	subs := unistdDefinedRe.FindStringSubmatch(line)
+	if subs == nil {
+		return nil, nil
+	}
+	nr, err := strconv.ParseInt(subs[3], 10, 0)
+	if err != nil {
+		return nil, err
+	}
+	return &syscallEntry{Arch: "arm64", Number: int(nr), Name: subs[2]}, nil
 }
 
 const outputTemplate = `// Code generated - DO NOT EDIT.
@@ -188,10 +188,10 @@ type templateData struct {
 	Arm64 []*syscallEntry
 }
 
-func generateMapCode(amd64, arm64 []*syscallEntry) (string, error) {
+func generateMapCode(amd64, arm64 []*syscallEntry) ([]byte, error) {
 	tmpl, err := template.New("utils-syscalls").Parse(outputTemplate)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var buf bytes.Buffer
@@ -199,30 +199,8 @@ func generateMapCode(amd64, arm64 []*syscallEntry) (string, error) {
 		Amd64: deduplicateByID(amd64),
 		Arm64: deduplicateByID(arm64),
 	}); err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return buf.String(), nil
-}
-
-func writeFileAndFormat(outputPath, content string) error {
-	tmpfile, err := os.CreateTemp(path.Dir(outputPath), "utils-syscalls-*")
-	if err != nil {
-		return err
-	}
-
-	if _, err := tmpfile.WriteString(content); err != nil {
-		return err
-	}
-
-	if err := tmpfile.Close(); err != nil {
-		return err
-	}
-
-	cmd := exec.Command("gofmt", "-s", "-w", tmpfile.Name())
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	return os.Rename(tmpfile.Name(), outputPath)
+	return format.Source(buf.Bytes())
 }

--- a/pkg/security/generators/utils_syscall_table_generator/main.go
+++ b/pkg/security/generators/utils_syscall_table_generator/main.go
@@ -1,0 +1,228 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package main generates pkg/security/utils/syscalls.go — a combined amd64+arm64
+// SyscallKey map — from the upstream Linux kernel syscall tables.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+func main() {
+	var (
+		amd64TableURL string
+		arm64TableURL string
+		outputPath    string
+	)
+
+	flag.StringVar(&amd64TableURL, "amd64-table-url", "", "URL of the x86_64 .tbl syscall table")
+	flag.StringVar(&arm64TableURL, "arm64-table-url", "", "URL of the arm64 unistd.h syscall table")
+	flag.StringVar(&outputPath, "output", "", "Output path of the generated Go file")
+	flag.Parse()
+
+	if amd64TableURL == "" || arm64TableURL == "" || outputPath == "" {
+		fmt.Fprintf(os.Stderr, "Please provide all required flags\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	amd64Syscalls, err := parseSyscallTable(amd64TableURL, []string{"common", "64"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse amd64 table: %v\n", err)
+		os.Exit(1)
+	}
+
+	arm64Syscalls, err := parseUnistdTable(arm64TableURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse arm64 table: %v\n", err)
+		os.Exit(1)
+	}
+
+	content, err := generateMapCode(amd64Syscalls, arm64Syscalls)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to generate code: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := writeFileAndFormat(outputPath, content); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write output: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+type syscallEntry struct {
+	Arch   string
+	Number int
+	Name   string
+}
+
+func parseLinuxFile(url string, perLine func(string) (*syscallEntry, error)) ([]*syscallEntry, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	var syscalls []*syscallEntry
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		entry, err := perLine(line)
+		if err != nil {
+			return nil, err
+		}
+		if entry != nil {
+			syscalls = append(syscalls, entry)
+		}
+	}
+
+	return syscalls, scanner.Err()
+}
+
+func parseSyscallTable(url string, abis []string) ([]*syscallEntry, error) {
+	return parseLinuxFile(url, func(line string) (*syscallEntry, error) {
+		if line == "" || strings.HasPrefix(line, "#") {
+			return nil, nil
+		}
+
+		parts := strings.Fields(line)
+		if len(parts) < 3 {
+			return nil, errors.New("found syscall with missing fields")
+		}
+
+		number, err := strconv.ParseInt(parts[0], 10, 0)
+		if err != nil {
+			return nil, err
+		}
+		abi := parts[1]
+		name := parts[2]
+
+		if slices.Contains(abis, abi) {
+			return &syscallEntry{Arch: "amd64", Number: int(number), Name: name}, nil
+		}
+		return nil, nil
+	})
+}
+
+var unistdDefinedRe = regexp.MustCompile(`#define __NR(3264)?_([0-9a-zA-Z_]+)\s+([0-9]+)`)
+
+func parseUnistdTable(url string) ([]*syscallEntry, error) {
+	return parseLinuxFile(url, func(line string) (*syscallEntry, error) {
+		subs := unistdDefinedRe.FindStringSubmatch(line)
+		if subs == nil {
+			return nil, nil
+		}
+		nr, err := strconv.ParseInt(subs[3], 10, 0)
+		if err != nil {
+			return nil, err
+		}
+		return &syscallEntry{Arch: "arm64", Number: int(nr), Name: subs[2]}, nil
+	})
+}
+
+const outputTemplate = `// Code generated - DO NOT EDIT.
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package utils groups multiple utils function that can be used by the secl package
+package utils
+
+// SyscallKey key representing the arch and syscall id
+type SyscallKey struct {
+	Arch string
+	ID   int
+}
+
+// Syscalls maps the (arch,syscall_id) to the syscall string
+var Syscalls = map[SyscallKey]string{
+	// amd64 syscalls
+{{- range .Amd64}}
+	{"amd64", {{.Number}}}: "{{.Name}}",
+{{- end}}
+
+	// arm64 syscalls
+{{- range .Arm64}}
+	{"arm64", {{.Number}}}: "{{.Name}}",
+{{- end}}
+}
+`
+
+// deduplicateByID resolves duplicate IDs by keeping the entry with the shorter name.
+func deduplicateByID(entries []*syscallEntry) []*syscallEntry {
+	seen := make(map[int]*syscallEntry)
+	for _, e := range entries {
+		if existing, ok := seen[e.Number]; !ok || len(e.Name) < len(existing.Name) {
+			seen[e.Number] = e
+		}
+	}
+	result := make([]*syscallEntry, 0, len(seen))
+	for _, e := range entries {
+		if seen[e.Number] == e {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+type templateData struct {
+	Amd64 []*syscallEntry
+	Arm64 []*syscallEntry
+}
+
+func generateMapCode(amd64, arm64 []*syscallEntry) (string, error) {
+	tmpl, err := template.New("utils-syscalls").Parse(outputTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, templateData{
+		Amd64: deduplicateByID(amd64),
+		Arm64: deduplicateByID(arm64),
+	}); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func writeFileAndFormat(outputPath, content string) error {
+	tmpfile, err := os.CreateTemp(path.Dir(outputPath), "utils-syscalls-*")
+	if err != nil {
+		return err
+	}
+
+	if _, err := tmpfile.WriteString(content); err != nil {
+		return err
+	}
+
+	if err := tmpfile.Close(); err != nil {
+		return err
+	}
+
+	cmd := exec.Command("gofmt", "-s", "-w", tmpfile.Name())
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpfile.Name(), outputPath)
+}

--- a/pkg/security/utils/BUILD.bazel
+++ b/pkg/security/utils/BUILD.bazel
@@ -1,1 +1,25 @@
+load("@bazel_lib//lib:run_binary.bzl", "run_binary")
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
+
 # gazelle:ignore
+
+run_binary(
+    name = "utils_syscall_table_gen",
+    srcs = [
+        "@linux_v6_13_syscall_64_tbl//file",
+        "@linux_v6_13_unistd_h//file",
+    ],
+    outs = ["utils_syscall_table_gen.go"],
+    args = [
+        "-amd64-table=$(execpath @linux_v6_13_syscall_64_tbl//file)",
+        "-arm64-table=$(execpath @linux_v6_13_unistd_h//file)",
+        "-output=$(execpath utils_syscall_table_gen.go)",
+    ],
+    tool = "//pkg/security/generators/utils_syscall_table_generator",
+)
+
+write_source_file(
+    name = "utils_syscall_table",
+    in_file = ":utils_syscall_table_gen",
+    out_file = "syscalls.go",
+)

--- a/pkg/security/utils/syscalls.go
+++ b/pkg/security/utils/syscalls.go
@@ -1,3 +1,4 @@
+// Code generated - DO NOT EDIT.
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
@@ -171,7 +172,7 @@ var Syscalls = map[SyscallKey]string{
 	{"amd64", 153}: "vhangup",
 	{"amd64", 154}: "modify_ldt",
 	{"amd64", 155}: "pivot_root",
-	{"amd64", 156}: "sysctl",
+	{"amd64", 156}: "_sysctl",
 	{"amd64", 157}: "prctl",
 	{"amd64", 158}: "arch_prctl",
 	{"amd64", 159}: "adjtimex",
@@ -350,6 +351,7 @@ var Syscalls = map[SyscallKey]string{
 	{"amd64", 332}: "statx",
 	{"amd64", 333}: "io_pgetevents",
 	{"amd64", 334}: "rseq",
+	{"amd64", 335}: "uretprobe",
 	{"amd64", 424}: "pidfd_send_signal",
 	{"amd64", 425}: "io_uring_setup",
 	{"amd64", 426}: "io_uring_enter",
@@ -389,6 +391,10 @@ var Syscalls = map[SyscallKey]string{
 	{"amd64", 460}: "lsm_set_self_attr",
 	{"amd64", 461}: "lsm_list_modules",
 	{"amd64", 462}: "mseal",
+	{"amd64", 463}: "setxattrat",
+	{"amd64", 464}: "getxattrat",
+	{"amd64", 465}: "listxattrat",
+	{"amd64", 466}: "removexattrat",
 
 	// arm64 syscalls
 	{"arm64", 0}:   "io_setup",
@@ -730,4 +736,9 @@ var Syscalls = map[SyscallKey]string{
 	{"arm64", 460}: "lsm_set_self_attr",
 	{"arm64", 461}: "lsm_list_modules",
 	{"arm64", 462}: "mseal",
+	{"arm64", 463}: "setxattrat",
+	{"arm64", 464}: "getxattrat",
+	{"arm64", 465}: "listxattrat",
+	{"arm64", 466}: "removexattrat",
+	{"arm64", 467}: "syscalls",
 }

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -582,6 +582,17 @@ def generate_syscall_table(ctx):
     )
 
 
+@task
+def generate_utils_syscall_table(ctx):
+    linux_version = "v6.13"
+    ctx.run(
+        f"go run github.com/DataDog/datadog-agent/pkg/security/generators/utils_syscall_table_generator"
+        f" -amd64-table-url https://raw.githubusercontent.com/torvalds/linux/{linux_version}/arch/x86/entry/syscalls/syscall_64.tbl"
+        f" -arm64-table-url https://raw.githubusercontent.com/torvalds/linux/{linux_version}/include/uapi/asm-generic/unistd.h"
+        f" -output pkg/security/utils/syscalls.go"
+    )
+
+
 DEFAULT_BTFHUB_CONSTANTS_PATH = "./pkg/security/probe/constantfetch/btfhub/constants.json"
 DEFAULT_BTFHUB_CONSTANTS_ARM64_PATH = "./pkg/security/probe/constantfetch/btfhub/constants_arm64.json"
 DEFAULT_BTFHUB_CONSTANTS_AMD64_PATH = "./pkg/security/probe/constantfetch/btfhub/constants_amd64.json"

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -584,13 +584,9 @@ def generate_syscall_table(ctx):
 
 @task
 def generate_utils_syscall_table(ctx):
-    linux_version = "v6.13"
-    ctx.run(
-        f"go run github.com/DataDog/datadog-agent/pkg/security/generators/utils_syscall_table_generator"
-        f" -amd64-table-url https://raw.githubusercontent.com/torvalds/linux/{linux_version}/arch/x86/entry/syscalls/syscall_64.tbl"
-        f" -arm64-table-url https://raw.githubusercontent.com/torvalds/linux/{linux_version}/include/uapi/asm-generic/unistd.h"
-        f" -output pkg/security/utils/syscalls.go"
-    )
+    # The kernel files are fetched as `http_file` repos pinned in MODULE.bazel;
+    # bumping the kernel version means updating those URLs and sha256 entries.
+    bazel(ctx, "run", "//pkg/security/utils:utils_syscall_table")
 
 
 DEFAULT_BTFHUB_CONSTANTS_PATH = "./pkg/security/probe/constantfetch/btfhub/constants.json"


### PR DESCRIPTION
- Add pkg/security/generators/utils_syscall_table_generator: a new generator that fetches the amd64 .tbl and arm64 unistd.h from the upstream Linux kernel, parses both architectures, and renders pkg/security/utils/syscalls.go with the combined SyscallKey map
- Add generate_utils_syscall_table invoke task in tasks/security_agent.py following the same pattern as generate_syscall_table (same linux_version pin, go run invocation)
- Mark pkg/security/utils/syscalls.go as code-generated and refresh its contents from Linux v6.13 (renames _sysctl, adds uretprobe/setxattrat/ getxattrat/listxattrat/removexattrat and arm64 sync_file_range2/syscalls)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
