### PR TITLE
Fix SQL obfuscator error on PostgreSQL array slice syntax with bind parameters

### DIFF
--- a/pkg/obfuscate/sql_test.go
+++ b/pkg/obfuscate/sql_test.go
@@ -3009,3 +3009,48 @@ func TestObfuscatorCacheKey(t *testing.T) {
 	assert.NotEqual(t, oq4.Query, oq.Query)
 	assert.Equal(t, obfuscator.queryCache.Metrics.Hits(), uint64(1))
 }
+
+// TestPostgresArraySliceObfuscation reproduces https://github.com/DataDog/datadog-agent/issues/49460.
+// PostgreSQL array slice syntax uses ':' as a range separator (e.g. arr[1:3], arr[$1:]).
+// The tokenizer mistakenly treats the ':' as the start of a bind variable (":name" form),
+// causing a LexError when the character after ':' is ']' or '$'.
+func TestPostgresArraySliceObfuscation(t *testing.T) {
+	o := NewObfuscator(Config{SQL: SQLConfig{DBMS: DBMSPostgres}})
+	for _, tt := range []struct {
+		in  string
+		out string
+	}{
+		// open upper bound: ':' followed by ']' — the minimal failing case
+		{
+			`SELECT arr[1:] FROM t`,
+			`SELECT arr [ ? : ] FROM t`,
+		},
+		// bind param as lower bound with open upper bound
+		{
+			`SELECT arr[$1:] FROM t`,
+			`SELECT arr [ ? : ] FROM t`,
+		},
+		// both bounds are bind params: ':' followed by '$'
+		{
+			`SELECT arr[$1:$2] FROM t`,
+			`SELECT arr [ ? : ? ] FROM t`,
+		},
+		// open lower bound: ':' followed by a digit still scans ':3' as a ValueArg
+		// (pre-existing quirk, not changed by this fix).
+		{
+			`SELECT arr[:3] FROM t`,
+			`SELECT arr [ :3 ] FROM t`,
+		},
+		// full query from the bug report (condensed to the problematic expression)
+		{
+			`SELECT river_job.attempted_by[$1:] FROM river_job`,
+			`SELECT river_job.attempted_by [ ? : ] FROM river_job`,
+		},
+	} {
+		t.Run(tt.in, func(t *testing.T) {
+			oq, err := o.ObfuscateSQLString(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.out, oq.Query)
+		})
+	}
+}

--- a/pkg/obfuscate/sql_tokenizer.go
+++ b/pkg/obfuscate/sql_tokenizer.go
@@ -301,6 +301,13 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 				// example scenario: "autovacuum: VACUUM ANALYZE fake.table"
 				return TokenKind(ch), tkn.bytes()
 			}
+			// PostgreSQL array slice syntax uses ':' as a range separator inside
+			// subscripts (e.g. arr[$1:] or arr[$1:$2]).  ']' and '$' can never
+			// begin a named bind variable, so treat ':' as a plain token here
+			// rather than erroring inside scanBindVar.
+			if tkn.lastChar == ']' || tkn.lastChar == '$' {
+				return TokenKind(ch), tkn.bytes()
+			}
 			if tkn.lastChar != '=' {
 				return tkn.scanBindVar()
 			}

--- a/releasenotes/notes/apm-fix-postgres-array-slice-obfuscation-288fc3b723a577db.yaml
+++ b/releasenotes/notes/apm-fix-postgres-array-slice-obfuscation-288fc3b723a577db.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    APM : Fix SQL obfuscation error when a query uses PostgreSQL array slice syntax
+    with bind parameters (e.g. ``arr[$1:]`` or ``arr[$1:$2]``). The tokenizer was
+    incorrectly treating the ``:`` range separator as the start of a named bind
+    variable, causing obfuscation to fail with a ``LexError``.


### PR DESCRIPTION
### What does this PR do?

Fixes a `LexError` in the SQL obfuscator when processing PostgreSQL queries that use array slice syntax with bind parameters (e.g. `arr[$1:]` or `arr[$1:$2]`).

The change is a one-line guard in `pkg/obfuscate/sql_tokenizer.go`: when the tokenizer encounters `:` followed by `]` or `$`, it now returns a plain colon token instead of calling `scanBindVar()`. Those two characters can never begin a named bind variable, so the `:` is the PostgreSQL array range separator and should be passed through as-is.

### Motivation

Fixes https://github.com/DataDog/datadog-agent/issues/49460.

Queries that use the PostgreSQL [array slice syntax](https://www.postgresql.org/docs/current/arrays.html#ARRAYS-ACCESSING) with a bind parameter as a bound — such as `river_job.attempted_by[array_length(...) + 2 - $2:]` — would fail obfuscation entirely, logging repeated errors of the form:

```
bind variables should start with letters or digits, got "]" (93)
```

This caused the span resource to be dropped rather than obfuscated.

### Describe how you validated your changes

- Added `TestPostgresArraySliceObfuscation` in `pkg/obfuscate/sql_test.go` covering the three failing patterns from the issue (`arr[1:]`, `arr[$1:]`, `arr[$1:$2]`) plus a regression case and the exact expression from the bug report. All were confirmed failing before the fix and passing after.
- Full `pkg/obfuscate` test suite passes with no regressions (including `TestSQLErrors` which covers the `:.name` malformed-bind-variable error path, which is intentionally preserved).
- `golangci-lint` reports 0 issues.

### Additional Notes

The case `arr[:3]` (`:` followed by a digit) still routes through `scanBindVar()` and produces `:3` as a `ValueArg` token — a pre-existing quirk that is out of scope for this fix. It does not cause an error and does not expose sensitive literal values.