### PR TITLE
chore: add octo-sts push-branch policy for deps-tidy workflow

### DIFF
--- a/.github/chainguard/self.deps-tidy.push-branch.sts.yaml
+++ b/.github/chainguard/self.deps-tidy.push-branch.sts.yaml
@@ -1,0 +1,12 @@
+---
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-agent:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  ref: refs/pull/[0-9]+/merge
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/deps-tidy\.yml@refs/pull/[0-9]+/merge
+
+permissions:
+  contents: write


### PR DESCRIPTION
## Summary
- Adds `.github/chainguard/self.deps-tidy.push-branch.sts.yaml` covering the new unified `deps-tidy.yml` workflow
- Existing `self.cargo-bazel-tidy.push-branch.sts.yaml` and `self.go-mod-tidy.push-branch.sts.yaml` are left untouched (removed in PR#3)
- **Must be merged before PR#3** so the new workflow has its policy in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)