### PR TITLE
dyninst: make TestDyninst faster

### DIFF
--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -124,6 +124,13 @@ func testDyninst(
 	t.Cleanup(testServer.s.Close)
 	cfg, err := module.NewConfig(nil)
 	require.NoError(t, err)
+	// In short mode (which never runs in CI), use uprobe_multi attachment to
+	// speed up integration tests on hosts that support it. Kernel feature
+	// detection is unreliable, so we opt in explicitly rather than
+	// auto-detecting in the loader.
+	if testing.Short() {
+		cfg.UseMultiAttach = true
+	}
 	loaderOpts := []loader.Option{
 		loader.WithAdditionalSerializer(&compiler.DebugSerializer{
 			Out: codeDump,

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -340,7 +340,12 @@ func runIntegrationTestSuite(
 	// use this environment variable to run all the tests individually.
 	const runAllDebugTestsEnv = "RUN_ALL_DEBUG_TESTS"
 	runAllDebugTests, _ := strconv.ParseBool(os.Getenv(runAllDebugTestsEnv))
-	for _, cfg := range cfgs {
+	// Debug mode runs are expensive and largely redundant across configs for
+	// the same binary. By default we only run debug=true for the first config;
+	// set RUN_ALL_DEBUG_CONFIGS=1 to run debug=true for every config.
+	const runAllDebugConfigsEnv = "RUN_ALL_DEBUG_CONFIGS"
+	runAllDebugConfigs, _ := strconv.ParseBool(os.Getenv(runAllDebugConfigsEnv))
+	for cfgIdx, cfg := range cfgs {
 		allProbes := testprogs.MustGetProbeDefinitions(t, service)
 		probes := slices.DeleteFunc(slices.Clone(allProbes), func(p ir.ProbeDefinition) bool {
 			return testprogs.HasIssueTag(p, cfg)
@@ -465,6 +470,12 @@ func runIntegrationTestSuite(
 				t.Run(fmt.Sprintf("debug=%t", debug), func(t *testing.T) {
 					if debug && testing.Short() {
 						t.Skip("skipping debug with short")
+					}
+					if debug && cfgIdx != 0 && !runAllDebugConfigs {
+						t.Skipf(
+							"skipping debug variant for non-first config; set %s=1 to run debug for every config",
+							runAllDebugConfigsEnv,
+						)
 					}
 					t.Parallel()
 					t.Run("all-probes", func(t *testing.T) {

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -86,6 +86,7 @@ func TestDyninst(t *testing.T) {
 			continue
 		}
 		t.Run(svc, func(t *testing.T) {
+			t.Parallel()
 			runIntegrationTestSuite(
 				t, svc, rewrite, sem, collector, cfgs...,
 			)

--- a/pkg/dyninst/loader/loader.go
+++ b/pkg/dyninst/loader/loader.go
@@ -67,6 +67,14 @@ func WithAdditionalSerializer(serializer compiler.CodeSerializer) Option {
 	return additionalSerializerOption{serializer}
 }
 
+// WithUseMultiAttach configures the loader to load programs for attachment
+// via the uprobe_multi link type (BPF_LINK_TYPE_UPROBE_MULTI). The caller is
+// responsible for ensuring the running kernel supports this link type
+// (Linux 6.6+); the loader does not probe for support.
+func WithUseMultiAttach(enabled bool) Option {
+	return useMultiAttachOption(enabled)
+}
+
 // NewLoader creates a new Loader.
 func NewLoader(opts ...Option) (*Loader, error) {
 	l := &Loader{}
@@ -106,6 +114,14 @@ func (l *Loader) Load(program compiler.Program) (*Program, error) {
 	}
 	ringbufMapSpec.MaxEntries = uint32(l.config.ringBufSize)
 
+	if l.config.useMultiAttach {
+		progSpec, ok := spec.Programs["probe_run_with_cookie"]
+		if !ok {
+			return nil, errors.New("probe_run_with_cookie program not found in eBPF spec")
+		}
+		progSpec.AttachType = ebpf.AttachTraceUprobeMulti
+	}
+
 	opts := ebpf.CollectionOptions{}
 	opts.MapReplacements = maps
 	opts.MapReplacements[ringbufMapName] = l.ringbufMap
@@ -125,9 +141,10 @@ func (l *Loader) Load(program compiler.Program) (*Program, error) {
 
 	maps = nil
 	return &Program{
-		Collection:   collection,
-		BpfProgram:   bpfProgram,
-		Attachpoints: serialized.bpfAttachPoints,
+		Collection:     collection,
+		BpfProgram:     bpfProgram,
+		Attachpoints:   serialized.bpfAttachPoints,
+		UseMultiAttach: l.config.useMultiAttach,
 	}, nil
 }
 
@@ -194,6 +211,10 @@ type Program struct {
 	Collection   *ebpf.Collection
 	BpfProgram   *ebpf.Program
 	Attachpoints []BPFAttachPoint
+	// UseMultiAttach indicates that the program was loaded with
+	// AttachTraceUprobeMulti and should be attached using
+	// link.Executable.UprobeMulti rather than per-address Uprobe calls.
+	UseMultiAttach bool
 }
 
 // Close releases the program resources.
@@ -271,6 +292,8 @@ type config struct {
 	dyninstDebugLevel   uint8
 	dyninstDebugEnabled bool
 
+	useMultiAttach bool
+
 	additionalSerializer compiler.CodeSerializer
 }
 
@@ -304,6 +327,12 @@ type additionalSerializerOption struct {
 
 func (o additionalSerializerOption) apply(c *config) {
 	c.additionalSerializer = o
+}
+
+type useMultiAttachOption bool
+
+func (o useMultiAttachOption) apply(c *config) {
+	c.useMultiAttach = bool(o)
 }
 
 func (l *Loader) init(opts ...Option) error {

--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -54,6 +54,14 @@ type Config struct {
 	// ActuatorConfig is the configuration for the actuator.
 	ActuatorConfig actuator.Config
 
+	// UseMultiAttach causes the loader to use the uprobe_multi link type
+	// (BPF_LINK_TYPE_UPROBE_MULTI) when attaching probes. This batches
+	// many attachments into a single bpf_link_create call and is much
+	// faster for programs with many attachpoints, but requires kernel
+	// support (Linux 6.6+). The caller is responsible for only enabling
+	// this on supported kernels.
+	UseMultiAttach bool
+
 	TestingKnobs struct {
 		LoaderOptions             []loader.Option
 		IRGeneratorOverride       func(IRGenerator) IRGenerator

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -254,6 +254,9 @@ func makeRealDependencies(
 	if config.TestingKnobs.LoaderOptions != nil {
 		loaderOpts = config.TestingKnobs.LoaderOptions
 	}
+	if config.UseMultiAttach {
+		loaderOpts = append(loaderOpts, loader.WithUseMultiAttach(true))
+	}
 	ret.loader, err = loader.NewLoader(loaderOpts...)
 	if err != nil {
 		return ret, fmt.Errorf("error creating loader: %w", err)

--- a/pkg/dyninst/uprobe/attach.go
+++ b/pkg/dyninst/uprobe/attach.go
@@ -96,6 +96,46 @@ func Attach(
 		)
 	}
 
+	if loaded.UseMultiAttach {
+		return attachMulti(loaded, linkExe, textSection, processID)
+	}
+	return attachSingle(loaded, linkExe, textSection, processID)
+}
+
+func attachMulti(
+	loaded *loader.Program,
+	linkExe *link.Executable,
+	textSection *safeelf.Section,
+	processID process.ID,
+) (*AttachedProgram, error) {
+	addresses := make([]uint64, len(loaded.Attachpoints))
+	cookies := make([]uint64, len(loaded.Attachpoints))
+	for i, ap := range loaded.Attachpoints {
+		addresses[i] = ap.PC - textSection.Addr + textSection.Offset
+		cookies[i] = ap.Cookie
+	}
+	l, err := linkExe.UprobeMulti(nil, loaded.BpfProgram, &link.UprobeMultiOptions{
+		Addresses: addresses,
+		Cookies:   cookies,
+		PID:       uint32(processID.PID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to attach uprobe multi: %w", err)
+	}
+	return &AttachedProgram{
+		processID:    processID,
+		loader:       loaded,
+		executable:   linkExe,
+		attachpoints: []link.Link{l},
+	}, nil
+}
+
+func attachSingle(
+	loaded *loader.Program,
+	linkExe *link.Executable,
+	textSection *safeelf.Section,
+	processID process.ID,
+) (*AttachedProgram, error) {
 	attached := make([]link.Link, 0, len(loaded.Attachpoints))
 	for _, attachpoint := range loaded.Attachpoints {
 		addr := attachpoint.PC - textSection.Addr + textSection.Offset


### PR DESCRIPTION
### What does this PR do?

This test makes the integration tests much faster to run. It does 3 things:

 * Only run the debug=true tests for one config (these things contend on the trace_pipe)
 * Run in parallel across binaries
 * Use multi_attach when using --short (doesn't work on all kernels but makes life so much better when it does)

### Motivation

Before this change, TestDyninst took 96s, now it takes 10s

### Describe how you validated your changes

It's testing and I ran them

### Additional Notes
