### PR TITLE
[ AGNTLOG-619 ] Add diagnostics to K8s log pipeline E2E tests

### DIFF
--- a/test/e2e-framework/testing/utils/k8s/k8s.go
+++ b/test/e2e-framework/testing/utils/k8s/k8s.go
@@ -151,14 +151,23 @@ func DumpK8sClusterState(ctx context.Context, kubeconfig *clientcmdapi.Config, o
 	return nil
 }
 
-// terminalWaitingReasons are container waiting reasons that indicate the pod will not recover without intervention.
+// terminalWaitingReasons are container waiting reasons caused by misconfiguration —
+// no amount of retrying will fix these.
 var terminalWaitingReasons = map[string]bool{
-	"ImagePullBackOff":           true,
-	"ErrImagePull":               true,
 	"InvalidImageName":           true,
-	"CrashLoopBackOff":           true,
 	"CreateContainerConfigError": true,
 }
+
+// transientWaitingReasons are container waiting reasons that may resolve on their own
+// (e.g. kubelet retrying an image pull after a network blip). We only treat them as
+// terminal after observing them for transientGracePeriod.
+var transientWaitingReasons = map[string]bool{
+	"ImagePullBackOff": true,
+	"ErrImagePull":     true,
+	"CrashLoopBackOff": true,
+}
+
+const transientGracePeriod = 30 * time.Second
 
 // WaitForJobPodRunning polls until a Job's Pod leaves the Pending phase or a terminal
 // error is detected. It returns the Pod on success, or an error describing why the Pod
@@ -173,7 +182,10 @@ func WaitForJobPodRunning(ctx context.Context, client kubernetes.Interface, name
 
 	var lastListErr error
 
-	// First check is immediate; subsequent checks wait for ticker.
+	// Tracks when we first observed a transient waiting reason per container.
+	// Key: "podName/containerName"
+	transientFirstSeen := make(map[string]time.Time)
+
 	for {
 		pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: fields.OneTermEqualSelector("job-name", jobName).String(),
@@ -191,6 +203,8 @@ func WaitForJobPodRunning(ctx context.Context, client kubernetes.Interface, name
 			continue
 		}
 
+		now := time.Now()
+
 		for i := range pods.Items {
 			pod := &pods.Items[i]
 
@@ -198,17 +212,34 @@ func WaitForJobPodRunning(ctx context.Context, client kubernetes.Interface, name
 				return pod, nil
 			}
 
-			// Check init container and regular container statuses for terminal errors
 			allStatuses := concatStatuses(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses)
 			for _, cs := range allStatuses {
-				if cs.State.Waiting != nil && terminalWaitingReasons[cs.State.Waiting.Reason] {
+				if cs.State.Waiting == nil {
+					continue
+				}
+				reason := cs.State.Waiting.Reason
+
+				if terminalWaitingReasons[reason] {
 					return nil, fmt.Errorf("job %s pod %s container %s: %s - %s",
 						jobName, pod.Name, cs.Name,
-						cs.State.Waiting.Reason, cs.State.Waiting.Message)
+						reason, cs.State.Waiting.Message)
+				}
+
+				if transientWaitingReasons[reason] {
+					key := pod.Name + "/" + cs.Name
+					if firstSeen, ok := transientFirstSeen[key]; ok {
+						if now.Sub(firstSeen) >= transientGracePeriod {
+							return nil, fmt.Errorf("job %s pod %s container %s: %s - %s (persisted for %s)",
+								jobName, pod.Name, cs.Name,
+								reason, cs.State.Waiting.Message,
+								now.Sub(firstSeen).Truncate(time.Second))
+						}
+					} else {
+						transientFirstSeen[key] = now
+					}
 				}
 			}
 
-			// Check for unschedulable conditions
 			for _, cond := range pod.Status.Conditions {
 				if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse && cond.Reason == corev1.PodReasonUnschedulable {
 					return nil, fmt.Errorf("job %s pod %s unschedulable: %s", jobName, pod.Name, cond.Message)
@@ -216,7 +247,7 @@ func WaitForJobPodRunning(ctx context.Context, client kubernetes.Interface, name
 			}
 		}
 
-		if time.Now().After(deadline) {
+		if now.After(deadline) {
 			if len(pods.Items) == 0 {
 				msg := fmt.Sprintf("job %s: no pods created within %s", jobName, timeout)
 				if lastListErr != nil {

--- a/test/e2e-framework/testing/utils/k8s/k8s.go
+++ b/test/e2e-framework/testing/utils/k8s/k8s.go
@@ -226,7 +226,7 @@ func WaitForJobPodRunning(ctx context.Context, client kubernetes.Interface, name
 				}
 
 				if transientWaitingReasons[reason] {
-					key := pod.Name + "/" + cs.Name
+					key := pod.Name + "/" + cs.Name + "/" + reason
 					if firstSeen, ok := transientFirstSeen[key]; ok {
 						if now.Sub(firstSeen) >= transientGracePeriod {
 							return nil, fmt.Errorf("job %s pod %s container %s: %s - %s (persisted for %s)",

--- a/test/e2e-framework/testing/utils/k8s/k8s.go
+++ b/test/e2e-framework/testing/utils/k8s/k8s.go
@@ -8,24 +8,22 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/client-go/kubernetes"
-
 	"io"
 	"os"
 	"strings"
-
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
-	"k8s.io/client-go/tools/clientcmd"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kubectlget "k8s.io/kubectl/pkg/cmd/get"
 	kubectlutil "k8s.io/kubectl/pkg/cmd/util"
@@ -151,4 +149,195 @@ func DumpK8sClusterState(ctx context.Context, kubeconfig *clientcmdapi.Config, o
 		}
 	}
 	return nil
+}
+
+// terminalWaitingReasons are container waiting reasons that indicate the pod will not recover without intervention.
+var terminalWaitingReasons = map[string]bool{
+	"ImagePullBackOff":           true,
+	"ErrImagePull":               true,
+	"InvalidImageName":           true,
+	"CrashLoopBackOff":           true,
+	"CreateContainerConfigError": true,
+}
+
+// WaitForJobPodRunning polls until a Job's Pod leaves the Pending phase or a terminal
+// error is detected. It returns the Pod on success, or an error describing why the Pod
+// could not start (image pull failure, scheduling issue, crash loop, or timeout).
+// The returned Pod may be in any non-Pending phase (Running, Succeeded, or Failed).
+// This function distinguishes infrastructure failures from runtime outcomes — a Pod
+// that started and exited non-zero is still considered "started" for this purpose.
+func WaitForJobPodRunning(ctx context.Context, client kubernetes.Interface, namespace, jobName string, timeout time.Duration) (*corev1.Pod, error) {
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	var lastListErr error
+
+	// First check is immediate; subsequent checks wait for ticker.
+	for {
+		pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fields.OneTermEqualSelector("job-name", jobName).String(),
+		})
+		if err != nil {
+			lastListErr = err
+			if time.Now().After(deadline) {
+				return nil, fmt.Errorf("error listing pods for job %s (deadline reached): %w", jobName, err)
+			}
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("waiting for job %s pod: %w", jobName, ctx.Err())
+			case <-ticker.C:
+			}
+			continue
+		}
+
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+
+			if pod.Status.Phase != corev1.PodPending {
+				return pod, nil
+			}
+
+			// Check init container and regular container statuses for terminal errors
+			allStatuses := concatStatuses(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses)
+			for _, cs := range allStatuses {
+				if cs.State.Waiting != nil && terminalWaitingReasons[cs.State.Waiting.Reason] {
+					return nil, fmt.Errorf("job %s pod %s container %s: %s - %s",
+						jobName, pod.Name, cs.Name,
+						cs.State.Waiting.Reason, cs.State.Waiting.Message)
+				}
+			}
+
+			// Check for unschedulable conditions
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse && cond.Reason == corev1.PodReasonUnschedulable {
+					return nil, fmt.Errorf("job %s pod %s unschedulable: %s", jobName, pod.Name, cond.Message)
+				}
+			}
+		}
+
+		if time.Now().After(deadline) {
+			if len(pods.Items) == 0 {
+				msg := fmt.Sprintf("job %s: no pods created within %s", jobName, timeout)
+				if lastListErr != nil {
+					msg += fmt.Sprintf(" (last list error: %v)", lastListErr)
+				}
+				return nil, errors.New(msg)
+			}
+			pod := &pods.Items[0]
+			return nil, fmt.Errorf("job %s pod %s still pending after %s (phase=%s, reason=%s, message=%s)",
+				jobName, pod.Name, timeout, pod.Status.Phase, pod.Status.Reason, pod.Status.Message)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("waiting for job %s pod: %w", jobName, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+// DescribeJob collects diagnostic information about a Job and its Pods into a human-readable
+// string. It is designed for use in failure messages and never returns an error — each
+// section is best-effort.
+func DescribeJob(ctx context.Context, client kubernetes.Interface, namespace, jobName string) string {
+	// Bound all API calls so diagnostics don't block indefinitely if the API server is slow.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	var out strings.Builder
+	fmt.Fprintf(&out, "--- Job %s/%s diagnostics ---\n", namespace, jobName)
+
+	job, err := client.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
+	if err != nil {
+		fmt.Fprintf(&out, "Error getting job: %v\n", err)
+		return out.String()
+	}
+	fmt.Fprintf(&out, "Job status: active=%d succeeded=%d failed=%d\n",
+		job.Status.Active, job.Status.Succeeded, job.Status.Failed)
+	for _, cond := range job.Status.Conditions {
+		fmt.Fprintf(&out, "  condition: type=%s status=%s reason=%s message=%s\n",
+			cond.Type, cond.Status, cond.Reason, cond.Message)
+	}
+
+	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fields.OneTermEqualSelector("job-name", jobName).String(),
+	})
+	if err != nil {
+		fmt.Fprintf(&out, "Error listing pods: %v\n", err)
+		return out.String()
+	}
+
+	for _, pod := range pods.Items {
+		fmt.Fprintf(&out, "\nPod %s: phase=%s reason=%s message=%s\n",
+			pod.Name, pod.Status.Phase, pod.Status.Reason, pod.Status.Message)
+
+		for _, cond := range pod.Status.Conditions {
+			if cond.Status == corev1.ConditionFalse {
+				fmt.Fprintf(&out, "  condition: type=%s reason=%s message=%s\n",
+					cond.Type, cond.Reason, cond.Message)
+			}
+		}
+
+		allStatuses := concatStatuses(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses)
+		for _, cs := range allStatuses {
+			fmt.Fprintf(&out, "  container %s: ", cs.Name)
+			switch {
+			case cs.State.Running != nil:
+				fmt.Fprintf(&out, "running since %s\n", cs.State.Running.StartedAt.Time)
+			case cs.State.Terminated != nil:
+				fmt.Fprintf(&out, "terminated: exitCode=%d reason=%s message=%s\n",
+					cs.State.Terminated.ExitCode, cs.State.Terminated.Reason, cs.State.Terminated.Message)
+			case cs.State.Waiting != nil:
+				fmt.Fprintf(&out, "waiting: reason=%s message=%s\n",
+					cs.State.Waiting.Reason, cs.State.Waiting.Message)
+			default:
+				fmt.Fprintf(&out, "unknown state\n")
+			}
+		}
+
+		// Pod events
+		events, err := client.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector("involvedObject.name", pod.Name).String(),
+		})
+		if err == nil && len(events.Items) > 0 {
+			fmt.Fprintf(&out, "  events:\n")
+			for _, event := range events.Items {
+				fmt.Fprintf(&out, "    %s %s: %s\n", event.Reason, event.Type, event.Message)
+			}
+		}
+
+		// Container logs (best-effort, short tail — includes init containers)
+		for _, cs := range allStatuses {
+			if cs.State.Terminated != nil || cs.State.Running != nil {
+				logs := fetchContainerLogs(ctx, client, namespace, pod.Name, cs.Name)
+				if logs != "" {
+					fmt.Fprintf(&out, "  logs for %s:\n%s\n", cs.Name, logs)
+				}
+			}
+		}
+	}
+
+	return out.String()
+}
+
+func fetchContainerLogs(ctx context.Context, client kubernetes.Interface, namespace, podName, containerName string) string {
+	logStream, err := client.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container: containerName,
+		TailLines: pointer.Ptr(int64(20)),
+	}).Stream(ctx)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	defer logStream.Close()
+	var buf strings.Builder
+	_, _ = io.Copy(&buf, io.LimitReader(logStream, 32*1024))
+	return buf.String()
+}
+
+func concatStatuses(init, regular []corev1.ContainerStatus) []corev1.ContainerStatus {
+	result := make([]corev1.ContainerStatus, 0, len(init)+len(regular))
+	result = append(result, init...)
+	result = append(result, regular...)
+	return result
 }

--- a/test/e2e-framework/testing/utils/k8s/k8s.go
+++ b/test/e2e-framework/testing/utils/k8s/k8s.go
@@ -183,7 +183,7 @@ func WaitForJobPodRunning(ctx context.Context, client kubernetes.Interface, name
 	var lastListErr error
 
 	// Tracks when we first observed a transient waiting reason per container.
-	// Key: "podName/containerName"
+	// Key: "podName/containerName/reason"
 	transientFirstSeen := make(map[string]time.Time)
 
 	for {

--- a/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_cca_off_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_cca_off_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	k8sutils "github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/k8s"
-	kindfilelogger "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-log-pipelines/kindfilelogging"
 )
 
 type k8sCCAOffSuite struct {

--- a/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_cca_off_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_cca_off_test.go
@@ -7,6 +7,7 @@ package k8sfiletailing
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	apps "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps"
@@ -20,9 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
-
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	k8sutils "github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/k8s"
+	kindfilelogger "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-log-pipelines/kindfilelogging"
 )
 
 type k8sCCAOffSuite struct {
@@ -40,7 +42,7 @@ func (v *k8sCCAOffSuite) TestADAnnotations() {
 	var backOffLimit int32 = 4
 	testLogMessage := "Annotations pod"
 
-	jobSpcec := &batchv1.Job{
+	jobSpec := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "annotations-job",
 			Namespace: "default",
@@ -69,19 +71,34 @@ func (v *k8sCCAOffSuite) TestADAnnotations() {
 		},
 	}
 
-	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpcec, metav1.CreateOptions{})
-	assert.NoError(v.T(), err, "Could not start autodiscovery job")
+	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpec, metav1.CreateOptions{})
+	require.NoError(v.T(), err, "Could not create autodiscovery job")
+
+	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "annotations-job", 30*time.Second)
+	if err != nil {
+		require.Fail(v.T(), "Annotations job pod failed to start",
+			"%v\n%s", err, k8sutils.DescribeJob(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "annotations-job"))
+	}
 
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		logsServiceNames, err := v.Env().FakeIntake.Client().GetLogServiceNames()
-		assert.NoError(c, err, "Error starting job")
+		if !assert.NoError(c, err, "Error getting log service names") {
+			return
+		}
 
-		if assert.Contains(c, logsServiceNames, "apps-alpine", "Alpine service not found") {
-			filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("apps-alpine")
-			assert.NoError(c, err, "Error filtering logs")
-			if assert.NotEmpty(c, filteredLogs, "Fake Intake returned no logs even though log service name exists") {
-				assert.Equal(c, testLogMessage, filteredLogs[0].Message, "Test log doesn't match")
-			}
+		if !slices.Contains(logsServiceNames, "apps-alpine") {
+			assert.Fail(c, "Alpine service not found",
+				"Known services: %q\n%s",
+				logsServiceNames, fakeintakeRouteStats(v.Env().FakeIntake))
+			return
+		}
+
+		filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("apps-alpine")
+		if !assert.NoError(c, err, "Error filtering logs") {
+			return
+		}
+		if assert.NotEmpty(c, filteredLogs, "Fake Intake returned no logs even though log service name exists") {
+			assert.Equal(c, testLogMessage, filteredLogs[0].Message, "Test log doesn't match")
 		}
 	}, 1*time.Minute, 10*time.Second)
 }
@@ -92,7 +109,7 @@ func (v *k8sCCAOffSuite) TestCCAOff() {
 	var backOffLimit int32 = 4
 	testLogMessage := "Test pod"
 
-	jobSpcec := &batchv1.Job{
+	jobSpec := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cca-off-job",
 			Namespace: "default",
@@ -116,12 +133,27 @@ func (v *k8sCCAOffSuite) TestCCAOff() {
 		},
 	}
 
-	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpcec, metav1.CreateOptions{})
-	assert.NoError(v.T(), err, "Could not start job")
+	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpec, metav1.CreateOptions{})
+	require.NoError(v.T(), err, "Could not create CCA-off job")
+
+	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "cca-off-job", 30*time.Second)
+	if err != nil {
+		require.Fail(v.T(), "CCA-off job pod failed to start",
+			"%v\n%s", err, k8sutils.DescribeJob(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "cca-off-job"))
+	}
 
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		logsServiceNames, err := v.Env().FakeIntake.Client().GetLogServiceNames()
-		assert.NoError(c, err, "Error starting job")
+		if !assert.NoError(c, err, "Error getting log service names") {
+			return
+		}
 		assert.NotContains(c, logsServiceNames, "apps-alpine", "Alpine service found with container collect all off")
 	}, 1*time.Minute, 10*time.Second)
+}
+
+func (v *k8sCCAOffSuite) AfterTest(suiteName, testName string) {
+	if v.T().Failed() {
+		v.T().Log(fakeintakeRouteStats(v.Env().FakeIntake))
+	}
+	v.BaseSuite.AfterTest(suiteName, testName)
 }

--- a/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_test.go
@@ -9,11 +9,11 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
 	apps "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps"
-	kindfilelogger "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-log-pipelines/kindfilelogging"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +23,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	k8sutils "github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/k8s"
+	kindfilelogger "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-log-pipelines/kindfilelogging"
 )
 
 type k8sSuite struct {
@@ -40,7 +42,7 @@ func (v *k8sSuite) TestSingleLogAndMetadata() {
 	var backOffLimit int32 = 4
 	testLogMessage := "Test log message"
 
-	jobSpcec := &batchv1.Job{
+	jobSpec := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "job-1",
 			Namespace: "default",
@@ -64,31 +66,38 @@ func (v *k8sSuite) TestSingleLogAndMetadata() {
 		},
 	}
 
-	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpcec, metav1.CreateOptions{})
-	require.NoError(v.T(), err, "Could not properly start job")
+	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpec, metav1.CreateOptions{})
+	require.NoError(v.T(), err, "Could not create job")
+
+	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "job-1", 30*time.Second)
+	if err != nil {
+		require.Fail(v.T(), "Job pod failed to start",
+			"%v\n%s", err, k8sutils.DescribeJob(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "job-1"))
+	}
 
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		logsServiceNames, err := v.Env().FakeIntake.Client().GetLogServiceNames()
-		assert.NoError(c, err, "Error starting job")
-		if err != nil {
+		if !assert.NoError(c, err, "Error getting log service names") {
 			return
 		}
 
-		if assert.Contains(c, logsServiceNames, "apps-alpine", "Alpine service not found") {
-			filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("apps-alpine")
-			assert.NoError(c, err, "Error filtering logs")
-			if err != nil {
-				return
-			}
-			if assert.NotEmpty(c, filteredLogs, "Fake Intake returned no logs even though log service name exists") {
-				assert.Equal(c, testLogMessage, filteredLogs[0].Message, "Test log doesn't match")
-				// Check container metatdata
-				assert.Equal(c, filteredLogs[0].Service, "apps-alpine", "Could not find service")
-				assert.NotNil(c, filteredLogs[0].HostName, "Hostname not found")
-				assert.NotNil(c, filteredLogs[0].Tags, "Log tags not found")
-			}
+		if !slices.Contains(logsServiceNames, "apps-alpine") {
+			assert.Fail(c, "Alpine service not found",
+				"Known services: %q\n%s",
+				logsServiceNames, fakeintakeRouteStats(v.Env().FakeIntake))
+			return
 		}
 
+		filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("apps-alpine")
+		if !assert.NoError(c, err, "Error filtering logs") {
+			return
+		}
+		if assert.NotEmpty(c, filteredLogs, "Fake Intake returned no logs even though log service name exists") {
+			assert.Equal(c, testLogMessage, filteredLogs[0].Message, "Test log doesn't match")
+			assert.Equal(c, "apps-alpine", filteredLogs[0].Service, "Could not find service")
+			assert.NotNil(c, filteredLogs[0].HostName, "Hostname not found")
+			assert.NotNil(c, filteredLogs[0].Tags, "Log tags not found")
+		}
 	}, 1*time.Minute, 10*time.Second)
 }
 
@@ -100,7 +109,7 @@ func (v *k8sSuite) TestLongLogLine() {
 	require.NoError(v.T(), err, "Could not reset the FakeIntake")
 	var backOffLimit int32 = 4
 
-	jobSpcec := &batchv1.Job{
+	jobSpec := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "long-line-job",
 			Namespace: "default",
@@ -124,27 +133,35 @@ func (v *k8sSuite) TestLongLogLine() {
 		},
 	}
 
-	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpcec, metav1.CreateOptions{})
-	require.NoError(v.T(), err, "Could not properly start job")
+	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpec, metav1.CreateOptions{})
+	require.NoError(v.T(), err, "Could not create job")
+
+	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "long-line-job", 30*time.Second)
+	if err != nil {
+		require.Fail(v.T(), "Long line job pod failed to start",
+			"%v\n%s", err, k8sutils.DescribeJob(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "long-line-job"))
+	}
 
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		logsServiceNames, err := v.Env().FakeIntake.Client().GetLogServiceNames()
-		assert.NoError(c, err, "Error starting job")
-		if err != nil {
+		if !assert.NoError(c, err, "Error getting log service names") {
 			return
 		}
 
-		if assert.Contains(c, logsServiceNames, "apps-alpine", "Alpine service not found") {
-			filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("apps-alpine")
-			assert.NoError(c, err, "Error filtering logs")
-			if err != nil {
-				return
-			}
-			if assert.NotEmpty(c, filteredLogs, "Fake Intake returned no logs even though log service name exists") {
-				assert.Equal(c, longLineLog, fmt.Sprintf("%s%s", filteredLogs[0].Message, "\n"), "Test log doesn't match")
-			}
+		if !slices.Contains(logsServiceNames, "apps-alpine") {
+			assert.Fail(c, "Alpine service not found",
+				"Known services: %q\n%s",
+				logsServiceNames, fakeintakeRouteStats(v.Env().FakeIntake))
+			return
 		}
 
+		filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("apps-alpine")
+		if !assert.NoError(c, err, "Error filtering logs") {
+			return
+		}
+		if assert.NotEmpty(c, filteredLogs, "Fake Intake returned no logs even though log service name exists") {
+			assert.Equal(c, longLineLog, fmt.Sprintf("%s%s", filteredLogs[0].Message, "\n"), "Test log doesn't match")
+		}
 	}, 1*time.Minute, 10*time.Second)
 }
 
@@ -165,7 +182,7 @@ func (v *k8sSuite) TestContainerExclude() {
 	var backOffLimit int32 = 4
 	testLogMessage := "Test log message here"
 
-	jobSpcec := &batchv1.Job{
+	jobSpec := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "exclude-job",
 			Namespace: namespaceName,
@@ -189,15 +206,27 @@ func (v *k8sSuite) TestContainerExclude() {
 		},
 	}
 
-	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs(namespaceName).Create(context.TODO(), jobSpcec, metav1.CreateOptions{})
-	require.NoError(v.T(), err, "Could not properly start job")
+	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs(namespaceName).Create(context.TODO(), jobSpec, metav1.CreateOptions{})
+	require.NoError(v.T(), err, "Could not create job")
+
+	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), namespaceName, "exclude-job", 30*time.Second)
+	if err != nil {
+		require.Fail(v.T(), "Exclude job pod failed to start",
+			"%v\n%s", err, k8sutils.DescribeJob(context.TODO(), v.Env().KubernetesCluster.Client(), namespaceName, "exclude-job"))
+	}
 
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		logsServiceNames, err := v.Env().FakeIntake.Client().GetLogServiceNames()
-		assert.NoError(c, err, "Error starting job")
-		if err != nil {
+		if !assert.NoError(c, err, "Error getting log service names") {
 			return
 		}
 		assert.NotContains(c, logsServiceNames, "apps-alpine", "Alpine service found after excluded")
 	}, 1*time.Minute, 10*time.Second)
+}
+
+func (v *k8sSuite) AfterTest(suiteName, testName string) {
+	if v.T().Failed() {
+		v.T().Log(fakeintakeRouteStats(v.Env().FakeIntake))
+	}
+	v.BaseSuite.AfterTest(suiteName, testName)
 }

--- a/test/new-e2e/tests/agent-log-pipelines/k8s-logs/helpers_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/k8s-logs/helpers_test.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package k8sfiletailing
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/components"
+)
+
+func fakeintakeRouteStats(fi *components.FakeIntake) string {
+	stats, err := fi.Client().RouteStats()
+	if err != nil {
+		return fmt.Sprintf("RouteStats error: %v", err)
+	}
+	return fmt.Sprintf("RouteStats: %v", stats)
+}


### PR DESCRIPTION
### What does this PR do?

Adds diagnostic infrastructure to the Kubernetes log pipeline E2E tests (`TestK8sCCAOff`, `TestK8sSuite`) so that failures produce actionable information instead of a generic "Ubuntu service not found" timeout.

Changes:
- **`WaitForJobPodRunning`** shared utility in `test/e2e-framework/testing/utils/k8s/k8s.go`: polls until a Job's Pod leaves Pending phase, returning immediately with a descriptive error on image pull failures (`ImagePullBackOff`, `ErrImagePull`), scheduling failures, or crash loops.
- **`DescribeJob`** shared utility: collects Job status, Pod phase/conditions, container states, Pod events, and container logs into a diagnostic string.
- **Enhanced assertion messages**: when "ubuntu" is not found in fakeintake service names, the message now includes the list of services that *were* found, fakeintake `RouteStats` (payload counts per endpoint), and full Job/Pod diagnostics.
- **`AfterTest` hooks** on both suites: dump fakeintake route stats on failure (following the NPM test pattern).
- **Error guards** added to the CCA-off test's `EventuallyWithT` callback (matching the CCA-on test pattern).

### Motivation

These tests have been failing in CI (tracked in AGNTLOG-619) with no useful diagnostic output. The failure message is always "Ubuntu service not found" regardless of whether the issue is an image pull failure, a scheduling problem, the agent not collecting logs, or a fakeintake transport issue. This makes triage impossible without reproducing the failure locally.

### Example: diagnostic output from a real CI failure

Before this PR, the test would time out after 30 seconds with only `"Ubuntu service not found"`. With this PR, the failure output from [pipeline 113482429](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/113482429) shows:

```
Error:      Annotations job pod failed to start
Messages:   job annotations-job pod annotations-job-qcmdm container annotations-job:
            ErrImagePull - failed to pull and unpack image "docker.io/library/ubuntu:latest":
            429 Too Many Requests

            --- Job default/annotations-job diagnostics ---
            Job status: active=1 succeeded=0 failed=0
            Pod annotations-job-qcmdm: phase=Pending reason= message=
              condition: type=Ready reason=ContainersNotReady
                         message=containers with unready status: [annotations-job]
              condition: type=ContainersReady reason=ContainersNotReady
                         message=containers with unready status: [annotations-job]
              container annotations-job: waiting: reason=ErrImagePull
                message=failed to pull and unpack image "docker.io/library/ubuntu:latest":
                429 Too Many Requests
              events:
                Scheduled Normal: Successfully assigned default/annotations-job-qcmdm to ...
                Pulling Normal: Pulling image "ubuntu"
                Failed Warning: Failed to pull image "ubuntu": 429 Too Many Requests
                Failed Warning: Error: ErrImagePull
                BackOff Normal: Back-off pulling image "ubuntu"
                Failed Warning: Error: ImagePullBackOff
```

The root cause (Docker Hub rate-limiting) is immediately identifiable without any local reproduction.

### Describe how you validated your changes

- `go vet` passes on all modified packages
- `golangci-lint` passes with zero issues
- Test files compile cleanly
- No behavioral change to existing test logic — all additions are diagnostic-only
- Verified diagnostic output in CI pipeline 113482429: `WaitForJobPodRunning` detected `ErrImagePull` immediately (no 30s timeout) and `DescribeJob` produced compact, scoped diagnostics showing only the relevant job pod