### PR TITLE
Add task-level tests for static quality gates

### DIFF
--- a/tasks/unit_tests/static_quality_gates/tasks_tests.py
+++ b/tasks/unit_tests/static_quality_gates/tasks_tests.py
@@ -21,11 +21,6 @@ from tasks.libs.package.size import InfraError
 from tasks.quality_gates import parse_and_trigger_gates
 from tasks.static_quality_gates.gates import ArtifactMeasurement, PackageArtifactMeasurer
 
-_PR_BRANCH_NAME = "feature/branch"
-_PR_BUCKET_BRANCH = 'dev'
-_CI_PIPELINE_ID = '999999999'
-_CI_COMMIT_SHA = '1234567890abcdef'
-
 
 def gitlab_ref_slug(git_ref):
     """
@@ -34,6 +29,12 @@ def gitlab_ref_slug(git_ref):
     (https://docs.gitlab.com/ci/variables/predefined_variables/)
     """
     return re.sub(r"[^0-9a-z]", "-", git_ref.lower())[:63]
+
+
+_PR_BRANCH_NAME = "feature/branch"
+_PR_BUCKET_BRANCH = 'dev'
+_CI_PIPELINE_ID = '999999999'
+_CI_COMMIT_SHA = '1234567890abcdef'
 
 
 _PR_ENV_VARS = {

--- a/tasks/unit_tests/static_quality_gates/tasks_tests.py
+++ b/tasks/unit_tests/static_quality_gates/tasks_tests.py
@@ -82,22 +82,27 @@ class GateScenario:
 
 
 @contextmanager
-def _gate_scenarios(*scenarios: GateScenario):
+def _gate_scenarios(*scenarios: GateScenario, ancestor_sha="ancestor-sha"):
     """
     Context manager that wires up gate scenarios for integration tests.
 
-    Yields a SimpleNamespace with:
-      - config_path: path to a temp YAML file with the gate limits
-      - ancestor_metrics: dict suitable for mocking query_gate_metrics_for_commit
-      - package_measure: side_effect for PackageArtifactMeasurer.measure
-      - docker_measure: side_effect for DockerArtifactMeasurer.measure
+    Patches PackageArtifactMeasurer.measure, DockerArtifactMeasurer.measure, and
+    query_gate_metrics_for_commit for the duration of the test.
+
+    Yields the path to a temp YAML file with the gate limits.
     """
     by_name = {s.name: s for s in scenarios}
+    by_ancestor_sha = {
+        ancestor_sha: {
+            s.name: {"current_on_disk_size": s.ancestor_disk, "current_on_wire_size": s.ancestor_wire}
+            for s in scenarios
+        }
+    }
 
     config = {s.name: {"max_on_disk_size": s.max_disk, "max_on_wire_size": s.max_wire} for s in scenarios}
-    ancestor_metrics = {
-        s.name: {"current_on_disk_size": s.ancestor_disk, "current_on_wire_size": s.ancestor_wire} for s in scenarios
-    }
+
+    def _query_metrics(sha):
+        return by_ancestor_sha[sha]
 
     def _package_measure(ctx, config):
         s = by_name[config.gate_name]
@@ -113,12 +118,21 @@ def _gate_scenarios(*scenarios: GateScenario):
         config_path = os.path.join(tmpdir, 'gates.yml')
         with open(config_path, 'w') as f:
             yaml.dump(config, f)
-        yield SimpleNamespace(
-            config_path=config_path,
-            ancestor_metrics=ancestor_metrics,
-            package_measure=_package_measure,
-            docker_measure=_docker_measure,
-        )
+        with (
+            patch(
+                "tasks.libs.common.datadog_api.query_gate_metrics_for_commit",
+                side_effect=_query_metrics,
+            ),
+            patch(
+                "tasks.static_quality_gates.gates.PackageArtifactMeasurer.measure",
+                side_effect=_package_measure,
+            ),
+            patch(
+                "tasks.static_quality_gates.gates.DockerArtifactMeasurer.measure",
+                side_effect=_docker_measure,
+            ),
+        ):
+            yield config_path
 
 
 class TestQualityGatesIntegration(unittest.TestCase):
@@ -157,20 +171,8 @@ class TestQualityGatesIntegration(unittest.TestCase):
             patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
-            _gate_scenarios(*gate_scenarios) as gate_fixture,
-            patch(
-                "tasks.libs.common.datadog_api.query_gate_metrics_for_commit",
-                return_value=gate_fixture.ancestor_metrics,
-            ) as mock_query_metrics,
+            _gate_scenarios(*gate_scenarios) as config_path,
             patch("tasks.static_quality_gates.gates.send_metrics") as mock_send_metrics,
-            patch(
-                "tasks.static_quality_gates.gates.PackageArtifactMeasurer.measure",
-                side_effect=gate_fixture.package_measure,
-            ),
-            patch(
-                "tasks.static_quality_gates.gates.DockerArtifactMeasurer.measure",
-                side_effect=gate_fixture.docker_measure,
-            ),
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
             patch(
                 "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
@@ -181,7 +183,7 @@ class TestQualityGatesIntegration(unittest.TestCase):
                     "datadog-ci tag --level job --tags static_quality_gates:\"success\"": Result("Done"),
                 }
             )
-            parse_and_trigger_gates(ctx, gate_fixture.config_path)
+            parse_and_trigger_gates(ctx, config_path)
 
             # Assert on metrics sent
             mock_send_metrics.assert_called_once()
@@ -216,9 +218,6 @@ class TestQualityGatesIntegration(unittest.TestCase):
                 rel_wire=0,
             )
 
-            # Assert ancestor SHA was looked up to compute relative sizes
-            mock_query_metrics.assert_called_once_with("ancestor-sha")
-
             mock_generate_reports.assert_called_once()
 
             # Assert PR comment was posted for the correct PR
@@ -251,27 +250,19 @@ class TestQualityGatesIntegration(unittest.TestCase):
             patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
-            _gate_scenarios(*gate_scenarios) as gate_fixture,
+            _gate_scenarios(*gate_scenarios) as config_path,
             patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_relative_size"),
             patch(
                 "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
             ) as mock_generate_reports,
             patch("tasks.static_quality_gates.gates.send_metrics") as mock_send_metrics,
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
-            patch(
-                "tasks.static_quality_gates.gates.PackageArtifactMeasurer.measure",
-                side_effect=gate_fixture.package_measure,
-            ),
-            patch(
-                "tasks.static_quality_gates.gates.DockerArtifactMeasurer.measure",
-                side_effect=gate_fixture.docker_measure,
-            ),
         ):
             ctx = MockContext(
                 run={"datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done")}
             )
             with self.assertRaises(Exit):
-                parse_and_trigger_gates(ctx, gate_fixture.config_path)
+                parse_and_trigger_gates(ctx, config_path)
             mock_send_metrics.assert_called_once()
             mock_generate_reports.assert_called_once()
             mock_pr_commenter.assert_called_once()
@@ -302,27 +293,19 @@ class TestQualityGatesIntegration(unittest.TestCase):
             patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
-            _gate_scenarios(*gate_scenarios) as gate_fixture,
+            _gate_scenarios(*gate_scenarios) as config_path,
             patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_relative_size"),
             patch(
                 "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
             ) as mock_generate_reports,
             patch("tasks.static_quality_gates.gates.send_metrics") as mock_send_metrics,
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
-            patch(
-                "tasks.static_quality_gates.gates.PackageArtifactMeasurer.measure",
-                side_effect=gate_fixture.package_measure,
-            ),
-            patch(
-                "tasks.static_quality_gates.gates.DockerArtifactMeasurer.measure",
-                side_effect=gate_fixture.docker_measure,
-            ),
         ):
             ctx = MockContext(
                 run={"datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done")}
             )
             with self.assertRaises(Exit):
-                parse_and_trigger_gates(ctx, gate_fixture.config_path)
+                parse_and_trigger_gates(ctx, config_path)
             mock_send_metrics.assert_called_once()
             mock_generate_reports.assert_called_once()
             mock_pr_commenter.assert_called_once()
@@ -354,20 +337,8 @@ class TestQualityGatesIntegration(unittest.TestCase):
             patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
-            _gate_scenarios(*gate_scenarios) as gate_fixture,
-            patch(
-                "tasks.libs.common.datadog_api.query_gate_metrics_for_commit",
-                return_value=gate_fixture.ancestor_metrics,
-            ),
+            _gate_scenarios(*gate_scenarios) as config_path,
             patch("tasks.static_quality_gates.gates.send_metrics"),
-            patch(
-                "tasks.static_quality_gates.gates.PackageArtifactMeasurer.measure",
-                side_effect=gate_fixture.package_measure,
-            ),
-            patch(
-                "tasks.static_quality_gates.gates.DockerArtifactMeasurer.measure",
-                side_effect=gate_fixture.docker_measure,
-            ),
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
             patch(
                 "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
@@ -377,7 +348,7 @@ class TestQualityGatesIntegration(unittest.TestCase):
                 run={"datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done")}
             )
             with self.assertRaises(Exit):
-                parse_and_trigger_gates(ctx, gate_fixture.config_path)
+                parse_and_trigger_gates(ctx, config_path)
             mock_generate_reports.assert_called_once()
             mock_pr_commenter.assert_called_once()
 
@@ -414,20 +385,8 @@ class TestQualityGatesIntegration(unittest.TestCase):
             patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.quality_gates.get_pr_for_branch", return_value=approved_pr),
-            _gate_scenarios(*gate_scenarios) as gate_fixture,
-            patch(
-                "tasks.libs.common.datadog_api.query_gate_metrics_for_commit",
-                return_value=gate_fixture.ancestor_metrics,
-            ),
+            _gate_scenarios(*gate_scenarios) as config_path,
             patch("tasks.static_quality_gates.gates.send_metrics"),
-            patch(
-                "tasks.static_quality_gates.gates.PackageArtifactMeasurer.measure",
-                side_effect=gate_fixture.package_measure,
-            ),
-            patch(
-                "tasks.static_quality_gates.gates.DockerArtifactMeasurer.measure",
-                side_effect=gate_fixture.docker_measure,
-            ),
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
             patch(
                 "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
@@ -436,7 +395,7 @@ class TestQualityGatesIntegration(unittest.TestCase):
             ctx = MockContext(
                 run={"datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done")}
             )
-            parse_and_trigger_gates(ctx, gate_fixture.config_path)
+            parse_and_trigger_gates(ctx, config_path)
             mock_generate_reports.assert_called_once()
             mock_pr_commenter.assert_called_once()
             self.assertIs(mock_pr_commenter.call_args.kwargs["pr"], approved_pr)

--- a/tasks/unit_tests/static_quality_gates/tasks_tests.py
+++ b/tasks/unit_tests/static_quality_gates/tasks_tests.py
@@ -4,18 +4,227 @@ Tests for static quality gates.
 Tests the top-level parse_and_trigger_gates orchestration.
 """
 
+import os
+import re
+import tempfile
 import unittest
+from contextlib import contextmanager
+from dataclasses import dataclass
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import yaml
 from invoke import MockContext, Result
 from invoke.exceptions import Exit
 
 from tasks.libs.package.size import InfraError
 from tasks.quality_gates import parse_and_trigger_gates
-from tasks.static_quality_gates.gates import PackageArtifactMeasurer
+from tasks.static_quality_gates.gates import ArtifactMeasurement, PackageArtifactMeasurer
+
+_PR_BRANCH_NAME = "feature/branch"
+_PR_BUCKET_BRANCH = 'dev'
+_CI_PIPELINE_ID = '999999999'
+_CI_COMMIT_SHA = '1234567890abcdef'
+
+
+def gitlab_ref_slug(git_ref):
+    """
+    CI_COMMIT_REF_NAME in lowercase, shortened to 63 bytes, and with everything
+    except 0-9 and a-z replaced with -. No leading / trailing -. Use in URLs, host names and domain names.
+    (https://docs.gitlab.com/ci/variables/predefined_variables/)
+    """
+    return re.sub(r"[^0-9a-z]", "-", git_ref.lower())[:63]
+
+
+class FakeGithubAPI:
+    PR = SimpleNamespace(
+        number=12345,
+        title="fix(somewhere): did something",
+        user=SimpleNamespace(login="some-author"),
+        get_reviews=lambda: [],
+    )
+
+    def get_pr_for_branch(self, branch):
+        return [self.PR] if branch == _PR_BRANCH_NAME else []
+
+    def get_pr(self, pr_id):
+        return self.PR if pr_id == self.PR.number else None
+
+
+_DEB_GATE = "static_quality_gate_agent_deb_amd64"
+_DOCKER_GATE = "static_quality_gate_docker_agent_amd64"
+
+_KiB = 1024
+_MiB = 1024 * _KiB
+
+
+@dataclass
+class GateScenario:
+    """Represents the desired state of a gate, for use with the _gate_scenarios fixture."""
+
+    name: str
+    current_disk: int
+    current_wire: int
+    ancestor_disk: int
+    ancestor_wire: int
+    max_disk: int
+    max_wire: int
+
+
+@contextmanager
+def _gate_scenarios(*scenarios: GateScenario):
+    """
+    Context manager that wires up gate scenarios for integration tests.
+
+    Yields a SimpleNamespace with:
+      - config_path: path to a temp YAML file with the gate limits
+      - ancestor_metrics: dict suitable for mocking query_gate_metrics_for_commit
+      - package_measure: side_effect for PackageArtifactMeasurer.measure
+      - docker_measure: side_effect for DockerArtifactMeasurer.measure
+    """
+    by_name = {s.name: s for s in scenarios}
+
+    config = {s.name: {"max_on_disk_size": s.max_disk, "max_on_wire_size": s.max_wire} for s in scenarios}
+    ancestor_metrics = {
+        s.name: {"current_on_disk_size": s.ancestor_disk, "current_on_wire_size": s.ancestor_wire} for s in scenarios
+    }
+
+    def _package_measure(ctx, config):
+        s = by_name[config.gate_name]
+        return ArtifactMeasurement(artifact_path='/fake/path', on_wire_size=s.current_wire, on_disk_size=s.current_disk)
+
+    def _docker_measure(ctx, config):
+        s = by_name[config.gate_name]
+        return ArtifactMeasurement(
+            artifact_path='fake-docker-image', on_wire_size=s.current_wire, on_disk_size=s.current_disk
+        )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, 'gates.yml')
+        with open(config_path, 'w') as f:
+            yaml.dump(config, f)
+        yield SimpleNamespace(
+            config_path=config_path,
+            ancestor_metrics=ancestor_metrics,
+            package_measure=_package_measure,
+            docker_measure=_docker_measure,
+        )
 
 
 class TestQualityGatesIntegration(unittest.TestCase):
+    def _assert_gate_metrics(self, sent, gate_name, *, on_disk, on_wire, max_disk, max_wire, rel_disk, rel_wire):
+        metric_prefix = "datadog.agent.static_quality_gate."
+        self.assertEqual(sent[(metric_prefix + "on_disk_size", gate_name)], on_disk)
+        self.assertEqual(sent[(metric_prefix + "on_wire_size", gate_name)], on_wire)
+        self.assertEqual(sent[(metric_prefix + "max_allowed_on_disk_size", gate_name)], max_disk)
+        self.assertEqual(sent[(metric_prefix + "max_allowed_on_wire_size", gate_name)], max_wire)
+        self.assertEqual(sent[(metric_prefix + "relative_on_disk_size", gate_name)], rel_disk)
+        self.assertEqual(sent[(metric_prefix + "relative_on_wire_size", gate_name)], rel_wire)
+
+    @patch.dict(
+        'os.environ',
+        {
+            'BUCKET_BRANCH': _PR_BUCKET_BRANCH,
+            'CI_COMMIT_BRANCH': _PR_BRANCH_NAME,
+            'CI_COMMIT_REF_SLUG': gitlab_ref_slug(_PR_BRANCH_NAME),
+            'CI_PIPELINE_ID': _CI_PIPELINE_ID,
+            'CI_COMMIT_SHA': _CI_COMMIT_SHA,
+        },
+        clear=True,
+    )
+    def test_pr_all_gates_pass_and_send_metrics(self):
+        gate_scenarios = [
+            GateScenario(
+                name=_DEB_GATE,
+                ancestor_disk=100 * _MiB,
+                ancestor_wire=50 * _MiB,
+                current_disk=100 * _MiB + 20 * _KiB,
+                current_wire=50 * _MiB,
+                max_disk=105 * _MiB,
+                max_wire=55 * _MiB,
+            ),
+            GateScenario(
+                name=_DOCKER_GATE,
+                ancestor_disk=600 * _MiB,
+                ancestor_wire=240 * _MiB,
+                current_disk=600 * _MiB + 20 * _KiB,
+                current_wire=240 * _MiB,
+                max_disk=700 * _MiB,
+                max_wire=250 * _MiB,
+            ),
+        ]
+        with (
+            patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
+            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
+            patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
+            _gate_scenarios(*gate_scenarios) as gate_fixture,
+            patch(
+                "tasks.libs.common.datadog_api.query_gate_metrics_for_commit",
+                return_value=gate_fixture.ancestor_metrics,
+            ) as mock_query_metrics,
+            patch("tasks.static_quality_gates.gates.send_metrics") as mock_send_metrics,
+            patch(
+                "tasks.static_quality_gates.gates.PackageArtifactMeasurer.measure",
+                side_effect=gate_fixture.package_measure,
+            ),
+            patch(
+                "tasks.static_quality_gates.gates.DockerArtifactMeasurer.measure",
+                side_effect=gate_fixture.docker_measure,
+            ),
+            patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
+            patch(
+                "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
+            ) as mock_generate_reports,
+        ):
+            ctx = MockContext(
+                run={
+                    "datadog-ci tag --level job --tags static_quality_gates:\"success\"": Result("Done"),
+                }
+            )
+            parse_and_trigger_gates(ctx, gate_fixture.config_path)
+
+            # Assert on metrics sent
+            mock_send_metrics.assert_called_once()
+            series = mock_send_metrics.call_args.kwargs["series"]
+            sent = {}
+            for m in series:
+                self.assertIn(f"git_ref:{gitlab_ref_slug(_PR_BRANCH_NAME)}", m.tags)
+                self.assertIn(f"bucket_branch:{_PR_BUCKET_BRANCH}", m.tags)
+                self.assertIn(f"pipeline_id:{_CI_PIPELINE_ID}", m.tags)
+                self.assertIn(f"ci_commit_sha:{_CI_COMMIT_SHA}", m.tags)
+                gate_name = next(t.split(":", 1)[1] for t in m.tags if t.startswith("gate_name:"))
+                sent[(m.metric, gate_name)] = m.points[0].value
+
+            self._assert_gate_metrics(
+                sent,
+                _DEB_GATE,
+                on_disk=100 * _MiB + 20 * _KiB,
+                on_wire=50 * _MiB,
+                max_disk=105 * _MiB,
+                max_wire=55 * _MiB,
+                rel_disk=20 * _KiB,
+                rel_wire=0,
+            )
+            self._assert_gate_metrics(
+                sent,
+                _DOCKER_GATE,
+                on_disk=600 * _MiB + 20 * _KiB,
+                on_wire=240 * _MiB,
+                max_disk=700 * _MiB,
+                max_wire=250 * _MiB,
+                rel_disk=20 * _KiB,
+                rel_wire=0,
+            )
+
+            # Assert ancestor SHA was looked up to compute relative sizes
+            mock_query_metrics.assert_called_once_with("ancestor-sha")
+
+            mock_generate_reports.assert_called_once()
+
+            # Assert PR comment was posted for the correct PR
+            mock_pr_commenter.assert_called_once()
+            self.assertIs(mock_pr_commenter.call_args.kwargs["pr"], FakeGithubAPI.PR)
+
     @patch.dict(
         'os.environ',
         {

--- a/tasks/unit_tests/static_quality_gates/tasks_tests.py
+++ b/tasks/unit_tests/static_quality_gates/tasks_tests.py
@@ -36,6 +36,15 @@ def gitlab_ref_slug(git_ref):
     return re.sub(r"[^0-9a-z]", "-", git_ref.lower())[:63]
 
 
+_PR_ENV_VARS = {
+    'BUCKET_BRANCH': _PR_BUCKET_BRANCH,
+    'CI_COMMIT_BRANCH': _PR_BRANCH_NAME,
+    'CI_COMMIT_REF_SLUG': gitlab_ref_slug(_PR_BRANCH_NAME),
+    'CI_PIPELINE_ID': _CI_PIPELINE_ID,
+    'CI_COMMIT_SHA': _CI_COMMIT_SHA,
+}
+
+
 class FakeGithubAPI:
     PR = SimpleNamespace(
         number=12345,
@@ -121,17 +130,7 @@ class TestQualityGatesIntegration(unittest.TestCase):
         self.assertEqual(sent[(metric_prefix + "relative_on_disk_size", gate_name)], rel_disk)
         self.assertEqual(sent[(metric_prefix + "relative_on_wire_size", gate_name)], rel_wire)
 
-    @patch.dict(
-        'os.environ',
-        {
-            'BUCKET_BRANCH': _PR_BUCKET_BRANCH,
-            'CI_COMMIT_BRANCH': _PR_BRANCH_NAME,
-            'CI_COMMIT_REF_SLUG': gitlab_ref_slug(_PR_BRANCH_NAME),
-            'CI_PIPELINE_ID': _CI_PIPELINE_ID,
-            'CI_COMMIT_SHA': _CI_COMMIT_SHA,
-        },
-        clear=True,
-    )
+    @patch.dict('os.environ', _PR_ENV_VARS, clear=True)
     def test_pr_all_gates_pass_and_send_metrics(self):
         gate_scenarios = [
             GateScenario(
@@ -225,17 +224,7 @@ class TestQualityGatesIntegration(unittest.TestCase):
             mock_pr_commenter.assert_called_once()
             self.assertIs(mock_pr_commenter.call_args.kwargs["pr"], FakeGithubAPI.PR)
 
-    @patch.dict(
-        'os.environ',
-        {
-            'BUCKET_BRANCH': _PR_BUCKET_BRANCH,
-            'CI_COMMIT_BRANCH': _PR_BRANCH_NAME,
-            'CI_COMMIT_REF_SLUG': gitlab_ref_slug(_PR_BRANCH_NAME),
-            'CI_PIPELINE_ID': _CI_PIPELINE_ID,
-            'CI_COMMIT_SHA': _CI_COMMIT_SHA,
-        },
-        clear=True,
-    )
+    @patch.dict('os.environ', _PR_ENV_VARS, clear=True)
     def test_gate_fails_absolute_disk_limit(self):
         gate_scenarios = [
             GateScenario(
@@ -286,17 +275,7 @@ class TestQualityGatesIntegration(unittest.TestCase):
             mock_generate_reports.assert_called_once()
             mock_pr_commenter.assert_called_once()
 
-    @patch.dict(
-        'os.environ',
-        {
-            'BUCKET_BRANCH': _PR_BUCKET_BRANCH,
-            'CI_COMMIT_BRANCH': _PR_BRANCH_NAME,
-            'CI_COMMIT_REF_SLUG': gitlab_ref_slug(_PR_BRANCH_NAME),
-            'CI_PIPELINE_ID': _CI_PIPELINE_ID,
-            'CI_COMMIT_SHA': _CI_COMMIT_SHA,
-        },
-        clear=True,
-    )
+    @patch.dict('os.environ', _PR_ENV_VARS, clear=True)
     def test_gate_fails_absolute_wire_limit(self):
         gate_scenarios = [
             GateScenario(
@@ -346,6 +325,120 @@ class TestQualityGatesIntegration(unittest.TestCase):
             mock_send_metrics.assert_called_once()
             mock_generate_reports.assert_called_once()
             mock_pr_commenter.assert_called_once()
+
+    @patch.dict('os.environ', _PR_ENV_VARS, clear=True)
+    def test_gate_fails_per_pr_disk_threshold(self):
+        """Gate passes absolute limits but on-disk delta exceeds per-PR threshold."""
+        gate_scenarios = [
+            GateScenario(
+                name=_DEB_GATE,
+                ancestor_disk=100 * _MiB,
+                ancestor_wire=50 * _MiB,
+                current_disk=100 * _MiB + 700 * _KiB,  # > PER_PR_THRESHOLD (600 KiB)
+                current_wire=50 * _MiB,
+                max_disk=105 * _MiB,
+                max_wire=55 * _MiB,
+            ),
+            GateScenario(
+                name=_DOCKER_GATE,
+                ancestor_disk=600 * _MiB,
+                ancestor_wire=240 * _MiB,
+                current_disk=600 * _MiB + 20 * _KiB,
+                current_wire=240 * _MiB,
+                max_disk=700 * _MiB,
+                max_wire=250 * _MiB,
+            ),
+        ]
+        with (
+            patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
+            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
+            patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
+            _gate_scenarios(*gate_scenarios) as gate_fixture,
+            patch(
+                "tasks.libs.common.datadog_api.query_gate_metrics_for_commit",
+                return_value=gate_fixture.ancestor_metrics,
+            ),
+            patch("tasks.static_quality_gates.gates.send_metrics"),
+            patch(
+                "tasks.static_quality_gates.gates.PackageArtifactMeasurer.measure",
+                side_effect=gate_fixture.package_measure,
+            ),
+            patch(
+                "tasks.static_quality_gates.gates.DockerArtifactMeasurer.measure",
+                side_effect=gate_fixture.docker_measure,
+            ),
+            patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
+            patch(
+                "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
+            ) as mock_generate_reports,
+        ):
+            ctx = MockContext(
+                run={"datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done")}
+            )
+            with self.assertRaises(Exit):
+                parse_and_trigger_gates(ctx, gate_fixture.config_path)
+            mock_generate_reports.assert_called_once()
+            mock_pr_commenter.assert_called_once()
+
+    @patch.dict('os.environ', _PR_ENV_VARS, clear=True)
+    def test_gate_fails_per_pr_disk_threshold_exception_approval(self):
+        """Gate exceeds per-PR threshold but an exception approver has approved, making it pass"""
+        approved_pr = SimpleNamespace(
+            number=12345,
+            title="fix(somewhere): did something",
+            user=SimpleNamespace(login="some-author"),
+            get_reviews=lambda: [SimpleNamespace(state="APPROVED", user=SimpleNamespace(login="cmourot"))],
+        )
+        gate_scenarios = [
+            GateScenario(
+                name=_DEB_GATE,
+                ancestor_disk=100 * _MiB,
+                ancestor_wire=50 * _MiB,
+                current_disk=100 * _MiB + 700 * _KiB,
+                current_wire=50 * _MiB,
+                max_disk=105 * _MiB,
+                max_wire=55 * _MiB,
+            ),
+            GateScenario(
+                name=_DOCKER_GATE,
+                ancestor_disk=600 * _MiB,
+                ancestor_wire=240 * _MiB,
+                current_disk=600 * _MiB + 20 * _KiB,
+                current_wire=240 * _MiB,
+                max_disk=700 * _MiB,
+                max_wire=250 * _MiB,
+            ),
+        ]
+        with (
+            patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
+            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
+            patch("tasks.quality_gates.get_pr_for_branch", return_value=approved_pr),
+            _gate_scenarios(*gate_scenarios) as gate_fixture,
+            patch(
+                "tasks.libs.common.datadog_api.query_gate_metrics_for_commit",
+                return_value=gate_fixture.ancestor_metrics,
+            ),
+            patch("tasks.static_quality_gates.gates.send_metrics"),
+            patch(
+                "tasks.static_quality_gates.gates.PackageArtifactMeasurer.measure",
+                side_effect=gate_fixture.package_measure,
+            ),
+            patch(
+                "tasks.static_quality_gates.gates.DockerArtifactMeasurer.measure",
+                side_effect=gate_fixture.docker_measure,
+            ),
+            patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
+            patch(
+                "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
+            ) as mock_generate_reports,
+        ):
+            ctx = MockContext(
+                run={"datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done")}
+            )
+            parse_and_trigger_gates(ctx, gate_fixture.config_path)
+            mock_generate_reports.assert_called_once()
+            mock_pr_commenter.assert_called_once()
+            self.assertIs(mock_pr_commenter.call_args.kwargs["pr"], approved_pr)
 
     @patch.dict(
         'os.environ',

--- a/tasks/unit_tests/static_quality_gates/tasks_tests.py
+++ b/tasks/unit_tests/static_quality_gates/tasks_tests.py
@@ -70,7 +70,7 @@ _MiB = 1024 * _KiB
 
 @dataclass
 class GateScenario:
-    """Represents the desired state of a gate, for use with the _gate_scenarios fixture."""
+    """Represents the desired state of a gate, for use with the _gate_scenarios_fixture fixture."""
 
     name: str
     current_disk: int
@@ -82,7 +82,7 @@ class GateScenario:
 
 
 @contextmanager
-def _gate_scenarios(*scenarios: GateScenario, ancestor_sha="ancestor-sha"):
+def _gate_scenarios_fixture(*scenarios: GateScenario, ancestor_sha="ancestor-sha"):
     """
     Context manager that wires up gate scenarios for integration tests.
 
@@ -168,10 +168,10 @@ class TestQualityGatesIntegration(unittest.TestCase):
             ),
         ]
         with (
+            _gate_scenarios_fixture(*gate_scenarios) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
-            _gate_scenarios(*gate_scenarios) as config_path,
             patch("tasks.static_quality_gates.gates.send_metrics") as mock_send_metrics,
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
             patch(
@@ -247,10 +247,10 @@ class TestQualityGatesIntegration(unittest.TestCase):
             ),
         ]
         with (
+            _gate_scenarios_fixture(*gate_scenarios) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
-            _gate_scenarios(*gate_scenarios) as config_path,
             patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_relative_size"),
             patch(
                 "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
@@ -290,10 +290,10 @@ class TestQualityGatesIntegration(unittest.TestCase):
             ),
         ]
         with (
+            _gate_scenarios_fixture(*gate_scenarios) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
-            _gate_scenarios(*gate_scenarios) as config_path,
             patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_relative_size"),
             patch(
                 "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
@@ -334,10 +334,10 @@ class TestQualityGatesIntegration(unittest.TestCase):
             ),
         ]
         with (
+            _gate_scenarios_fixture(*gate_scenarios) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
-            _gate_scenarios(*gate_scenarios) as config_path,
             patch("tasks.static_quality_gates.gates.send_metrics"),
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
             patch(
@@ -382,10 +382,10 @@ class TestQualityGatesIntegration(unittest.TestCase):
             ),
         ]
         with (
+            _gate_scenarios_fixture(*gate_scenarios) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.quality_gates.get_pr_for_branch", return_value=approved_pr),
-            _gate_scenarios(*gate_scenarios) as config_path,
             patch("tasks.static_quality_gates.gates.send_metrics"),
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
             patch(

--- a/tasks/unit_tests/static_quality_gates/tasks_tests.py
+++ b/tasks/unit_tests/static_quality_gates/tasks_tests.py
@@ -35,6 +35,7 @@ _PR_BRANCH_NAME = "feature/branch"
 _PR_BUCKET_BRANCH = 'dev'
 _CI_PIPELINE_ID = '999999999'
 _CI_COMMIT_SHA = '1234567890abcdef'
+_ANCESTOR_SHA = 'ancestor-sha'
 
 
 _PR_ENV_VARS = {
@@ -82,7 +83,7 @@ class GateScenario:
 
 
 @contextmanager
-def _gate_scenarios_fixture(*scenarios: GateScenario, ancestor_sha="ancestor-sha"):
+def _gate_scenarios_fixture(*scenarios: GateScenario, ancestor_sha: str):
     """
     Context manager that wires up gate scenarios for integration tests.
 
@@ -168,8 +169,8 @@ class TestQualityGatesIntegration(unittest.TestCase):
             ),
         ]
         with (
-            _gate_scenarios_fixture(*gate_scenarios) as config_path,
-            patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
+            _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
+            patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
             patch("tasks.static_quality_gates.gates.send_metrics") as mock_send_metrics,
@@ -247,8 +248,8 @@ class TestQualityGatesIntegration(unittest.TestCase):
             ),
         ]
         with (
-            _gate_scenarios_fixture(*gate_scenarios) as config_path,
-            patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
+            _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
+            patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
             patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_relative_size"),
@@ -290,8 +291,8 @@ class TestQualityGatesIntegration(unittest.TestCase):
             ),
         ]
         with (
-            _gate_scenarios_fixture(*gate_scenarios) as config_path,
-            patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
+            _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
+            patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
             patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_relative_size"),
@@ -334,8 +335,8 @@ class TestQualityGatesIntegration(unittest.TestCase):
             ),
         ]
         with (
-            _gate_scenarios_fixture(*gate_scenarios) as config_path,
-            patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
+            _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
+            patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
             patch("tasks.static_quality_gates.gates.send_metrics"),
@@ -382,8 +383,8 @@ class TestQualityGatesIntegration(unittest.TestCase):
             ),
         ]
         with (
-            _gate_scenarios_fixture(*gate_scenarios) as config_path,
-            patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
+            _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
+            patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
             patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.quality_gates.get_pr_for_branch", return_value=approved_pr),
             patch("tasks.static_quality_gates.gates.send_metrics"),

--- a/tasks/unit_tests/static_quality_gates/tasks_tests.py
+++ b/tasks/unit_tests/static_quality_gates/tasks_tests.py
@@ -228,6 +228,128 @@ class TestQualityGatesIntegration(unittest.TestCase):
     @patch.dict(
         'os.environ',
         {
+            'BUCKET_BRANCH': _PR_BUCKET_BRANCH,
+            'CI_COMMIT_BRANCH': _PR_BRANCH_NAME,
+            'CI_COMMIT_REF_SLUG': gitlab_ref_slug(_PR_BRANCH_NAME),
+            'CI_PIPELINE_ID': _CI_PIPELINE_ID,
+            'CI_COMMIT_SHA': _CI_COMMIT_SHA,
+        },
+        clear=True,
+    )
+    def test_gate_fails_absolute_disk_limit(self):
+        gate_scenarios = [
+            GateScenario(
+                name=_DEB_GATE,
+                ancestor_disk=100 * _MiB,
+                ancestor_wire=50 * _MiB,
+                current_disk=110 * _MiB,  # exceeds max_disk
+                current_wire=50 * _MiB,
+                max_disk=105 * _MiB,
+                max_wire=55 * _MiB,
+            ),
+            GateScenario(
+                name=_DOCKER_GATE,
+                ancestor_disk=600 * _MiB,
+                ancestor_wire=240 * _MiB,
+                current_disk=600 * _MiB + 20 * _KiB,
+                current_wire=240 * _MiB,
+                max_disk=700 * _MiB,
+                max_wire=250 * _MiB,
+            ),
+        ]
+        with (
+            patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
+            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
+            patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
+            _gate_scenarios(*gate_scenarios) as gate_fixture,
+            patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_relative_size"),
+            patch(
+                "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
+            ) as mock_generate_reports,
+            patch("tasks.static_quality_gates.gates.send_metrics") as mock_send_metrics,
+            patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
+            patch(
+                "tasks.static_quality_gates.gates.PackageArtifactMeasurer.measure",
+                side_effect=gate_fixture.package_measure,
+            ),
+            patch(
+                "tasks.static_quality_gates.gates.DockerArtifactMeasurer.measure",
+                side_effect=gate_fixture.docker_measure,
+            ),
+        ):
+            ctx = MockContext(
+                run={"datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done")}
+            )
+            with self.assertRaises(Exit):
+                parse_and_trigger_gates(ctx, gate_fixture.config_path)
+            mock_send_metrics.assert_called_once()
+            mock_generate_reports.assert_called_once()
+            mock_pr_commenter.assert_called_once()
+
+    @patch.dict(
+        'os.environ',
+        {
+            'BUCKET_BRANCH': _PR_BUCKET_BRANCH,
+            'CI_COMMIT_BRANCH': _PR_BRANCH_NAME,
+            'CI_COMMIT_REF_SLUG': gitlab_ref_slug(_PR_BRANCH_NAME),
+            'CI_PIPELINE_ID': _CI_PIPELINE_ID,
+            'CI_COMMIT_SHA': _CI_COMMIT_SHA,
+        },
+        clear=True,
+    )
+    def test_gate_fails_absolute_wire_limit(self):
+        gate_scenarios = [
+            GateScenario(
+                name=_DEB_GATE,
+                ancestor_disk=100 * _MiB,
+                ancestor_wire=50 * _MiB,
+                current_disk=100 * _MiB + 20 * _KiB,
+                current_wire=60 * _MiB,  # exceeds max_wire
+                max_disk=105 * _MiB,
+                max_wire=55 * _MiB,
+            ),
+            GateScenario(
+                name=_DOCKER_GATE,
+                ancestor_disk=600 * _MiB,
+                ancestor_wire=240 * _MiB,
+                current_disk=600 * _MiB + 20 * _KiB,
+                current_wire=240 * _MiB,
+                max_disk=700 * _MiB,
+                max_wire=250 * _MiB,
+            ),
+        ]
+        with (
+            patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha"),
+            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
+            patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
+            _gate_scenarios(*gate_scenarios) as gate_fixture,
+            patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_relative_size"),
+            patch(
+                "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
+            ) as mock_generate_reports,
+            patch("tasks.static_quality_gates.gates.send_metrics") as mock_send_metrics,
+            patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
+            patch(
+                "tasks.static_quality_gates.gates.PackageArtifactMeasurer.measure",
+                side_effect=gate_fixture.package_measure,
+            ),
+            patch(
+                "tasks.static_quality_gates.gates.DockerArtifactMeasurer.measure",
+                side_effect=gate_fixture.docker_measure,
+            ),
+        ):
+            ctx = MockContext(
+                run={"datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done")}
+            )
+            with self.assertRaises(Exit):
+                parse_and_trigger_gates(ctx, gate_fixture.config_path)
+            mock_send_metrics.assert_called_once()
+            mock_generate_reports.assert_called_once()
+            mock_pr_commenter.assert_called_once()
+
+    @patch.dict(
+        'os.environ',
+        {
             'CI_COMMIT_REF_NAME': 'pikachu',
             'CI_COMMIT_BRANCH': 'sequoia',
             'CI_COMMIT_REF_SLUG': 'pikachu',


### PR DESCRIPTION
### What does this PR do?

It adds tests to exercise scenarios for the `parse_and_trigger_gates` task (implementing the static quality gates as such) covering the entire task, and adds common fixtures to support this sort of testing.

The scenarios tested are all for PR cases, for which we test:
- "Happy path" where gates pass.
- Gate failure due to exceeding absolute limit (on-disk and on-wire separately).
- Scenarios testing #48477 (per-PR relative limit violation, with and without approval).

### Motivation

Making the changes to implement [ABLD-450](https://datadoghq.atlassian.net/browse/ABLD-450) with more confidence. A lot of the logic is implemented at this function's level and thus mostly untested, and refactors I'm looking at would make existing unit test coverage irrelevant.

### Describe how you validated your changes

Passing tests.

### Additional Notes

The creation of test-level abstractions and relative heavyweight is to make up for the lack of proper abstractions and seams in the code under test. The selected "seams" to inject fakes and mocks makes the tests a bit noisy but hopefully allows for future refactors to be done with reasonable confidence.

[ABLD-450]: https://datadoghq.atlassian.net/browse/ABLD-450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ