### PR TITLE
[AGENTRUN-1273] packaging/aix: create /etc/datadog-agent/checks.d at install time

### DIFF
--- a/packaging/aix/stages/10-assemble.sh
+++ b/packaging/aix/stages/10-assemble.sh
@@ -131,6 +131,7 @@ mkdir -p "$STAGING/var/run/datadog"
 mkdir -p "$STAGING/opt/datadog-agent/run"
 mkdir -p "$STAGING/opt/datadog-agent/checks.d"
 mkdir -p "$STAGING/opt/datadog-agent/conf.d"
+mkdir -p "$STAGING/etc/datadog-agent/checks.d"
 log "Runtime directories created"
 
 # ─── Step 4: Copy package lifecycle scripts into the staging tree ──────────────


### PR DESCRIPTION
### What does this PR do?

Adds `mkdir -p "$STAGING/etc/datadog-agent/checks.d"` to the AIX packaging stage 10 (assemble).

### Motivation

The agent advertises `/etc/datadog-agent/checks.d` as the location for user custom Python checks (`additional_checksd` config, `checks.d:` in `agent status`), but the AIX installp package never created that directory. Users had no obvious place to put custom checks without manual intervention.

Linux deb/rpm packages include this directory in their package manifests so it exists out of the box after installation. This aligns AIX with that behaviour.

Note: `/opt/datadog-agent/checks.d` is a separate path used for legacy integrations-core checks (`PyChecksPath`) and is already created correctly.

### Describe how you validated your changes

Installed the AIX package on an AIX 7.2 TL2 host and confirmed `/etc/datadog-agent/checks.d` exists after installation. Placed a custom check there and verified it was picked up by the agent.

### Additional Notes

N/A