### PR TITLE
update gopacket with atomic status reads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1253,7 +1253,7 @@ exclude go.opentelemetry.io/proto/otlp v1.1.0
 // Exclude ambiguous tencentcloud import required by vault
 exclude github.com/tencentcloud/tencentcloud-sdk-go v1.0.162
 
-replace github.com/google/gopacket v1.1.19 => github.com/DataDog/gopacket v0.0.0-20251104174046-ae42df68210e
+replace github.com/google/gopacket v1.1.19 => github.com/DataDog/gopacket v0.0.0-20260429164037-ee5a3263d056
 
 // Remove once https://github.com/kubernetes/kube-state-metrics/pull/2928 is merged
 replace k8s.io/kube-state-metrics/v2 v2.18.0 => github.com/L3n41c/kube-state-metrics/v2 v2.18.1-0.20260415185427-29e500020566

--- a/go.sum
+++ b/go.sum
@@ -2582,8 +2582,8 @@ github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJx
 github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee/go.mod h1:nTot/Iy0kW16bXgXr6blEc8gFeAS7vTqYlhAxh+dbc0=
-github.com/DataDog/gopacket v0.0.0-20251104174046-ae42df68210e h1:kWyz88c8oMYcA/26/mG3lmsbHF9MTdmukzK4vWRbwMw=
-github.com/DataDog/gopacket v0.0.0-20251104174046-ae42df68210e/go.mod h1:riddUzxTSBpJXk3qBHtYr4qOhFhT6k/1c0E3qkQjQpA=
+github.com/DataDog/gopacket v0.0.0-20260429164037-ee5a3263d056 h1:S7D0BKyRGQvojPhbLV2R8pZKza+iy+CPSsu1Uz86xRk=
+github.com/DataDog/gopacket v0.0.0-20260429164037-ee5a3263d056/go.mod h1:HRh7JESdpg5Hh6f8QMoFPht5/r/fPs/Hl3qghMoDztI=
 github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=
 github.com/DataDog/gostackparse v0.7.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/DataDog/jsonapi v0.12.0 h1:N4e9RpmUflcV5hzceltSz8XUpM3PMtQr5C9Bhv0g87s=
@@ -5125,7 +5125,6 @@ github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVO
 github.com/vibrantbyte/go-antpath v1.1.1 h1:SWDIMx4pSjyo7QoAsgTkpNU7QD0X9O0JAgr5O3TsYKk=
 github.com/vibrantbyte/go-antpath v1.1.1/go.mod h1:ZqMGIk+no3BL2o6OdEZ3ZDiWfIteuastNSaTFv7kgUY=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vito/go-sse v1.0.0 h1:e6/iTrrvy8BRrOwJwmQmlndlil+TLdxXvHi55ZDzH6M=

--- a/pkg/network/filter/packet_source_linux.go
+++ b/pkg/network/filter/packet_source_linux.go
@@ -83,27 +83,32 @@ func (p *AFPacketSource) GetPacketInfoBuffer() *AFPacketInfo {
 	return p.afPacketInfo
 }
 
+type packetSourceConfig struct {
+	snapLen uint16
+}
+
+// Option configures AFPacketSource
+type Option func(*packetSourceConfig)
+
 // OptSnapLen specifies the maximum length of the packet to read
 //
 // Defaults to 4096 bytes
-type OptSnapLen int
+func OptSnapLen(v uint16) Option {
+	return func(p *packetSourceConfig) {
+		p.snapLen = v
+	}
+}
 
 // NewAFPacketSource creates an AFPacketSource using the provided BPF filter
-func NewAFPacketSource(size int, opts ...interface{}) (*AFPacketSource, error) {
-	snapLen := defaultSnapLen
+func NewAFPacketSource(size uint32, opts ...Option) (*AFPacketSource, error) {
+	cfg := packetSourceConfig{
+		snapLen: defaultSnapLen,
+	}
 	for _, opt := range opts {
-		switch o := opt.(type) {
-		case OptSnapLen:
-			snapLen = int(o)
-			if snapLen <= 0 || snapLen > 65536 {
-				return nil, errors.New("snap len should be between 0 and 65536")
-			}
-		default:
-			return nil, fmt.Errorf("unknown option %+v", opt)
-		}
+		opt(&cfg)
 	}
 
-	frameSize, blockSize, numBlocks, err := afpacketComputeSize(size, snapLen, os.Getpagesize())
+	frameSize, blockSize, numBlocks, err := afpacketComputeSize(size, cfg.snapLen, uint32(os.Getpagesize()))
 	if err != nil {
 		return nil, fmt.Errorf("error computing mmap'ed buffer parameters: %w", err)
 	}
@@ -115,8 +120,8 @@ func NewAFPacketSource(size int, opts ...interface{}) (*AFPacketSource, error) {
 		afpacket.OptBlockSize(blockSize),
 		afpacket.OptNumBlocks(numBlocks),
 		afpacket.OptAddPktType(true),
+		afpacket.OptTPacketVersion(afpacket.TPacketVersion3),
 	)
-
 	if err != nil {
 		return nil, fmt.Errorf("error creating raw socket: %s", err)
 	}
@@ -170,11 +175,11 @@ func visitPackets(p zeroCopyPacketReader, visit AFPacketVisitor) error {
 		data, stats, err := p.ZeroCopyReadPacketData()
 
 		// Immediately retry for EAGAIN
-		if err == syscall.EAGAIN {
+		if errors.Is(err, syscall.EAGAIN) {
 			continue
 		}
 
-		if err == afpacket.ErrTimeout || err == afpacket.ErrCancelled {
+		if errors.Is(err, afpacket.ErrTimeout) || errors.Is(err, afpacket.ErrCancelled) {
 			return nil
 		}
 
@@ -246,13 +251,13 @@ func (p *AFPacketSource) pollStats() {
 
 			packetSourceTelemetry.polls.Add(sourceStats.Polls - prevPolls)
 			packetSourceTelemetry.processed.Add(sourceStats.Packets - prevProcessed)
-			packetSourceTelemetry.captured.Add(int64(socketStats.Packets()) - prevCaptured)
-			packetSourceTelemetry.dropped.Add(int64(socketStats.Drops()) - prevDropped)
+			packetSourceTelemetry.captured.Add(int64(socketStats.Packets) - prevCaptured)
+			packetSourceTelemetry.dropped.Add(int64(socketStats.Drops) - prevDropped)
 
 			prevPolls = sourceStats.Polls
 			prevProcessed = sourceStats.Packets
-			prevCaptured = int64(socketStats.Packets())
-			prevDropped = int64(socketStats.Drops())
+			prevCaptured = int64(socketStats.Packets)
+			prevDropped = int64(socketStats.Drops)
 		case <-p.exit:
 			return
 		}
@@ -265,10 +270,10 @@ func (p *AFPacketSource) pollStats() {
 // frame size and page size.
 //
 // See https://www.kernel.org/doc/Documentation/networking/packet_mmap.txt
-func afpacketComputeSize(targetSize, snaplen, pageSize int) (frameSize, blockSize, numBlocks int, err error) {
-	frameSize = tpacketAlign(unix.TPACKET_HDRLEN) + tpacketAlign(snaplen)
+func afpacketComputeSize(targetSize uint32, snaplen uint16, pageSize uint32) (frameSize, blockSize, numBlocks uint32, err error) {
+	frameSize = uint32(tpacketAlign(unix.TPACKET_HDRLEN)) + uint32(tpacketAlign(int(snaplen)))
 	if frameSize <= pageSize {
-		frameSize = int(nextPowerOf2(int64(frameSize)))
+		frameSize = uint32(nextPowerOf2(int64(frameSize)))
 		if frameSize <= pageSize {
 			blockSize = pageSize
 		}

--- a/pkg/network/filter/packet_source_linux.go
+++ b/pkg/network/filter/packet_source_linux.go
@@ -107,6 +107,9 @@ func NewAFPacketSource(size uint32, opts ...Option) (*AFPacketSource, error) {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+	if cfg.snapLen == 0 {
+		return nil, errors.New("SnapLen should be greater than zero")
+	}
 
 	frameSize, blockSize, numBlocks, err := afpacketComputeSize(size, cfg.snapLen, uint32(os.Getpagesize()))
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Updates our `gopacket` fork to a version that uses atomic reads on the status field shared with the kernel, indicating whether a packet/block is ready to be read by userspace.

See https://github.com/DataDog/gopacket/pull/13 and specifically https://github.com/DataDog/gopacket/pull/13/changes/c888f16d2c6447b7d922a23f85b230d972ff112b

### Motivation

The hope is to fix segfault panics like below:
```
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x2 addr=0x7ff77013001a pc=0x14d69a1]
goroutine 675 gp=0xc0011cfc00 m=5 mp=0xc000730008 [running]:
runtime.throw({0x2b7e854?, 0xc0012a0d28?})
	runtime/panic.go:1094 +0x48 fp=0xc0012a0c68 sp=0xc0012a0c38 pc=0x48c928
runtime.sigpanic()
	runtime/signal_unix.go:939 +0x26c fp=0xc0012a0cc8 sp=0xc0012a0c68 pc=0x48f06c
github.com/google/gopacket/afpacket.(*v3wrapper).getData(0x0?, 0x0?)
	github.com/google/gopacket@v1.1.19/afpacket/header.go:180 +0x21 fp=0xc0012a0d60 sp=0xc0012a0cc8 pc=0x14d69a1
github.com/google/gopacket/afpacket.(*TPacket).ZeroCopyReadPacketData(0xc001ecda40)
...
```

### Describe how you validated your changes

### Additional Notes
