### PR TITLE
coord run-log (full) — 2026-04-29 18:16

### DIFF
--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -33,6 +33,10 @@ type bocpdSeriesState struct {
 	warmupM2     float64   // sum of squared deviations (Welford)
 	warmupBuffer []float64 // buffered values for posterior replay after init
 
+	// warmupFallbackFired is set to true after the z-score warmup fallback has
+	// fired once for this series. Only one warmup anomaly is emitted per series.
+	warmupFallbackFired bool
+
 	// Baseline (set once after warmup).
 	baselineMean   float64
 	baselineStddev float64
@@ -96,6 +100,21 @@ type BOCPDConfig struct {
 	// to exit alert state. Default: 10
 	RecoveryPoints int `json:"recovery_points"`
 
+	// WarmupFallbackEnabled enables the z-score fallback during warmup. When
+	// true, a single anomaly is emitted if a point deviates more than
+	// WarmupZThreshold standard deviations from the running warmup mean once at
+	// least WarmupMinSamples have been collected. Default: true
+	WarmupFallbackEnabled bool `json:"warmup_fallback_enabled"`
+
+	// WarmupMinSamples is the minimum number of warmup points that must be
+	// accumulated before the z-score fallback becomes active. Default: 30
+	WarmupMinSamples int `json:"warmup_min_samples"`
+
+	// WarmupZThreshold is the z-score threshold for the warmup fallback. Only
+	// points deviating at least this many standard deviations from the warmup
+	// mean will trigger the fallback anomaly. Default: 6.0
+	WarmupZThreshold float64 `json:"warmup_z_threshold"`
+
 	// Aggregations to run detection on. Default: [Average, Count]
 	Aggregations []observer.Aggregate `json:"-"`
 }
@@ -103,15 +122,18 @@ type BOCPDConfig struct {
 // DefaultBOCPDConfig returns a BOCPDConfig with default values.
 func DefaultBOCPDConfig() BOCPDConfig {
 	return BOCPDConfig{
-		WarmupPoints:       120,
-		Hazard:             0.05,
-		CPThreshold:        0.6,
-		ShortRunLength:     5,
-		CPMassThreshold:    0.7,
-		MaxRunLength:       200,
-		PriorVarianceScale: 10.0,
-		MinVariance:        1.0,
-		RecoveryPoints:     10,
+		WarmupPoints:          120,
+		Hazard:                0.05,
+		CPThreshold:           0.6,
+		ShortRunLength:        5,
+		CPMassThreshold:       0.7,
+		MaxRunLength:          200,
+		PriorVarianceScale:    10.0,
+		MinVariance:           1.0,
+		RecoveryPoints:        10,
+		WarmupFallbackEnabled: true,
+		WarmupMinSamples:      30,
+		WarmupZThreshold:      6.0,
 		Aggregations: []observer.Aggregate{
 			observer.AggregateAverage,
 			observer.AggregateCount,
@@ -166,6 +188,14 @@ func NewBOCPDDetector(config BOCPDConfig) *BOCPDDetector {
 	if config.RecoveryPoints <= 0 {
 		config.RecoveryPoints = defaults.RecoveryPoints
 	}
+	if config.WarmupMinSamples <= 0 {
+		config.WarmupMinSamples = defaults.WarmupMinSamples
+	}
+	if config.WarmupZThreshold <= 0 {
+		config.WarmupZThreshold = defaults.WarmupZThreshold
+	}
+	// WarmupFallbackEnabled is stored as-is; caller must set it explicitly to
+	// false to disable. DefaultBOCPDConfig() initialises it to true.
 	if len(config.Aggregations) == 0 {
 		config.Aggregations = defaults.Aggregations
 	}
@@ -262,7 +292,7 @@ func (b *BOCPDDetector) processPoint(state *bocpdSeriesState, p observer.Point, 
 	x := p.Value
 
 	if !state.initialized {
-		return b.warmupPoint(state, x)
+		return b.warmupPoint(state, p)
 	}
 
 	triggered, cpProb, shortRunMass := b.updatePosterior(state, x)
@@ -288,13 +318,61 @@ func (b *BOCPDDetector) processPoint(state *bocpdSeriesState, p observer.Point, 
 }
 
 // warmupPoint accumulates a point during the warmup phase using Welford's algorithm.
-func (b *BOCPDDetector) warmupPoint(state *bocpdSeriesState, x float64) *observer.Anomaly {
+// It also applies a one-shot z-score fallback: once WarmupMinSamples have been
+// collected, each new point is evaluated against the running statistics computed
+// BEFORE including that point. If the deviation exceeds WarmupZThreshold, a single
+// warmup-fallback anomaly is emitted and the flag is set to prevent further fires.
+func (b *BOCPDDetector) warmupPoint(state *bocpdSeriesState, p observer.Point) *observer.Anomaly {
+	x := p.Value
+
+	// Snapshot pre-update statistics so the z-score is computed against the
+	// running baseline, not the statistics that already include the spike.
+	prevCount := state.warmupCount
+	prevMean := state.warmupMean
+	prevM2 := state.warmupM2
+
 	state.warmupCount++
 	state.warmupBuffer = append(state.warmupBuffer, x)
 	delta := x - state.warmupMean
 	state.warmupMean += delta / float64(state.warmupCount)
 	delta2 := x - state.warmupMean
 	state.warmupM2 += delta * delta2
+
+	// Z-score fallback while warmup data is being collected. Fires once per
+	// series during warmup so anomalies in the first ~2 minutes are not
+	// silently dropped.
+	if b.config.WarmupFallbackEnabled &&
+		!state.warmupFallbackFired &&
+		prevCount >= b.config.WarmupMinSamples &&
+		prevCount >= 2 { // need at least 2 for Bessel's correction
+		variance := prevM2 / float64(prevCount-1)
+		if variance < b.config.MinVariance {
+			variance = b.config.MinVariance
+		}
+		stddev := math.Sqrt(variance)
+		if stddev > 1e-12 {
+			z := math.Abs(x-prevMean) / stddev
+			if z >= b.config.WarmupZThreshold {
+				state.warmupFallbackFired = true
+				score := z
+				return &observer.Anomaly{
+					Type:         observer.AnomalyTypeMetric,
+					DetectorName: b.Name(),
+					Title:        "BOCPD warmup-fallback: spike",
+					Description: fmt.Sprintf("warmup z=%.2f (mean=%.4f, std=%.4f, x=%.4f, n=%d)",
+						z, prevMean, stddev, x, prevCount),
+					Timestamp: p.Timestamp,
+					Score:     &score,
+					DebugInfo: &observer.AnomalyDebugInfo{
+						BaselineMean:   prevMean,
+						BaselineStddev: stddev,
+						CurrentValue:   x,
+						DeviationSigma: z,
+					},
+				}
+			}
+		}
+	}
 
 	if state.warmupCount >= b.config.WarmupPoints {
 		b.initializeFromWarmup(state)

--- a/comp/observer/impl/metrics_detector_bocpd_test.go
+++ b/comp/observer/impl/metrics_detector_bocpd_test.go
@@ -464,6 +464,131 @@ func TestFindingM7_WarmupPointsOneCausesNaN(t *testing.T) {
 	}
 }
 
+// --- Warmup fallback tests ---
+
+// TestBOCPD_WarmupFallback_FiresOnSpike verifies that a large spike during warmup
+// triggers exactly one warmup-fallback anomaly once WarmupMinSamples have accumulated.
+func TestBOCPD_WarmupFallback_FiresOnSpike(t *testing.T) {
+	cfg := DefaultBOCPDConfig()
+	cfg.WarmupPoints = 120
+	cfg.WarmupMinSamples = 30
+	cfg.WarmupZThreshold = 6.0
+	cfg.Aggregations = []observer.Aggregate{observer.AggregateAverage}
+	d := NewBOCPDDetector(cfg)
+
+	storage := newTimeSeriesStorage()
+
+	// 30 stable points at value=50 → warmup baseline mean=50, variance≈0.
+	for i := 0; i < 30; i++ {
+		storage.Add("ns", "m", 50.0, int64(i+1), nil)
+	}
+	// 1 large spike: z = (500-50)/sqrt(MinVariance=1.0) = 450 >> 6.0.
+	storage.Add("ns", "m", 500.0, 31, nil)
+
+	result := d.Detect(storage, 31)
+
+	// Exactly one warmup-fallback anomaly should appear.
+	var warmupAnomalies []observer.Anomaly
+	for _, a := range result.Anomalies {
+		if a.DetectorName == "bocpd_detector" {
+			warmupAnomalies = append(warmupAnomalies, a)
+		}
+	}
+	require.Len(t, warmupAnomalies, 1, "expected exactly one warmup-fallback anomaly")
+	assert.Contains(t, warmupAnomalies[0].Title, "warmup-fallback")
+	assert.Equal(t, int64(31), warmupAnomalies[0].Timestamp)
+	require.NotNil(t, warmupAnomalies[0].Score)
+	assert.Greater(t, *warmupAnomalies[0].Score, 6.0, "z-score should exceed threshold")
+}
+
+// TestBOCPD_WarmupFallback_OnlyFiresOnce verifies that at most one warmup-fallback
+// anomaly is emitted per series even when multiple spikes occur during warmup.
+func TestBOCPD_WarmupFallback_OnlyFiresOnce(t *testing.T) {
+	cfg := DefaultBOCPDConfig()
+	cfg.WarmupPoints = 120
+	cfg.WarmupMinSamples = 30
+	cfg.WarmupZThreshold = 6.0
+	cfg.Aggregations = []observer.Aggregate{observer.AggregateAverage}
+	d := NewBOCPDDetector(cfg)
+
+	storage := newTimeSeriesStorage()
+
+	// 30 stable points.
+	for i := 0; i < 30; i++ {
+		storage.Add("ns", "m", 50.0, int64(i+1), nil)
+	}
+	// Spike at index 31.
+	storage.Add("ns", "m", 500.0, 31, nil)
+	// One stable point in between.
+	storage.Add("ns", "m", 50.0, 32, nil)
+	// Second spike at index 33.
+	storage.Add("ns", "m", 500.0, 33, nil)
+
+	result := d.Detect(storage, 33)
+
+	var warmupAnomalies []observer.Anomaly
+	for _, a := range result.Anomalies {
+		if a.DetectorName == "bocpd_detector" {
+			warmupAnomalies = append(warmupAnomalies, a)
+		}
+	}
+	assert.Len(t, warmupAnomalies, 1, "warmup fallback should fire at most once per series")
+}
+
+// TestBOCPD_WarmupFallback_RespectsThreshold verifies that a spike below the
+// z-score threshold does not trigger the warmup fallback.
+func TestBOCPD_WarmupFallback_RespectsThreshold(t *testing.T) {
+	cfg := DefaultBOCPDConfig()
+	cfg.WarmupPoints = 120
+	cfg.WarmupMinSamples = 30
+	cfg.WarmupZThreshold = 6.0
+	cfg.Aggregations = []observer.Aggregate{observer.AggregateAverage}
+	d := NewBOCPDDetector(cfg)
+
+	storage := newTimeSeriesStorage()
+
+	// 50 stable points at exactly 50 → variance=0, MinVariance=1.0 gives stddev=1.
+	for i := 0; i < 50; i++ {
+		storage.Add("ns", "m", 50.0, int64(i+1), nil)
+	}
+	// Spike at z=4 (50+4*1=54), below the 6.0 threshold.
+	storage.Add("ns", "m", 54.0, 51, nil)
+
+	result := d.Detect(storage, 51)
+
+	for _, a := range result.Anomalies {
+		assert.NotContains(t, a.Title, "warmup-fallback",
+			"z=4 spike should not trigger warmup fallback (threshold=6.0)")
+	}
+}
+
+// TestBOCPD_WarmupFallback_Disabled verifies that setting WarmupFallbackEnabled=false
+// suppresses the warmup fallback even for large spikes.
+func TestBOCPD_WarmupFallback_Disabled(t *testing.T) {
+	cfg := DefaultBOCPDConfig()
+	cfg.WarmupPoints = 120
+	cfg.WarmupMinSamples = 30
+	cfg.WarmupZThreshold = 6.0
+	cfg.WarmupFallbackEnabled = false
+	cfg.Aggregations = []observer.Aggregate{observer.AggregateAverage}
+	d := NewBOCPDDetector(cfg)
+
+	storage := newTimeSeriesStorage()
+
+	// 30 stable points + a large spike.
+	for i := 0; i < 30; i++ {
+		storage.Add("ns", "m", 50.0, int64(i+1), nil)
+	}
+	storage.Add("ns", "m", 500.0, 31, nil)
+
+	result := d.Detect(storage, 31)
+
+	for _, a := range result.Anomalies {
+		assert.NotContains(t, a.Title, "warmup-fallback",
+			"disabled warmup fallback should not produce warmup-fallback anomaly")
+	}
+}
+
 func TestFindingM8_ShortRunMassExcludesCPProb(t *testing.T) {
 	// shortRunLengthMass should sum runProbs[1] through runProbs[ShortRunLength],
 	// excluding runProbs[0] (cpProb). The two trigger conditions (peak cpProb


### PR DESCRIPTION
Coordinator harness run-log.

- Mode: `full`
- Scratch branch: `claude/observer-full-20260429T1816`
- PR base: `ella/claude-coordinator-harness` (harness + observer; PR diff = ships only)
- Upstream merge source: `q-branch-observer`
- Started: 2026-04-29T18:16:15

_This PR is the bidirectional control channel: status comments posted by the coordinator; steering comments by the operator. Each shipped candidate becomes one commit on this branch, making the run a self-contained eval-matrix entry diffable against `ella/claude-coordinator-harness`._
