### PR TITLE
coord run-log (full) — 2026-04-29 18:16

### DIFF
--- a/comp/observer/impl/anomaly_correlator_anomaly_rank.go
+++ b/comp/observer/impl/anomaly_correlator_anomaly_rank.go
@@ -1,0 +1,260 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// AnomalyRankConfig configures the AnomalyRankCorrelator.
+//
+// AnomalyRank is a watchdog-style post-filter on raw anomalies: it sits
+// alongside the other correlators, ingests the same per-anomaly stream, and
+// re-emits only the highest-ranked anomalies per detector per window. Its
+// purpose is to suppress weak / borderline detections rather than create new
+// ones — see the SIGMOD 2020 paper "AnomalyRank: A Two-Stage Anomaly Detection
+// System" and Datadog's watchdog blog post.
+type AnomalyRankConfig struct {
+	// WindowSeconds is the rolling window the correlator considers. Anomalies
+	// older than (currentDataTs - WindowSeconds) are evicted on Advance.
+	// Default: 60.
+	WindowSeconds int64 `json:"window_seconds"`
+	// TopKPerDetector caps the number of anomalies emitted per detector per
+	// ActiveCorrelations call. Default: 8.
+	TopKPerDetector int `json:"top_k_per_detector"`
+	// MinScore is a hard floor: anomalies with rankScore < MinScore are
+	// dropped at ProcessAnomaly time and never tracked. Default: 0 (disabled).
+	MinScore float64 `json:"min_score"`
+	// QuantileFloor is a dynamic floor: only anomalies in the top
+	// QuantileFloor fraction of seen scores in the window are emitted.
+	// Default: 0.5 (top half). Set to 1.0 to disable quantile gating.
+	QuantileFloor float64 `json:"quantile_floor"`
+}
+
+// DefaultAnomalyRankConfig returns the canonical default AnomalyRankConfig.
+func DefaultAnomalyRankConfig() AnomalyRankConfig {
+	return AnomalyRankConfig{
+		WindowSeconds:   60,
+		TopKPerDetector: 8,
+		MinScore:        0,
+		QuantileFloor:   0.5,
+	}
+}
+
+// rankedAnomaly pairs an anomaly with its precomputed rank score so we don't
+// recompute on every ActiveCorrelations sort.
+type rankedAnomaly struct {
+	anomaly observer.Anomaly
+	score   float64
+	ts      int64
+}
+
+// rankBuffer is a per-detector ring of anomalies in arrival order. It is
+// trimmed on Advance based on timestamp; ActiveCorrelations sorts a copy.
+type rankBuffer struct {
+	items []rankedAnomaly
+}
+
+// AnomalyRankCorrelator implements a top-K-per-detector post-filter on the
+// raw anomaly stream. It is purely additive: it cannot create anomalies, only
+// suppress weak ones. The hot path runs only on detection events
+// (ProcessAnomaly), so ticks where no detector fires incur zero overhead.
+type AnomalyRankCorrelator struct {
+	cfg           AnomalyRankConfig
+	perDetector   map[string]*rankBuffer
+	currentDataTs int64
+	mu            sync.RWMutex
+}
+
+// NewAnomalyRankCorrelator returns a configured AnomalyRankCorrelator.
+// Zero-valued config fields fall back to the documented defaults.
+func NewAnomalyRankCorrelator(cfg AnomalyRankConfig) *AnomalyRankCorrelator {
+	if cfg.WindowSeconds <= 0 {
+		cfg.WindowSeconds = 60
+	}
+	if cfg.TopKPerDetector <= 0 {
+		cfg.TopKPerDetector = 8
+	}
+	// QuantileFloor is allowed to be 0 (= emit nothing) explicitly via JSON,
+	// but a struct-zero default is treated as "use the documented default".
+	// Distinguish "set to 0.0 deliberately" from "unset" is awkward without a
+	// pointer; we rely on the catalog's DefaultAnomalyRankConfig() seeding 0.5
+	// before JSON unmarshal overlays caller values, so this branch only fires
+	// for callers who construct the config directly with the zero struct.
+	if cfg.QuantileFloor == 0 {
+		cfg.QuantileFloor = 0.5
+	}
+	if cfg.QuantileFloor > 1 {
+		cfg.QuantileFloor = 1
+	}
+	return &AnomalyRankCorrelator{
+		cfg:         cfg,
+		perDetector: make(map[string]*rankBuffer),
+	}
+}
+
+// Name returns the correlator name.
+func (c *AnomalyRankCorrelator) Name() string {
+	return "anomaly_rank_correlator"
+}
+
+// rankScore returns a comparable float for an anomaly. Order of preference:
+// explicit Score field, |DeviationSigma| from DebugInfo, else 0. This
+// single-source helper keeps rank semantics consistent everywhere.
+func rankScore(a observer.Anomaly) float64 {
+	if a.Score != nil {
+		return *a.Score
+	}
+	if a.DebugInfo != nil {
+		return math.Abs(a.DebugInfo.DeviationSigma)
+	}
+	return 0
+}
+
+// ProcessAnomaly accumulates an anomaly into its detector's window buffer.
+// Anomalies below MinScore are dropped without being tracked.
+func (c *AnomalyRankCorrelator) ProcessAnomaly(a observer.Anomaly) {
+	score := rankScore(a)
+	if score < c.cfg.MinScore {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if a.Timestamp > c.currentDataTs {
+		c.currentDataTs = a.Timestamp
+	}
+
+	rb, ok := c.perDetector[a.DetectorName]
+	if !ok {
+		rb = &rankBuffer{}
+		c.perDetector[a.DetectorName] = rb
+	}
+	rb.items = append(rb.items, rankedAnomaly{anomaly: a, score: score, ts: a.Timestamp})
+}
+
+// Advance drops anomalies whose timestamps are older than
+// (currentDataTs - WindowSeconds). Same in-place filter pattern as
+// TimeClusterCorrelator.evictOldClustersLocked.
+func (c *AnomalyRankCorrelator) Advance(dataTime int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if dataTime > c.currentDataTs {
+		c.currentDataTs = dataTime
+	}
+	cutoff := c.currentDataTs - c.cfg.WindowSeconds
+
+	for det, rb := range c.perDetector {
+		kept := rb.items[:0]
+		for _, it := range rb.items {
+			if it.ts >= cutoff {
+				kept = append(kept, it)
+			}
+		}
+		rb.items = kept
+		if len(rb.items) == 0 {
+			// Free the detector slot to keep iteration tight when a noisy
+			// detector goes silent for a while.
+			delete(c.perDetector, det)
+		}
+	}
+}
+
+// ActiveCorrelations returns the top-K-per-detector anomalies that survive
+// the QuantileFloor gate, one ActiveCorrelation per surviving anomaly. Each
+// emitted correlation mirrors DetectorPassthroughCorrelator's single-anomaly
+// shape so downstream reporters can score detections individually.
+func (c *AnomalyRankCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// Sort detector names for deterministic ordering across calls.
+	detectors := make([]string, 0, len(c.perDetector))
+	for d := range c.perDetector {
+		detectors = append(detectors, d)
+	}
+	sort.Strings(detectors)
+
+	var result []observer.ActiveCorrelation
+	for _, det := range detectors {
+		rb := c.perDetector[det]
+		if len(rb.items) == 0 {
+			continue
+		}
+
+		// Copy then sort descending by score (stable on ties for determinism).
+		sorted := make([]rankedAnomaly, len(rb.items))
+		copy(sorted, rb.items)
+		sort.SliceStable(sorted, func(i, j int) bool {
+			return sorted[i].score > sorted[j].score
+		})
+
+		// Quantile gate: only emit items whose score falls in the top
+		// QuantileFloor fraction of in-window scores.
+		threshold := -math.MaxFloat64
+		if c.cfg.QuantileFloor < 1 && len(sorted) > 0 {
+			// q is the index such that scores[0..q] are the top
+			// QuantileFloor fraction. floor(len * QuantileFloor) gives the
+			// count of "top" items; clamp to [1, len].
+			count := int(math.Floor(float64(len(sorted)) * c.cfg.QuantileFloor))
+			if count < 1 {
+				count = 1
+			}
+			if count > len(sorted) {
+				count = len(sorted)
+			}
+			threshold = sorted[count-1].score
+		}
+
+		// Take the top min(TopKPerDetector, len) items whose score >= threshold.
+		limit := c.cfg.TopKPerDetector
+		if limit > len(sorted) {
+			limit = len(sorted)
+		}
+		kept := make([]rankedAnomaly, 0, limit)
+		for i := 0; i < limit; i++ {
+			if sorted[i].score < threshold {
+				break
+			}
+			kept = append(kept, sorted[i])
+		}
+
+		// Sort kept items by timestamp ascending so the per-detector emission
+		// order is stable and chronological — easier for reporters to consume.
+		sort.SliceStable(kept, func(i, j int) bool {
+			return kept[i].ts < kept[j].ts
+		})
+
+		for i, ra := range kept {
+			a := ra.anomaly
+			result = append(result, observer.ActiveCorrelation{
+				Pattern:     fmt.Sprintf("anomaly_rank_%s_%d", det, i),
+				Title:       fmt.Sprintf("Ranked[%s]: %s", det, a.Source),
+				Members:     []observer.SeriesDescriptor{a.Source},
+				Anomalies:   []observer.Anomaly{a},
+				FirstSeen:   a.Timestamp,
+				LastUpdated: a.Timestamp,
+			})
+		}
+	}
+
+	return result
+}
+
+// Reset clears all internal state.
+func (c *AnomalyRankCorrelator) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.perDetector = make(map[string]*rankBuffer)
+	c.currentDataTs = 0
+}

--- a/comp/observer/impl/anomaly_correlator_anomaly_rank_test.go
+++ b/comp/observer/impl/anomaly_correlator_anomaly_rank_test.go
@@ -1,0 +1,253 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rankSource is a tiny helper to build a SeriesDescriptor for tests, mirroring
+// the passthroughSource helper in anomaly_correlator_passthrough_test.go.
+func rankSource(name string) observer.SeriesDescriptor {
+	return observer.SeriesDescriptor{Name: name}
+}
+
+// rankAnomaly builds an Anomaly with an explicit Score and Timestamp. The
+// Source is derived from the detector + score so each anomaly has a unique
+// series identity, which keeps downstream Members/Source assertions clean.
+func rankAnomaly(detector string, score float64, ts int64) observer.Anomaly {
+	s := score // local for &
+	return observer.Anomaly{
+		DetectorName: detector,
+		Source:       rankSource("metric.test"),
+		Timestamp:    ts,
+		Score:        &s,
+	}
+}
+
+func TestAnomalyRank_Name(t *testing.T) {
+	c := NewAnomalyRankCorrelator(DefaultAnomalyRankConfig())
+	assert.Equal(t, "anomaly_rank_correlator", c.Name())
+}
+
+func TestAnomalyRank_ImplementsCorrelator(_ *testing.T) {
+	var _ observer.Correlator = NewAnomalyRankCorrelator(DefaultAnomalyRankConfig())
+}
+
+// PassesAllWhenWithinTopK: with TopK=8 and quantile gating disabled, all 3
+// anomalies for one detector are emitted.
+func TestAnomalyRank_PassesAllWhenWithinTopK(t *testing.T) {
+	c := NewAnomalyRankCorrelator(AnomalyRankConfig{
+		WindowSeconds:   60,
+		TopKPerDetector: 8,
+		QuantileFloor:   1.0, // disable quantile gating
+	})
+
+	c.ProcessAnomaly(rankAnomaly("cusum", 1.0, 100))
+	c.ProcessAnomaly(rankAnomaly("cusum", 5.0, 101))
+	c.ProcessAnomaly(rankAnomaly("cusum", 9.0, 102))
+
+	corrs := c.ActiveCorrelations()
+	require.Len(t, corrs, 3)
+	// Emission is timestamp-ascending per detector.
+	assert.Equal(t, int64(100), corrs[0].FirstSeen)
+	assert.Equal(t, int64(101), corrs[1].FirstSeen)
+	assert.Equal(t, int64(102), corrs[2].FirstSeen)
+	// Patterns and titles use the documented format.
+	assert.Equal(t, "anomaly_rank_cusum_0", corrs[0].Pattern)
+	assert.Contains(t, corrs[0].Title, "Ranked[cusum]")
+}
+
+// PrunesBelowQuantile: 10 anomalies with scores 1..10, QuantileFloor=0.5 → top
+// 5 (scores 6..10) survive.
+func TestAnomalyRank_PrunesBelowQuantile(t *testing.T) {
+	c := NewAnomalyRankCorrelator(AnomalyRankConfig{
+		WindowSeconds:   60,
+		TopKPerDetector: 100, // don't let TopK clamp before quantile gate
+		QuantileFloor:   0.5,
+	})
+
+	for i := 1; i <= 10; i++ {
+		c.ProcessAnomaly(rankAnomaly("cusum", float64(i), int64(100+i)))
+	}
+
+	corrs := c.ActiveCorrelations()
+	require.Len(t, corrs, 5)
+
+	// Each correlation wraps a single anomaly; collect their scores.
+	got := make([]float64, 0, len(corrs))
+	for _, c := range corrs {
+		require.Len(t, c.Anomalies, 1)
+		require.NotNil(t, c.Anomalies[0].Score)
+		got = append(got, *c.Anomalies[0].Score)
+	}
+	// Order is timestamp-ascending; scores 6..10 were inserted at ts 106..110.
+	assert.Equal(t, []float64{6, 7, 8, 9, 10}, got)
+}
+
+// PerDetectorTopK: 12 anomalies for "scanmw" plus 12 for "bocpd"; TopK=4,
+// QuantileFloor=1 → exactly 4 from each detector.
+func TestAnomalyRank_PerDetectorTopK(t *testing.T) {
+	c := NewAnomalyRankCorrelator(AnomalyRankConfig{
+		WindowSeconds:   600,
+		TopKPerDetector: 4,
+		QuantileFloor:   1.0,
+	})
+
+	for i := 1; i <= 12; i++ {
+		c.ProcessAnomaly(rankAnomaly("scanmw", float64(i), int64(100+i)))
+		c.ProcessAnomaly(rankAnomaly("bocpd", float64(i), int64(200+i)))
+	}
+
+	corrs := c.ActiveCorrelations()
+	// 4 from each = 8 total.
+	require.Len(t, corrs, 8)
+
+	perDetector := map[string]int{}
+	for _, ac := range corrs {
+		require.Len(t, ac.Anomalies, 1)
+		perDetector[ac.Anomalies[0].DetectorName]++
+	}
+	assert.Equal(t, 4, perDetector["scanmw"])
+	assert.Equal(t, 4, perDetector["bocpd"])
+}
+
+// AdvanceEvicts: anomaly at ts=10, Advance(80) with WindowSeconds=60 → cutoff
+// is 20 → buffer becomes empty.
+func TestAnomalyRank_AdvanceEvicts(t *testing.T) {
+	c := NewAnomalyRankCorrelator(AnomalyRankConfig{
+		WindowSeconds:   60,
+		TopKPerDetector: 8,
+		QuantileFloor:   1.0,
+	})
+
+	c.ProcessAnomaly(rankAnomaly("cusum", 5.0, 10))
+	require.Len(t, c.ActiveCorrelations(), 1)
+
+	c.Advance(80)
+	assert.Empty(t, c.ActiveCorrelations(), "anomaly older than cutoff should be evicted")
+}
+
+// AdvanceKeepsInsideWindow: an anomaly inside the window survives Advance.
+func TestAnomalyRank_AdvanceKeepsInsideWindow(t *testing.T) {
+	c := NewAnomalyRankCorrelator(AnomalyRankConfig{
+		WindowSeconds:   60,
+		TopKPerDetector: 8,
+		QuantileFloor:   1.0,
+	})
+
+	c.ProcessAnomaly(rankAnomaly("cusum", 5.0, 50))
+	c.Advance(80) // cutoff = 80 - 60 = 20; ts=50 >= 20, so keep
+	require.Len(t, c.ActiveCorrelations(), 1)
+}
+
+// MinScoreFloor: ProcessAnomaly drops anomalies below MinScore.
+func TestAnomalyRank_MinScoreFloor(t *testing.T) {
+	c := NewAnomalyRankCorrelator(AnomalyRankConfig{
+		WindowSeconds:   60,
+		TopKPerDetector: 8,
+		MinScore:        1.0,
+		QuantileFloor:   1.0,
+	})
+
+	c.ProcessAnomaly(rankAnomaly("cusum", 0.1, 100))
+	assert.Empty(t, c.ActiveCorrelations(), "score below MinScore should be dropped")
+	assert.Empty(t, c.perDetector, "MinScore-rejected anomalies must not be tracked")
+}
+
+// HandlesMissingScore: nil Score and nil DebugInfo → rankScore returns 0.
+// MinScore=0 keeps it; MinScore>0 drops it.
+func TestAnomalyRank_HandlesMissingScore(t *testing.T) {
+	t.Run("kept when MinScore=0", func(t *testing.T) {
+		c := NewAnomalyRankCorrelator(AnomalyRankConfig{
+			WindowSeconds:   60,
+			TopKPerDetector: 8,
+			MinScore:        0,
+			QuantileFloor:   1.0,
+		})
+		c.ProcessAnomaly(observer.Anomaly{
+			DetectorName: "cusum",
+			Source:       rankSource("m"),
+			Timestamp:    100,
+			// Score nil, DebugInfo nil → rankScore = 0
+		})
+		require.Len(t, c.ActiveCorrelations(), 1)
+	})
+
+	t.Run("dropped when MinScore>0", func(t *testing.T) {
+		c := NewAnomalyRankCorrelator(AnomalyRankConfig{
+			WindowSeconds:   60,
+			TopKPerDetector: 8,
+			MinScore:        0.0001,
+			QuantileFloor:   1.0,
+		})
+		c.ProcessAnomaly(observer.Anomaly{
+			DetectorName: "cusum",
+			Source:       rankSource("m"),
+			Timestamp:    100,
+		})
+		assert.Empty(t, c.ActiveCorrelations())
+	})
+}
+
+// rankScore_PrefersExplicitScore: when Score is set, rankScore ignores
+// DebugInfo. When Score is nil, falls back to |DeviationSigma|.
+func TestAnomalyRank_RankScoreFallback(t *testing.T) {
+	score := 3.5
+	a1 := observer.Anomaly{Score: &score, DebugInfo: &observer.AnomalyDebugInfo{DeviationSigma: 99}}
+	assert.InDelta(t, 3.5, rankScore(a1), 1e-9)
+
+	a2 := observer.Anomaly{DebugInfo: &observer.AnomalyDebugInfo{DeviationSigma: -4}}
+	assert.InDelta(t, 4.0, rankScore(a2), 1e-9, "absolute value of DeviationSigma when Score is nil")
+
+	a3 := observer.Anomaly{}
+	assert.InDelta(t, 0.0, rankScore(a3), 1e-9)
+}
+
+// Reset: clears all internal state.
+func TestAnomalyRank_Reset(t *testing.T) {
+	c := NewAnomalyRankCorrelator(AnomalyRankConfig{
+		WindowSeconds:   60,
+		TopKPerDetector: 8,
+		QuantileFloor:   1.0,
+	})
+	c.ProcessAnomaly(rankAnomaly("cusum", 5.0, 100))
+	require.Len(t, c.ActiveCorrelations(), 1)
+
+	c.Reset()
+	assert.Empty(t, c.ActiveCorrelations())
+	assert.Equal(t, int64(0), c.currentDataTs)
+}
+
+// Empty: ActiveCorrelations on a fresh correlator returns no items.
+func TestAnomalyRank_Empty(t *testing.T) {
+	c := NewAnomalyRankCorrelator(DefaultAnomalyRankConfig())
+	assert.Empty(t, c.ActiveCorrelations())
+}
+
+// CatalogRegistration: anomaly_rank is wired into the default catalog as a
+// correlator and is enabled by default.
+func TestAnomalyRank_CatalogRegistration(t *testing.T) {
+	cat := defaultCatalog()
+	var found *componentEntry
+	for i := range cat.entries {
+		if cat.entries[i].name == "anomaly_rank" {
+			found = &cat.entries[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "anomaly_rank must be registered in the default catalog")
+	assert.Equal(t, componentCorrelator, found.kind)
+	assert.True(t, found.defaultEnabled)
+	// Factory must accept the typed config and return a Correlator.
+	inst := found.factory(found.defaultConfig)
+	_, ok := inst.(observer.Correlator)
+	assert.True(t, ok, "anomaly_rank factory must produce an observer.Correlator")
+}

--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -203,6 +203,21 @@ func defaultCatalog() *componentCatalog {
 			},
 			// ---- Correlators ----
 			{
+				name:           "anomaly_rank",
+				displayName:    "AnomalyRank",
+				kind:           componentCorrelator,
+				defaultConfig:  DefaultAnomalyRankConfig(),
+				factory:        func(cfg any) any { return NewAnomalyRankCorrelator(cfg.(AnomalyRankConfig)) },
+				defaultEnabled: true,
+				parseJSON: func(defaults any, raw []byte) (any, error) {
+					cfg := defaults.(AnomalyRankConfig)
+					if err := json.Unmarshal(raw, &cfg); err != nil {
+						return nil, err
+					}
+					return cfg, nil
+				},
+			},
+			{
 				name:           "cross_signal",
 				displayName:    "CrossSignal",
 				kind:           componentCorrelator,


### PR DESCRIPTION
Coordinator harness run-log.

- Mode: `full`
- Scratch branch: `claude/observer-full-20260429T1815`
- PR base: `ella/claude-coordinator-harness` (harness + observer; PR diff = ships only)
- Upstream merge source: `q-branch-observer`
- Started: 2026-04-29T18:16:06

_This PR is the bidirectional control channel: status comments posted by the coordinator; steering comments by the operator. Each shipped candidate becomes one commit on this branch, making the run a self-contained eval-matrix entry diffable against `ella/claude-coordinator-harness`._
