### PR TITLE
[Backport 7.79.x] Bump rshell dependency from v0.0.13 to v0.0.14 (#49958)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -969,7 +969,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.79.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace v0.79.0-rc.3
 	github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5
-	github.com/DataDog/rshell v0.0.13
+	github.com/DataDog/rshell v0.0.14
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8
 	github.com/aymerick/raymond v2.0.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2598,8 +2598,8 @@ github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816 h1:8diKw2aLYE6LsjWfYxD
 github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816/go.mod h1:7cPuErOAt7k/oVWAVJnxqAC6mwArrAazkvk0RXiih2A=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260317195537-817b91eb7dd4 h1:9+K8vjF7sQSLjVJporNyv6nw46cMg/Q8ogxbBZmrf+A=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260317195537-817b91eb7dd4/go.mod h1:KEBv+q78RzBcDPNFm1WB0V0za14gY95E/Atp3dJZ/8M=
-github.com/DataDog/rshell v0.0.13 h1:fPb2Zmpjx6vhLMG7LThgz6mnVo2eNy9Gdcn1+00HXEo=
-github.com/DataDog/rshell v0.0.13/go.mod h1:r2pK0NQpE1SL+ESYjlfhigWDEELPY5LacwLbisR9nxI=
+github.com/DataDog/rshell v0.0.14 h1:1BJxm8FQ0uZ6amxItyKmlG4e2y2CPTNvjxtY/Nx1Pg0=
+github.com/DataDog/rshell v0.0.14/go.mod h1:r2pK0NQpE1SL+ESYjlfhigWDEELPY5LacwLbisR9nxI=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=
 github.com/DataDog/sketches-go v1.4.8/go.mod h1:a/wjRUqzqtGS8qRHRPDCs4EAQfmvPDZGDlMIF5mxXOE=
 github.com/DataDog/trivy v0.0.0-20260407220859-6cf8ddc1826c h1:oiwmRrkRVblZBI3SFVEnrwxkQ28W7nmwwI/VHgex0ZU=

--- a/releasenotes/notes/bump-rshell-v0.0.14-9f648c7f74024a46.yaml
+++ b/releasenotes/notes/bump-rshell-v0.0.14-9f648c7f74024a46.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Bump ``rshell`` to v0.0.14.


### PR DESCRIPTION
Backport of #49958 to `7.79.x`.

### What does this PR do?

- Bumps `github.com/DataDog/rshell` from `v0.0.13` to `v0.0.14`. No call-site changes.

### Motivation

- v0.0.13..v0.0.14 contains a single commit, [DataDog/rshell#200](https://github.com/DataDog/rshell/pull/200), which adds an opt-in `interp.WarningsWriter(io.Writer)` option and a `Runner.Warnings() []string` accessor. Today's PAR rshell handler does not pass either, so behaviour is byte-for-byte unchanged: sandbox warnings continue to fall back to `r.stderr`, which is where the handler already routes them.
- Backporting keeps `7.79.x` aligned with `main` so the follow-up PR wiring `runner.Warnings()` into `RunCommandOutputs.SandboxWarnings` can be cherry-picked cleanly without `go.mod`/`go.sum` noise.

### Describe how you validated your changes

- Cherry-picked `e083f5b19df2121690b8f9924fae312468bc4cb1` from `main`. Conflict in `go.sum` (expected — branch had drifted on unrelated deps); resolved by keeping the `7.79.x` baseline and running `dda inv tidy`, which reconciled it to swap only the `DataDog/rshell` entries from v0.0.13 → v0.0.14.
- `git diff` confirms only `go.mod`, `go.sum` (rshell entries only), and the new release note changed.

### Additional Notes

- Original PR: #49958 (merge commit `e083f5b19df2121690b8f9924fae312468bc4cb1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)