### PR TITLE
[Backport 7.79.x] dyninst/symdb: don't yield packages for displaced inlines

### DIFF
--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -1032,17 +1032,6 @@ func (b *packagesIterator) innerIterator() iter.Seq2[Package, error] {
 			yield(Package{}, err)
 			return
 		}
-
-		// Yield packages for functions that were found in a compile unit
-		// different from their defining package (e.g. abstract inlined
-		// functions from other packages).
-		for _, pkg := range b.displacedFunctions {
-			if len(pkg.Functions) > 0 {
-				if !yield(*pkg, nil) {
-					return
-				}
-			}
-		}
 	}
 }
 

--- a/pkg/dyninst/symdb/symdb_test.go
+++ b/pkg/dyninst/symdb/symdb_test.go
@@ -9,6 +9,7 @@ package symdb_test
 
 import (
 	"flag"
+	"fmt"
 	_ "net/http/pprof"
 	"os"
 	"path"
@@ -67,6 +68,10 @@ var rewrite = flag.Bool("rewrite", rewriteFromEnv, "rewrite the snapshot files")
 
 const snapshotDir = "testdata/snapshot"
 
+// TestSymDBSnapshot exercises the streaming PackagesIterator API — the
+// one used by the production uploader at pkg/dyninst/module/symdb.go —
+// and records every yield in the golden. Each yield is written as a
+// distinct "=== yield N [final=T/F] ===" section.
 func TestSymDBSnapshot(t *testing.T) {
 	cfgs := testprogs.MustGetCommonConfigs(t)
 	progs := testprogs.MustGetPrograms(t)
@@ -80,19 +85,26 @@ func TestSymDBSnapshot(t *testing.T) {
 					defer sem.Acquire()()
 					binaryPath := testprogs.MustGetBinary(t, prog, cfg)
 					t.Logf("exploring binary: %s", binaryPath)
-					symbols, err := symdb.ExtractSymbols(
+					it, err := symdb.PackagesIterator(
 						binaryPath,
 						object.NewInMemoryLoader(),
 						symdb.ExtractOptions{
 							Scope: symdb.ExtractScopeMainModuleOnly,
 						})
-					require.NoError(t, err, "failed to extract symbols from %s", binaryPath)
-					require.NotEmpty(t, symbols.Packages)
+					require.NoError(t, err, "failed to open iterator on %s", binaryPath)
 
 					var sb strings.Builder
-					symbols.Serialize(symdbutil.MakePanickingWriter(&sb))
-					out := sb.String()
+					w := symdbutil.MakePanickingWriter(&sb)
+					yieldIdx := 0
+					for pkg, err := range it {
+						require.NoError(t, err)
+						yieldIdx++
+						w.WriteString(fmt.Sprintf("=== yield %d [final=%t] ===\n", yieldIdx, pkg.Final))
+						pkg.Package.Serialize(w)
+					}
+					require.NotZero(t, yieldIdx, "expected at least one package yield")
 
+					out := sb.String()
 					outputFile := path.Join(snapshotDir, prog+".streaming."+cfg.String()+".out")
 					if *rewrite {
 						tmpFile, err := os.CreateTemp(snapshotDir, ".out")

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56] injectible: [21-27], [46-47], [49-51], [53-54], [56-56]
 		Arg: concurrency: int (declared at line 21, available: [21-56])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/fault.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: callMe (main.callMe) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/fault/main.go [53:55] injectible: [53-55]
 		Arg: s1: string (declared at line 53, available: [53-55])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
 		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [54:88] injectible: [54-54], [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [54-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [54:88] injectible: [54-54], [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [54-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [60:88] injectible: [60-60], [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [60-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
 		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1183,6 +1183,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1198,7 +1199,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1237,11 +1237,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-64])
@@ -1284,3 +1280,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1280,12 +1280,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1171,6 +1171,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1186,7 +1187,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1225,11 +1225,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-64])
@@ -1272,3 +1268,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1268,12 +1268,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1168,6 +1168,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1183,7 +1184,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1222,11 +1222,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-64])
@@ -1269,3 +1265,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1265,12 +1265,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1168,6 +1168,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1183,7 +1184,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1222,11 +1222,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-59], [60-64])
@@ -1269,3 +1265,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1265,12 +1265,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1190,6 +1190,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1205,7 +1206,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1244,11 +1244,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-64])
@@ -1291,3 +1287,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1287,12 +1287,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1178,6 +1178,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1193,7 +1194,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1232,11 +1232,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-64])
@@ -1279,3 +1275,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1275,12 +1275,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1175,6 +1175,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-106])
@@ -1190,7 +1191,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1229,11 +1229,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-64])
@@ -1276,3 +1272,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1272,12 +1272,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=false] ===
 Package: main
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
@@ -1175,6 +1175,7 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
+=== yield 2 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Filter[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [102:109] injectible: [102-102], [104-106], [109-109]
 		Arg: items: .param0 (declared at line 102, available: [102-104])
@@ -1190,7 +1191,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Arg: f: .param1 (declared at line 94, available: [94-95])
 		Arg: ~r0: .param2 (declared at line 94, available: )
 	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [29:30] injectible: [30-30]
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 
 	Function: Reduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Reduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [115:120] injectible: [115-115], [117-118], [120-120]
 		Arg: items: .param0 (declared at line 115, available: [115-117])
 		Arg: init: .param1 (declared at line 115, available: [115-117])
@@ -1229,11 +1229,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Swap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Pair[...].Swap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [86:87] injectible: [86-87]
 			Arg: p: .param0 (declared at line 86, available: [86-87])
 			Arg: ~r0: .param1 (declared at line 86, available: )
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
-	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
-		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
-			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 3 [final=false] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2
 	Function: BoxAndReduce[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.BoxAndReduce[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [58:64] injectible: [58-61], [64-64]
 		Arg: items: .param1 (declared at line 58, available: [58-59], [60-64])
@@ -1276,3 +1272,12 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
+=== yield 4 [final=false] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
+=== yield 5 [final=true] ===
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1272,12 +1272,9 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 		Function: Unwrap (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2.Wrapper[...].Unwrap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib2/lib2.go [30:31] injectible: [30-31]
 			Arg: w: .param2 (declared at line 30, available: [30-31])
 			Arg: ~r0: .param3 (declared at line 30, available: )
-=== yield 4 [final=false] ===
+=== yield 4 [final=true] ===
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24] injectible: [22-24]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
-=== yield 5 [final=true] ===
-Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: NewImmutableSet[...] (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.NewImmutableSet[go.shape.string]) in  [29:0] injectible: 

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [341:342] injectible: [342-342]
 		Arg: ptr: *****int (declared at line 0, available: [342-342])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [341:342] injectible: [342-342]
 		Arg: ptr: *****int (declared at line 0, available: [342-342])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [341:342] injectible: [342-342]
 		Arg: ptr: *****int (declared at line 0, available: [342-342])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [341:342] injectible: [342-342]
 		Arg: ptr: *****int (declared at line 0, available: [342-342])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [341:342] injectible: [342-342]
 		Arg: ptr: *****int (declared at line 0, available: [342-342])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [341:342] injectible: [342-342]
 		Arg: ptr: *****int (declared at line 0, available: [342-342])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [341:342] injectible: [342-342]
 		Arg: ptr: *****int (declared at line 0, available: [342-342])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,4 +1,4 @@
-Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+=== yield 1 [final=true] ===
 Package: main
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [341:342] injectible: [342-342]
 		Arg: ptr: *****int (declared at line 0, available: [342-342])


### PR DESCRIPTION
 ### What does this PR do?

  Backports a two-commit fix from #49860 to 7.79.x:

  1. **dyninst/symdb: snapshot-test the streaming `PackagesIterator`** — replaces the
     old slice-flattened `ExtractSymbols` snapshot test with one that drives the
     streaming `PackagesIterator` (the API the production uploader actually uses
     in `pkg/dyninst/module/symdb.go`). Each yield is recorded under a distinct
     `=== yield N [final=T/F] ===` header so the goldens reflect both *what* gets
     emitted and the *order* it is emitted in. This is what makes the bug in the
     second commit observable as a snapshot diff.

  2. **dyninst/symdb: don't yield phantom packages for displaced inlined functions**
     — drops a dead drain loop in `PackagesIterator` that was emitting a second
     `Package` entry for every package whose abstract inlined functions appeared
     in another compile unit's DWARF. Those functions are already merged into
     their owning package during normal iteration; the post-loop drain just
     re-emitted them inside a near-empty `Package` (single function, empty file,
     `[29:0]` line range, no injectible PC ranges).

  ### Motivation

  The duplicate-package emission was introduced by **#48822** ("dyninst: add
  support for probing Go generic functions") in 7.79. We deliberately did not
  prioritise backporting anything from #49860 at the time because we believed
  the symdb backend would tolerate the extra phantom package. In production
  this turned out not to be the case — the spurious second record is causing
  **major problems** for users on 7.79.x — so we now want a minimal, targeted
  fix on the release branch.

  The diff is intentionally small:
  - 1 production change: 11 lines removed from `pkg/dyninst/symdb/symdb.go`
  - Snapshot updates: only the `sample` program goldens change, and only to
    *remove* the spurious final yield (`=== yield 5 ===`). All other goldens
    change one byte (the new `final=true` field added by the test rewrite).

  ### Describe how you validated your changes

  - `dda inv test --targets=./pkg/dyninst/symdb` passes against the updated goldens.
  - Snapshot diffs confirm the only behavioural change is the disappearance of
    the phantom `.../sample/lib` package containing a stub `NewImmutableSet[...]`
    entry.
  - The new streaming snapshot test exercises the same code path the production
    uploader uses, so any future regression of this shape will fail the goldens
    pre-merge instead of in production.

  ### Additional notes

  - Source PRs: #49860 (symdb test rewrite + this fix, among other changes),
    #48822 (introduced the regression).
  - Fixes https://datadoghq.atlassian.net/browse/DEBUG-5519
