### PR TITLE
irprinter: stream JSON directly into yaml.Node tree

### DIFF
--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
@@ -443,7 +443,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -822,7 +822,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1156,7 +1156,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
@@ -466,7 +466,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -851,7 +851,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1213,7 +1213,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.25.0.yaml
@@ -500,7 +500,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -891,7 +891,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1254,7 +1254,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.26rc1.yaml
@@ -514,7 +514,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1281,7 +1281,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
@@ -449,7 +449,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -828,7 +828,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1162,7 +1162,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
@@ -472,7 +472,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -857,7 +857,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1219,7 +1219,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.25.0.yaml
@@ -506,7 +506,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -897,7 +897,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1260,7 +1260,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.26rc1.yaml
@@ -520,7 +520,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1287,7 +1287,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -296,7 +296,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 9 BaseType int
           Locations:
             - Range: 0x647bcb..0x647bcb
@@ -325,7 +325,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 9 BaseType int
           Locations:
             - Range: 0x647bf1..0x647bf4
@@ -409,7 +409,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 9 BaseType int
           Locations:
             - Range: 0x647f02..0x647f02
@@ -4972,7 +4972,7 @@ Types:
         - Name: buf
           Offset: 16
           Type: 38 GoSliceHeaderType []uint8
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 9 BaseType int
         - Name: wr
@@ -4988,7 +4988,7 @@ Types:
         - Name: buf
           Offset: 0
           Type: 38 GoSliceHeaderType []uint8
-        - Name: off
+        - Name: "off"
           Offset: 24
           Type: 9 BaseType int
         - Name: lastRead
@@ -5891,7 +5891,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 474 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 13 BaseType int64
     - __kind: GoInterfaceType
@@ -7609,7 +7609,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -7803,7 +7803,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 474 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 13 BaseType int64
     - __kind: GoInterfaceType
@@ -9882,7 +9882,7 @@ Types:
         - Name: _
           Offset: 0
           Type: 805 ArrayType net/http.http2incomparable
-        - Name: n
+        - Name: "n"
           Offset: 0
           Type: 12 BaseType int32
         - Name: conn
@@ -10541,7 +10541,7 @@ Types:
         - Name: streamID
           Offset: 0
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
@@ -10589,7 +10589,7 @@ Types:
         - Name: i
           Offset: 32
           Type: 13 BaseType int64
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 13 BaseType int64
         - Name: err
@@ -10886,7 +10886,7 @@ Types:
         - Name: r
           Offset: 0
           Type: 550 PointerType *bufio.Reader
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 11 BaseType uint64
         - Name: err
@@ -11355,7 +11355,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 13 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 9 BaseType int
         - Name: signed
@@ -11690,7 +11690,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -12028,7 +12028,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -12737,7 +12737,7 @@ Types:
         - Name: i
           Offset: 216
           Type: 9 BaseType int
-        - Name: n
+        - Name: "n"
           Offset: 224
           Type: 9 BaseType int
         - Name: storage
@@ -12765,7 +12765,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 285 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 9 BaseType int
         - Name: index

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -288,7 +288,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x613e2b..0x613e2b
@@ -317,7 +317,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x613e51..0x613e54
@@ -401,7 +401,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x614122..0x614122
@@ -4885,7 +4885,7 @@ Types:
         - Name: buf
           Offset: 16
           Type: 38 GoSliceHeaderType []uint8
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 7 BaseType int
         - Name: wr
@@ -4901,7 +4901,7 @@ Types:
         - Name: buf
           Offset: 0
           Type: 38 GoSliceHeaderType []uint8
-        - Name: off
+        - Name: "off"
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
@@ -5226,7 +5226,7 @@ Types:
         - Name: a
           Offset: 0
           Type: 1054 ArrayType [200]uint8
-        - Name: n
+        - Name: "n"
           Offset: 200
           Type: 7 BaseType int
         - Name: rate
@@ -5893,7 +5893,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 490 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 12 BaseType int64
     - __kind: GoInterfaceType
@@ -7285,7 +7285,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -7492,7 +7492,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 490 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 12 BaseType int64
     - __kind: GoInterfaceType
@@ -10234,7 +10234,7 @@ Types:
         - Name: _
           Offset: 0
           Type: 861 ArrayType net/http.http2incomparable
-        - Name: n
+        - Name: "n"
           Offset: 0
           Type: 10 BaseType int32
         - Name: conn
@@ -10924,7 +10924,7 @@ Types:
         - Name: streamID
           Offset: 0
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
@@ -10972,7 +10972,7 @@ Types:
         - Name: i
           Offset: 32
           Type: 12 BaseType int64
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 12 BaseType int64
         - Name: err
@@ -11298,7 +11298,7 @@ Types:
         - Name: r
           Offset: 0
           Type: 563 PointerType *bufio.Reader
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 8 BaseType uint64
         - Name: err
@@ -12397,7 +12397,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 12 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -12738,7 +12738,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -13100,7 +13100,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -14214,7 +14214,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 292 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 7 BaseType int
         - Name: index

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -288,7 +288,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x61b7eb..0x61b7eb
@@ -317,7 +317,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x61b811..0x61b814
@@ -405,7 +405,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x61bb81..0x61bb81
@@ -5298,7 +5298,7 @@ Types:
         - Name: buf
           Offset: 16
           Type: 38 GoSliceHeaderType []uint8
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 7 BaseType int
         - Name: wr
@@ -5314,7 +5314,7 @@ Types:
         - Name: buf
           Offset: 0
           Type: 38 GoSliceHeaderType []uint8
-        - Name: off
+        - Name: "off"
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
@@ -5626,7 +5626,7 @@ Types:
         - Name: a
           Offset: 0
           Type: 1161 ArrayType [200]uint8
-        - Name: n
+        - Name: "n"
           Offset: 200
           Type: 7 BaseType int
         - Name: rate
@@ -6289,7 +6289,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 597 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 12 BaseType int64
     - __kind: GoInterfaceType
@@ -7709,7 +7709,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -8012,7 +8012,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 597 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 12 BaseType int64
     - __kind: GoInterfaceType
@@ -10811,7 +10811,7 @@ Types:
         - Name: _
           Offset: 0
           Type: 968 ArrayType net/http.http2incomparable
-        - Name: n
+        - Name: "n"
           Offset: 0
           Type: 10 BaseType int32
         - Name: conn
@@ -11501,7 +11501,7 @@ Types:
         - Name: streamID
           Offset: 0
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
@@ -11549,7 +11549,7 @@ Types:
         - Name: i
           Offset: 32
           Type: 12 BaseType int64
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 12 BaseType int64
         - Name: err
@@ -11878,7 +11878,7 @@ Types:
         - Name: r
           Offset: 0
           Type: 671 PointerType *bufio.Reader
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 8 BaseType uint64
         - Name: err
@@ -13078,7 +13078,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 12 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -13131,7 +13131,7 @@ Types:
         - Name: alllink
           Offset: 16
           Type: 370 PointerType *runtime.cleanupBlock
-        - Name: n
+        - Name: "n"
           Offset: 24
           Type: 2 BaseType uint32
     - __kind: StructureType
@@ -13618,7 +13618,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -14359,7 +14359,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -14378,7 +14378,7 @@ Types:
         - Name: base
           Offset: 0
           Type: 355 PointerType *runtime.notInHeap
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 1 BaseType uintptr
     - __kind: StructureType
@@ -15847,7 +15847,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 309 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 7 BaseType int
         - Name: index

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.26rc1.yaml
@@ -288,7 +288,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x63716b..0x63716b
@@ -317,7 +317,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x637191..0x637194
@@ -405,7 +405,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x637538..0x637538
@@ -5370,7 +5370,7 @@ Types:
         - Name: buf
           Offset: 16
           Type: 39 GoSliceHeaderType []uint8
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 7 BaseType int
         - Name: wr
@@ -5386,7 +5386,7 @@ Types:
         - Name: buf
           Offset: 0
           Type: 39 GoSliceHeaderType []uint8
-        - Name: off
+        - Name: "off"
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
@@ -5726,7 +5726,7 @@ Types:
         - Name: a
           Offset: 0
           Type: 1188 ArrayType [200]uint8
-        - Name: n
+        - Name: "n"
           Offset: 200
           Type: 7 BaseType int
         - Name: rate
@@ -6402,7 +6402,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 621 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 12 BaseType int64
     - __kind: GoInterfaceType
@@ -7830,7 +7830,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -8123,7 +8123,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 621 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 12 BaseType int64
     - __kind: GoInterfaceType
@@ -10925,7 +10925,7 @@ Types:
         - Name: _
           Offset: 0
           Type: 998 ArrayType net/http.http2incomparable
-        - Name: n
+        - Name: "n"
           Offset: 0
           Type: 10 BaseType int32
         - Name: conn
@@ -11601,7 +11601,7 @@ Types:
         - Name: streamID
           Offset: 0
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
@@ -11649,7 +11649,7 @@ Types:
         - Name: i
           Offset: 32
           Type: 12 BaseType int64
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 12 BaseType int64
         - Name: err
@@ -11978,7 +11978,7 @@ Types:
         - Name: r
           Offset: 0
           Type: 698 PointerType *bufio.Reader
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 8 BaseType uint64
         - Name: err
@@ -13197,7 +13197,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 12 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -13244,7 +13244,7 @@ Types:
         - Name: alllink
           Offset: 16
           Type: 387 PointerType *runtime.cleanupBlock
-        - Name: n
+        - Name: "n"
           Offset: 24
           Type: 2 BaseType uint32
     - __kind: StructureType
@@ -14521,7 +14521,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -14540,7 +14540,7 @@ Types:
         - Name: base
           Offset: 0
           Type: 365 PointerType *runtime.notInHeap
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 1 BaseType uintptr
     - __kind: StructureType
@@ -16262,7 +16262,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 320 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 7 BaseType int
         - Name: index

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -282,7 +282,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 9 BaseType int
           Locations:
             - Range: 0x21df60..0x21df60
@@ -311,7 +311,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 9 BaseType int
           Locations:
             - Range: 0x21df98..0x21df9c
@@ -397,7 +397,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 9 BaseType int
           Locations:
             - Range: 0x21e2a4..0x21e2a4
@@ -4959,7 +4959,7 @@ Types:
         - Name: buf
           Offset: 16
           Type: 38 GoSliceHeaderType []uint8
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 9 BaseType int
         - Name: wr
@@ -4975,7 +4975,7 @@ Types:
         - Name: buf
           Offset: 0
           Type: 38 GoSliceHeaderType []uint8
-        - Name: off
+        - Name: "off"
           Offset: 24
           Type: 9 BaseType int
         - Name: lastRead
@@ -5878,7 +5878,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 474 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 14 BaseType int64
     - __kind: GoInterfaceType
@@ -7596,7 +7596,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -7790,7 +7790,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 474 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 14 BaseType int64
     - __kind: GoInterfaceType
@@ -9869,7 +9869,7 @@ Types:
         - Name: _
           Offset: 0
           Type: 805 ArrayType net/http.http2incomparable
-        - Name: n
+        - Name: "n"
           Offset: 0
           Type: 13 BaseType int32
         - Name: conn
@@ -10528,7 +10528,7 @@ Types:
         - Name: streamID
           Offset: 0
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
@@ -10576,7 +10576,7 @@ Types:
         - Name: i
           Offset: 32
           Type: 14 BaseType int64
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 14 BaseType int64
         - Name: err
@@ -10873,7 +10873,7 @@ Types:
         - Name: r
           Offset: 0
           Type: 550 PointerType *bufio.Reader
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 11 BaseType uint64
         - Name: err
@@ -11342,7 +11342,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 14 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 9 BaseType int
         - Name: signed
@@ -11677,7 +11677,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -12015,7 +12015,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -12724,7 +12724,7 @@ Types:
         - Name: i
           Offset: 216
           Type: 9 BaseType int
-        - Name: n
+        - Name: "n"
           Offset: 224
           Type: 9 BaseType int
         - Name: storage
@@ -12752,7 +12752,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 285 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 9 BaseType int
         - Name: index

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -282,7 +282,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x1f7960..0x1f7960
@@ -311,7 +311,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x1f7998..0x1f799c
@@ -397,7 +397,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x1f7c74..0x1f7c74
@@ -4880,7 +4880,7 @@ Types:
         - Name: buf
           Offset: 16
           Type: 38 GoSliceHeaderType []uint8
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 7 BaseType int
         - Name: wr
@@ -4896,7 +4896,7 @@ Types:
         - Name: buf
           Offset: 0
           Type: 38 GoSliceHeaderType []uint8
-        - Name: off
+        - Name: "off"
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
@@ -5221,7 +5221,7 @@ Types:
         - Name: a
           Offset: 0
           Type: 1054 ArrayType [200]uint8
-        - Name: n
+        - Name: "n"
           Offset: 200
           Type: 7 BaseType int
         - Name: rate
@@ -5888,7 +5888,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 490 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 13 BaseType int64
     - __kind: GoInterfaceType
@@ -7280,7 +7280,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -7487,7 +7487,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 490 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 13 BaseType int64
     - __kind: GoInterfaceType
@@ -10229,7 +10229,7 @@ Types:
         - Name: _
           Offset: 0
           Type: 861 ArrayType net/http.http2incomparable
-        - Name: n
+        - Name: "n"
           Offset: 0
           Type: 12 BaseType int32
         - Name: conn
@@ -10919,7 +10919,7 @@ Types:
         - Name: streamID
           Offset: 0
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
@@ -10967,7 +10967,7 @@ Types:
         - Name: i
           Offset: 32
           Type: 13 BaseType int64
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 13 BaseType int64
         - Name: err
@@ -11293,7 +11293,7 @@ Types:
         - Name: r
           Offset: 0
           Type: 563 PointerType *bufio.Reader
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 8 BaseType uint64
         - Name: err
@@ -12392,7 +12392,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 13 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -12733,7 +12733,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -13095,7 +13095,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -14209,7 +14209,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 292 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 7 BaseType int
         - Name: index

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -282,7 +282,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x1f1794..0x1f17c0
@@ -309,7 +309,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x1f17c4..0x1f1800
@@ -391,7 +391,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x1f1b04..0x1f1b30
@@ -5283,7 +5283,7 @@ Types:
         - Name: buf
           Offset: 16
           Type: 38 GoSliceHeaderType []uint8
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 7 BaseType int
         - Name: wr
@@ -5299,7 +5299,7 @@ Types:
         - Name: buf
           Offset: 0
           Type: 38 GoSliceHeaderType []uint8
-        - Name: off
+        - Name: "off"
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
@@ -5611,7 +5611,7 @@ Types:
         - Name: a
           Offset: 0
           Type: 1161 ArrayType [200]uint8
-        - Name: n
+        - Name: "n"
           Offset: 200
           Type: 7 BaseType int
         - Name: rate
@@ -6274,7 +6274,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 597 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 13 BaseType int64
     - __kind: GoInterfaceType
@@ -7694,7 +7694,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -7997,7 +7997,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 597 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 13 BaseType int64
     - __kind: GoInterfaceType
@@ -10796,7 +10796,7 @@ Types:
         - Name: _
           Offset: 0
           Type: 968 ArrayType net/http.http2incomparable
-        - Name: n
+        - Name: "n"
           Offset: 0
           Type: 12 BaseType int32
         - Name: conn
@@ -11486,7 +11486,7 @@ Types:
         - Name: streamID
           Offset: 0
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
@@ -11534,7 +11534,7 @@ Types:
         - Name: i
           Offset: 32
           Type: 13 BaseType int64
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 13 BaseType int64
         - Name: err
@@ -11863,7 +11863,7 @@ Types:
         - Name: r
           Offset: 0
           Type: 671 PointerType *bufio.Reader
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 8 BaseType uint64
         - Name: err
@@ -13063,7 +13063,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 13 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -13116,7 +13116,7 @@ Types:
         - Name: alllink
           Offset: 16
           Type: 370 PointerType *runtime.cleanupBlock
-        - Name: n
+        - Name: "n"
           Offset: 24
           Type: 2 BaseType uint32
     - __kind: StructureType
@@ -13603,7 +13603,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -14344,7 +14344,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -14363,7 +14363,7 @@ Types:
         - Name: base
           Offset: 0
           Type: 355 PointerType *runtime.notInHeap
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 1 BaseType uintptr
     - __kind: StructureType
@@ -15832,7 +15832,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 309 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 7 BaseType int
         - Name: index

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.26rc1.yaml
@@ -282,7 +282,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x205374..0x2053a0
@@ -309,7 +309,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x2053a4..0x2053e0
@@ -391,7 +391,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x205704..0x205730
@@ -5355,7 +5355,7 @@ Types:
         - Name: buf
           Offset: 16
           Type: 39 GoSliceHeaderType []uint8
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 7 BaseType int
         - Name: wr
@@ -5371,7 +5371,7 @@ Types:
         - Name: buf
           Offset: 0
           Type: 39 GoSliceHeaderType []uint8
-        - Name: off
+        - Name: "off"
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
@@ -5711,7 +5711,7 @@ Types:
         - Name: a
           Offset: 0
           Type: 1187 ArrayType [200]uint8
-        - Name: n
+        - Name: "n"
           Offset: 200
           Type: 7 BaseType int
         - Name: rate
@@ -6387,7 +6387,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 620 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 13 BaseType int64
     - __kind: GoInterfaceType
@@ -7815,7 +7815,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -8108,7 +8108,7 @@ Types:
         - Name: R
           Offset: 0
           Type: 620 GoInterfaceType io.Reader
-        - Name: N
+        - Name: "N"
           Offset: 16
           Type: 13 BaseType int64
     - __kind: GoInterfaceType
@@ -10910,7 +10910,7 @@ Types:
         - Name: _
           Offset: 0
           Type: 997 ArrayType net/http.http2incomparable
-        - Name: n
+        - Name: "n"
           Offset: 0
           Type: 12 BaseType int32
         - Name: conn
@@ -11586,7 +11586,7 @@ Types:
         - Name: streamID
           Offset: 0
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
@@ -11634,7 +11634,7 @@ Types:
         - Name: i
           Offset: 32
           Type: 13 BaseType int64
-        - Name: n
+        - Name: "n"
           Offset: 40
           Type: 13 BaseType int64
         - Name: err
@@ -11963,7 +11963,7 @@ Types:
         - Name: r
           Offset: 0
           Type: 697 PointerType *bufio.Reader
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 8 BaseType uint64
         - Name: err
@@ -13182,7 +13182,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 13 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -13229,7 +13229,7 @@ Types:
         - Name: alllink
           Offset: 16
           Type: 387 PointerType *runtime.cleanupBlock
-        - Name: n
+        - Name: "n"
           Offset: 24
           Type: 2 BaseType uint32
     - __kind: StructureType
@@ -14506,7 +14506,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -14525,7 +14525,7 @@ Types:
         - Name: base
           Offset: 0
           Type: 365 PointerType *runtime.notInHeap
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 1 BaseType uintptr
     - __kind: StructureType
@@ -16223,7 +16223,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 320 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 7 BaseType int
         - Name: index

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
@@ -524,7 +524,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -903,7 +903,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1237,7 +1237,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
@@ -547,7 +547,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -932,7 +932,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1294,7 +1294,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
@@ -581,7 +581,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -972,7 +972,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1335,7 +1335,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.26rc1.yaml
@@ -601,7 +601,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1368,7 +1368,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
@@ -530,7 +530,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -909,7 +909,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1243,7 +1243,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
@@ -553,7 +553,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -938,7 +938,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1300,7 +1300,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
@@ -587,7 +587,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -978,7 +978,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1341,7 +1341,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.26rc1.yaml
@@ -607,7 +607,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1374,7 +1374,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -158,7 +158,7 @@ Types:
       ID: 107
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.17632e+06
+      GoRuntimeType: 2176320
       GoKind: 22
       Pointee: 108 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -193,14 +193,14 @@ Types:
       ID: 105
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
-      GoRuntimeType: 2.187104e+06
+      GoRuntimeType: 2187104
       GoKind: 22
       Pointee: 106 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 115
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.396768e+06
+      GoRuntimeType: 1396768
       GoKind: 22
       Pointee: 116 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
@@ -259,42 +259,42 @@ Types:
       ID: 103
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.219392e+06
+      GoRuntimeType: 2219392
       GoKind: 22
       Pointee: 104 StructureType net/http.Request
     - __kind: PointerType
       ID: 174
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.63216e+06
+      GoRuntimeType: 1632160
       GoKind: 22
       Pointee: 175 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 152
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.876224e+06
+      GoRuntimeType: 1876224
       GoKind: 22
       Pointee: 153 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 177
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.45312e+06
+      GoRuntimeType: 1453120
       GoKind: 22
       Pointee: 178 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 154
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.117184e+06
+      GoRuntimeType: 2117184
       GoKind: 22
       Pointee: 155 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 156
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.00192e+06
+      GoRuntimeType: 2001920
       GoKind: 22
       Pointee: 157 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -308,7 +308,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.261856e+06
+      GoRuntimeType: 1261856
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -336,7 +336,7 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.012544e+06
+      GoRuntimeType: 1012544
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
@@ -357,14 +357,14 @@ Types:
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 1.966272e+06
+      GoRuntimeType: 1966272
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.464256e+06
+      GoRuntimeType: 1464256
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -383,105 +383,105 @@ Types:
       ID: 121
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.532416e+06
+      GoRuntimeType: 1532416
       GoKind: 22
       Pointee: 122 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.656736e+06
+      GoRuntimeType: 1656736
       GoKind: 22
       Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 117
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.532032e+06
+      GoRuntimeType: 1532032
       GoKind: 22
       Pointee: 118 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 127
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.655968e+06
+      GoRuntimeType: 1655968
       GoKind: 22
       Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.726624e+06
+      GoRuntimeType: 1726624
       GoKind: 22
       Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 129
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.65616e+06
+      GoRuntimeType: 1656160
       GoKind: 22
       Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 125
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.655776e+06
+      GoRuntimeType: 1655776
       GoKind: 22
       Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.726176e+06
+      GoRuntimeType: 1726176
       GoKind: 22
       Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 145
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.794496e+06
+      GoRuntimeType: 1794496
       GoKind: 22
       Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.7264e+06
+      GoRuntimeType: 1726400
       GoKind: 22
       Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 123
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.532608e+06
+      GoRuntimeType: 1532608
       GoKind: 22
       Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 119
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.532224e+06
+      GoRuntimeType: 1532224
       GoKind: 22
       Pointee: 120 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 131
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.656352e+06
+      GoRuntimeType: 1656352
       GoKind: 22
       Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 143
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.726848e+06
+      GoRuntimeType: 1726848
       GoKind: 22
       Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.656544e+06
+      GoRuntimeType: 1656544
       GoKind: 22
       Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -851,7 +851,7 @@ Types:
       ID: 176
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.215552e+06
+      GoRuntimeType: 1215552
       GoKind: 20
       RawFields:
         - Name: tab
@@ -868,7 +868,7 @@ Types:
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.01088e+06
+      GoRuntimeType: 1010880
       GoKind: 20
       RawFields:
         - Name: tab
@@ -915,7 +915,7 @@ Types:
       ID: 147
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.265696e+06
+      GoRuntimeType: 1265696
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1030,7 +1030,7 @@ Types:
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.761344e+06
+      GoRuntimeType: 1761344
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1042,7 +1042,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1052,7 +1052,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.152e+06
+      GoRuntimeType: 1152000
       GoKind: 25
       RawFields:
         - Name: u
@@ -1062,7 +1062,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.483264e+06
+      GoRuntimeType: 1483264
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1078,7 +1078,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.337344e+06
+      GoRuntimeType: 1337344
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1091,7 +1091,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.337184e+06
+      GoRuntimeType: 1337184
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1104,7 +1104,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.337504e+06
+      GoRuntimeType: 1337504
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1129,7 +1129,7 @@ Types:
       ID: 165
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.092864e+06
+      GoRuntimeType: 1092864
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1153,7 +1153,7 @@ Types:
       ID: 150
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.006528e+06
+      GoRuntimeType: 1006528
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1166,7 +1166,7 @@ Types:
       ID: 148
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.00512e+06
+      GoRuntimeType: 1005120
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1179,14 +1179,14 @@ Types:
       ID: 158
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 1.963712e+06
+      GoRuntimeType: 1963712
       GoKind: 21
       HeaderType: 160 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
       ID: 151
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.005248e+06
+      GoRuntimeType: 1005248
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1199,7 +1199,7 @@ Types:
       ID: 149
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.005504e+06
+      GoRuntimeType: 1005504
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1212,7 +1212,7 @@ Types:
       ID: 104
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.255712e+06
+      GoRuntimeType: 2255712
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1301,7 +1301,7 @@ Types:
       ID: 102
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.125248e+06
+      GoRuntimeType: 1125248
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1330,7 +1330,7 @@ Types:
       ID: 168
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.71184e+06
+      GoRuntimeType: 1711840
       GoKind: 21
       HeaderType: 160 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
@@ -1359,7 +1359,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 2.314368e+06
+      GoRuntimeType: 2314368
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1534,7 +1534,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.136512e+06
+      GoRuntimeType: 1136512
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1544,7 +1544,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.879392e+06
+      GoRuntimeType: 1879392
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1572,7 +1572,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.319584e+06
+      GoRuntimeType: 1319584
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1585,7 +1585,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.666112e+06
+      GoRuntimeType: 1666112
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1610,7 +1610,7 @@ Types:
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.319424e+06
+      GoRuntimeType: 1319424
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1623,13 +1623,13 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.824576e+06
+      GoRuntimeType: 1824576
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1654,7 +1654,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 2.32048e+06
+      GoRuntimeType: 2320480
       GoKind: 25
       RawFields:
         - Name: g0
@@ -1874,7 +1874,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.82432e+06
+      GoRuntimeType: 1824320
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -1899,7 +1899,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 1.46464e+06
+      GoRuntimeType: 1464640
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -1915,7 +1915,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 1.464448e+06
+      GoRuntimeType: 1464448
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -1941,14 +1941,14 @@ Types:
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.136128e+06
+      GoRuntimeType: 1136128
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.319264e+06
+      GoRuntimeType: 1319264
       GoKind: 25
       RawFields:
         - Name: entries
@@ -1961,13 +1961,13 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.66688e+06
+      GoRuntimeType: 1666880
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -1995,7 +1995,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.317664e+06
+      GoRuntimeType: 1317664
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2032,7 +2032,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.318624e+06
+      GoRuntimeType: 1318624
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2045,7 +2045,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.093888e+06
+      GoRuntimeType: 1093888
       GoKind: 8
     - __kind: StructureType
       ID: 75
@@ -2076,7 +2076,7 @@ Types:
       ID: 122
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.855808e+06
+      GoRuntimeType: 1855808
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2089,7 +2089,7 @@ Types:
       ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 1.931104e+06
+      GoRuntimeType: 1931104
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2105,7 +2105,7 @@ Types:
       ID: 118
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.855296e+06
+      GoRuntimeType: 1855296
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2118,7 +2118,7 @@ Types:
       ID: 128
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 1.929952e+06
+      GoRuntimeType: 1929952
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2134,7 +2134,7 @@ Types:
       ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 1.999552e+06
+      GoRuntimeType: 1999552
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2153,7 +2153,7 @@ Types:
       ID: 130
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 1.93024e+06
+      GoRuntimeType: 1930240
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2169,7 +2169,7 @@ Types:
       ID: 126
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 1.929664e+06
+      GoRuntimeType: 1929664
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2185,7 +2185,7 @@ Types:
       ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 1.998912e+06
+      GoRuntimeType: 1998912
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2204,7 +2204,7 @@ Types:
       ID: 146
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.058656e+06
+      GoRuntimeType: 2058656
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2226,7 +2226,7 @@ Types:
       ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 1.999232e+06
+      GoRuntimeType: 1999232
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2245,7 +2245,7 @@ Types:
       ID: 124
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.856064e+06
+      GoRuntimeType: 1856064
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2258,7 +2258,7 @@ Types:
       ID: 120
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.855552e+06
+      GoRuntimeType: 1855552
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2271,7 +2271,7 @@ Types:
       ID: 132
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 1.930528e+06
+      GoRuntimeType: 1930528
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2287,7 +2287,7 @@ Types:
       ID: 144
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 1.999872e+06
+      GoRuntimeType: 1999872
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2306,7 +2306,7 @@ Types:
       ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 1.930816e+06
+      GoRuntimeType: 1930816
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -158,7 +158,7 @@ Types:
       ID: 112
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.316768e+06
+      GoRuntimeType: 2316768
       GoKind: 22
       Pointee: 113 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -193,14 +193,14 @@ Types:
       ID: 110
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
-      GoRuntimeType: 2.32752e+06
+      GoRuntimeType: 2327520
       GoKind: 22
       Pointee: 111 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 120
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.577632e+06
+      GoRuntimeType: 1577632
       GoKind: 22
       Pointee: 121 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
@@ -259,42 +259,42 @@ Types:
       ID: 108
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.360384e+06
+      GoRuntimeType: 2360384
       GoKind: 22
       Pointee: 109 StructureType net/http.Request
     - __kind: PointerType
       ID: 177
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.751392e+06
+      GoRuntimeType: 1751392
       GoKind: 22
       Pointee: 178 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 157
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 2.045344e+06
+      GoRuntimeType: 2045344
       GoKind: 22
       Pointee: 158 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 180
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.637792e+06
+      GoRuntimeType: 1637792
       GoKind: 22
       Pointee: 181 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 159
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.254144e+06
+      GoRuntimeType: 2254144
       GoKind: 22
       Pointee: 160 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 161
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.16048e+06
+      GoRuntimeType: 2160480
       GoKind: 22
       Pointee: 162 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -318,7 +318,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.436512e+06
+      GoRuntimeType: 1436512
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -346,7 +346,7 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.051776e+06
+      GoRuntimeType: 1051776
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
@@ -360,21 +360,21 @@ Types:
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 1.575392e+06
+      GoRuntimeType: 1575392
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.096416e+06
+      GoRuntimeType: 2096416
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.64912e+06
+      GoRuntimeType: 1649120
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -393,105 +393,105 @@ Types:
       ID: 126
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.716704e+06
+      GoRuntimeType: 1716704
       GoKind: 22
       Pointee: 127 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 140
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.774624e+06
+      GoRuntimeType: 1774624
       GoKind: 22
       Pointee: 141 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 122
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.71632e+06
+      GoRuntimeType: 1716320
       GoKind: 22
       Pointee: 123 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 132
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.773856e+06
+      GoRuntimeType: 1773856
       GoKind: 22
       Pointee: 133 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 146
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.845888e+06
+      GoRuntimeType: 1845888
       GoKind: 22
       Pointee: 147 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 134
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.774048e+06
+      GoRuntimeType: 1774048
       GoKind: 22
       Pointee: 135 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 130
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.773664e+06
+      GoRuntimeType: 1773664
       GoKind: 22
       Pointee: 131 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 142
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.84544e+06
+      GoRuntimeType: 1845440
       GoKind: 22
       Pointee: 143 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 150
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.918112e+06
+      GoRuntimeType: 1918112
       GoKind: 22
       Pointee: 151 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 144
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.845664e+06
+      GoRuntimeType: 1845664
       GoKind: 22
       Pointee: 145 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 128
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.716896e+06
+      GoRuntimeType: 1716896
       GoKind: 22
       Pointee: 129 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 124
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.716512e+06
+      GoRuntimeType: 1716512
       GoKind: 22
       Pointee: 125 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 136
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.77424e+06
+      GoRuntimeType: 1774240
       GoKind: 22
       Pointee: 137 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 148
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.846112e+06
+      GoRuntimeType: 1846112
       GoKind: 22
       Pointee: 149 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 138
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.774432e+06
+      GoRuntimeType: 1774432
       GoKind: 22
       Pointee: 139 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -831,7 +831,7 @@ Types:
       ID: 179
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.298688e+06
+      GoRuntimeType: 1298688
       GoKind: 20
       RawFields:
         - Name: tab
@@ -848,7 +848,7 @@ Types:
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.049984e+06
+      GoRuntimeType: 1049984
       GoKind: 20
       RawFields:
         - Name: tab
@@ -895,7 +895,7 @@ Types:
       ID: 152
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.440512e+06
+      GoRuntimeType: 1440512
       GoKind: 20
       RawFields:
         - Name: tab
@@ -970,7 +970,7 @@ Types:
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.883616e+06
+      GoRuntimeType: 1883616
       GoKind: 25
       RawFields:
         - Name: buf
@@ -982,7 +982,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -992,7 +992,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.2336e+06
+      GoRuntimeType: 1233600
       GoKind: 25
       RawFields:
         - Name: u
@@ -1002,7 +1002,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.667936e+06
+      GoRuntimeType: 1667936
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1018,7 +1018,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.513632e+06
+      GoRuntimeType: 1513632
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1031,7 +1031,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.513472e+06
+      GoRuntimeType: 1513472
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1044,7 +1044,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.513792e+06
+      GoRuntimeType: 1513792
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1056,20 +1056,20 @@ Types:
     - __kind: StructureType
       ID: 69
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 1.007968e+06
+      GoRuntimeType: 1007968
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 1.007872e+06
+      GoRuntimeType: 1007872
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
       ID: 168
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.130304e+06
+      GoRuntimeType: 1130304
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1146,7 +1146,7 @@ Types:
       ID: 182
       Name: map[string]string
       ByteSize: 8
-      GoRuntimeType: 1.149376e+06
+      GoRuntimeType: 1149376
       GoKind: 21
       HeaderType: 184 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
@@ -1157,7 +1157,7 @@ Types:
       ID: 155
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.04576e+06
+      GoRuntimeType: 1045760
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1170,7 +1170,7 @@ Types:
       ID: 153
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.044352e+06
+      GoRuntimeType: 1044352
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1183,14 +1183,14 @@ Types:
       ID: 163
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 2.148192e+06
+      GoRuntimeType: 2148192
       GoKind: 21
       HeaderType: 165 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
       ID: 156
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.04448e+06
+      GoRuntimeType: 1044480
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1203,7 +1203,7 @@ Types:
       ID: 154
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.044736e+06
+      GoRuntimeType: 1044736
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1216,7 +1216,7 @@ Types:
       ID: 109
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.398144e+06
+      GoRuntimeType: 2398144
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1305,7 +1305,7 @@ Types:
       ID: 107
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.206848e+06
+      GoRuntimeType: 1206848
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1334,7 +1334,7 @@ Types:
       ID: 171
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.9208e+06
+      GoRuntimeType: 1920800
       GoKind: 21
       HeaderType: 165 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
@@ -1359,7 +1359,7 @@ Types:
       ID: 190
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.312128e+06
+      GoRuntimeType: 1312128
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1372,7 +1372,7 @@ Types:
       ID: 200
       Name: noalg.map.group[string]string
       ByteSize: 264
-      GoRuntimeType: 1.314432e+06
+      GoRuntimeType: 1314432
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1385,7 +1385,7 @@ Types:
       ID: 192
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.312e+06
+      GoRuntimeType: 1312000
       GoKind: 25
       RawFields:
         - Name: key
@@ -1398,7 +1398,7 @@ Types:
       ID: 202
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
-      GoRuntimeType: 1.314304e+06
+      GoRuntimeType: 1314304
       GoKind: 25
       RawFields:
         - Name: key
@@ -1426,14 +1426,14 @@ Types:
     - __kind: StructureType
       ID: 84
       Name: runtime.dlogPerM
-      GoRuntimeType: 1.003936e+06
+      GoRuntimeType: 1003936
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.46048e+06
+      GoRuntimeType: 2460480
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1614,7 +1614,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.217856e+06
+      GoRuntimeType: 1217856
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1624,7 +1624,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 2.008032e+06
+      GoRuntimeType: 2008032
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1652,7 +1652,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.495072e+06
+      GoRuntimeType: 1495072
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1665,7 +1665,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.783808e+06
+      GoRuntimeType: 1783808
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1690,7 +1690,7 @@ Types:
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.494912e+06
+      GoRuntimeType: 1494912
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1703,13 +1703,13 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.94944e+06
+      GoRuntimeType: 1949440
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1734,7 +1734,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 2.465536e+06
+      GoRuntimeType: 2465536
       GoKind: 25
       RawFields:
         - Name: g0
@@ -1957,7 +1957,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 2.00832e+06
+      GoRuntimeType: 2008320
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -1985,7 +1985,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.873536e+06
+      GoRuntimeType: 1873536
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2007,7 +2007,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.873312e+06
+      GoRuntimeType: 1873312
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2029,7 +2029,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 1.2176e+06
+      GoRuntimeType: 1217600
       GoKind: 25
       RawFields:
         - Name: next
@@ -2045,14 +2045,14 @@ Types:
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.217472e+06
+      GoRuntimeType: 1217472
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.494752e+06
+      GoRuntimeType: 1494752
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2065,13 +2065,13 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.784576e+06
+      GoRuntimeType: 1784576
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2099,7 +2099,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.493152e+06
+      GoRuntimeType: 1493152
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2140,7 +2140,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.494112e+06
+      GoRuntimeType: 1494112
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2153,12 +2153,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.300096e+06
+      GoRuntimeType: 1300096
       GoKind: 8
     - __kind: StructureType
       ID: 79
       Name: runtime.winlibcall
-      GoRuntimeType: 1.00384e+06
+      GoRuntimeType: 1003840
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
@@ -2184,7 +2184,7 @@ Types:
       ID: 127
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.982976e+06
+      GoRuntimeType: 1982976
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2197,7 +2197,7 @@ Types:
       ID: 141
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.06032e+06
+      GoRuntimeType: 2060320
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2213,7 +2213,7 @@ Types:
       ID: 123
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.982464e+06
+      GoRuntimeType: 1982464
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2226,7 +2226,7 @@ Types:
       ID: 133
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.059168e+06
+      GoRuntimeType: 2059168
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2242,7 +2242,7 @@ Types:
       ID: 147
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.129376e+06
+      GoRuntimeType: 2129376
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2261,7 +2261,7 @@ Types:
       ID: 135
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.059456e+06
+      GoRuntimeType: 2059456
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2277,7 +2277,7 @@ Types:
       ID: 131
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 2.05888e+06
+      GoRuntimeType: 2058880
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2293,7 +2293,7 @@ Types:
       ID: 143
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 2.128736e+06
+      GoRuntimeType: 2128736
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2312,7 +2312,7 @@ Types:
       ID: 151
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.191008e+06
+      GoRuntimeType: 2191008
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2334,7 +2334,7 @@ Types:
       ID: 145
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.129056e+06
+      GoRuntimeType: 2129056
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2353,7 +2353,7 @@ Types:
       ID: 129
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.983232e+06
+      GoRuntimeType: 1983232
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2366,7 +2366,7 @@ Types:
       ID: 125
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.98272e+06
+      GoRuntimeType: 1982720
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2379,7 +2379,7 @@ Types:
       ID: 137
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.059744e+06
+      GoRuntimeType: 2059744
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2395,7 +2395,7 @@ Types:
       ID: 149
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.129696e+06
+      GoRuntimeType: 2129696
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2414,7 +2414,7 @@ Types:
       ID: 139
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.060032e+06
+      GoRuntimeType: 2060032
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -169,7 +169,7 @@ Types:
       ID: 114
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.321376e+06
+      GoRuntimeType: 2321376
       GoKind: 22
       Pointee: 115 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -204,14 +204,14 @@ Types:
       ID: 112
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
-      GoRuntimeType: 2.33264e+06
+      GoRuntimeType: 2332640
       GoKind: 22
       Pointee: 113 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 125
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.582816e+06
+      GoRuntimeType: 1582816
       GoKind: 22
       Pointee: 126 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
@@ -270,42 +270,42 @@ Types:
       ID: 110
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.365504e+06
+      GoRuntimeType: 2365504
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
       ID: 182
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.7584e+06
+      GoRuntimeType: 1758400
       GoKind: 22
       Pointee: 183 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 162
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 2.053472e+06
+      GoRuntimeType: 2053472
       GoKind: 22
       Pointee: 163 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 185
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.642688e+06
+      GoRuntimeType: 1642688
       GoKind: 22
       Pointee: 186 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 164
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.27712e+06
+      GoRuntimeType: 2277120
       GoKind: 22
       Pointee: 165 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 166
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.167328e+06
+      GoRuntimeType: 2167328
       GoKind: 22
       Pointee: 167 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -329,7 +329,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.440704e+06
+      GoRuntimeType: 1440704
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -357,14 +357,14 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.441344e+06
+      GoRuntimeType: 1441344
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.055968e+06
+      GoRuntimeType: 1055968
       GoKind: 22
       Pointee: 122 UnresolvedPointeeType runtime.p
     - __kind: PointerType
@@ -378,21 +378,21 @@ Types:
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.580576e+06
+      GoRuntimeType: 1580576
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.103392e+06
+      GoRuntimeType: 2103392
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.654208e+06
+      GoRuntimeType: 1654208
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -411,105 +411,105 @@ Types:
       ID: 131
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.722368e+06
+      GoRuntimeType: 1722368
       GoKind: 22
       Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 145
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.781632e+06
+      GoRuntimeType: 1781632
       GoKind: 22
       Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 127
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.721984e+06
+      GoRuntimeType: 1721984
       GoKind: 22
       Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.780864e+06
+      GoRuntimeType: 1780864
       GoKind: 22
       Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 151
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.853888e+06
+      GoRuntimeType: 1853888
       GoKind: 22
       Pointee: 152 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.781056e+06
+      GoRuntimeType: 1781056
       GoKind: 22
       Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.780672e+06
+      GoRuntimeType: 1780672
       GoKind: 22
       Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 147
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.85344e+06
+      GoRuntimeType: 1853440
       GoKind: 22
       Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 155
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.925792e+06
+      GoRuntimeType: 1925792
       GoKind: 22
       Pointee: 156 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 149
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.853664e+06
+      GoRuntimeType: 1853664
       GoKind: 22
       Pointee: 150 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.72256e+06
+      GoRuntimeType: 1722560
       GoKind: 22
       Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 129
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.722176e+06
+      GoRuntimeType: 1722176
       GoKind: 22
       Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.781248e+06
+      GoRuntimeType: 1781248
       GoKind: 22
       Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 153
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.854112e+06
+      GoRuntimeType: 1854112
       GoKind: 22
       Pointee: 154 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 143
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.78144e+06
+      GoRuntimeType: 1781440
       GoKind: 22
       Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -865,7 +865,7 @@ Types:
       ID: 184
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.3032e+06
+      GoRuntimeType: 1303200
       GoKind: 20
       RawFields:
         - Name: tab
@@ -882,7 +882,7 @@ Types:
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.054304e+06
+      GoRuntimeType: 1054304
       GoKind: 20
       RawFields:
         - Name: tab
@@ -929,7 +929,7 @@ Types:
       ID: 157
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.445024e+06
+      GoRuntimeType: 1445024
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1004,7 +1004,7 @@ Types:
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.892192e+06
+      GoRuntimeType: 1892192
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1016,7 +1016,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1026,7 +1026,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.237472e+06
+      GoRuntimeType: 1237472
       GoKind: 25
       RawFields:
         - Name: u
@@ -1036,7 +1036,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.673024e+06
+      GoRuntimeType: 1673024
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1052,7 +1052,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.518816e+06
+      GoRuntimeType: 1518816
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1065,7 +1065,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.518656e+06
+      GoRuntimeType: 1518656
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1078,7 +1078,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.518976e+06
+      GoRuntimeType: 1518976
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1090,20 +1090,20 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 1.012384e+06
+      GoRuntimeType: 1012384
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 1.012288e+06
+      GoRuntimeType: 1012288
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
       ID: 173
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.135168e+06
+      GoRuntimeType: 1135168
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1186,7 +1186,7 @@ Types:
       ID: 187
       Name: map[string]string
       ByteSize: 8
-      GoRuntimeType: 1.15424e+06
+      GoRuntimeType: 1154240
       GoKind: 21
       HeaderType: 189 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
@@ -1197,7 +1197,7 @@ Types:
       ID: 160
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.05008e+06
+      GoRuntimeType: 1050080
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1210,7 +1210,7 @@ Types:
       ID: 158
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.048544e+06
+      GoRuntimeType: 1048544
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1223,14 +1223,14 @@ Types:
       ID: 168
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 2.15504e+06
+      GoRuntimeType: 2155040
       GoKind: 21
       HeaderType: 170 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
       ID: 161
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.048672e+06
+      GoRuntimeType: 1048672
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1243,7 +1243,7 @@ Types:
       ID: 159
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.048928e+06
+      GoRuntimeType: 1048928
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1256,7 +1256,7 @@ Types:
       ID: 111
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.401888e+06
+      GoRuntimeType: 2401888
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1345,7 +1345,7 @@ Types:
       ID: 109
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.210848e+06
+      GoRuntimeType: 1210848
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1374,7 +1374,7 @@ Types:
       ID: 176
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.92848e+06
+      GoRuntimeType: 1928480
       GoKind: 21
       HeaderType: 170 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
@@ -1399,7 +1399,7 @@ Types:
       ID: 195
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.31664e+06
+      GoRuntimeType: 1316640
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1412,7 +1412,7 @@ Types:
       ID: 205
       Name: noalg.map.group[string]string
       ByteSize: 264
-      GoRuntimeType: 1.319072e+06
+      GoRuntimeType: 1319072
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1425,7 +1425,7 @@ Types:
       ID: 197
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.316512e+06
+      GoRuntimeType: 1316512
       GoKind: 25
       RawFields:
         - Name: key
@@ -1438,7 +1438,7 @@ Types:
       ID: 207
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
-      GoRuntimeType: 1.318944e+06
+      GoRuntimeType: 1318944
       GoKind: 25
       RawFields:
         - Name: key
@@ -1466,14 +1466,14 @@ Types:
     - __kind: StructureType
       ID: 87
       Name: runtime.dlogPerM
-      GoRuntimeType: 1.008352e+06
+      GoRuntimeType: 1008352
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.46592e+06
+      GoRuntimeType: 2465920
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1663,7 +1663,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.2216e+06
+      GoRuntimeType: 1221600
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1673,7 +1673,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.957664e+06
+      GoRuntimeType: 1957664
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1698,7 +1698,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.500096e+06
+      GoRuntimeType: 1500096
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1711,7 +1711,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.791776e+06
+      GoRuntimeType: 1791776
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1736,7 +1736,7 @@ Types:
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.499936e+06
+      GoRuntimeType: 1499936
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1749,13 +1749,13 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.958432e+06
+      GoRuntimeType: 1958432
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1780,7 +1780,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 2.469216e+06
+      GoRuntimeType: 2469216
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2000,7 +2000,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.958176e+06
+      GoRuntimeType: 1958176
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2025,7 +2025,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.882336e+06
+      GoRuntimeType: 1882336
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2047,7 +2047,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.882112e+06
+      GoRuntimeType: 1882112
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2069,7 +2069,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.499616e+06
+      GoRuntimeType: 1499616
       GoKind: 25
       RawFields:
         - Name: next
@@ -2088,7 +2088,7 @@ Types:
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.221344e+06
+      GoRuntimeType: 1221344
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -2099,7 +2099,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.499776e+06
+      GoRuntimeType: 1499776
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2112,13 +2112,13 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.792736e+06
+      GoRuntimeType: 1792736
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2146,7 +2146,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.497856e+06
+      GoRuntimeType: 1497856
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2187,7 +2187,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.498816e+06
+      GoRuntimeType: 1498816
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2200,12 +2200,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.304608e+06
+      GoRuntimeType: 1304608
       GoKind: 8
     - __kind: StructureType
       ID: 82
       Name: runtime.winlibcall
-      GoRuntimeType: 1.008256e+06
+      GoRuntimeType: 1008256
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
@@ -2231,7 +2231,7 @@ Types:
       ID: 132
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.991456e+06
+      GoRuntimeType: 1991456
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2244,7 +2244,7 @@ Types:
       ID: 146
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.067584e+06
+      GoRuntimeType: 2067584
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2260,7 +2260,7 @@ Types:
       ID: 128
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.990944e+06
+      GoRuntimeType: 1990944
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2273,7 +2273,7 @@ Types:
       ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.066432e+06
+      GoRuntimeType: 2066432
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2289,7 +2289,7 @@ Types:
       ID: 152
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.137312e+06
+      GoRuntimeType: 2137312
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2308,7 +2308,7 @@ Types:
       ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.06672e+06
+      GoRuntimeType: 2066720
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2324,7 +2324,7 @@ Types:
       ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 2.066144e+06
+      GoRuntimeType: 2066144
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2340,7 +2340,7 @@ Types:
       ID: 148
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 2.136672e+06
+      GoRuntimeType: 2136672
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2359,7 +2359,7 @@ Types:
       ID: 156
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.199296e+06
+      GoRuntimeType: 2199296
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2381,7 +2381,7 @@ Types:
       ID: 150
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.136992e+06
+      GoRuntimeType: 2136992
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2400,7 +2400,7 @@ Types:
       ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.991712e+06
+      GoRuntimeType: 1991712
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2413,7 +2413,7 @@ Types:
       ID: 130
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.9912e+06
+      GoRuntimeType: 1991200
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2426,7 +2426,7 @@ Types:
       ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.067008e+06
+      GoRuntimeType: 2067008
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2442,7 +2442,7 @@ Types:
       ID: 154
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.137632e+06
+      GoRuntimeType: 2137632
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2461,7 +2461,7 @@ Types:
       ID: 144
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.067296e+06
+      GoRuntimeType: 2067296
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.26rc1.yaml
@@ -169,7 +169,7 @@ Types:
       ID: 120
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.35312e+06
+      GoRuntimeType: 2353120
       GoKind: 22
       Pointee: 121 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -211,14 +211,14 @@ Types:
       ID: 118
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
-      GoRuntimeType: 2.353664e+06
+      GoRuntimeType: 2353664
       GoKind: 22
       Pointee: 119 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 131
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.597376e+06
+      GoRuntimeType: 1597376
       GoKind: 22
       Pointee: 132 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
@@ -260,7 +260,7 @@ Types:
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
       ByteSize: 8
-      GoRuntimeType: 1.617536e+06
+      GoRuntimeType: 1617536
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
@@ -284,42 +284,42 @@ Types:
       ID: 116
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.387136e+06
+      GoRuntimeType: 2387136
       GoKind: 22
       Pointee: 117 StructureType net/http.Request
     - __kind: PointerType
       ID: 188
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.775552e+06
+      GoRuntimeType: 1775552
       GoKind: 22
       Pointee: 189 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 168
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 2.075136e+06
+      GoRuntimeType: 2075136
       GoKind: 22
       Pointee: 169 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 191
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.65888e+06
+      GoRuntimeType: 1658880
       GoKind: 22
       Pointee: 192 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 170
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.300128e+06
+      GoRuntimeType: 2300128
       GoKind: 22
       Pointee: 171 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 172
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.20352e+06
+      GoRuntimeType: 2203520
       GoKind: 22
       Pointee: 173 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -343,7 +343,7 @@ Types:
       ID: 25
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.451136e+06
+      GoRuntimeType: 1451136
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -364,21 +364,21 @@ Types:
       ID: 59
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 1.229056e+06
+      GoRuntimeType: 1229056
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.451776e+06
+      GoRuntimeType: 1451776
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 68
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.065344e+06
+      GoRuntimeType: 1065344
       GoKind: 22
       Pointee: 128 UnresolvedPointeeType runtime.p
     - __kind: PointerType
@@ -392,21 +392,21 @@ Types:
       ID: 50
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.594816e+06
+      GoRuntimeType: 1594816
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 45
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.12528e+06
+      GoRuntimeType: 2125280
       GoKind: 22
       Pointee: 46 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 83
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.670592e+06
+      GoRuntimeType: 1670592
       GoKind: 22
       Pointee: 84 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -432,105 +432,105 @@ Types:
       ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.73952e+06
+      GoRuntimeType: 1739520
       GoKind: 22
       Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 151
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.799744e+06
+      GoRuntimeType: 1799744
       GoKind: 22
       Pointee: 152 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.739136e+06
+      GoRuntimeType: 1739136
       GoKind: 22
       Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 143
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.798976e+06
+      GoRuntimeType: 1798976
       GoKind: 22
       Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 157
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.87232e+06
+      GoRuntimeType: 1872320
       GoKind: 22
       Pointee: 158 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 145
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.799168e+06
+      GoRuntimeType: 1799168
       GoKind: 22
       Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.798784e+06
+      GoRuntimeType: 1798784
       GoKind: 22
       Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 153
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.871872e+06
+      GoRuntimeType: 1871872
       GoKind: 22
       Pointee: 154 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 161
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.944224e+06
+      GoRuntimeType: 1944224
       GoKind: 22
       Pointee: 162 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 155
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.872096e+06
+      GoRuntimeType: 1872096
       GoKind: 22
       Pointee: 156 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.739712e+06
+      GoRuntimeType: 1739712
       GoKind: 22
       Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.739328e+06
+      GoRuntimeType: 1739328
       GoKind: 22
       Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 147
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.79936e+06
+      GoRuntimeType: 1799360
       GoKind: 22
       Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 159
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.872544e+06
+      GoRuntimeType: 1872544
       GoKind: 22
       Pointee: 160 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 149
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.799552e+06
+      GoRuntimeType: 1799552
       GoKind: 22
       Pointee: 150 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -886,7 +886,7 @@ Types:
       ID: 190
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.3136e+06
+      GoRuntimeType: 1313600
       GoKind: 20
       RawFields:
         - Name: tab
@@ -903,7 +903,7 @@ Types:
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.063808e+06
+      GoRuntimeType: 1063808
       GoKind: 20
       RawFields:
         - Name: tab
@@ -950,7 +950,7 @@ Types:
       ID: 163
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.456096e+06
+      GoRuntimeType: 1456096
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1025,7 +1025,7 @@ Types:
       ID: 92
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.911072e+06
+      GoRuntimeType: 1911072
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1037,7 +1037,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1047,7 +1047,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.24672e+06
+      GoRuntimeType: 1246720
       GoKind: 25
       RawFields:
         - Name: u
@@ -1057,7 +1057,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.689024e+06
+      GoRuntimeType: 1689024
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1077,7 +1077,7 @@ Types:
       ID: 33
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.532096e+06
+      GoRuntimeType: 1532096
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1090,7 +1090,7 @@ Types:
       ID: 37
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.531936e+06
+      GoRuntimeType: 1531936
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1102,20 +1102,20 @@ Types:
     - __kind: StructureType
       ID: 77
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 1.021824e+06
+      GoRuntimeType: 1021824
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 34
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 1.021728e+06
+      GoRuntimeType: 1021728
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
       ID: 179
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.143968e+06
+      GoRuntimeType: 1143968
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1198,7 +1198,7 @@ Types:
       ID: 193
       Name: map[string]string
       ByteSize: 8
-      GoRuntimeType: 1.163168e+06
+      GoRuntimeType: 1163168
       GoKind: 21
       HeaderType: 195 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
@@ -1209,7 +1209,7 @@ Types:
       ID: 166
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.059584e+06
+      GoRuntimeType: 1059584
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1222,7 +1222,7 @@ Types:
       ID: 164
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.05792e+06
+      GoRuntimeType: 1057920
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1235,14 +1235,14 @@ Types:
       ID: 174
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 2.176896e+06
+      GoRuntimeType: 2176896
       GoKind: 21
       HeaderType: 176 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
       ID: 167
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.058048e+06
+      GoRuntimeType: 1058048
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1255,7 +1255,7 @@ Types:
       ID: 165
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.058304e+06
+      GoRuntimeType: 1058304
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1268,7 +1268,7 @@ Types:
       ID: 117
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.42288e+06
+      GoRuntimeType: 2422880
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1357,7 +1357,7 @@ Types:
       ID: 115
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.218944e+06
+      GoRuntimeType: 1218944
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1386,7 +1386,7 @@ Types:
       ID: 182
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.946912e+06
+      GoRuntimeType: 1946912
       GoKind: 21
       HeaderType: 176 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
@@ -1411,7 +1411,7 @@ Types:
       ID: 201
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.327552e+06
+      GoRuntimeType: 1327552
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1424,7 +1424,7 @@ Types:
       ID: 211
       Name: noalg.map.group[string]string
       ByteSize: 264
-      GoRuntimeType: 1.329984e+06
+      GoRuntimeType: 1329984
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1437,7 +1437,7 @@ Types:
       ID: 203
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.327424e+06
+      GoRuntimeType: 1327424
       GoKind: 25
       RawFields:
         - Name: key
@@ -1450,7 +1450,7 @@ Types:
       ID: 213
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
-      GoRuntimeType: 1.329856e+06
+      GoRuntimeType: 1329856
       GoKind: 25
       RawFields:
         - Name: key
@@ -1478,14 +1478,14 @@ Types:
     - __kind: StructureType
       ID: 90
       Name: runtime.dlogPerM
-      GoRuntimeType: 1.017792e+06
+      GoRuntimeType: 1017792
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 23
       Name: runtime.g
       ByteSize: 456
-      GoRuntimeType: 2.489088e+06
+      GoRuntimeType: 2489088
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1687,7 +1687,7 @@ Types:
       ID: 55
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.228928e+06
+      GoRuntimeType: 1228928
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1697,7 +1697,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.976928e+06
+      GoRuntimeType: 1976928
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1722,7 +1722,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.509856e+06
+      GoRuntimeType: 1509856
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1735,7 +1735,7 @@ Types:
       ID: 60
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.810048e+06
+      GoRuntimeType: 1810048
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1760,7 +1760,7 @@ Types:
       ID: 96
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.512256e+06
+      GoRuntimeType: 1512256
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1773,7 +1773,7 @@ Types:
       ID: 72
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 1.511456e+06
+      GoRuntimeType: 1511456
       GoKind: 25
       RawFields:
         - Name: prev
@@ -1792,7 +1792,7 @@ Types:
       ID: 30
       Name: runtime.m
       ByteSize: 1824
-      GoRuntimeType: 2.494368e+06
+      GoRuntimeType: 2494368
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2021,7 +2021,7 @@ Types:
       ID: 75
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.97744e+06
+      GoRuntimeType: 1977440
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2046,7 +2046,7 @@ Types:
       ID: 91
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.901664e+06
+      GoRuntimeType: 1901664
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2068,7 +2068,7 @@ Types:
       ID: 80
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 1.977696e+06
+      GoRuntimeType: 1977696
       GoKind: 25
       RawFields:
         - Name: writing
@@ -2093,7 +2093,7 @@ Types:
       ID: 74
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.511936e+06
+      GoRuntimeType: 1511936
       GoKind: 25
       RawFields:
         - Name: next
@@ -2106,7 +2106,7 @@ Types:
       ID: 98
       Name: runtime.mWeakPointer
       ByteSize: 8
-      GoRuntimeType: 1.595296e+06
+      GoRuntimeType: 1595296
       GoKind: 25
       RawFields:
         - Name: m
@@ -2122,7 +2122,7 @@ Types:
       ID: 71
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.229952e+06
+      GoRuntimeType: 1229952
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -2133,7 +2133,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.512096e+06
+      GoRuntimeType: 1512096
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2146,13 +2146,13 @@ Types:
       ID: 89
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.811008e+06
+      GoRuntimeType: 1811008
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2180,7 +2180,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.508576e+06
+      GoRuntimeType: 1508576
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2221,7 +2221,7 @@ Types:
       ID: 56
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.510176e+06
+      GoRuntimeType: 1510176
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2234,19 +2234,19 @@ Types:
       ID: 35
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.639488e+06
+      GoRuntimeType: 1639488
       GoKind: 8
     - __kind: StructureType
       ID: 85
       Name: runtime.winlibcall
-      GoRuntimeType: 1.017696e+06
+      GoRuntimeType: 1017696
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 52
       Name: runtime.xRegPerG
       ByteSize: 8
-      GoRuntimeType: 1.2288e+06
+      GoRuntimeType: 1228800
       GoKind: 25
       RawFields:
         - Name: state
@@ -2279,7 +2279,7 @@ Types:
       ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 2.012e+06
+      GoRuntimeType: 2012000
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2292,7 +2292,7 @@ Types:
       ID: 152
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.090112e+06
+      GoRuntimeType: 2090112
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2308,7 +2308,7 @@ Types:
       ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 2.011488e+06
+      GoRuntimeType: 2011488
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2321,7 +2321,7 @@ Types:
       ID: 144
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.08896e+06
+      GoRuntimeType: 2088960
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2337,7 +2337,7 @@ Types:
       ID: 158
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.15952e+06
+      GoRuntimeType: 2159520
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2356,7 +2356,7 @@ Types:
       ID: 146
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.089248e+06
+      GoRuntimeType: 2089248
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2372,7 +2372,7 @@ Types:
       ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 2.088672e+06
+      GoRuntimeType: 2088672
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2388,7 +2388,7 @@ Types:
       ID: 154
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 2.15888e+06
+      GoRuntimeType: 2158880
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2407,7 +2407,7 @@ Types:
       ID: 162
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.221568e+06
+      GoRuntimeType: 2221568
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2429,7 +2429,7 @@ Types:
       ID: 156
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.1592e+06
+      GoRuntimeType: 2159200
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2448,7 +2448,7 @@ Types:
       ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 2.012256e+06
+      GoRuntimeType: 2012256
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2461,7 +2461,7 @@ Types:
       ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 2.011744e+06
+      GoRuntimeType: 2011744
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2474,7 +2474,7 @@ Types:
       ID: 148
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.089536e+06
+      GoRuntimeType: 2089536
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2490,7 +2490,7 @@ Types:
       ID: 160
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.15984e+06
+      GoRuntimeType: 2159840
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2509,7 +2509,7 @@ Types:
       ID: 150
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.089824e+06
+      GoRuntimeType: 2089824
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -158,7 +158,7 @@ Types:
       ID: 107
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.176896e+06
+      GoRuntimeType: 2176896
       GoKind: 22
       Pointee: 108 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -193,14 +193,14 @@ Types:
       ID: 105
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
-      GoRuntimeType: 2.18768e+06
+      GoRuntimeType: 2187680
       GoKind: 22
       Pointee: 106 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 115
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.397152e+06
+      GoRuntimeType: 1397152
       GoKind: 22
       Pointee: 116 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
@@ -259,42 +259,42 @@ Types:
       ID: 103
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.219968e+06
+      GoRuntimeType: 2219968
       GoKind: 22
       Pointee: 104 StructureType net/http.Request
     - __kind: PointerType
       ID: 174
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.632736e+06
+      GoRuntimeType: 1632736
       GoKind: 22
       Pointee: 175 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 152
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.8768e+06
+      GoRuntimeType: 1876800
       GoKind: 22
       Pointee: 153 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 177
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.453504e+06
+      GoRuntimeType: 1453504
       GoKind: 22
       Pointee: 178 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 154
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.11776e+06
+      GoRuntimeType: 2117760
       GoKind: 22
       Pointee: 155 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 156
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.002496e+06
+      GoRuntimeType: 2002496
       GoKind: 22
       Pointee: 157 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -308,7 +308,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.26208e+06
+      GoRuntimeType: 1262080
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -336,7 +336,7 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.012768e+06
+      GoRuntimeType: 1012768
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
@@ -357,14 +357,14 @@ Types:
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 1.966848e+06
+      GoRuntimeType: 1966848
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.46464e+06
+      GoRuntimeType: 1464640
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -383,105 +383,105 @@ Types:
       ID: 121
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.5328e+06
+      GoRuntimeType: 1532800
       GoKind: 22
       Pointee: 122 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.657312e+06
+      GoRuntimeType: 1657312
       GoKind: 22
       Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 117
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.532416e+06
+      GoRuntimeType: 1532416
       GoKind: 22
       Pointee: 118 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 127
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.656544e+06
+      GoRuntimeType: 1656544
       GoKind: 22
       Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.7272e+06
+      GoRuntimeType: 1727200
       GoKind: 22
       Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 129
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.656736e+06
+      GoRuntimeType: 1656736
       GoKind: 22
       Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 125
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.656352e+06
+      GoRuntimeType: 1656352
       GoKind: 22
       Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.726752e+06
+      GoRuntimeType: 1726752
       GoKind: 22
       Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 145
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.795072e+06
+      GoRuntimeType: 1795072
       GoKind: 22
       Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.726976e+06
+      GoRuntimeType: 1726976
       GoKind: 22
       Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 123
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.532992e+06
+      GoRuntimeType: 1532992
       GoKind: 22
       Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 119
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.532608e+06
+      GoRuntimeType: 1532608
       GoKind: 22
       Pointee: 120 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 131
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.656928e+06
+      GoRuntimeType: 1656928
       GoKind: 22
       Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 143
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.727424e+06
+      GoRuntimeType: 1727424
       GoKind: 22
       Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.65712e+06
+      GoRuntimeType: 1657120
       GoKind: 22
       Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -851,7 +851,7 @@ Types:
       ID: 176
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.215776e+06
+      GoRuntimeType: 1215776
       GoKind: 20
       RawFields:
         - Name: tab
@@ -868,7 +868,7 @@ Types:
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.011104e+06
+      GoRuntimeType: 1011104
       GoKind: 20
       RawFields:
         - Name: tab
@@ -915,7 +915,7 @@ Types:
       ID: 147
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.26592e+06
+      GoRuntimeType: 1265920
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1030,7 +1030,7 @@ Types:
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.76192e+06
+      GoRuntimeType: 1761920
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1042,7 +1042,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1052,7 +1052,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.152224e+06
+      GoRuntimeType: 1152224
       GoKind: 25
       RawFields:
         - Name: u
@@ -1062,7 +1062,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.483648e+06
+      GoRuntimeType: 1483648
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1078,7 +1078,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.337568e+06
+      GoRuntimeType: 1337568
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1091,7 +1091,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.337408e+06
+      GoRuntimeType: 1337408
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1104,7 +1104,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.337728e+06
+      GoRuntimeType: 1337728
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1129,7 +1129,7 @@ Types:
       ID: 165
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.093088e+06
+      GoRuntimeType: 1093088
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1153,7 +1153,7 @@ Types:
       ID: 150
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.006752e+06
+      GoRuntimeType: 1006752
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1166,7 +1166,7 @@ Types:
       ID: 148
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.005344e+06
+      GoRuntimeType: 1005344
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1179,14 +1179,14 @@ Types:
       ID: 158
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 1.964288e+06
+      GoRuntimeType: 1964288
       GoKind: 21
       HeaderType: 160 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
       ID: 151
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.005472e+06
+      GoRuntimeType: 1005472
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1199,7 +1199,7 @@ Types:
       ID: 149
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.005728e+06
+      GoRuntimeType: 1005728
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1212,7 +1212,7 @@ Types:
       ID: 104
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.256288e+06
+      GoRuntimeType: 2256288
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1301,7 +1301,7 @@ Types:
       ID: 102
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.125472e+06
+      GoRuntimeType: 1125472
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1330,7 +1330,7 @@ Types:
       ID: 168
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.712416e+06
+      GoRuntimeType: 1712416
       GoKind: 21
       HeaderType: 160 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
@@ -1359,7 +1359,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 2.314944e+06
+      GoRuntimeType: 2314944
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1534,7 +1534,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.136736e+06
+      GoRuntimeType: 1136736
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1544,7 +1544,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.879968e+06
+      GoRuntimeType: 1879968
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1572,7 +1572,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.319808e+06
+      GoRuntimeType: 1319808
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1585,7 +1585,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.666688e+06
+      GoRuntimeType: 1666688
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1610,7 +1610,7 @@ Types:
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.319648e+06
+      GoRuntimeType: 1319648
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1623,13 +1623,13 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.825152e+06
+      GoRuntimeType: 1825152
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1654,7 +1654,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 2.321056e+06
+      GoRuntimeType: 2321056
       GoKind: 25
       RawFields:
         - Name: g0
@@ -1874,7 +1874,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.824896e+06
+      GoRuntimeType: 1824896
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -1899,7 +1899,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 1.465024e+06
+      GoRuntimeType: 1465024
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -1915,7 +1915,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 1.464832e+06
+      GoRuntimeType: 1464832
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -1941,14 +1941,14 @@ Types:
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.136352e+06
+      GoRuntimeType: 1136352
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.319488e+06
+      GoRuntimeType: 1319488
       GoKind: 25
       RawFields:
         - Name: entries
@@ -1961,13 +1961,13 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.667456e+06
+      GoRuntimeType: 1667456
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -1995,7 +1995,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.317888e+06
+      GoRuntimeType: 1317888
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2032,7 +2032,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.318848e+06
+      GoRuntimeType: 1318848
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2045,7 +2045,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.094112e+06
+      GoRuntimeType: 1094112
       GoKind: 8
     - __kind: StructureType
       ID: 75
@@ -2076,7 +2076,7 @@ Types:
       ID: 122
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.856384e+06
+      GoRuntimeType: 1856384
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2089,7 +2089,7 @@ Types:
       ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 1.93168e+06
+      GoRuntimeType: 1931680
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2105,7 +2105,7 @@ Types:
       ID: 118
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.855872e+06
+      GoRuntimeType: 1855872
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2118,7 +2118,7 @@ Types:
       ID: 128
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 1.930528e+06
+      GoRuntimeType: 1930528
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2134,7 +2134,7 @@ Types:
       ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.000128e+06
+      GoRuntimeType: 2000128
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2153,7 +2153,7 @@ Types:
       ID: 130
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 1.930816e+06
+      GoRuntimeType: 1930816
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2169,7 +2169,7 @@ Types:
       ID: 126
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 1.93024e+06
+      GoRuntimeType: 1930240
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2185,7 +2185,7 @@ Types:
       ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 1.999488e+06
+      GoRuntimeType: 1999488
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2204,7 +2204,7 @@ Types:
       ID: 146
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.059232e+06
+      GoRuntimeType: 2059232
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2226,7 +2226,7 @@ Types:
       ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 1.999808e+06
+      GoRuntimeType: 1999808
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2245,7 +2245,7 @@ Types:
       ID: 124
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.85664e+06
+      GoRuntimeType: 1856640
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2258,7 +2258,7 @@ Types:
       ID: 120
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.856128e+06
+      GoRuntimeType: 1856128
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2271,7 +2271,7 @@ Types:
       ID: 132
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 1.931104e+06
+      GoRuntimeType: 1931104
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2287,7 +2287,7 @@ Types:
       ID: 144
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.000448e+06
+      GoRuntimeType: 2000448
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2306,7 +2306,7 @@ Types:
       ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 1.931392e+06
+      GoRuntimeType: 1931392
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -158,7 +158,7 @@ Types:
       ID: 112
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.316032e+06
+      GoRuntimeType: 2316032
       GoKind: 22
       Pointee: 113 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -193,14 +193,14 @@ Types:
       ID: 110
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
-      GoRuntimeType: 2.326784e+06
+      GoRuntimeType: 2326784
       GoKind: 22
       Pointee: 111 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 120
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.57712e+06
+      GoRuntimeType: 1577120
       GoKind: 22
       Pointee: 121 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
@@ -259,42 +259,42 @@ Types:
       ID: 108
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.359648e+06
+      GoRuntimeType: 2359648
       GoKind: 22
       Pointee: 109 StructureType net/http.Request
     - __kind: PointerType
       ID: 177
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.75088e+06
+      GoRuntimeType: 1750880
       GoKind: 22
       Pointee: 178 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 157
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 2.044608e+06
+      GoRuntimeType: 2044608
       GoKind: 22
       Pointee: 158 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 180
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.63728e+06
+      GoRuntimeType: 1637280
       GoKind: 22
       Pointee: 181 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 159
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.253408e+06
+      GoRuntimeType: 2253408
       GoKind: 22
       Pointee: 160 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 161
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.159744e+06
+      GoRuntimeType: 2159744
       GoKind: 22
       Pointee: 162 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -318,7 +318,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.43584e+06
+      GoRuntimeType: 1435840
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -346,7 +346,7 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.051104e+06
+      GoRuntimeType: 1051104
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
@@ -360,21 +360,21 @@ Types:
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 1.57488e+06
+      GoRuntimeType: 1574880
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.09568e+06
+      GoRuntimeType: 2095680
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.648608e+06
+      GoRuntimeType: 1648608
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -393,105 +393,105 @@ Types:
       ID: 126
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.716192e+06
+      GoRuntimeType: 1716192
       GoKind: 22
       Pointee: 127 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 140
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.774112e+06
+      GoRuntimeType: 1774112
       GoKind: 22
       Pointee: 141 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 122
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.715808e+06
+      GoRuntimeType: 1715808
       GoKind: 22
       Pointee: 123 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 132
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.773344e+06
+      GoRuntimeType: 1773344
       GoKind: 22
       Pointee: 133 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 146
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.845376e+06
+      GoRuntimeType: 1845376
       GoKind: 22
       Pointee: 147 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 134
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.773536e+06
+      GoRuntimeType: 1773536
       GoKind: 22
       Pointee: 135 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 130
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.773152e+06
+      GoRuntimeType: 1773152
       GoKind: 22
       Pointee: 131 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 142
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.844928e+06
+      GoRuntimeType: 1844928
       GoKind: 22
       Pointee: 143 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 150
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.917376e+06
+      GoRuntimeType: 1917376
       GoKind: 22
       Pointee: 151 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 144
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.845152e+06
+      GoRuntimeType: 1845152
       GoKind: 22
       Pointee: 145 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 128
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.716384e+06
+      GoRuntimeType: 1716384
       GoKind: 22
       Pointee: 129 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 124
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.716e+06
+      GoRuntimeType: 1716000
       GoKind: 22
       Pointee: 125 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 136
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.773728e+06
+      GoRuntimeType: 1773728
       GoKind: 22
       Pointee: 137 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 148
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.8456e+06
+      GoRuntimeType: 1845600
       GoKind: 22
       Pointee: 149 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 138
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.77392e+06
+      GoRuntimeType: 1773920
       GoKind: 22
       Pointee: 139 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -831,7 +831,7 @@ Types:
       ID: 179
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.298016e+06
+      GoRuntimeType: 1298016
       GoKind: 20
       RawFields:
         - Name: tab
@@ -848,7 +848,7 @@ Types:
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.049312e+06
+      GoRuntimeType: 1049312
       GoKind: 20
       RawFields:
         - Name: tab
@@ -895,7 +895,7 @@ Types:
       ID: 152
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.43984e+06
+      GoRuntimeType: 1439840
       GoKind: 20
       RawFields:
         - Name: tab
@@ -970,7 +970,7 @@ Types:
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.883104e+06
+      GoRuntimeType: 1883104
       GoKind: 25
       RawFields:
         - Name: buf
@@ -982,7 +982,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -992,7 +992,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.232928e+06
+      GoRuntimeType: 1232928
       GoKind: 25
       RawFields:
         - Name: u
@@ -1002,7 +1002,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.667424e+06
+      GoRuntimeType: 1667424
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1018,7 +1018,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.51296e+06
+      GoRuntimeType: 1512960
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1031,7 +1031,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.5128e+06
+      GoRuntimeType: 1512800
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1044,7 +1044,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.51312e+06
+      GoRuntimeType: 1513120
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1056,20 +1056,20 @@ Types:
     - __kind: StructureType
       ID: 69
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 1.007296e+06
+      GoRuntimeType: 1007296
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 1.0072e+06
+      GoRuntimeType: 1007200
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
       ID: 168
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.129632e+06
+      GoRuntimeType: 1129632
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1146,7 +1146,7 @@ Types:
       ID: 182
       Name: map[string]string
       ByteSize: 8
-      GoRuntimeType: 1.148704e+06
+      GoRuntimeType: 1148704
       GoKind: 21
       HeaderType: 184 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
@@ -1157,7 +1157,7 @@ Types:
       ID: 155
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.045088e+06
+      GoRuntimeType: 1045088
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1170,7 +1170,7 @@ Types:
       ID: 153
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.04368e+06
+      GoRuntimeType: 1043680
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1183,14 +1183,14 @@ Types:
       ID: 163
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 2.147456e+06
+      GoRuntimeType: 2147456
       GoKind: 21
       HeaderType: 165 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
       ID: 156
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.043808e+06
+      GoRuntimeType: 1043808
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1203,7 +1203,7 @@ Types:
       ID: 154
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.044064e+06
+      GoRuntimeType: 1044064
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1216,7 +1216,7 @@ Types:
       ID: 109
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.397408e+06
+      GoRuntimeType: 2397408
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1305,7 +1305,7 @@ Types:
       ID: 107
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.206176e+06
+      GoRuntimeType: 1206176
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1334,7 +1334,7 @@ Types:
       ID: 171
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.920064e+06
+      GoRuntimeType: 1920064
       GoKind: 21
       HeaderType: 165 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
@@ -1359,7 +1359,7 @@ Types:
       ID: 190
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.311456e+06
+      GoRuntimeType: 1311456
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1372,7 +1372,7 @@ Types:
       ID: 200
       Name: noalg.map.group[string]string
       ByteSize: 264
-      GoRuntimeType: 1.31376e+06
+      GoRuntimeType: 1313760
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1385,7 +1385,7 @@ Types:
       ID: 192
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.311328e+06
+      GoRuntimeType: 1311328
       GoKind: 25
       RawFields:
         - Name: key
@@ -1398,7 +1398,7 @@ Types:
       ID: 202
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
-      GoRuntimeType: 1.313632e+06
+      GoRuntimeType: 1313632
       GoKind: 25
       RawFields:
         - Name: key
@@ -1426,14 +1426,14 @@ Types:
     - __kind: StructureType
       ID: 84
       Name: runtime.dlogPerM
-      GoRuntimeType: 1.003264e+06
+      GoRuntimeType: 1003264
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.459744e+06
+      GoRuntimeType: 2459744
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1614,7 +1614,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.217184e+06
+      GoRuntimeType: 1217184
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1624,7 +1624,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 2.007296e+06
+      GoRuntimeType: 2007296
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1652,7 +1652,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.4944e+06
+      GoRuntimeType: 1494400
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1665,7 +1665,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.783296e+06
+      GoRuntimeType: 1783296
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1690,7 +1690,7 @@ Types:
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.49424e+06
+      GoRuntimeType: 1494240
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1703,13 +1703,13 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.948704e+06
+      GoRuntimeType: 1948704
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1734,7 +1734,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 2.4648e+06
+      GoRuntimeType: 2464800
       GoKind: 25
       RawFields:
         - Name: g0
@@ -1957,7 +1957,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 2.007584e+06
+      GoRuntimeType: 2007584
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -1985,7 +1985,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.873024e+06
+      GoRuntimeType: 1873024
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2007,7 +2007,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.8728e+06
+      GoRuntimeType: 1872800
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2029,7 +2029,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 1.216928e+06
+      GoRuntimeType: 1216928
       GoKind: 25
       RawFields:
         - Name: next
@@ -2045,14 +2045,14 @@ Types:
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.2168e+06
+      GoRuntimeType: 1216800
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.49408e+06
+      GoRuntimeType: 1494080
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2065,13 +2065,13 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.784064e+06
+      GoRuntimeType: 1784064
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2099,7 +2099,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.49248e+06
+      GoRuntimeType: 1492480
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2140,7 +2140,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.49344e+06
+      GoRuntimeType: 1493440
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2153,12 +2153,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.299424e+06
+      GoRuntimeType: 1299424
       GoKind: 8
     - __kind: StructureType
       ID: 79
       Name: runtime.winlibcall
-      GoRuntimeType: 1.003168e+06
+      GoRuntimeType: 1003168
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
@@ -2184,7 +2184,7 @@ Types:
       ID: 127
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.98224e+06
+      GoRuntimeType: 1982240
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2197,7 +2197,7 @@ Types:
       ID: 141
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.059584e+06
+      GoRuntimeType: 2059584
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2213,7 +2213,7 @@ Types:
       ID: 123
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.981728e+06
+      GoRuntimeType: 1981728
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2226,7 +2226,7 @@ Types:
       ID: 133
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.058432e+06
+      GoRuntimeType: 2058432
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2242,7 +2242,7 @@ Types:
       ID: 147
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.12864e+06
+      GoRuntimeType: 2128640
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2261,7 +2261,7 @@ Types:
       ID: 135
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.05872e+06
+      GoRuntimeType: 2058720
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2277,7 +2277,7 @@ Types:
       ID: 131
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 2.058144e+06
+      GoRuntimeType: 2058144
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2293,7 +2293,7 @@ Types:
       ID: 143
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 2.128e+06
+      GoRuntimeType: 2128000
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2312,7 +2312,7 @@ Types:
       ID: 151
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.190272e+06
+      GoRuntimeType: 2190272
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2334,7 +2334,7 @@ Types:
       ID: 145
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.12832e+06
+      GoRuntimeType: 2128320
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2353,7 +2353,7 @@ Types:
       ID: 129
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.982496e+06
+      GoRuntimeType: 1982496
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2366,7 +2366,7 @@ Types:
       ID: 125
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.981984e+06
+      GoRuntimeType: 1981984
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2379,7 +2379,7 @@ Types:
       ID: 137
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.059008e+06
+      GoRuntimeType: 2059008
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2395,7 +2395,7 @@ Types:
       ID: 149
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.12896e+06
+      GoRuntimeType: 2128960
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2414,7 +2414,7 @@ Types:
       ID: 139
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.059296e+06
+      GoRuntimeType: 2059296
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -169,7 +169,7 @@ Types:
       ID: 114
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.320608e+06
+      GoRuntimeType: 2320608
       GoKind: 22
       Pointee: 115 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -204,14 +204,14 @@ Types:
       ID: 112
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
-      GoRuntimeType: 2.331872e+06
+      GoRuntimeType: 2331872
       GoKind: 22
       Pointee: 113 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 125
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.582272e+06
+      GoRuntimeType: 1582272
       GoKind: 22
       Pointee: 126 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
@@ -270,42 +270,42 @@ Types:
       ID: 110
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.364736e+06
+      GoRuntimeType: 2364736
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
       ID: 182
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.757856e+06
+      GoRuntimeType: 1757856
       GoKind: 22
       Pointee: 183 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 162
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 2.052704e+06
+      GoRuntimeType: 2052704
       GoKind: 22
       Pointee: 163 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 185
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.642144e+06
+      GoRuntimeType: 1642144
       GoKind: 22
       Pointee: 186 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 164
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.276352e+06
+      GoRuntimeType: 2276352
       GoKind: 22
       Pointee: 165 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 166
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.16656e+06
+      GoRuntimeType: 2166560
       GoKind: 22
       Pointee: 167 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -329,7 +329,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.44e+06
+      GoRuntimeType: 1440000
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -357,14 +357,14 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.44064e+06
+      GoRuntimeType: 1440640
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.055264e+06
+      GoRuntimeType: 1055264
       GoKind: 22
       Pointee: 122 UnresolvedPointeeType runtime.p
     - __kind: PointerType
@@ -378,21 +378,21 @@ Types:
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.580032e+06
+      GoRuntimeType: 1580032
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.102624e+06
+      GoRuntimeType: 2102624
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.653664e+06
+      GoRuntimeType: 1653664
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -411,105 +411,105 @@ Types:
       ID: 131
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.721824e+06
+      GoRuntimeType: 1721824
       GoKind: 22
       Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 145
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.781088e+06
+      GoRuntimeType: 1781088
       GoKind: 22
       Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 127
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.72144e+06
+      GoRuntimeType: 1721440
       GoKind: 22
       Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.78032e+06
+      GoRuntimeType: 1780320
       GoKind: 22
       Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 151
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.853344e+06
+      GoRuntimeType: 1853344
       GoKind: 22
       Pointee: 152 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.780512e+06
+      GoRuntimeType: 1780512
       GoKind: 22
       Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.780128e+06
+      GoRuntimeType: 1780128
       GoKind: 22
       Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 147
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.852896e+06
+      GoRuntimeType: 1852896
       GoKind: 22
       Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 155
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.925024e+06
+      GoRuntimeType: 1925024
       GoKind: 22
       Pointee: 156 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 149
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.85312e+06
+      GoRuntimeType: 1853120
       GoKind: 22
       Pointee: 150 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.722016e+06
+      GoRuntimeType: 1722016
       GoKind: 22
       Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 129
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.721632e+06
+      GoRuntimeType: 1721632
       GoKind: 22
       Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.780704e+06
+      GoRuntimeType: 1780704
       GoKind: 22
       Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 153
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.853568e+06
+      GoRuntimeType: 1853568
       GoKind: 22
       Pointee: 154 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 143
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.780896e+06
+      GoRuntimeType: 1780896
       GoKind: 22
       Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -865,7 +865,7 @@ Types:
       ID: 184
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.302496e+06
+      GoRuntimeType: 1302496
       GoKind: 20
       RawFields:
         - Name: tab
@@ -882,7 +882,7 @@ Types:
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.0536e+06
+      GoRuntimeType: 1053600
       GoKind: 20
       RawFields:
         - Name: tab
@@ -929,7 +929,7 @@ Types:
       ID: 157
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.44432e+06
+      GoRuntimeType: 1444320
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1004,7 +1004,7 @@ Types:
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.891648e+06
+      GoRuntimeType: 1891648
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1016,7 +1016,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1026,7 +1026,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.236768e+06
+      GoRuntimeType: 1236768
       GoKind: 25
       RawFields:
         - Name: u
@@ -1036,7 +1036,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.67248e+06
+      GoRuntimeType: 1672480
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1052,7 +1052,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.518112e+06
+      GoRuntimeType: 1518112
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1065,7 +1065,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.517952e+06
+      GoRuntimeType: 1517952
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1078,7 +1078,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.518272e+06
+      GoRuntimeType: 1518272
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1090,20 +1090,20 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 1.01168e+06
+      GoRuntimeType: 1011680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 1.011584e+06
+      GoRuntimeType: 1011584
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
       ID: 173
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.134464e+06
+      GoRuntimeType: 1134464
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1186,7 +1186,7 @@ Types:
       ID: 187
       Name: map[string]string
       ByteSize: 8
-      GoRuntimeType: 1.153536e+06
+      GoRuntimeType: 1153536
       GoKind: 21
       HeaderType: 189 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
@@ -1197,7 +1197,7 @@ Types:
       ID: 160
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.049376e+06
+      GoRuntimeType: 1049376
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1210,7 +1210,7 @@ Types:
       ID: 158
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.04784e+06
+      GoRuntimeType: 1047840
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1223,14 +1223,14 @@ Types:
       ID: 168
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 2.154272e+06
+      GoRuntimeType: 2154272
       GoKind: 21
       HeaderType: 170 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
       ID: 161
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.047968e+06
+      GoRuntimeType: 1047968
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1243,7 +1243,7 @@ Types:
       ID: 159
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.048224e+06
+      GoRuntimeType: 1048224
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1256,7 +1256,7 @@ Types:
       ID: 111
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.40112e+06
+      GoRuntimeType: 2401120
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1345,7 +1345,7 @@ Types:
       ID: 109
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.210144e+06
+      GoRuntimeType: 1210144
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1374,7 +1374,7 @@ Types:
       ID: 176
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.927712e+06
+      GoRuntimeType: 1927712
       GoKind: 21
       HeaderType: 170 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
@@ -1399,7 +1399,7 @@ Types:
       ID: 195
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.315936e+06
+      GoRuntimeType: 1315936
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1412,7 +1412,7 @@ Types:
       ID: 205
       Name: noalg.map.group[string]string
       ByteSize: 264
-      GoRuntimeType: 1.318368e+06
+      GoRuntimeType: 1318368
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1425,7 +1425,7 @@ Types:
       ID: 197
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.315808e+06
+      GoRuntimeType: 1315808
       GoKind: 25
       RawFields:
         - Name: key
@@ -1438,7 +1438,7 @@ Types:
       ID: 207
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
-      GoRuntimeType: 1.31824e+06
+      GoRuntimeType: 1318240
       GoKind: 25
       RawFields:
         - Name: key
@@ -1466,14 +1466,14 @@ Types:
     - __kind: StructureType
       ID: 87
       Name: runtime.dlogPerM
-      GoRuntimeType: 1.007648e+06
+      GoRuntimeType: 1007648
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.465152e+06
+      GoRuntimeType: 2465152
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1663,7 +1663,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.220896e+06
+      GoRuntimeType: 1220896
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1673,7 +1673,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.956896e+06
+      GoRuntimeType: 1956896
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1698,7 +1698,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.499392e+06
+      GoRuntimeType: 1499392
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1711,7 +1711,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.791232e+06
+      GoRuntimeType: 1791232
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1736,7 +1736,7 @@ Types:
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.499232e+06
+      GoRuntimeType: 1499232
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1749,13 +1749,13 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.957664e+06
+      GoRuntimeType: 1957664
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1780,7 +1780,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 2.468448e+06
+      GoRuntimeType: 2468448
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2000,7 +2000,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.957408e+06
+      GoRuntimeType: 1957408
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2025,7 +2025,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.881792e+06
+      GoRuntimeType: 1881792
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2047,7 +2047,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.881568e+06
+      GoRuntimeType: 1881568
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2069,7 +2069,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.498912e+06
+      GoRuntimeType: 1498912
       GoKind: 25
       RawFields:
         - Name: next
@@ -2088,7 +2088,7 @@ Types:
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.22064e+06
+      GoRuntimeType: 1220640
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -2099,7 +2099,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.499072e+06
+      GoRuntimeType: 1499072
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2112,13 +2112,13 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.792192e+06
+      GoRuntimeType: 1792192
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2146,7 +2146,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.497152e+06
+      GoRuntimeType: 1497152
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2187,7 +2187,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.498112e+06
+      GoRuntimeType: 1498112
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2200,12 +2200,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.303904e+06
+      GoRuntimeType: 1303904
       GoKind: 8
     - __kind: StructureType
       ID: 82
       Name: runtime.winlibcall
-      GoRuntimeType: 1.007552e+06
+      GoRuntimeType: 1007552
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
@@ -2231,7 +2231,7 @@ Types:
       ID: 132
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.990688e+06
+      GoRuntimeType: 1990688
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2244,7 +2244,7 @@ Types:
       ID: 146
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.066816e+06
+      GoRuntimeType: 2066816
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2260,7 +2260,7 @@ Types:
       ID: 128
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.990176e+06
+      GoRuntimeType: 1990176
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2273,7 +2273,7 @@ Types:
       ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.065664e+06
+      GoRuntimeType: 2065664
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2289,7 +2289,7 @@ Types:
       ID: 152
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.136544e+06
+      GoRuntimeType: 2136544
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2308,7 +2308,7 @@ Types:
       ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.065952e+06
+      GoRuntimeType: 2065952
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2324,7 +2324,7 @@ Types:
       ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 2.065376e+06
+      GoRuntimeType: 2065376
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2340,7 +2340,7 @@ Types:
       ID: 148
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 2.135904e+06
+      GoRuntimeType: 2135904
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2359,7 +2359,7 @@ Types:
       ID: 156
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.198528e+06
+      GoRuntimeType: 2198528
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2381,7 +2381,7 @@ Types:
       ID: 150
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.136224e+06
+      GoRuntimeType: 2136224
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2400,7 +2400,7 @@ Types:
       ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.990944e+06
+      GoRuntimeType: 1990944
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2413,7 +2413,7 @@ Types:
       ID: 130
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.990432e+06
+      GoRuntimeType: 1990432
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2426,7 +2426,7 @@ Types:
       ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.06624e+06
+      GoRuntimeType: 2066240
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2442,7 +2442,7 @@ Types:
       ID: 154
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.136864e+06
+      GoRuntimeType: 2136864
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2461,7 +2461,7 @@ Types:
       ID: 144
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.066528e+06
+      GoRuntimeType: 2066528
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.26rc1.yaml
@@ -169,7 +169,7 @@ Types:
       ID: 120
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.35232e+06
+      GoRuntimeType: 2352320
       GoKind: 22
       Pointee: 121 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -211,14 +211,14 @@ Types:
       ID: 118
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
-      GoRuntimeType: 2.352864e+06
+      GoRuntimeType: 2352864
       GoKind: 22
       Pointee: 119 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 131
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.5968e+06
+      GoRuntimeType: 1596800
       GoKind: 22
       Pointee: 132 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
@@ -260,7 +260,7 @@ Types:
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
       ByteSize: 8
-      GoRuntimeType: 1.61696e+06
+      GoRuntimeType: 1616960
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
@@ -284,42 +284,42 @@ Types:
       ID: 116
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.386336e+06
+      GoRuntimeType: 2386336
       GoKind: 22
       Pointee: 117 StructureType net/http.Request
     - __kind: PointerType
       ID: 188
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.774976e+06
+      GoRuntimeType: 1774976
       GoKind: 22
       Pointee: 189 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 168
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 2.074336e+06
+      GoRuntimeType: 2074336
       GoKind: 22
       Pointee: 169 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 191
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.658304e+06
+      GoRuntimeType: 1658304
       GoKind: 22
       Pointee: 192 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 170
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.299328e+06
+      GoRuntimeType: 2299328
       GoKind: 22
       Pointee: 171 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 172
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.20272e+06
+      GoRuntimeType: 2202720
       GoKind: 22
       Pointee: 173 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -343,7 +343,7 @@ Types:
       ID: 25
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.4504e+06
+      GoRuntimeType: 1450400
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -364,21 +364,21 @@ Types:
       ID: 59
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 1.22832e+06
+      GoRuntimeType: 1228320
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.45104e+06
+      GoRuntimeType: 1451040
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 68
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.064608e+06
+      GoRuntimeType: 1064608
       GoKind: 22
       Pointee: 128 UnresolvedPointeeType runtime.p
     - __kind: PointerType
@@ -392,21 +392,21 @@ Types:
       ID: 50
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.59424e+06
+      GoRuntimeType: 1594240
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 45
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.12448e+06
+      GoRuntimeType: 2124480
       GoKind: 22
       Pointee: 46 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 83
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.670016e+06
+      GoRuntimeType: 1670016
       GoKind: 22
       Pointee: 84 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -432,105 +432,105 @@ Types:
       ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.738944e+06
+      GoRuntimeType: 1738944
       GoKind: 22
       Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 151
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.799168e+06
+      GoRuntimeType: 1799168
       GoKind: 22
       Pointee: 152 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.73856e+06
+      GoRuntimeType: 1738560
       GoKind: 22
       Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 143
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.7984e+06
+      GoRuntimeType: 1798400
       GoKind: 22
       Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 157
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.871744e+06
+      GoRuntimeType: 1871744
       GoKind: 22
       Pointee: 158 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 145
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.798592e+06
+      GoRuntimeType: 1798592
       GoKind: 22
       Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.798208e+06
+      GoRuntimeType: 1798208
       GoKind: 22
       Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 153
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.871296e+06
+      GoRuntimeType: 1871296
       GoKind: 22
       Pointee: 154 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 161
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.943424e+06
+      GoRuntimeType: 1943424
       GoKind: 22
       Pointee: 162 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 155
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.87152e+06
+      GoRuntimeType: 1871520
       GoKind: 22
       Pointee: 156 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.739136e+06
+      GoRuntimeType: 1739136
       GoKind: 22
       Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.738752e+06
+      GoRuntimeType: 1738752
       GoKind: 22
       Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 147
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.798784e+06
+      GoRuntimeType: 1798784
       GoKind: 22
       Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 159
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.871968e+06
+      GoRuntimeType: 1871968
       GoKind: 22
       Pointee: 160 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 149
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.798976e+06
+      GoRuntimeType: 1798976
       GoKind: 22
       Pointee: 150 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -886,7 +886,7 @@ Types:
       ID: 190
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.312864e+06
+      GoRuntimeType: 1312864
       GoKind: 20
       RawFields:
         - Name: tab
@@ -903,7 +903,7 @@ Types:
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.063072e+06
+      GoRuntimeType: 1063072
       GoKind: 20
       RawFields:
         - Name: tab
@@ -950,7 +950,7 @@ Types:
       ID: 163
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.45536e+06
+      GoRuntimeType: 1455360
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1025,7 +1025,7 @@ Types:
       ID: 92
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.910496e+06
+      GoRuntimeType: 1910496
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1037,7 +1037,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1047,7 +1047,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.245984e+06
+      GoRuntimeType: 1245984
       GoKind: 25
       RawFields:
         - Name: u
@@ -1057,7 +1057,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.688448e+06
+      GoRuntimeType: 1688448
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1077,7 +1077,7 @@ Types:
       ID: 33
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.53136e+06
+      GoRuntimeType: 1531360
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1090,7 +1090,7 @@ Types:
       ID: 37
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.5312e+06
+      GoRuntimeType: 1531200
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1102,20 +1102,20 @@ Types:
     - __kind: StructureType
       ID: 77
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 1.021088e+06
+      GoRuntimeType: 1021088
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 34
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 1.020992e+06
+      GoRuntimeType: 1020992
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
       ID: 179
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.143232e+06
+      GoRuntimeType: 1143232
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1198,7 +1198,7 @@ Types:
       ID: 193
       Name: map[string]string
       ByteSize: 8
-      GoRuntimeType: 1.162432e+06
+      GoRuntimeType: 1162432
       GoKind: 21
       HeaderType: 195 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
@@ -1209,7 +1209,7 @@ Types:
       ID: 166
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.058848e+06
+      GoRuntimeType: 1058848
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1222,7 +1222,7 @@ Types:
       ID: 164
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.057184e+06
+      GoRuntimeType: 1057184
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1235,14 +1235,14 @@ Types:
       ID: 174
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 2.176096e+06
+      GoRuntimeType: 2176096
       GoKind: 21
       HeaderType: 176 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
       ID: 167
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.057312e+06
+      GoRuntimeType: 1057312
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1255,7 +1255,7 @@ Types:
       ID: 165
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.057568e+06
+      GoRuntimeType: 1057568
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1268,7 +1268,7 @@ Types:
       ID: 117
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.42208e+06
+      GoRuntimeType: 2422080
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1357,7 +1357,7 @@ Types:
       ID: 115
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.218208e+06
+      GoRuntimeType: 1218208
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1386,7 +1386,7 @@ Types:
       ID: 182
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.946112e+06
+      GoRuntimeType: 1946112
       GoKind: 21
       HeaderType: 176 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
@@ -1411,7 +1411,7 @@ Types:
       ID: 201
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.326816e+06
+      GoRuntimeType: 1326816
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1424,7 +1424,7 @@ Types:
       ID: 211
       Name: noalg.map.group[string]string
       ByteSize: 264
-      GoRuntimeType: 1.329248e+06
+      GoRuntimeType: 1329248
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1437,7 +1437,7 @@ Types:
       ID: 203
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.326688e+06
+      GoRuntimeType: 1326688
       GoKind: 25
       RawFields:
         - Name: key
@@ -1450,7 +1450,7 @@ Types:
       ID: 213
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
-      GoRuntimeType: 1.32912e+06
+      GoRuntimeType: 1329120
       GoKind: 25
       RawFields:
         - Name: key
@@ -1478,14 +1478,14 @@ Types:
     - __kind: StructureType
       ID: 90
       Name: runtime.dlogPerM
-      GoRuntimeType: 1.017056e+06
+      GoRuntimeType: 1017056
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 23
       Name: runtime.g
       ByteSize: 456
-      GoRuntimeType: 2.488096e+06
+      GoRuntimeType: 2488096
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1687,7 +1687,7 @@ Types:
       ID: 55
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.228192e+06
+      GoRuntimeType: 1228192
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1697,7 +1697,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.976128e+06
+      GoRuntimeType: 1976128
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1722,7 +1722,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.50912e+06
+      GoRuntimeType: 1509120
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1735,7 +1735,7 @@ Types:
       ID: 60
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.809472e+06
+      GoRuntimeType: 1809472
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1760,7 +1760,7 @@ Types:
       ID: 96
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.51152e+06
+      GoRuntimeType: 1511520
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1773,7 +1773,7 @@ Types:
       ID: 72
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 1.51072e+06
+      GoRuntimeType: 1510720
       GoKind: 25
       RawFields:
         - Name: prev
@@ -1792,7 +1792,7 @@ Types:
       ID: 30
       Name: runtime.m
       ByteSize: 1824
-      GoRuntimeType: 2.493376e+06
+      GoRuntimeType: 2493376
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2021,7 +2021,7 @@ Types:
       ID: 75
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.97664e+06
+      GoRuntimeType: 1976640
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2046,7 +2046,7 @@ Types:
       ID: 91
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.901088e+06
+      GoRuntimeType: 1901088
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2068,7 +2068,7 @@ Types:
       ID: 80
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 1.976896e+06
+      GoRuntimeType: 1976896
       GoKind: 25
       RawFields:
         - Name: writing
@@ -2093,7 +2093,7 @@ Types:
       ID: 74
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.5112e+06
+      GoRuntimeType: 1511200
       GoKind: 25
       RawFields:
         - Name: next
@@ -2106,7 +2106,7 @@ Types:
       ID: 98
       Name: runtime.mWeakPointer
       ByteSize: 8
-      GoRuntimeType: 1.59472e+06
+      GoRuntimeType: 1594720
       GoKind: 25
       RawFields:
         - Name: m
@@ -2122,7 +2122,7 @@ Types:
       ID: 71
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.229216e+06
+      GoRuntimeType: 1229216
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -2133,7 +2133,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.51136e+06
+      GoRuntimeType: 1511360
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2146,13 +2146,13 @@ Types:
       ID: 89
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.810432e+06
+      GoRuntimeType: 1810432
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2180,7 +2180,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.50784e+06
+      GoRuntimeType: 1507840
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2221,7 +2221,7 @@ Types:
       ID: 56
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.50944e+06
+      GoRuntimeType: 1509440
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2234,19 +2234,19 @@ Types:
       ID: 35
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.638912e+06
+      GoRuntimeType: 1638912
       GoKind: 8
     - __kind: StructureType
       ID: 85
       Name: runtime.winlibcall
-      GoRuntimeType: 1.01696e+06
+      GoRuntimeType: 1016960
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 52
       Name: runtime.xRegPerG
       ByteSize: 8
-      GoRuntimeType: 1.228064e+06
+      GoRuntimeType: 1228064
       GoKind: 25
       RawFields:
         - Name: state
@@ -2279,7 +2279,7 @@ Types:
       ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 2.0112e+06
+      GoRuntimeType: 2011200
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2292,7 +2292,7 @@ Types:
       ID: 152
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.089312e+06
+      GoRuntimeType: 2089312
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2308,7 +2308,7 @@ Types:
       ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 2.010688e+06
+      GoRuntimeType: 2010688
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2321,7 +2321,7 @@ Types:
       ID: 144
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.08816e+06
+      GoRuntimeType: 2088160
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2337,7 +2337,7 @@ Types:
       ID: 158
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.15872e+06
+      GoRuntimeType: 2158720
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2356,7 +2356,7 @@ Types:
       ID: 146
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.088448e+06
+      GoRuntimeType: 2088448
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2372,7 +2372,7 @@ Types:
       ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 2.087872e+06
+      GoRuntimeType: 2087872
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2388,7 +2388,7 @@ Types:
       ID: 154
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 2.15808e+06
+      GoRuntimeType: 2158080
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2407,7 +2407,7 @@ Types:
       ID: 162
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.220768e+06
+      GoRuntimeType: 2220768
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2429,7 +2429,7 @@ Types:
       ID: 156
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.1584e+06
+      GoRuntimeType: 2158400
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2448,7 +2448,7 @@ Types:
       ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 2.011456e+06
+      GoRuntimeType: 2011456
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2461,7 +2461,7 @@ Types:
       ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 2.010944e+06
+      GoRuntimeType: 2010944
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2474,7 +2474,7 @@ Types:
       ID: 148
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.088736e+06
+      GoRuntimeType: 2088736
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2490,7 +2490,7 @@ Types:
       ID: 160
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.15904e+06
+      GoRuntimeType: 2159040
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2509,7 +2509,7 @@ Types:
       ID: 150
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.089024e+06
+      GoRuntimeType: 2089024
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -174,7 +174,7 @@ Types:
       ID: 105
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.114976e+06
+      GoRuntimeType: 2114976
       GoKind: 22
       Pointee: 106 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -209,7 +209,7 @@ Types:
       ID: 114
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.361664e+06
+      GoRuntimeType: 1361664
       GoKind: 22
       Pointee: 115 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
@@ -268,42 +268,42 @@ Types:
       ID: 103
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.154176e+06
+      GoRuntimeType: 2154176
       GoKind: 22
       Pointee: 104 StructureType net/http.Request
     - __kind: PointerType
       ID: 173
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.590912e+06
+      GoRuntimeType: 1590912
       GoKind: 22
       Pointee: 174 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 151
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.832832e+06
+      GoRuntimeType: 1832832
       GoKind: 22
       Pointee: 152 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 176
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.416224e+06
+      GoRuntimeType: 1416224
       GoKind: 22
       Pointee: 177 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 153
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.059008e+06
+      GoRuntimeType: 2059008
       GoKind: 22
       Pointee: 154 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 155
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 1.949216e+06
+      GoRuntimeType: 1949216
       GoKind: 22
       Pointee: 156 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -317,7 +317,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.231968e+06
+      GoRuntimeType: 1231968
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -366,14 +366,14 @@ Types:
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 1.92e+06
+      GoRuntimeType: 1920000
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.427744e+06
+      GoRuntimeType: 1427744
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -392,105 +392,105 @@ Types:
       ID: 120
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.495904e+06
+      GoRuntimeType: 1495904
       GoKind: 22
       Pointee: 121 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 134
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.61568e+06
+      GoRuntimeType: 1615680
       GoKind: 22
       Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 116
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.49552e+06
+      GoRuntimeType: 1495520
       GoKind: 22
       Pointee: 117 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 126
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.614912e+06
+      GoRuntimeType: 1614912
       GoKind: 22
       Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 140
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.684896e+06
+      GoRuntimeType: 1684896
       GoKind: 22
       Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 128
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.615104e+06
+      GoRuntimeType: 1615104
       GoKind: 22
       Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 124
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.61472e+06
+      GoRuntimeType: 1614720
       GoKind: 22
       Pointee: 125 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 136
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.684448e+06
+      GoRuntimeType: 1684448
       GoKind: 22
       Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 144
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.750176e+06
+      GoRuntimeType: 1750176
       GoKind: 22
       Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 138
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.684672e+06
+      GoRuntimeType: 1684672
       GoKind: 22
       Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 122
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.496096e+06
+      GoRuntimeType: 1496096
       GoKind: 22
       Pointee: 123 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 118
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.495712e+06
+      GoRuntimeType: 1495712
       GoKind: 22
       Pointee: 119 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 130
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.615296e+06
+      GoRuntimeType: 1615296
       GoKind: 22
       Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 142
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.68512e+06
+      GoRuntimeType: 1685120
       GoKind: 22
       Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 132
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.615488e+06
+      GoRuntimeType: 1615488
       GoKind: 22
       Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -860,7 +860,7 @@ Types:
       ID: 175
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.187104e+06
+      GoRuntimeType: 1187104
       GoKind: 20
       RawFields:
         - Name: tab
@@ -920,7 +920,7 @@ Types:
       ID: 146
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.235648e+06
+      GoRuntimeType: 1235648
       GoKind: 20
       RawFields:
         - Name: tab
@@ -937,7 +937,7 @@ Types:
       ID: 107
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
-      GoRuntimeType: 1.295936e+06
+      GoRuntimeType: 1295936
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1048,7 +1048,7 @@ Types:
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.7168e+06
+      GoRuntimeType: 1716800
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1060,7 +1060,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1070,7 +1070,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.12304e+06
+      GoRuntimeType: 1123040
       GoKind: 25
       RawFields:
         - Name: u
@@ -1080,7 +1080,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.445024e+06
+      GoRuntimeType: 1445024
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1096,7 +1096,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.305216e+06
+      GoRuntimeType: 1305216
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1109,7 +1109,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.305056e+06
+      GoRuntimeType: 1305056
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1122,7 +1122,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.305376e+06
+      GoRuntimeType: 1305376
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1147,7 +1147,7 @@ Types:
       ID: 164
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.067136e+06
+      GoRuntimeType: 1067136
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1197,7 +1197,7 @@ Types:
       ID: 157
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 1.91744e+06
+      GoRuntimeType: 1917440
       GoKind: 21
       HeaderType: 159 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
@@ -1230,7 +1230,7 @@ Types:
       ID: 104
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.189984e+06
+      GoRuntimeType: 2189984
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1319,7 +1319,7 @@ Types:
       ID: 102
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.098336e+06
+      GoRuntimeType: 1098336
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1348,7 +1348,7 @@ Types:
       ID: 167
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.670784e+06
+      GoRuntimeType: 1670784
       GoKind: 21
       HeaderType: 159 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
@@ -1377,7 +1377,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 2.248608e+06
+      GoRuntimeType: 2248608
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1552,7 +1552,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.109344e+06
+      GoRuntimeType: 1109344
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1562,7 +1562,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.836288e+06
+      GoRuntimeType: 1836288
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1590,7 +1590,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.288096e+06
+      GoRuntimeType: 1288096
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1603,7 +1603,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.625632e+06
+      GoRuntimeType: 1625632
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1628,7 +1628,7 @@ Types:
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.287936e+06
+      GoRuntimeType: 1287936
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1641,13 +1641,13 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.778912e+06
+      GoRuntimeType: 1778912
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1672,7 +1672,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 2.25472e+06
+      GoRuntimeType: 2254720
       GoKind: 25
       RawFields:
         - Name: g0
@@ -1892,7 +1892,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.778656e+06
+      GoRuntimeType: 1778656
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -1917,7 +1917,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 1.428128e+06
+      GoRuntimeType: 1428128
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -1933,7 +1933,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 1.427936e+06
+      GoRuntimeType: 1427936
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -1959,14 +1959,14 @@ Types:
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.10896e+06
+      GoRuntimeType: 1108960
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.287776e+06
+      GoRuntimeType: 1287776
       GoKind: 25
       RawFields:
         - Name: entries
@@ -1979,13 +1979,13 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.6264e+06
+      GoRuntimeType: 1626400
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2013,7 +2013,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.286176e+06
+      GoRuntimeType: 1286176
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2050,7 +2050,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.287136e+06
+      GoRuntimeType: 1287136
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2063,7 +2063,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.06816e+06
+      GoRuntimeType: 1068160
       GoKind: 8
     - __kind: StructureType
       ID: 75
@@ -2094,7 +2094,7 @@ Types:
       ID: 121
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.810144e+06
+      GoRuntimeType: 1810144
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2107,7 +2107,7 @@ Types:
       ID: 135
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 1.885248e+06
+      GoRuntimeType: 1885248
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2123,7 +2123,7 @@ Types:
       ID: 117
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.809632e+06
+      GoRuntimeType: 1809632
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2136,7 +2136,7 @@ Types:
       ID: 127
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 1.884096e+06
+      GoRuntimeType: 1884096
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2152,7 +2152,7 @@ Types:
       ID: 141
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 1.9472e+06
+      GoRuntimeType: 1947200
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2171,7 +2171,7 @@ Types:
       ID: 129
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 1.884384e+06
+      GoRuntimeType: 1884384
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2187,7 +2187,7 @@ Types:
       ID: 125
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 1.883808e+06
+      GoRuntimeType: 1883808
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2203,7 +2203,7 @@ Types:
       ID: 137
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 1.94656e+06
+      GoRuntimeType: 1946560
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2222,7 +2222,7 @@ Types:
       ID: 145
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.005088e+06
+      GoRuntimeType: 2005088
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2244,7 +2244,7 @@ Types:
       ID: 139
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 1.94688e+06
+      GoRuntimeType: 1946880
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2263,7 +2263,7 @@ Types:
       ID: 123
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.8104e+06
+      GoRuntimeType: 1810400
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2276,7 +2276,7 @@ Types:
       ID: 119
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.809888e+06
+      GoRuntimeType: 1809888
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2289,7 +2289,7 @@ Types:
       ID: 131
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 1.884672e+06
+      GoRuntimeType: 1884672
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2305,7 +2305,7 @@ Types:
       ID: 143
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 1.94752e+06
+      GoRuntimeType: 1947520
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2324,7 +2324,7 @@ Types:
       ID: 133
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 1.88496e+06
+      GoRuntimeType: 1884960
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -174,7 +174,7 @@ Types:
       ID: 110
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.245824e+06
+      GoRuntimeType: 2245824
       GoKind: 22
       Pointee: 111 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -209,7 +209,7 @@ Types:
       ID: 119
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.539904e+06
+      GoRuntimeType: 1539904
       GoKind: 22
       Pointee: 120 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
@@ -268,42 +268,42 @@ Types:
       ID: 108
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.285568e+06
+      GoRuntimeType: 2285568
       GoKind: 22
       Pointee: 109 StructureType net/http.Request
     - __kind: PointerType
       ID: 176
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.706048e+06
+      GoRuntimeType: 1706048
       GoKind: 22
       Pointee: 177 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 156
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.99632e+06
+      GoRuntimeType: 1996320
       GoKind: 22
       Pointee: 157 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 179
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.597952e+06
+      GoRuntimeType: 1597952
       GoKind: 22
       Pointee: 180 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 158
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.189984e+06
+      GoRuntimeType: 2189984
       GoKind: 22
       Pointee: 159 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 160
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.100096e+06
+      GoRuntimeType: 2100096
       GoKind: 22
       Pointee: 161 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -327,7 +327,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.40448e+06
+      GoRuntimeType: 1404480
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -355,7 +355,7 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.02512e+06
+      GoRuntimeType: 1025120
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
@@ -369,21 +369,21 @@ Types:
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 1.537504e+06
+      GoRuntimeType: 1537504
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.044832e+06
+      GoRuntimeType: 2044832
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.609664e+06
+      GoRuntimeType: 1609664
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -402,105 +402,105 @@ Types:
       ID: 125
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.677056e+06
+      GoRuntimeType: 1677056
       GoKind: 22
       Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 139
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.729472e+06
+      GoRuntimeType: 1729472
       GoKind: 22
       Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 121
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.676672e+06
+      GoRuntimeType: 1676672
       GoKind: 22
       Pointee: 122 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 131
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.728704e+06
+      GoRuntimeType: 1728704
       GoKind: 22
       Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 145
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.800096e+06
+      GoRuntimeType: 1800096
       GoKind: 22
       Pointee: 146 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 133
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.728896e+06
+      GoRuntimeType: 1728896
       GoKind: 22
       Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 129
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.728512e+06
+      GoRuntimeType: 1728512
       GoKind: 22
       Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 141
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.799648e+06
+      GoRuntimeType: 1799648
       GoKind: 22
       Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 149
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.869504e+06
+      GoRuntimeType: 1869504
       GoKind: 22
       Pointee: 150 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 143
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.799872e+06
+      GoRuntimeType: 1799872
       GoKind: 22
       Pointee: 144 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 127
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.677248e+06
+      GoRuntimeType: 1677248
       GoKind: 22
       Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 123
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.676864e+06
+      GoRuntimeType: 1676864
       GoKind: 22
       Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 135
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.729088e+06
+      GoRuntimeType: 1729088
       GoKind: 22
       Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 147
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.80032e+06
+      GoRuntimeType: 1800320
       GoKind: 22
       Pointee: 148 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 137
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.72928e+06
+      GoRuntimeType: 1729280
       GoKind: 22
       Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -840,7 +840,7 @@ Types:
       ID: 178
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.267616e+06
+      GoRuntimeType: 1267616
       GoKind: 20
       RawFields:
         - Name: tab
@@ -857,7 +857,7 @@ Types:
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.023328e+06
+      GoRuntimeType: 1023328
       GoKind: 20
       RawFields:
         - Name: tab
@@ -900,7 +900,7 @@ Types:
       ID: 151
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.40832e+06
+      GoRuntimeType: 1408320
       GoKind: 20
       RawFields:
         - Name: tab
@@ -917,7 +917,7 @@ Types:
       ID: 112
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
-      GoRuntimeType: 1.469568e+06
+      GoRuntimeType: 1469568
       GoKind: 20
       RawFields:
         - Name: tab
@@ -988,7 +988,7 @@ Types:
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.834784e+06
+      GoRuntimeType: 1834784
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1000,7 +1000,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1010,7 +1010,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.20176e+06
+      GoRuntimeType: 1201760
       GoKind: 25
       RawFields:
         - Name: u
@@ -1020,7 +1020,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.626752e+06
+      GoRuntimeType: 1626752
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1036,7 +1036,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.479488e+06
+      GoRuntimeType: 1479488
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1049,7 +1049,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.479328e+06
+      GoRuntimeType: 1479328
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1062,7 +1062,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.479648e+06
+      GoRuntimeType: 1479648
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1087,7 +1087,7 @@ Types:
       ID: 167
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.10128e+06
+      GoRuntimeType: 1101280
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1164,7 +1164,7 @@ Types:
       ID: 181
       Name: map[string]string
       ByteSize: 8
-      GoRuntimeType: 1.119712e+06
+      GoRuntimeType: 1119712
       GoKind: 21
       HeaderType: 183 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
@@ -1175,7 +1175,7 @@ Types:
       ID: 154
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.019104e+06
+      GoRuntimeType: 1019104
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1188,7 +1188,7 @@ Types:
       ID: 152
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.017696e+06
+      GoRuntimeType: 1017696
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1201,14 +1201,14 @@ Types:
       ID: 162
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 2.088128e+06
+      GoRuntimeType: 2088128
       GoKind: 21
       HeaderType: 164 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
       ID: 155
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.017824e+06
+      GoRuntimeType: 1017824
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1221,7 +1221,7 @@ Types:
       ID: 153
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.01808e+06
+      GoRuntimeType: 1018080
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1234,7 +1234,7 @@ Types:
       ID: 109
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.322816e+06
+      GoRuntimeType: 2322816
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1323,7 +1323,7 @@ Types:
       ID: 107
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.177056e+06
+      GoRuntimeType: 1177056
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1352,7 +1352,7 @@ Types:
       ID: 170
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.871296e+06
+      GoRuntimeType: 1871296
       GoKind: 21
       HeaderType: 164 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
@@ -1377,7 +1377,7 @@ Types:
       ID: 189
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.281056e+06
+      GoRuntimeType: 1281056
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1390,7 +1390,7 @@ Types:
       ID: 199
       Name: noalg.map.group[string]string
       ByteSize: 264
-      GoRuntimeType: 1.28336e+06
+      GoRuntimeType: 1283360
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1403,7 +1403,7 @@ Types:
       ID: 191
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.280928e+06
+      GoRuntimeType: 1280928
       GoKind: 25
       RawFields:
         - Name: key
@@ -1416,7 +1416,7 @@ Types:
       ID: 201
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
-      GoRuntimeType: 1.283232e+06
+      GoRuntimeType: 1283232
       GoKind: 25
       RawFields:
         - Name: key
@@ -1451,7 +1451,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.38512e+06
+      GoRuntimeType: 2385120
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1632,7 +1632,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.187808e+06
+      GoRuntimeType: 1187808
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1642,7 +1642,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.960896e+06
+      GoRuntimeType: 1960896
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1670,7 +1670,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.461568e+06
+      GoRuntimeType: 1461568
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1683,7 +1683,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.739232e+06
+      GoRuntimeType: 1739232
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1708,7 +1708,7 @@ Types:
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.461408e+06
+      GoRuntimeType: 1461408
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1721,13 +1721,13 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.899264e+06
+      GoRuntimeType: 1899264
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1752,7 +1752,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 2.390176e+06
+      GoRuntimeType: 2390176
       GoKind: 25
       RawFields:
         - Name: g0
@@ -1975,7 +1975,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.961184e+06
+      GoRuntimeType: 1961184
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2003,7 +2003,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.8256e+06
+      GoRuntimeType: 1825600
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2025,7 +2025,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.825376e+06
+      GoRuntimeType: 1825376
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2047,7 +2047,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 1.187552e+06
+      GoRuntimeType: 1187552
       GoKind: 25
       RawFields:
         - Name: next
@@ -2063,14 +2063,14 @@ Types:
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.187424e+06
+      GoRuntimeType: 1187424
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.461248e+06
+      GoRuntimeType: 1461248
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2083,13 +2083,13 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.74e+06
+      GoRuntimeType: 1740000
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2117,7 +2117,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.459648e+06
+      GoRuntimeType: 1459648
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2158,7 +2158,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.460608e+06
+      GoRuntimeType: 1460608
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2171,7 +2171,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.269024e+06
+      GoRuntimeType: 1269024
       GoKind: 8
     - __kind: StructureType
       ID: 79
@@ -2202,7 +2202,7 @@ Types:
       ID: 126
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.9328e+06
+      GoRuntimeType: 1932800
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2215,7 +2215,7 @@ Types:
       ID: 140
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.010432e+06
+      GoRuntimeType: 2010432
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2231,7 +2231,7 @@ Types:
       ID: 122
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.932288e+06
+      GoRuntimeType: 1932288
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2244,7 +2244,7 @@ Types:
       ID: 132
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.00928e+06
+      GoRuntimeType: 2009280
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2260,7 +2260,7 @@ Types:
       ID: 146
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.071712e+06
+      GoRuntimeType: 2071712
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2279,7 +2279,7 @@ Types:
       ID: 134
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.009568e+06
+      GoRuntimeType: 2009568
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2295,7 +2295,7 @@ Types:
       ID: 130
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 2.008992e+06
+      GoRuntimeType: 2008992
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2311,7 +2311,7 @@ Types:
       ID: 142
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 2.071072e+06
+      GoRuntimeType: 2071072
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2330,7 +2330,7 @@ Types:
       ID: 150
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.131456e+06
+      GoRuntimeType: 2131456
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2352,7 +2352,7 @@ Types:
       ID: 144
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.071392e+06
+      GoRuntimeType: 2071392
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2371,7 +2371,7 @@ Types:
       ID: 128
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.933056e+06
+      GoRuntimeType: 1933056
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2384,7 +2384,7 @@ Types:
       ID: 124
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.932544e+06
+      GoRuntimeType: 1932544
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2397,7 +2397,7 @@ Types:
       ID: 136
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.009856e+06
+      GoRuntimeType: 2009856
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2413,7 +2413,7 @@ Types:
       ID: 148
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.072032e+06
+      GoRuntimeType: 2072032
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2432,7 +2432,7 @@ Types:
       ID: 138
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.010144e+06
+      GoRuntimeType: 2010144
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -185,7 +185,7 @@ Types:
       ID: 112
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.260704e+06
+      GoRuntimeType: 2260704
       GoKind: 22
       Pointee: 113 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -220,7 +220,7 @@ Types:
       ID: 124
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.550528e+06
+      GoRuntimeType: 1550528
       GoKind: 22
       Pointee: 125 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
@@ -279,42 +279,42 @@ Types:
       ID: 110
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.30096e+06
+      GoRuntimeType: 2300960
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
       ID: 181
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.718816e+06
+      GoRuntimeType: 1718816
       GoKind: 22
       Pointee: 182 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 161
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 2.010368e+06
+      GoRuntimeType: 2010368
       GoKind: 22
       Pointee: 162 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 184
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.608608e+06
+      GoRuntimeType: 1608608
       GoKind: 22
       Pointee: 185 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 163
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.218272e+06
+      GoRuntimeType: 2218272
       GoKind: 22
       Pointee: 164 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 165
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.1136e+06
+      GoRuntimeType: 2113600
       GoKind: 22
       Pointee: 166 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -338,7 +338,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.413792e+06
+      GoRuntimeType: 1413792
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -366,14 +366,14 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.414432e+06
+      GoRuntimeType: 1414432
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.03344e+06
+      GoRuntimeType: 1033440
       GoKind: 22
       Pointee: 121 UnresolvedPointeeType runtime.p
     - __kind: PointerType
@@ -387,21 +387,21 @@ Types:
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.548128e+06
+      GoRuntimeType: 1548128
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.057728e+06
+      GoRuntimeType: 2057728
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.620512e+06
+      GoRuntimeType: 1620512
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -420,105 +420,105 @@ Types:
       ID: 130
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.68848e+06
+      GoRuntimeType: 1688480
       GoKind: 22
       Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 144
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.74224e+06
+      GoRuntimeType: 1742240
       GoKind: 22
       Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 126
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.688096e+06
+      GoRuntimeType: 1688096
       GoKind: 22
       Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 136
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.741472e+06
+      GoRuntimeType: 1741472
       GoKind: 22
       Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 150
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.814048e+06
+      GoRuntimeType: 1814048
       GoKind: 22
       Pointee: 151 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 138
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.741664e+06
+      GoRuntimeType: 1741664
       GoKind: 22
       Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 134
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.74128e+06
+      GoRuntimeType: 1741280
       GoKind: 22
       Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 146
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.8136e+06
+      GoRuntimeType: 1813600
       GoKind: 22
       Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 154
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.882912e+06
+      GoRuntimeType: 1882912
       GoKind: 22
       Pointee: 155 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 148
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.813824e+06
+      GoRuntimeType: 1813824
       GoKind: 22
       Pointee: 149 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 132
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.688672e+06
+      GoRuntimeType: 1688672
       GoKind: 22
       Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 128
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.688288e+06
+      GoRuntimeType: 1688288
       GoKind: 22
       Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 140
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.741856e+06
+      GoRuntimeType: 1741856
       GoKind: 22
       Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 152
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.814272e+06
+      GoRuntimeType: 1814272
       GoKind: 22
       Pointee: 153 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 142
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.742048e+06
+      GoRuntimeType: 1742048
       GoKind: 22
       Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -874,7 +874,7 @@ Types:
       ID: 183
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.276992e+06
+      GoRuntimeType: 1276992
       GoKind: 20
       RawFields:
         - Name: tab
@@ -891,7 +891,7 @@ Types:
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.031776e+06
+      GoRuntimeType: 1031776
       GoKind: 20
       RawFields:
         - Name: tab
@@ -934,7 +934,7 @@ Types:
       ID: 156
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.417952e+06
+      GoRuntimeType: 1417952
       GoKind: 20
       RawFields:
         - Name: tab
@@ -951,7 +951,7 @@ Types:
       ID: 114
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
-      GoRuntimeType: 1.479712e+06
+      GoRuntimeType: 1479712
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1022,7 +1022,7 @@ Types:
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.849088e+06
+      GoRuntimeType: 1849088
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1034,7 +1034,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1044,7 +1044,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.210368e+06
+      GoRuntimeType: 1210368
       GoKind: 25
       RawFields:
         - Name: u
@@ -1054,7 +1054,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.6376e+06
+      GoRuntimeType: 1637600
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1070,7 +1070,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.489632e+06
+      GoRuntimeType: 1489632
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1083,7 +1083,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.489472e+06
+      GoRuntimeType: 1489472
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1096,7 +1096,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.489792e+06
+      GoRuntimeType: 1489792
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1121,7 +1121,7 @@ Types:
       ID: 172
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.110464e+06
+      GoRuntimeType: 1110464
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1204,7 +1204,7 @@ Types:
       ID: 186
       Name: map[string]string
       ByteSize: 8
-      GoRuntimeType: 1.129024e+06
+      GoRuntimeType: 1129024
       GoKind: 21
       HeaderType: 188 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
@@ -1215,7 +1215,7 @@ Types:
       ID: 159
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.027552e+06
+      GoRuntimeType: 1027552
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1228,7 +1228,7 @@ Types:
       ID: 157
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.026016e+06
+      GoRuntimeType: 1026016
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1241,14 +1241,14 @@ Types:
       ID: 167
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 2.101632e+06
+      GoRuntimeType: 2101632
       GoKind: 21
       HeaderType: 169 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
       ID: 160
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.026144e+06
+      GoRuntimeType: 1026144
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1261,7 +1261,7 @@ Types:
       ID: 158
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.0264e+06
+      GoRuntimeType: 1026400
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1274,7 +1274,7 @@ Types:
       ID: 111
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.336832e+06
+      GoRuntimeType: 2336832
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1363,7 +1363,7 @@ Types:
       ID: 109
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.185792e+06
+      GoRuntimeType: 1185792
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1392,7 +1392,7 @@ Types:
       ID: 175
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.885152e+06
+      GoRuntimeType: 1885152
       GoKind: 21
       HeaderType: 169 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
@@ -1417,7 +1417,7 @@ Types:
       ID: 194
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.290432e+06
+      GoRuntimeType: 1290432
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1430,7 +1430,7 @@ Types:
       ID: 204
       Name: noalg.map.group[string]string
       ByteSize: 264
-      GoRuntimeType: 1.292864e+06
+      GoRuntimeType: 1292864
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1443,7 +1443,7 @@ Types:
       ID: 196
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.290304e+06
+      GoRuntimeType: 1290304
       GoKind: 25
       RawFields:
         - Name: key
@@ -1456,7 +1456,7 @@ Types:
       ID: 206
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
-      GoRuntimeType: 1.292736e+06
+      GoRuntimeType: 1292736
       GoKind: 25
       RawFields:
         - Name: key
@@ -1491,7 +1491,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.400832e+06
+      GoRuntimeType: 2400832
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1681,7 +1681,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.196288e+06
+      GoRuntimeType: 1196288
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1691,7 +1691,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.913664e+06
+      GoRuntimeType: 1913664
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1716,7 +1716,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.471552e+06
+      GoRuntimeType: 1471552
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1729,7 +1729,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.75296e+06
+      GoRuntimeType: 1752960
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1754,7 +1754,7 @@ Types:
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.471392e+06
+      GoRuntimeType: 1471392
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1767,13 +1767,13 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.914432e+06
+      GoRuntimeType: 1914432
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1798,7 +1798,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 2.404128e+06
+      GoRuntimeType: 2404128
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2018,7 +2018,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.914176e+06
+      GoRuntimeType: 1914176
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2043,7 +2043,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.840128e+06
+      GoRuntimeType: 1840128
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2065,7 +2065,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.839904e+06
+      GoRuntimeType: 1839904
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2087,7 +2087,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.471072e+06
+      GoRuntimeType: 1471072
       GoKind: 25
       RawFields:
         - Name: next
@@ -2106,7 +2106,7 @@ Types:
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.196032e+06
+      GoRuntimeType: 1196032
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -2117,7 +2117,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.471232e+06
+      GoRuntimeType: 1471232
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2130,13 +2130,13 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.75392e+06
+      GoRuntimeType: 1753920
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2164,7 +2164,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.469312e+06
+      GoRuntimeType: 1469312
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2205,7 +2205,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.470272e+06
+      GoRuntimeType: 1470272
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2218,7 +2218,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.2784e+06
+      GoRuntimeType: 1278400
       GoKind: 8
     - __kind: StructureType
       ID: 82
@@ -2249,7 +2249,7 @@ Types:
       ID: 131
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.947456e+06
+      GoRuntimeType: 1947456
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2262,7 +2262,7 @@ Types:
       ID: 145
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.023616e+06
+      GoRuntimeType: 2023616
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2278,7 +2278,7 @@ Types:
       ID: 127
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.946944e+06
+      GoRuntimeType: 1946944
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2291,7 +2291,7 @@ Types:
       ID: 137
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.022464e+06
+      GoRuntimeType: 2022464
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2307,7 +2307,7 @@ Types:
       ID: 151
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.085568e+06
+      GoRuntimeType: 2085568
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2326,7 +2326,7 @@ Types:
       ID: 139
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.022752e+06
+      GoRuntimeType: 2022752
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2342,7 +2342,7 @@ Types:
       ID: 135
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 2.022176e+06
+      GoRuntimeType: 2022176
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2358,7 +2358,7 @@ Types:
       ID: 147
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 2.084928e+06
+      GoRuntimeType: 2084928
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2377,7 +2377,7 @@ Types:
       ID: 155
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.1464e+06
+      GoRuntimeType: 2146400
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2399,7 +2399,7 @@ Types:
       ID: 149
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.085248e+06
+      GoRuntimeType: 2085248
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2418,7 +2418,7 @@ Types:
       ID: 133
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.947712e+06
+      GoRuntimeType: 1947712
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2431,7 +2431,7 @@ Types:
       ID: 129
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.9472e+06
+      GoRuntimeType: 1947200
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2444,7 +2444,7 @@ Types:
       ID: 141
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.02304e+06
+      GoRuntimeType: 2023040
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2460,7 +2460,7 @@ Types:
       ID: 153
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.085888e+06
+      GoRuntimeType: 2085888
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2479,7 +2479,7 @@ Types:
       ID: 143
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.023328e+06
+      GoRuntimeType: 2023328
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.26rc1.yaml
@@ -185,7 +185,7 @@ Types:
       ID: 118
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.290784e+06
+      GoRuntimeType: 2290784
       GoKind: 22
       Pointee: 119 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -227,7 +227,7 @@ Types:
       ID: 130
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.56496e+06
+      GoRuntimeType: 1564960
       GoKind: 22
       Pointee: 131 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
@@ -269,7 +269,7 @@ Types:
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
       ByteSize: 8
-      GoRuntimeType: 1.58544e+06
+      GoRuntimeType: 1585440
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
@@ -293,42 +293,42 @@ Types:
       ID: 116
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.322432e+06
+      GoRuntimeType: 2322432
       GoKind: 22
       Pointee: 117 StructureType net/http.Request
     - __kind: PointerType
       ID: 187
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.73584e+06
+      GoRuntimeType: 1735840
       GoKind: 22
       Pointee: 188 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 167
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 2.031904e+06
+      GoRuntimeType: 2031904
       GoKind: 22
       Pointee: 168 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 190
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.624672e+06
+      GoRuntimeType: 1624672
       GoKind: 22
       Pointee: 191 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 169
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.241152e+06
+      GoRuntimeType: 2241152
       GoKind: 22
       Pointee: 170 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 171
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.149344e+06
+      GoRuntimeType: 2149344
       GoKind: 22
       Pointee: 172 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -352,7 +352,7 @@ Types:
       ID: 25
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.424064e+06
+      GoRuntimeType: 1424064
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -373,21 +373,21 @@ Types:
       ID: 59
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 1.203584e+06
+      GoRuntimeType: 1203584
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.424704e+06
+      GoRuntimeType: 1424704
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 68
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.042656e+06
+      GoRuntimeType: 1042656
       GoKind: 22
       Pointee: 127 UnresolvedPointeeType runtime.p
     - __kind: PointerType
@@ -401,21 +401,21 @@ Types:
       ID: 50
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.56224e+06
+      GoRuntimeType: 1562240
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 45
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.079488e+06
+      GoRuntimeType: 2079488
       GoKind: 22
       Pointee: 46 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 83
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.636768e+06
+      GoRuntimeType: 1636768
       GoKind: 22
       Pointee: 84 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -441,105 +441,105 @@ Types:
       ID: 136
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.705504e+06
+      GoRuntimeType: 1705504
       GoKind: 22
       Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 150
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.760224e+06
+      GoRuntimeType: 1760224
       GoKind: 22
       Pointee: 151 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 132
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.70512e+06
+      GoRuntimeType: 1705120
       GoKind: 22
       Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 142
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.759456e+06
+      GoRuntimeType: 1759456
       GoKind: 22
       Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 156
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.832352e+06
+      GoRuntimeType: 1832352
       GoKind: 22
       Pointee: 157 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 144
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.759648e+06
+      GoRuntimeType: 1759648
       GoKind: 22
       Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 140
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.759264e+06
+      GoRuntimeType: 1759264
       GoKind: 22
       Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 152
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.831904e+06
+      GoRuntimeType: 1831904
       GoKind: 22
       Pointee: 153 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 160
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.901216e+06
+      GoRuntimeType: 1901216
       GoKind: 22
       Pointee: 161 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 154
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.832128e+06
+      GoRuntimeType: 1832128
       GoKind: 22
       Pointee: 155 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 138
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.705696e+06
+      GoRuntimeType: 1705696
       GoKind: 22
       Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 134
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.705312e+06
+      GoRuntimeType: 1705312
       GoKind: 22
       Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 146
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.75984e+06
+      GoRuntimeType: 1759840
       GoKind: 22
       Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 158
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.832576e+06
+      GoRuntimeType: 1832576
       GoKind: 22
       Pointee: 159 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 148
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.760032e+06
+      GoRuntimeType: 1760032
       GoKind: 22
       Pointee: 149 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -895,7 +895,7 @@ Types:
       ID: 189
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.287232e+06
+      GoRuntimeType: 1287232
       GoKind: 20
       RawFields:
         - Name: tab
@@ -912,7 +912,7 @@ Types:
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.04112e+06
+      GoRuntimeType: 1041120
       GoKind: 20
       RawFields:
         - Name: tab
@@ -955,7 +955,7 @@ Types:
       ID: 162
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.428864e+06
+      GoRuntimeType: 1428864
       GoKind: 20
       RawFields:
         - Name: tab
@@ -972,7 +972,7 @@ Types:
       ID: 120
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
-      GoRuntimeType: 1.492864e+06
+      GoRuntimeType: 1492864
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1043,7 +1043,7 @@ Types:
       ID: 92
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.86784e+06
+      GoRuntimeType: 1867840
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1055,7 +1055,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1065,7 +1065,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.219456e+06
+      GoRuntimeType: 1219456
       GoKind: 25
       RawFields:
         - Name: u
@@ -1075,7 +1075,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.653472e+06
+      GoRuntimeType: 1653472
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1095,7 +1095,7 @@ Types:
       ID: 33
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.502784e+06
+      GoRuntimeType: 1502784
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1108,7 +1108,7 @@ Types:
       ID: 37
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.502624e+06
+      GoRuntimeType: 1502624
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1133,7 +1133,7 @@ Types:
       ID: 178
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.119104e+06
+      GoRuntimeType: 1119104
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1216,7 +1216,7 @@ Types:
       ID: 192
       Name: map[string]string
       ByteSize: 8
-      GoRuntimeType: 1.137792e+06
+      GoRuntimeType: 1137792
       GoKind: 21
       HeaderType: 194 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
@@ -1227,7 +1227,7 @@ Types:
       ID: 165
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.036896e+06
+      GoRuntimeType: 1036896
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1240,7 +1240,7 @@ Types:
       ID: 163
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.035232e+06
+      GoRuntimeType: 1035232
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1253,14 +1253,14 @@ Types:
       ID: 173
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 2.12336e+06
+      GoRuntimeType: 2123360
       GoKind: 21
       HeaderType: 175 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
       ID: 166
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.03536e+06
+      GoRuntimeType: 1035360
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1273,7 +1273,7 @@ Types:
       ID: 164
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.035616e+06
+      GoRuntimeType: 1035616
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1286,7 +1286,7 @@ Types:
       ID: 117
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.357664e+06
+      GoRuntimeType: 2357664
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1375,7 +1375,7 @@ Types:
       ID: 115
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.193728e+06
+      GoRuntimeType: 1193728
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1404,7 +1404,7 @@ Types:
       ID: 181
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.903456e+06
+      GoRuntimeType: 1903456
       GoKind: 21
       HeaderType: 175 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
@@ -1429,7 +1429,7 @@ Types:
       ID: 200
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.301184e+06
+      GoRuntimeType: 1301184
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1442,7 +1442,7 @@ Types:
       ID: 210
       Name: noalg.map.group[string]string
       ByteSize: 264
-      GoRuntimeType: 1.303616e+06
+      GoRuntimeType: 1303616
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1455,7 +1455,7 @@ Types:
       ID: 202
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.301056e+06
+      GoRuntimeType: 1301056
       GoKind: 25
       RawFields:
         - Name: key
@@ -1468,7 +1468,7 @@ Types:
       ID: 212
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
-      GoRuntimeType: 1.303488e+06
+      GoRuntimeType: 1303488
       GoKind: 25
       RawFields:
         - Name: key
@@ -1503,7 +1503,7 @@ Types:
       ID: 23
       Name: runtime.g
       ByteSize: 456
-      GoRuntimeType: 2.42384e+06
+      GoRuntimeType: 2423840
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1705,7 +1705,7 @@ Types:
       ID: 55
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.203456e+06
+      GoRuntimeType: 1203456
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1715,7 +1715,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.9328e+06
+      GoRuntimeType: 1932800
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1740,7 +1740,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.481184e+06
+      GoRuntimeType: 1481184
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1753,7 +1753,7 @@ Types:
       ID: 60
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.771104e+06
+      GoRuntimeType: 1771104
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1778,7 +1778,7 @@ Types:
       ID: 96
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.483584e+06
+      GoRuntimeType: 1483584
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1791,7 +1791,7 @@ Types:
       ID: 72
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 1.482784e+06
+      GoRuntimeType: 1482784
       GoKind: 25
       RawFields:
         - Name: prev
@@ -1810,7 +1810,7 @@ Types:
       ID: 30
       Name: runtime.m
       ByteSize: 1824
-      GoRuntimeType: 2.42912e+06
+      GoRuntimeType: 2429120
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2039,7 +2039,7 @@ Types:
       ID: 75
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.933312e+06
+      GoRuntimeType: 1933312
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2064,7 +2064,7 @@ Types:
       ID: 91
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.859328e+06
+      GoRuntimeType: 1859328
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2086,7 +2086,7 @@ Types:
       ID: 80
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 1.933568e+06
+      GoRuntimeType: 1933568
       GoKind: 25
       RawFields:
         - Name: writing
@@ -2111,7 +2111,7 @@ Types:
       ID: 74
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.483264e+06
+      GoRuntimeType: 1483264
       GoKind: 25
       RawFields:
         - Name: next
@@ -2124,7 +2124,7 @@ Types:
       ID: 98
       Name: runtime.mWeakPointer
       ByteSize: 8
-      GoRuntimeType: 1.56272e+06
+      GoRuntimeType: 1562720
       GoKind: 25
       RawFields:
         - Name: m
@@ -2140,7 +2140,7 @@ Types:
       ID: 71
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.20448e+06
+      GoRuntimeType: 1204480
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -2151,7 +2151,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.483424e+06
+      GoRuntimeType: 1483424
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2164,13 +2164,13 @@ Types:
       ID: 89
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.772064e+06
+      GoRuntimeType: 1772064
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2198,7 +2198,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.479904e+06
+      GoRuntimeType: 1479904
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2239,7 +2239,7 @@ Types:
       ID: 56
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.481504e+06
+      GoRuntimeType: 1481504
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2252,7 +2252,7 @@ Types:
       ID: 35
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.607072e+06
+      GoRuntimeType: 1607072
       GoKind: 8
     - __kind: StructureType
       ID: 85
@@ -2264,7 +2264,7 @@ Types:
       ID: 52
       Name: runtime.xRegPerG
       ByteSize: 8
-      GoRuntimeType: 1.203328e+06
+      GoRuntimeType: 1203328
       GoKind: 25
       RawFields:
         - Name: state
@@ -2297,7 +2297,7 @@ Types:
       ID: 137
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.967872e+06
+      GoRuntimeType: 1967872
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2310,7 +2310,7 @@ Types:
       ID: 151
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.046016e+06
+      GoRuntimeType: 2046016
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2326,7 +2326,7 @@ Types:
       ID: 133
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.96736e+06
+      GoRuntimeType: 1967360
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2339,7 +2339,7 @@ Types:
       ID: 143
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.044864e+06
+      GoRuntimeType: 2044864
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2355,7 +2355,7 @@ Types:
       ID: 157
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.107648e+06
+      GoRuntimeType: 2107648
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2374,7 +2374,7 @@ Types:
       ID: 145
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.045152e+06
+      GoRuntimeType: 2045152
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2390,7 +2390,7 @@ Types:
       ID: 141
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 2.044576e+06
+      GoRuntimeType: 2044576
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2406,7 +2406,7 @@ Types:
       ID: 153
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 2.107008e+06
+      GoRuntimeType: 2107008
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2425,7 +2425,7 @@ Types:
       ID: 161
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.168544e+06
+      GoRuntimeType: 2168544
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2447,7 +2447,7 @@ Types:
       ID: 155
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.107328e+06
+      GoRuntimeType: 2107328
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2466,7 +2466,7 @@ Types:
       ID: 139
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.968128e+06
+      GoRuntimeType: 1968128
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2479,7 +2479,7 @@ Types:
       ID: 135
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.967616e+06
+      GoRuntimeType: 1967616
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2492,7 +2492,7 @@ Types:
       ID: 147
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.04544e+06
+      GoRuntimeType: 2045440
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2508,7 +2508,7 @@ Types:
       ID: 159
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.107968e+06
+      GoRuntimeType: 2107968
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2527,7 +2527,7 @@ Types:
       ID: 149
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.045728e+06
+      GoRuntimeType: 2045728
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -174,7 +174,7 @@ Types:
       ID: 105
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.11552e+06
+      GoRuntimeType: 2115520
       GoKind: 22
       Pointee: 106 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -209,7 +209,7 @@ Types:
       ID: 114
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.362016e+06
+      GoRuntimeType: 1362016
       GoKind: 22
       Pointee: 115 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
@@ -268,42 +268,42 @@ Types:
       ID: 103
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.15472e+06
+      GoRuntimeType: 2154720
       GoKind: 22
       Pointee: 104 StructureType net/http.Request
     - __kind: PointerType
       ID: 173
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.591456e+06
+      GoRuntimeType: 1591456
       GoKind: 22
       Pointee: 174 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 151
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.833376e+06
+      GoRuntimeType: 1833376
       GoKind: 22
       Pointee: 152 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 176
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.416576e+06
+      GoRuntimeType: 1416576
       GoKind: 22
       Pointee: 177 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 153
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.059552e+06
+      GoRuntimeType: 2059552
       GoKind: 22
       Pointee: 154 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 155
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 1.94976e+06
+      GoRuntimeType: 1949760
       GoKind: 22
       Pointee: 156 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -317,7 +317,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.23216e+06
+      GoRuntimeType: 1232160
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -366,14 +366,14 @@ Types:
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 1.920544e+06
+      GoRuntimeType: 1920544
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.428096e+06
+      GoRuntimeType: 1428096
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -392,105 +392,105 @@ Types:
       ID: 120
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.496256e+06
+      GoRuntimeType: 1496256
       GoKind: 22
       Pointee: 121 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 134
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.616224e+06
+      GoRuntimeType: 1616224
       GoKind: 22
       Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 116
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.495872e+06
+      GoRuntimeType: 1495872
       GoKind: 22
       Pointee: 117 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 126
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.615456e+06
+      GoRuntimeType: 1615456
       GoKind: 22
       Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 140
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.68544e+06
+      GoRuntimeType: 1685440
       GoKind: 22
       Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 128
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.615648e+06
+      GoRuntimeType: 1615648
       GoKind: 22
       Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 124
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.615264e+06
+      GoRuntimeType: 1615264
       GoKind: 22
       Pointee: 125 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 136
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.684992e+06
+      GoRuntimeType: 1684992
       GoKind: 22
       Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 144
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.75072e+06
+      GoRuntimeType: 1750720
       GoKind: 22
       Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 138
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.685216e+06
+      GoRuntimeType: 1685216
       GoKind: 22
       Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 122
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.496448e+06
+      GoRuntimeType: 1496448
       GoKind: 22
       Pointee: 123 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 118
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.496064e+06
+      GoRuntimeType: 1496064
       GoKind: 22
       Pointee: 119 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 130
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.61584e+06
+      GoRuntimeType: 1615840
       GoKind: 22
       Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 142
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.685664e+06
+      GoRuntimeType: 1685664
       GoKind: 22
       Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 132
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.616032e+06
+      GoRuntimeType: 1616032
       GoKind: 22
       Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -860,7 +860,7 @@ Types:
       ID: 175
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.187296e+06
+      GoRuntimeType: 1187296
       GoKind: 20
       RawFields:
         - Name: tab
@@ -920,7 +920,7 @@ Types:
       ID: 146
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.23584e+06
+      GoRuntimeType: 1235840
       GoKind: 20
       RawFields:
         - Name: tab
@@ -937,7 +937,7 @@ Types:
       ID: 107
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
-      GoRuntimeType: 1.296128e+06
+      GoRuntimeType: 1296128
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1048,7 +1048,7 @@ Types:
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.717344e+06
+      GoRuntimeType: 1717344
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1060,7 +1060,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1070,7 +1070,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.123232e+06
+      GoRuntimeType: 1123232
       GoKind: 25
       RawFields:
         - Name: u
@@ -1080,7 +1080,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.445376e+06
+      GoRuntimeType: 1445376
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1096,7 +1096,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.305408e+06
+      GoRuntimeType: 1305408
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1109,7 +1109,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.305248e+06
+      GoRuntimeType: 1305248
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1122,7 +1122,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.305568e+06
+      GoRuntimeType: 1305568
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1147,7 +1147,7 @@ Types:
       ID: 164
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.067328e+06
+      GoRuntimeType: 1067328
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1197,7 +1197,7 @@ Types:
       ID: 157
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 1.917984e+06
+      GoRuntimeType: 1917984
       GoKind: 21
       HeaderType: 159 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
@@ -1230,7 +1230,7 @@ Types:
       ID: 104
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.190528e+06
+      GoRuntimeType: 2190528
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1319,7 +1319,7 @@ Types:
       ID: 102
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.098528e+06
+      GoRuntimeType: 1098528
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1348,7 +1348,7 @@ Types:
       ID: 167
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.671328e+06
+      GoRuntimeType: 1671328
       GoKind: 21
       HeaderType: 159 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
@@ -1377,7 +1377,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 2.249152e+06
+      GoRuntimeType: 2249152
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1552,7 +1552,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.109536e+06
+      GoRuntimeType: 1109536
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1562,7 +1562,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.836832e+06
+      GoRuntimeType: 1836832
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1590,7 +1590,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.288288e+06
+      GoRuntimeType: 1288288
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1603,7 +1603,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.626176e+06
+      GoRuntimeType: 1626176
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1628,7 +1628,7 @@ Types:
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.288128e+06
+      GoRuntimeType: 1288128
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1641,13 +1641,13 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.779456e+06
+      GoRuntimeType: 1779456
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1672,7 +1672,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 2.255264e+06
+      GoRuntimeType: 2255264
       GoKind: 25
       RawFields:
         - Name: g0
@@ -1892,7 +1892,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.7792e+06
+      GoRuntimeType: 1779200
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -1917,7 +1917,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 1.42848e+06
+      GoRuntimeType: 1428480
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -1933,7 +1933,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 1.428288e+06
+      GoRuntimeType: 1428288
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -1959,14 +1959,14 @@ Types:
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.109152e+06
+      GoRuntimeType: 1109152
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.287968e+06
+      GoRuntimeType: 1287968
       GoKind: 25
       RawFields:
         - Name: entries
@@ -1979,13 +1979,13 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.626944e+06
+      GoRuntimeType: 1626944
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2013,7 +2013,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.286368e+06
+      GoRuntimeType: 1286368
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2050,7 +2050,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.287328e+06
+      GoRuntimeType: 1287328
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2063,7 +2063,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.068352e+06
+      GoRuntimeType: 1068352
       GoKind: 8
     - __kind: StructureType
       ID: 75
@@ -2094,7 +2094,7 @@ Types:
       ID: 121
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.810688e+06
+      GoRuntimeType: 1810688
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2107,7 +2107,7 @@ Types:
       ID: 135
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 1.885792e+06
+      GoRuntimeType: 1885792
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2123,7 +2123,7 @@ Types:
       ID: 117
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.810176e+06
+      GoRuntimeType: 1810176
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2136,7 +2136,7 @@ Types:
       ID: 127
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 1.88464e+06
+      GoRuntimeType: 1884640
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2152,7 +2152,7 @@ Types:
       ID: 141
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 1.947744e+06
+      GoRuntimeType: 1947744
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2171,7 +2171,7 @@ Types:
       ID: 129
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 1.884928e+06
+      GoRuntimeType: 1884928
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2187,7 +2187,7 @@ Types:
       ID: 125
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 1.884352e+06
+      GoRuntimeType: 1884352
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2203,7 +2203,7 @@ Types:
       ID: 137
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 1.947104e+06
+      GoRuntimeType: 1947104
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2222,7 +2222,7 @@ Types:
       ID: 145
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.005632e+06
+      GoRuntimeType: 2005632
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2244,7 +2244,7 @@ Types:
       ID: 139
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 1.947424e+06
+      GoRuntimeType: 1947424
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2263,7 +2263,7 @@ Types:
       ID: 123
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.810944e+06
+      GoRuntimeType: 1810944
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2276,7 +2276,7 @@ Types:
       ID: 119
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.810432e+06
+      GoRuntimeType: 1810432
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2289,7 +2289,7 @@ Types:
       ID: 131
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 1.885216e+06
+      GoRuntimeType: 1885216
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2305,7 +2305,7 @@ Types:
       ID: 143
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 1.948064e+06
+      GoRuntimeType: 1948064
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2324,7 +2324,7 @@ Types:
       ID: 133
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 1.885504e+06
+      GoRuntimeType: 1885504
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -174,7 +174,7 @@ Types:
       ID: 110
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.245056e+06
+      GoRuntimeType: 2245056
       GoKind: 22
       Pointee: 111 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -209,7 +209,7 @@ Types:
       ID: 119
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.53936e+06
+      GoRuntimeType: 1539360
       GoKind: 22
       Pointee: 120 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
@@ -268,42 +268,42 @@ Types:
       ID: 108
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.2848e+06
+      GoRuntimeType: 2284800
       GoKind: 22
       Pointee: 109 StructureType net/http.Request
     - __kind: PointerType
       ID: 176
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.705504e+06
+      GoRuntimeType: 1705504
       GoKind: 22
       Pointee: 177 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 156
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.995552e+06
+      GoRuntimeType: 1995552
       GoKind: 22
       Pointee: 157 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 179
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.597408e+06
+      GoRuntimeType: 1597408
       GoKind: 22
       Pointee: 180 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 158
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.189216e+06
+      GoRuntimeType: 2189216
       GoKind: 22
       Pointee: 159 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 160
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.099328e+06
+      GoRuntimeType: 2099328
       GoKind: 22
       Pointee: 161 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -327,7 +327,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.403776e+06
+      GoRuntimeType: 1403776
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -355,7 +355,7 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.024416e+06
+      GoRuntimeType: 1024416
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
@@ -369,21 +369,21 @@ Types:
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 1.53696e+06
+      GoRuntimeType: 1536960
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.044064e+06
+      GoRuntimeType: 2044064
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.60912e+06
+      GoRuntimeType: 1609120
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -402,105 +402,105 @@ Types:
       ID: 125
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.676512e+06
+      GoRuntimeType: 1676512
       GoKind: 22
       Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 139
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.728928e+06
+      GoRuntimeType: 1728928
       GoKind: 22
       Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 121
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.676128e+06
+      GoRuntimeType: 1676128
       GoKind: 22
       Pointee: 122 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 131
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.72816e+06
+      GoRuntimeType: 1728160
       GoKind: 22
       Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 145
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.799552e+06
+      GoRuntimeType: 1799552
       GoKind: 22
       Pointee: 146 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 133
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.728352e+06
+      GoRuntimeType: 1728352
       GoKind: 22
       Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 129
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.727968e+06
+      GoRuntimeType: 1727968
       GoKind: 22
       Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 141
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.799104e+06
+      GoRuntimeType: 1799104
       GoKind: 22
       Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 149
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.868736e+06
+      GoRuntimeType: 1868736
       GoKind: 22
       Pointee: 150 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 143
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.799328e+06
+      GoRuntimeType: 1799328
       GoKind: 22
       Pointee: 144 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 127
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.676704e+06
+      GoRuntimeType: 1676704
       GoKind: 22
       Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 123
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.67632e+06
+      GoRuntimeType: 1676320
       GoKind: 22
       Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 135
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.728544e+06
+      GoRuntimeType: 1728544
       GoKind: 22
       Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 147
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.799776e+06
+      GoRuntimeType: 1799776
       GoKind: 22
       Pointee: 148 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 137
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.728736e+06
+      GoRuntimeType: 1728736
       GoKind: 22
       Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -840,7 +840,7 @@ Types:
       ID: 178
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.266912e+06
+      GoRuntimeType: 1266912
       GoKind: 20
       RawFields:
         - Name: tab
@@ -857,7 +857,7 @@ Types:
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.022624e+06
+      GoRuntimeType: 1022624
       GoKind: 20
       RawFields:
         - Name: tab
@@ -900,7 +900,7 @@ Types:
       ID: 151
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.407616e+06
+      GoRuntimeType: 1407616
       GoKind: 20
       RawFields:
         - Name: tab
@@ -917,7 +917,7 @@ Types:
       ID: 112
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
-      GoRuntimeType: 1.468864e+06
+      GoRuntimeType: 1468864
       GoKind: 20
       RawFields:
         - Name: tab
@@ -988,7 +988,7 @@ Types:
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.83424e+06
+      GoRuntimeType: 1834240
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1000,7 +1000,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1010,7 +1010,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.201056e+06
+      GoRuntimeType: 1201056
       GoKind: 25
       RawFields:
         - Name: u
@@ -1020,7 +1020,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.626208e+06
+      GoRuntimeType: 1626208
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1036,7 +1036,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.478784e+06
+      GoRuntimeType: 1478784
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1049,7 +1049,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.478624e+06
+      GoRuntimeType: 1478624
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1062,7 +1062,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.478944e+06
+      GoRuntimeType: 1478944
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1087,7 +1087,7 @@ Types:
       ID: 167
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.100576e+06
+      GoRuntimeType: 1100576
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1164,7 +1164,7 @@ Types:
       ID: 181
       Name: map[string]string
       ByteSize: 8
-      GoRuntimeType: 1.119008e+06
+      GoRuntimeType: 1119008
       GoKind: 21
       HeaderType: 183 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
@@ -1175,7 +1175,7 @@ Types:
       ID: 154
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.0184e+06
+      GoRuntimeType: 1018400
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1188,7 +1188,7 @@ Types:
       ID: 152
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.016992e+06
+      GoRuntimeType: 1016992
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1201,14 +1201,14 @@ Types:
       ID: 162
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 2.08736e+06
+      GoRuntimeType: 2087360
       GoKind: 21
       HeaderType: 164 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
       ID: 155
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.01712e+06
+      GoRuntimeType: 1017120
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1221,7 +1221,7 @@ Types:
       ID: 153
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.017376e+06
+      GoRuntimeType: 1017376
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1234,7 +1234,7 @@ Types:
       ID: 109
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.322048e+06
+      GoRuntimeType: 2322048
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1323,7 +1323,7 @@ Types:
       ID: 107
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.176352e+06
+      GoRuntimeType: 1176352
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1352,7 +1352,7 @@ Types:
       ID: 170
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.870528e+06
+      GoRuntimeType: 1870528
       GoKind: 21
       HeaderType: 164 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
@@ -1377,7 +1377,7 @@ Types:
       ID: 189
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.280352e+06
+      GoRuntimeType: 1280352
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1390,7 +1390,7 @@ Types:
       ID: 199
       Name: noalg.map.group[string]string
       ByteSize: 264
-      GoRuntimeType: 1.282656e+06
+      GoRuntimeType: 1282656
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1403,7 +1403,7 @@ Types:
       ID: 191
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.280224e+06
+      GoRuntimeType: 1280224
       GoKind: 25
       RawFields:
         - Name: key
@@ -1416,7 +1416,7 @@ Types:
       ID: 201
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
-      GoRuntimeType: 1.282528e+06
+      GoRuntimeType: 1282528
       GoKind: 25
       RawFields:
         - Name: key
@@ -1451,7 +1451,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.384352e+06
+      GoRuntimeType: 2384352
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1632,7 +1632,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.187104e+06
+      GoRuntimeType: 1187104
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1642,7 +1642,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.960128e+06
+      GoRuntimeType: 1960128
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1670,7 +1670,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.460864e+06
+      GoRuntimeType: 1460864
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1683,7 +1683,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.738688e+06
+      GoRuntimeType: 1738688
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1708,7 +1708,7 @@ Types:
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.460704e+06
+      GoRuntimeType: 1460704
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1721,13 +1721,13 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.898496e+06
+      GoRuntimeType: 1898496
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1752,7 +1752,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 2.389408e+06
+      GoRuntimeType: 2389408
       GoKind: 25
       RawFields:
         - Name: g0
@@ -1975,7 +1975,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.960416e+06
+      GoRuntimeType: 1960416
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2003,7 +2003,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.825056e+06
+      GoRuntimeType: 1825056
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2025,7 +2025,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.824832e+06
+      GoRuntimeType: 1824832
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2047,7 +2047,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 1.186848e+06
+      GoRuntimeType: 1186848
       GoKind: 25
       RawFields:
         - Name: next
@@ -2063,14 +2063,14 @@ Types:
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.18672e+06
+      GoRuntimeType: 1186720
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.460544e+06
+      GoRuntimeType: 1460544
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2083,13 +2083,13 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.739456e+06
+      GoRuntimeType: 1739456
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2117,7 +2117,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.458944e+06
+      GoRuntimeType: 1458944
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2158,7 +2158,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.459904e+06
+      GoRuntimeType: 1459904
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2171,7 +2171,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.26832e+06
+      GoRuntimeType: 1268320
       GoKind: 8
     - __kind: StructureType
       ID: 79
@@ -2202,7 +2202,7 @@ Types:
       ID: 126
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.932032e+06
+      GoRuntimeType: 1932032
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2215,7 +2215,7 @@ Types:
       ID: 140
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.009664e+06
+      GoRuntimeType: 2009664
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2231,7 +2231,7 @@ Types:
       ID: 122
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.93152e+06
+      GoRuntimeType: 1931520
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2244,7 +2244,7 @@ Types:
       ID: 132
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.008512e+06
+      GoRuntimeType: 2008512
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2260,7 +2260,7 @@ Types:
       ID: 146
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.070944e+06
+      GoRuntimeType: 2070944
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2279,7 +2279,7 @@ Types:
       ID: 134
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.0088e+06
+      GoRuntimeType: 2008800
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2295,7 +2295,7 @@ Types:
       ID: 130
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 2.008224e+06
+      GoRuntimeType: 2008224
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2311,7 +2311,7 @@ Types:
       ID: 142
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 2.070304e+06
+      GoRuntimeType: 2070304
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2330,7 +2330,7 @@ Types:
       ID: 150
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.130688e+06
+      GoRuntimeType: 2130688
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2352,7 +2352,7 @@ Types:
       ID: 144
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.070624e+06
+      GoRuntimeType: 2070624
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2371,7 +2371,7 @@ Types:
       ID: 128
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.932288e+06
+      GoRuntimeType: 1932288
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2384,7 +2384,7 @@ Types:
       ID: 124
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.931776e+06
+      GoRuntimeType: 1931776
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2397,7 +2397,7 @@ Types:
       ID: 136
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.009088e+06
+      GoRuntimeType: 2009088
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2413,7 +2413,7 @@ Types:
       ID: 148
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.071264e+06
+      GoRuntimeType: 2071264
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2432,7 +2432,7 @@ Types:
       ID: 138
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.009376e+06
+      GoRuntimeType: 2009376
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -179,7 +179,7 @@ Types:
       ID: 112
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.259936e+06
+      GoRuntimeType: 2259936
       GoKind: 22
       Pointee: 113 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -214,7 +214,7 @@ Types:
       ID: 124
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.549984e+06
+      GoRuntimeType: 1549984
       GoKind: 22
       Pointee: 125 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
@@ -273,42 +273,42 @@ Types:
       ID: 110
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.300192e+06
+      GoRuntimeType: 2300192
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
       ID: 181
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.718272e+06
+      GoRuntimeType: 1718272
       GoKind: 22
       Pointee: 182 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 161
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 2.0096e+06
+      GoRuntimeType: 2009600
       GoKind: 22
       Pointee: 162 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 184
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.608064e+06
+      GoRuntimeType: 1608064
       GoKind: 22
       Pointee: 185 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 163
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.217504e+06
+      GoRuntimeType: 2217504
       GoKind: 22
       Pointee: 164 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 165
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.112832e+06
+      GoRuntimeType: 2112832
       GoKind: 22
       Pointee: 166 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -332,7 +332,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.413088e+06
+      GoRuntimeType: 1413088
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -360,14 +360,14 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.413728e+06
+      GoRuntimeType: 1413728
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.032736e+06
+      GoRuntimeType: 1032736
       GoKind: 22
       Pointee: 121 UnresolvedPointeeType runtime.p
     - __kind: PointerType
@@ -381,21 +381,21 @@ Types:
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.547584e+06
+      GoRuntimeType: 1547584
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.05696e+06
+      GoRuntimeType: 2056960
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.619968e+06
+      GoRuntimeType: 1619968
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -414,105 +414,105 @@ Types:
       ID: 130
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.687936e+06
+      GoRuntimeType: 1687936
       GoKind: 22
       Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 144
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.741696e+06
+      GoRuntimeType: 1741696
       GoKind: 22
       Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 126
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.687552e+06
+      GoRuntimeType: 1687552
       GoKind: 22
       Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 136
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.740928e+06
+      GoRuntimeType: 1740928
       GoKind: 22
       Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 150
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.813504e+06
+      GoRuntimeType: 1813504
       GoKind: 22
       Pointee: 151 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 138
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.74112e+06
+      GoRuntimeType: 1741120
       GoKind: 22
       Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 134
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.740736e+06
+      GoRuntimeType: 1740736
       GoKind: 22
       Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 146
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.813056e+06
+      GoRuntimeType: 1813056
       GoKind: 22
       Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 154
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.882144e+06
+      GoRuntimeType: 1882144
       GoKind: 22
       Pointee: 155 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 148
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.81328e+06
+      GoRuntimeType: 1813280
       GoKind: 22
       Pointee: 149 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 132
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.688128e+06
+      GoRuntimeType: 1688128
       GoKind: 22
       Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 128
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.687744e+06
+      GoRuntimeType: 1687744
       GoKind: 22
       Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 140
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.741312e+06
+      GoRuntimeType: 1741312
       GoKind: 22
       Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 152
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.813728e+06
+      GoRuntimeType: 1813728
       GoKind: 22
       Pointee: 153 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 142
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.741504e+06
+      GoRuntimeType: 1741504
       GoKind: 22
       Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -868,7 +868,7 @@ Types:
       ID: 183
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.276288e+06
+      GoRuntimeType: 1276288
       GoKind: 20
       RawFields:
         - Name: tab
@@ -885,7 +885,7 @@ Types:
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.031072e+06
+      GoRuntimeType: 1031072
       GoKind: 20
       RawFields:
         - Name: tab
@@ -928,7 +928,7 @@ Types:
       ID: 156
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.417248e+06
+      GoRuntimeType: 1417248
       GoKind: 20
       RawFields:
         - Name: tab
@@ -945,7 +945,7 @@ Types:
       ID: 114
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
-      GoRuntimeType: 1.479008e+06
+      GoRuntimeType: 1479008
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1016,7 +1016,7 @@ Types:
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.848544e+06
+      GoRuntimeType: 1848544
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1028,7 +1028,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1038,7 +1038,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.209664e+06
+      GoRuntimeType: 1209664
       GoKind: 25
       RawFields:
         - Name: u
@@ -1048,7 +1048,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.637056e+06
+      GoRuntimeType: 1637056
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1064,7 +1064,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.488928e+06
+      GoRuntimeType: 1488928
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1077,7 +1077,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.488768e+06
+      GoRuntimeType: 1488768
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1090,7 +1090,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.489088e+06
+      GoRuntimeType: 1489088
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1115,7 +1115,7 @@ Types:
       ID: 172
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.10976e+06
+      GoRuntimeType: 1109760
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1198,7 +1198,7 @@ Types:
       ID: 186
       Name: map[string]string
       ByteSize: 8
-      GoRuntimeType: 1.12832e+06
+      GoRuntimeType: 1128320
       GoKind: 21
       HeaderType: 188 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
@@ -1209,7 +1209,7 @@ Types:
       ID: 159
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.026848e+06
+      GoRuntimeType: 1026848
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1222,7 +1222,7 @@ Types:
       ID: 157
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.025312e+06
+      GoRuntimeType: 1025312
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1235,14 +1235,14 @@ Types:
       ID: 167
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 2.100864e+06
+      GoRuntimeType: 2100864
       GoKind: 21
       HeaderType: 169 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
       ID: 160
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.02544e+06
+      GoRuntimeType: 1025440
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1255,7 +1255,7 @@ Types:
       ID: 158
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.025696e+06
+      GoRuntimeType: 1025696
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1268,7 +1268,7 @@ Types:
       ID: 111
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.336064e+06
+      GoRuntimeType: 2336064
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1357,7 +1357,7 @@ Types:
       ID: 109
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.185088e+06
+      GoRuntimeType: 1185088
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1386,7 +1386,7 @@ Types:
       ID: 175
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.884384e+06
+      GoRuntimeType: 1884384
       GoKind: 21
       HeaderType: 169 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
@@ -1411,7 +1411,7 @@ Types:
       ID: 194
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.289728e+06
+      GoRuntimeType: 1289728
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1424,7 +1424,7 @@ Types:
       ID: 204
       Name: noalg.map.group[string]string
       ByteSize: 264
-      GoRuntimeType: 1.29216e+06
+      GoRuntimeType: 1292160
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1437,7 +1437,7 @@ Types:
       ID: 196
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.2896e+06
+      GoRuntimeType: 1289600
       GoKind: 25
       RawFields:
         - Name: key
@@ -1450,7 +1450,7 @@ Types:
       ID: 206
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
-      GoRuntimeType: 1.292032e+06
+      GoRuntimeType: 1292032
       GoKind: 25
       RawFields:
         - Name: key
@@ -1485,7 +1485,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.400064e+06
+      GoRuntimeType: 2400064
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1675,7 +1675,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.195584e+06
+      GoRuntimeType: 1195584
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1685,7 +1685,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.912896e+06
+      GoRuntimeType: 1912896
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1710,7 +1710,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.470848e+06
+      GoRuntimeType: 1470848
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1723,7 +1723,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.752416e+06
+      GoRuntimeType: 1752416
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1748,7 +1748,7 @@ Types:
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.470688e+06
+      GoRuntimeType: 1470688
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1761,13 +1761,13 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.913664e+06
+      GoRuntimeType: 1913664
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -1792,7 +1792,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 2.40336e+06
+      GoRuntimeType: 2403360
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2012,7 +2012,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.913408e+06
+      GoRuntimeType: 1913408
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2037,7 +2037,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.839584e+06
+      GoRuntimeType: 1839584
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2059,7 +2059,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.83936e+06
+      GoRuntimeType: 1839360
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2081,7 +2081,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.470368e+06
+      GoRuntimeType: 1470368
       GoKind: 25
       RawFields:
         - Name: next
@@ -2100,7 +2100,7 @@ Types:
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.195328e+06
+      GoRuntimeType: 1195328
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -2111,7 +2111,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.470528e+06
+      GoRuntimeType: 1470528
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2124,13 +2124,13 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.753376e+06
+      GoRuntimeType: 1753376
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2158,7 +2158,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.468608e+06
+      GoRuntimeType: 1468608
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2199,7 +2199,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.469568e+06
+      GoRuntimeType: 1469568
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2212,7 +2212,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.277696e+06
+      GoRuntimeType: 1277696
       GoKind: 8
     - __kind: StructureType
       ID: 82
@@ -2243,7 +2243,7 @@ Types:
       ID: 131
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.946688e+06
+      GoRuntimeType: 1946688
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2256,7 +2256,7 @@ Types:
       ID: 145
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.022848e+06
+      GoRuntimeType: 2022848
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2272,7 +2272,7 @@ Types:
       ID: 127
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.946176e+06
+      GoRuntimeType: 1946176
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2285,7 +2285,7 @@ Types:
       ID: 137
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.021696e+06
+      GoRuntimeType: 2021696
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2301,7 +2301,7 @@ Types:
       ID: 151
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.0848e+06
+      GoRuntimeType: 2084800
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2320,7 +2320,7 @@ Types:
       ID: 139
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.021984e+06
+      GoRuntimeType: 2021984
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2336,7 +2336,7 @@ Types:
       ID: 135
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 2.021408e+06
+      GoRuntimeType: 2021408
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2352,7 +2352,7 @@ Types:
       ID: 147
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 2.08416e+06
+      GoRuntimeType: 2084160
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2371,7 +2371,7 @@ Types:
       ID: 155
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.145632e+06
+      GoRuntimeType: 2145632
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2393,7 +2393,7 @@ Types:
       ID: 149
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.08448e+06
+      GoRuntimeType: 2084480
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2412,7 +2412,7 @@ Types:
       ID: 133
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.946944e+06
+      GoRuntimeType: 1946944
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2425,7 +2425,7 @@ Types:
       ID: 129
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.946432e+06
+      GoRuntimeType: 1946432
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2438,7 +2438,7 @@ Types:
       ID: 141
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.022272e+06
+      GoRuntimeType: 2022272
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2454,7 +2454,7 @@ Types:
       ID: 153
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.08512e+06
+      GoRuntimeType: 2085120
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2473,7 +2473,7 @@ Types:
       ID: 143
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.02256e+06
+      GoRuntimeType: 2022560
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.26rc1.yaml
@@ -179,7 +179,7 @@ Types:
       ID: 118
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.289984e+06
+      GoRuntimeType: 2289984
       GoKind: 22
       Pointee: 119 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -221,7 +221,7 @@ Types:
       ID: 130
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
-      GoRuntimeType: 1.564384e+06
+      GoRuntimeType: 1564384
       GoKind: 22
       Pointee: 131 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
@@ -263,7 +263,7 @@ Types:
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
       ByteSize: 8
-      GoRuntimeType: 1.584864e+06
+      GoRuntimeType: 1584864
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
@@ -287,42 +287,42 @@ Types:
       ID: 116
       Name: '*net/http.Request'
       ByteSize: 8
-      GoRuntimeType: 2.321632e+06
+      GoRuntimeType: 2321632
       GoKind: 22
       Pointee: 117 StructureType net/http.Request
     - __kind: PointerType
       ID: 187
       Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 1.735264e+06
+      GoRuntimeType: 1735264
       GoKind: 22
       Pointee: 188 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 167
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
-      GoRuntimeType: 2.031104e+06
+      GoRuntimeType: 2031104
       GoKind: 22
       Pointee: 168 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
       ID: 190
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1.624096e+06
+      GoRuntimeType: 1624096
       GoKind: 22
       Pointee: 191 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 169
       Name: '*net/http.response'
       ByteSize: 8
-      GoRuntimeType: 2.240352e+06
+      GoRuntimeType: 2240352
       GoKind: 22
       Pointee: 170 UnresolvedPointeeType net/http.response
     - __kind: PointerType
       ID: 171
       Name: '*net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 2.148544e+06
+      GoRuntimeType: 2148544
       GoKind: 22
       Pointee: 172 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
@@ -346,7 +346,7 @@ Types:
       ID: 25
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.423328e+06
+      GoRuntimeType: 1423328
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -367,21 +367,21 @@ Types:
       ID: 59
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 1.202848e+06
+      GoRuntimeType: 1202848
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.423968e+06
+      GoRuntimeType: 1423968
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 68
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.04192e+06
+      GoRuntimeType: 1041920
       GoKind: 22
       Pointee: 127 UnresolvedPointeeType runtime.p
     - __kind: PointerType
@@ -395,21 +395,21 @@ Types:
       ID: 50
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.561664e+06
+      GoRuntimeType: 1561664
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 45
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.078688e+06
+      GoRuntimeType: 2078688
       GoKind: 22
       Pointee: 46 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 83
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.636192e+06
+      GoRuntimeType: 1636192
       GoKind: 22
       Pointee: 84 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -435,105 +435,105 @@ Types:
       ID: 136
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.704928e+06
+      GoRuntimeType: 1704928
       GoKind: 22
       Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 150
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.759648e+06
+      GoRuntimeType: 1759648
       GoKind: 22
       Pointee: 151 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 132
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
-      GoRuntimeType: 1.704544e+06
+      GoRuntimeType: 1704544
       GoKind: 22
       Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
       ID: 142
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.75888e+06
+      GoRuntimeType: 1758880
       GoKind: 22
       Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 156
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.831776e+06
+      GoRuntimeType: 1831776
       GoKind: 22
       Pointee: 157 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 144
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.759072e+06
+      GoRuntimeType: 1759072
       GoKind: 22
       Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 140
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.758688e+06
+      GoRuntimeType: 1758688
       GoKind: 22
       Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
       ID: 152
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.831328e+06
+      GoRuntimeType: 1831328
       GoKind: 22
       Pointee: 153 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 160
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.900416e+06
+      GoRuntimeType: 1900416
       GoKind: 22
       Pointee: 161 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 154
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.831552e+06
+      GoRuntimeType: 1831552
       GoKind: 22
       Pointee: 155 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 138
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.70512e+06
+      GoRuntimeType: 1705120
       GoKind: 22
       Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
       ID: 134
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
-      GoRuntimeType: 1.704736e+06
+      GoRuntimeType: 1704736
       GoKind: 22
       Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
       ID: 146
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
-      GoRuntimeType: 1.759264e+06
+      GoRuntimeType: 1759264
       GoKind: 22
       Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
       ID: 158
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.832e+06
+      GoRuntimeType: 1832000
       GoKind: 22
       Pointee: 159 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
       ID: 148
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
-      GoRuntimeType: 1.759456e+06
+      GoRuntimeType: 1759456
       GoKind: 22
       Pointee: 149 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
@@ -889,7 +889,7 @@ Types:
       ID: 189
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1.286496e+06
+      GoRuntimeType: 1286496
       GoKind: 20
       RawFields:
         - Name: tab
@@ -906,7 +906,7 @@ Types:
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.040384e+06
+      GoRuntimeType: 1040384
       GoKind: 20
       RawFields:
         - Name: tab
@@ -949,7 +949,7 @@ Types:
       ID: 162
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
-      GoRuntimeType: 1.428128e+06
+      GoRuntimeType: 1428128
       GoKind: 20
       RawFields:
         - Name: tab
@@ -966,7 +966,7 @@ Types:
       ID: 120
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
-      GoRuntimeType: 1.492128e+06
+      GoRuntimeType: 1492128
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1037,7 +1037,7 @@ Types:
       ID: 92
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.867264e+06
+      GoRuntimeType: 1867264
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1049,7 +1049,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -1059,7 +1059,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.21872e+06
+      GoRuntimeType: 1218720
       GoKind: 25
       RawFields:
         - Name: u
@@ -1069,7 +1069,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.652896e+06
+      GoRuntimeType: 1652896
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1089,7 +1089,7 @@ Types:
       ID: 33
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.502048e+06
+      GoRuntimeType: 1502048
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1102,7 +1102,7 @@ Types:
       ID: 37
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.501888e+06
+      GoRuntimeType: 1501888
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1127,7 +1127,7 @@ Types:
       ID: 178
       Name: io.ReadCloser
       ByteSize: 16
-      GoRuntimeType: 1.118368e+06
+      GoRuntimeType: 1118368
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1210,7 +1210,7 @@ Types:
       ID: 192
       Name: map[string]string
       ByteSize: 8
-      GoRuntimeType: 1.137056e+06
+      GoRuntimeType: 1137056
       GoKind: 21
       HeaderType: 194 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
@@ -1221,7 +1221,7 @@ Types:
       ID: 165
       Name: net/http.CloseNotifier
       ByteSize: 16
-      GoRuntimeType: 1.03616e+06
+      GoRuntimeType: 1036160
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1234,7 +1234,7 @@ Types:
       ID: 163
       Name: net/http.Flusher
       ByteSize: 16
-      GoRuntimeType: 1.034496e+06
+      GoRuntimeType: 1034496
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1247,14 +1247,14 @@ Types:
       ID: 173
       Name: net/http.Header
       ByteSize: 8
-      GoRuntimeType: 2.12256e+06
+      GoRuntimeType: 2122560
       GoKind: 21
       HeaderType: 175 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
       ID: 166
       Name: net/http.Hijacker
       ByteSize: 16
-      GoRuntimeType: 1.034624e+06
+      GoRuntimeType: 1034624
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1267,7 +1267,7 @@ Types:
       ID: 164
       Name: net/http.Pusher
       ByteSize: 16
-      GoRuntimeType: 1.03488e+06
+      GoRuntimeType: 1034880
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1280,7 +1280,7 @@ Types:
       ID: 117
       Name: net/http.Request
       ByteSize: 304
-      GoRuntimeType: 2.356864e+06
+      GoRuntimeType: 2356864
       GoKind: 25
       RawFields:
         - Name: Method
@@ -1369,7 +1369,7 @@ Types:
       ID: 115
       Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.192992e+06
+      GoRuntimeType: 1192992
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1398,7 +1398,7 @@ Types:
       ID: 181
       Name: net/url.Values
       ByteSize: 8
-      GoRuntimeType: 1.902656e+06
+      GoRuntimeType: 1902656
       GoKind: 21
       HeaderType: 175 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
@@ -1423,7 +1423,7 @@ Types:
       ID: 200
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.300448e+06
+      GoRuntimeType: 1300448
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1436,7 +1436,7 @@ Types:
       ID: 210
       Name: noalg.map.group[string]string
       ByteSize: 264
-      GoRuntimeType: 1.30288e+06
+      GoRuntimeType: 1302880
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1449,7 +1449,7 @@ Types:
       ID: 202
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.30032e+06
+      GoRuntimeType: 1300320
       GoKind: 25
       RawFields:
         - Name: key
@@ -1462,7 +1462,7 @@ Types:
       ID: 212
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
-      GoRuntimeType: 1.302752e+06
+      GoRuntimeType: 1302752
       GoKind: 25
       RawFields:
         - Name: key
@@ -1497,7 +1497,7 @@ Types:
       ID: 23
       Name: runtime.g
       ByteSize: 456
-      GoRuntimeType: 2.422848e+06
+      GoRuntimeType: 2422848
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1699,7 +1699,7 @@ Types:
       ID: 55
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.20272e+06
+      GoRuntimeType: 1202720
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1709,7 +1709,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.932e+06
+      GoRuntimeType: 1932000
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1734,7 +1734,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.480448e+06
+      GoRuntimeType: 1480448
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1747,7 +1747,7 @@ Types:
       ID: 60
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.770528e+06
+      GoRuntimeType: 1770528
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1772,7 +1772,7 @@ Types:
       ID: 96
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.482848e+06
+      GoRuntimeType: 1482848
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1785,7 +1785,7 @@ Types:
       ID: 72
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 1.482048e+06
+      GoRuntimeType: 1482048
       GoKind: 25
       RawFields:
         - Name: prev
@@ -1804,7 +1804,7 @@ Types:
       ID: 30
       Name: runtime.m
       ByteSize: 1824
-      GoRuntimeType: 2.428128e+06
+      GoRuntimeType: 2428128
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2033,7 +2033,7 @@ Types:
       ID: 75
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.932512e+06
+      GoRuntimeType: 1932512
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2058,7 +2058,7 @@ Types:
       ID: 91
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.858752e+06
+      GoRuntimeType: 1858752
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2080,7 +2080,7 @@ Types:
       ID: 80
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 1.932768e+06
+      GoRuntimeType: 1932768
       GoKind: 25
       RawFields:
         - Name: writing
@@ -2105,7 +2105,7 @@ Types:
       ID: 74
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.482528e+06
+      GoRuntimeType: 1482528
       GoKind: 25
       RawFields:
         - Name: next
@@ -2118,7 +2118,7 @@ Types:
       ID: 98
       Name: runtime.mWeakPointer
       ByteSize: 8
-      GoRuntimeType: 1.562144e+06
+      GoRuntimeType: 1562144
       GoKind: 25
       RawFields:
         - Name: m
@@ -2134,7 +2134,7 @@ Types:
       ID: 71
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.203744e+06
+      GoRuntimeType: 1203744
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -2145,7 +2145,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.482688e+06
+      GoRuntimeType: 1482688
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2158,13 +2158,13 @@ Types:
       ID: 89
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.771488e+06
+      GoRuntimeType: 1771488
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -2192,7 +2192,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.479168e+06
+      GoRuntimeType: 1479168
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2233,7 +2233,7 @@ Types:
       ID: 56
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.480768e+06
+      GoRuntimeType: 1480768
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2246,7 +2246,7 @@ Types:
       ID: 35
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.606496e+06
+      GoRuntimeType: 1606496
       GoKind: 8
     - __kind: StructureType
       ID: 85
@@ -2258,7 +2258,7 @@ Types:
       ID: 52
       Name: runtime.xRegPerG
       ByteSize: 8
-      GoRuntimeType: 1.202592e+06
+      GoRuntimeType: 1202592
       GoKind: 25
       RawFields:
         - Name: state
@@ -2291,7 +2291,7 @@ Types:
       ID: 137
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
-      GoRuntimeType: 1.967072e+06
+      GoRuntimeType: 1967072
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2304,7 +2304,7 @@ Types:
       ID: 151
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.045216e+06
+      GoRuntimeType: 2045216
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2320,7 +2320,7 @@ Types:
       ID: 133
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
-      GoRuntimeType: 1.96656e+06
+      GoRuntimeType: 1966560
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2333,7 +2333,7 @@ Types:
       ID: 143
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.044064e+06
+      GoRuntimeType: 2044064
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2349,7 +2349,7 @@ Types:
       ID: 157
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.106848e+06
+      GoRuntimeType: 2106848
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2368,7 +2368,7 @@ Types:
       ID: 145
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.044352e+06
+      GoRuntimeType: 2044352
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2384,7 +2384,7 @@ Types:
       ID: 141
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
-      GoRuntimeType: 2.043776e+06
+      GoRuntimeType: 2043776
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2400,7 +2400,7 @@ Types:
       ID: 153
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
-      GoRuntimeType: 2.106208e+06
+      GoRuntimeType: 2106208
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2419,7 +2419,7 @@ Types:
       ID: 161
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
-      GoRuntimeType: 2.167744e+06
+      GoRuntimeType: 2167744
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2441,7 +2441,7 @@ Types:
       ID: 155
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.106528e+06
+      GoRuntimeType: 2106528
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2460,7 +2460,7 @@ Types:
       ID: 139
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
-      GoRuntimeType: 1.967328e+06
+      GoRuntimeType: 1967328
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2473,7 +2473,7 @@ Types:
       ID: 135
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
-      GoRuntimeType: 1.966816e+06
+      GoRuntimeType: 1966816
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2486,7 +2486,7 @@ Types:
       ID: 147
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
-      GoRuntimeType: 2.04464e+06
+      GoRuntimeType: 2044640
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2502,7 +2502,7 @@ Types:
       ID: 159
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
-      GoRuntimeType: 2.107168e+06
+      GoRuntimeType: 2107168
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter
@@ -2521,7 +2521,7 @@ Types:
       ID: 149
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
-      GoRuntimeType: 2.044928e+06
+      GoRuntimeType: 2044928
       GoKind: 25
       RawFields:
         - Name: monitoredResponseWriter

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -576,8 +576,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 86}
@@ -600,7 +600,7 @@ Probes:
                   EventExpressionIndex: 1
                 - ', '
                 - Error: failed to resolve reference "y"
-                  DSL: y
+                  DSL: "y"
     - id: testConflictingReturn
       version: 0
       type: LOG_PROBE
@@ -1713,8 +1713,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 53}
@@ -1735,8 +1735,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
     - id: testInlinedBBA
@@ -5475,8 +5475,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
         - ', '
         - json: {ref: z}
           dsl: z
@@ -5496,8 +5496,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
                 - ', '
@@ -6832,7 +6832,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 9 BaseType int
           Locations:
             - Range: 0xd08640..0xd08667
@@ -7371,7 +7371,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 16 BaseType float32
           Locations:
             - Range: 0xd0ad60..0xd0ad61
@@ -7402,7 +7402,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 16 BaseType float32
           Locations:
             - Range: 0xd0ada0..0xd0ada1
@@ -9580,7 +9580,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0xd0e7e0..0xd0e7e1
@@ -11214,7 +11214,7 @@ Types:
       ID: 1025
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.85776e+06
+      GoRuntimeType: 1857760
       GoKind: 22
       Pointee: 1026 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
@@ -11233,7 +11233,7 @@ Types:
       ID: 965
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.258944e+06
+      GoRuntimeType: 1258944
       GoKind: 22
       Pointee: 966 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
@@ -11254,21 +11254,21 @@ Types:
       ID: 1012
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.782048e+06
+      GoRuntimeType: 1782048
       GoKind: 22
       Pointee: 1013 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 941
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.021184e+06
+      GoRuntimeType: 1021184
       GoKind: 22
       Pointee: 942 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 943
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.02144e+06
+      GoRuntimeType: 1021440
       GoKind: 22
       Pointee: 944 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
@@ -11417,21 +11417,21 @@ Types:
       ID: 989
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.038944e+06
+      GoRuntimeType: 2038944
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1016
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.824e+06
+      GoRuntimeType: 1824000
       GoKind: 22
       Pointee: 1017 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1061
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.131904e+06
+      GoRuntimeType: 2131904
       GoKind: 22
       Pointee: 1062 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -11457,7 +11457,7 @@ Types:
       ID: 963
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.249184e+06
+      GoRuntimeType: 1249184
       GoKind: 22
       Pointee: 964 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
@@ -11471,14 +11471,14 @@ Types:
       ID: 985
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.608672e+06
+      GoRuntimeType: 1608672
       GoKind: 22
       Pointee: 986 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 821
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.12336e+06
+      GoRuntimeType: 1123360
       GoKind: 22
       Pointee: 822 StructureType context.deadlineExceededError
     - __kind: PointerType
@@ -11499,14 +11499,14 @@ Types:
       ID: 975
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
-      GoRuntimeType: 1.380576e+06
+      GoRuntimeType: 1380576
       GoKind: 22
       Pointee: 976 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
       ID: 1000
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.68768e+06
+      GoRuntimeType: 1687680
       GoKind: 22
       Pointee: 1001 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
@@ -11520,21 +11520,21 @@ Types:
       ID: 1008
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 1.779232e+06
+      GoRuntimeType: 1779232
       GoKind: 22
       Pointee: 1009 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1002
       Name: '*crypto/sha256.digest'
       ByteSize: 8
-      GoRuntimeType: 1.688128e+06
+      GoRuntimeType: 1688128
       GoKind: 22
       Pointee: 1003 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
       ID: 1004
       Name: '*crypto/sha512.digest'
       ByteSize: 8
-      GoRuntimeType: 1.688576e+06
+      GoRuntimeType: 1688576
       GoKind: 22
       Pointee: 1005 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
@@ -11548,14 +11548,14 @@ Types:
       ID: 761
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.009024e+06
+      GoRuntimeType: 1009024
       GoKind: 22
       Pointee: 762 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1087
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.241024e+06
+      GoRuntimeType: 2241024
       GoKind: 22
       Pointee: 1088 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
@@ -11576,35 +11576,35 @@ Types:
       ID: 760
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.00736e+06
+      GoRuntimeType: 1007360
       GoKind: 22
       Pointee: 717 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 973
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.377696e+06
+      GoRuntimeType: 1377696
       GoKind: 22
       Pointee: 974 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
       ID: 980
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.45824e+06
+      GoRuntimeType: 1458240
       GoKind: 22
       Pointee: 981 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 856
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.249504e+06
+      GoRuntimeType: 1249504
       GoKind: 22
       Pointee: 857 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 871
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 1.914912e+06
+      GoRuntimeType: 1914912
       GoKind: 22
       Pointee: 872 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
@@ -11639,7 +11639,7 @@ Types:
       ID: 766
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.014912e+06
+      GoRuntimeType: 1014912
       GoKind: 22
       Pointee: 767 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
@@ -11688,7 +11688,7 @@ Types:
       ID: 931
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.004544e+06
+      GoRuntimeType: 1004544
       GoKind: 22
       Pointee: 932 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -11709,7 +11709,7 @@ Types:
       ID: 752
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.000192e+06
+      GoRuntimeType: 1000192
       GoKind: 22
       Pointee: 753 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
@@ -11744,7 +11744,7 @@ Types:
       ID: 1067
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.157472e+06
+      GoRuntimeType: 2157472
       GoKind: 22
       Pointee: 1068 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
@@ -11758,7 +11758,7 @@ Types:
       ID: 939
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.017728e+06
+      GoRuntimeType: 1017728
       GoKind: 22
       Pointee: 940 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
@@ -11798,7 +11798,7 @@ Types:
       ID: 1045
       Name: '*encoding/xml.printer'
       ByteSize: 8
-      GoRuntimeType: 2.027424e+06
+      GoRuntimeType: 2027424
       GoKind: 22
       Pointee: 1046 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
@@ -11840,7 +11840,7 @@ Types:
       ID: 1055
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.1232e+06
+      GoRuntimeType: 2123200
       GoKind: 22
       Pointee: 1056 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
@@ -11939,14 +11939,14 @@ Types:
       ID: 953
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.12912e+06
+      GoRuntimeType: 1129120
       GoKind: 22
       Pointee: 954 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1033
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 1.93024e+06
+      GoRuntimeType: 1930240
       GoKind: 22
       Pointee: 1034 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
@@ -11960,14 +11960,14 @@ Types:
       ID: 830
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.132448e+06
+      GoRuntimeType: 1132448
       GoKind: 22
       Pointee: 831 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1063
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.13344e+06
+      GoRuntimeType: 2133440
       GoKind: 22
       Pointee: 1064 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
@@ -12119,7 +12119,7 @@ Types:
       ID: 992
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.684768e+06
+      GoRuntimeType: 1684768
       GoKind: 22
       Pointee: 993 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
@@ -12133,21 +12133,21 @@ Types:
       ID: 971
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.376576e+06
+      GoRuntimeType: 1376576
       GoKind: 22
       Pointee: 972 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 927
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.00352e+06
+      GoRuntimeType: 1003520
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 961
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.247264e+06
+      GoRuntimeType: 1247264
       GoKind: 22
       Pointee: 962 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
@@ -12161,28 +12161,28 @@ Types:
       ID: 1023
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.848256e+06
+      GoRuntimeType: 1848256
       GoKind: 22
       Pointee: 1024 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1038
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.002464e+06
+      GoRuntimeType: 2002464
       GoKind: 22
       Pointee: 1035 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1037
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.00208e+06
+      GoRuntimeType: 2002080
       GoKind: 22
       Pointee: 1036 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 929
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.003648e+06
+      GoRuntimeType: 1003648
       GoKind: 22
       Pointee: 930 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
@@ -12203,70 +12203,70 @@ Types:
       ID: 996
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.686336e+06
+      GoRuntimeType: 1686336
       GoKind: 22
       Pointee: 997 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1029
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.88384e+06
+      GoRuntimeType: 1883840
       GoKind: 22
       Pointee: 1030 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1031
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.914592e+06
+      GoRuntimeType: 1914592
       GoKind: 22
       Pointee: 1032 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 861
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.261344e+06
+      GoRuntimeType: 1261344
       GoKind: 22
       Pointee: 862 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 774
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.02912e+06
+      GoRuntimeType: 1029120
       GoKind: 22
       Pointee: 775 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 772
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.028992e+06
+      GoRuntimeType: 1028992
       GoKind: 22
       Pointee: 773 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 776
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.033088e+06
+      GoRuntimeType: 1033088
       GoKind: 22
       Pointee: 777 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 778
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.033216e+06
+      GoRuntimeType: 1033216
       GoKind: 22
       Pointee: 779 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 982
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.485888e+06
+      GoRuntimeType: 1485888
       GoKind: 22
       Pointee: 983 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 768
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.01568e+06
+      GoRuntimeType: 1015680
       GoKind: 22
       Pointee: 769 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
@@ -12280,28 +12280,28 @@ Types:
       ID: 1079
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.220128e+06
+      GoRuntimeType: 2220128
       GoKind: 22
       Pointee: 1080 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 832
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.14064e+06
+      GoRuntimeType: 1140640
       GoKind: 22
       Pointee: 833 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 805
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.11952e+06
+      GoRuntimeType: 1119520
       GoKind: 22
       Pointee: 806 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 799
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.119136e+06
+      GoRuntimeType: 1119136
       GoKind: 22
       Pointee: 800 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
@@ -12315,7 +12315,7 @@ Types:
       ID: 811
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.119904e+06
+      GoRuntimeType: 1119904
       GoKind: 22
       Pointee: 812 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
@@ -12329,42 +12329,42 @@ Types:
       ID: 803
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.119392e+06
+      GoRuntimeType: 1119392
       GoKind: 22
       Pointee: 804 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 801
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.119264e+06
+      GoRuntimeType: 1119264
       GoKind: 22
       Pointee: 802 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 809
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.119776e+06
+      GoRuntimeType: 1119776
       GoKind: 22
       Pointee: 810 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 807
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.119648e+06
+      GoRuntimeType: 1119648
       GoKind: 22
       Pointee: 808 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1083
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.231168e+06
+      GoRuntimeType: 2231168
       GoKind: 22
       Pointee: 1084 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 815
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.120288e+06
+      GoRuntimeType: 1120288
       GoKind: 22
       Pointee: 816 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
@@ -12385,7 +12385,7 @@ Types:
       ID: 813
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.12016e+06
+      GoRuntimeType: 1120160
       GoKind: 22
       Pointee: 814 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -12448,35 +12448,35 @@ Types:
       ID: 874
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.484352e+06
+      GoRuntimeType: 1484352
       GoKind: 22
       Pointee: 875 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 782
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.048064e+06
+      GoRuntimeType: 1048064
       GoKind: 22
       Pointee: 783 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 959
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.179552e+06
+      GoRuntimeType: 1179552
       GoKind: 22
       Pointee: 960 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1043
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.017056e+06
+      GoRuntimeType: 2017056
       GoKind: 22
       Pointee: 1044 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 945
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.050368e+06
+      GoRuntimeType: 1050368
       GoKind: 22
       Pointee: 946 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
@@ -12490,7 +12490,7 @@ Types:
       ID: 840
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.181216e+06
+      GoRuntimeType: 1181216
       GoKind: 22
       Pointee: 841 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
@@ -12552,7 +12552,7 @@ Types:
       ID: 1041
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.015136e+06
+      GoRuntimeType: 2015136
       GoKind: 22
       Pointee: 1042 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -12580,14 +12580,14 @@ Types:
       ID: 838
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.178144e+06
+      GoRuntimeType: 1178144
       GoKind: 22
       Pointee: 839 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 863
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.268704e+06
+      GoRuntimeType: 1268704
       GoKind: 22
       Pointee: 864 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
@@ -12601,21 +12601,21 @@ Types:
       ID: 1006
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.693056e+06
+      GoRuntimeType: 1693056
       GoKind: 22
       Pointee: 1007 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 957
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.174688e+06
+      GoRuntimeType: 1174688
       GoKind: 22
       Pointee: 958 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 780
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.042304e+06
+      GoRuntimeType: 1042304
       GoKind: 22
       Pointee: 781 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
@@ -12636,21 +12636,21 @@ Types:
       ID: 770
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.019136e+06
+      GoRuntimeType: 1019136
       GoKind: 22
       Pointee: 771 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 836
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.1464e+06
+      GoRuntimeType: 1146400
       GoKind: 22
       Pointee: 837 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 834
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.146144e+06
+      GoRuntimeType: 1146144
       GoKind: 22
       Pointee: 835 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
@@ -12678,7 +12678,7 @@ Types:
       ID: 994
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.68544e+06
+      GoRuntimeType: 1685440
       GoKind: 22
       Pointee: 995 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
@@ -12883,21 +12883,21 @@ Types:
       ID: 797
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.118368e+06
+      GoRuntimeType: 1118368
       GoKind: 22
       Pointee: 798 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1085
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.23584e+06
+      GoRuntimeType: 2235840
       GoKind: 22
       Pointee: 1086 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 795
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.11824e+06
+      GoRuntimeType: 1118240
       GoKind: 22
       Pointee: 796 StructureType internal/poll.errNetClosing
     - __kind: PointerType
@@ -12911,14 +12911,14 @@ Types:
       ID: 949
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.109664e+06
+      GoRuntimeType: 1109664
       GoKind: 22
       Pointee: 950 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 947
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.10928e+06
+      GoRuntimeType: 1109280
       GoKind: 22
       Pointee: 948 StructureType io.discard
     - __kind: PointerType
@@ -12932,14 +12932,14 @@ Types:
       ID: 793
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.117984e+06
+      GoRuntimeType: 1117984
       GoKind: 22
       Pointee: 794 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 998
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.68656e+06
+      GoRuntimeType: 1686560
       GoKind: 22
       Pointee: 999 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13211,63 +13211,63 @@ Types:
       ID: 824
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.126688e+06
+      GoRuntimeType: 1126688
       GoKind: 22
       Pointee: 825 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 850
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.245504e+06
+      GoRuntimeType: 1245504
       GoKind: 22
       Pointee: 851 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1049
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.095872e+06
+      GoRuntimeType: 2095872
       GoKind: 22
       Pointee: 1050 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 848
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.245184e+06
+      GoRuntimeType: 1245184
       GoKind: 22
       Pointee: 849 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 826
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.126816e+06
+      GoRuntimeType: 1126816
       GoKind: 22
       Pointee: 827 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1059
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.125248e+06
+      GoRuntimeType: 2125248
       GoKind: 22
       Pointee: 1060 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1069
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.170208e+06
+      GoRuntimeType: 2170208
       GoKind: 22
       Pointee: 1070 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1057
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.124736e+06
+      GoRuntimeType: 2124736
       GoKind: 22
       Pointee: 1058 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 823
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.12592e+06
+      GoRuntimeType: 1125920
       GoKind: 22
       Pointee: 786 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13279,28 +13279,28 @@ Types:
       ID: 754
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.00096e+06
+      GoRuntimeType: 1000960
       GoKind: 22
       Pointee: 755 StructureType net.canceledError
     - __kind: PointerType
       ID: 1027
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 1.881536e+06
+      GoRuntimeType: 1881536
       GoKind: 22
       Pointee: 1028 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 892
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.726208e+06
+      GoRuntimeType: 1726208
       GoKind: 22
       Pointee: 893 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1071
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.174464e+06
+      GoRuntimeType: 2174464
       GoKind: 22
       Pointee: 1072 UnresolvedPointeeType net.netFD
     - __kind: PointerType
@@ -13321,28 +13321,28 @@ Types:
       ID: 1053
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.11024e+06
+      GoRuntimeType: 2110240
       GoKind: 22
       Pointee: 1054 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1051
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.10976e+06
+      GoRuntimeType: 2109760
       GoKind: 22
       Pointee: 1052 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 828
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.127456e+06
+      GoRuntimeType: 1127456
       GoKind: 22
       Pointee: 829 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 852
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.245664e+06
+      GoRuntimeType: 1245664
       GoKind: 22
       Pointee: 853 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
@@ -13377,7 +13377,7 @@ Types:
       ID: 844
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.241344e+06
+      GoRuntimeType: 1241344
       GoKind: 22
       Pointee: 845 StructureType net/http.http2StreamError
     - __kind: PointerType
@@ -13391,7 +13391,7 @@ Types:
       ID: 967
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.373216e+06
+      GoRuntimeType: 1373216
       GoKind: 22
       Pointee: 968 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
@@ -13434,7 +13434,7 @@ Types:
       ID: 819
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.122464e+06
+      GoRuntimeType: 1122464
       GoKind: 22
       Pointee: 820 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
@@ -13448,7 +13448,7 @@ Types:
       ID: 1018
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.825536e+06
+      GoRuntimeType: 1825536
       GoKind: 22
       Pointee: 1019 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
@@ -13481,7 +13481,7 @@ Types:
       ID: 969
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.040608e+06
+      GoRuntimeType: 2040608
       GoKind: 22
       Pointee: 970 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
@@ -13495,7 +13495,7 @@ Types:
       ID: 951
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.12144e+06
+      GoRuntimeType: 1121440
       GoKind: 22
       Pointee: 952 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
@@ -13509,14 +13509,14 @@ Types:
       ID: 846
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.242464e+06
+      GoRuntimeType: 1242464
       GoKind: 22
       Pointee: 847 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 817
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.122336e+06
+      GoRuntimeType: 1122336
       GoKind: 22
       Pointee: 818 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
@@ -13537,14 +13537,14 @@ Types:
       ID: 1020
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.827072e+06
+      GoRuntimeType: 1827072
       GoKind: 22
       Pointee: 1021 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 935
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.010048e+06
+      GoRuntimeType: 1010048
       GoKind: 22
       Pointee: 936 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
@@ -13565,14 +13565,14 @@ Types:
       ID: 977
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 1.989856e+06
+      GoRuntimeType: 1989856
       GoKind: 22
       Pointee: 978 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 937
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.015168e+06
+      GoRuntimeType: 1015168
       GoKind: 22
       Pointee: 938 StructureType net/smtp.dataCloser
     - __kind: PointerType
@@ -13598,14 +13598,14 @@ Types:
       ID: 933
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.009408e+06
+      GoRuntimeType: 1009408
       GoKind: 22
       Pointee: 934 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 854
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.245984e+06
+      GoRuntimeType: 1245984
       GoKind: 22
       Pointee: 855 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
@@ -13636,7 +13636,7 @@ Types:
       ID: 1077
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.211712e+06
+      GoRuntimeType: 2211712
       GoKind: 22
       Pointee: 1078 UnresolvedPointeeType os.File
     - __kind: PointerType
@@ -13650,49 +13650,49 @@ Types:
       ID: 789
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.111072e+06
+      GoRuntimeType: 1111072
       GoKind: 22
       Pointee: 790 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1075
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.208768e+06
+      GoRuntimeType: 2208768
       GoKind: 22
       Pointee: 1076 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1073
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.208032e+06
+      GoRuntimeType: 2208032
       GoKind: 22
       Pointee: 1074 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 756
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.00608e+06
+      GoRuntimeType: 1006080
       GoKind: 22
       Pointee: 757 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 895
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 1.96112e+06
+      GoRuntimeType: 1961120
       GoKind: 22
       Pointee: 896 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 955
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.133472e+06
+      GoRuntimeType: 1133472
       GoKind: 22
       Pointee: 956 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 758
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.006208e+06
+      GoRuntimeType: 1006208
       GoKind: 22
       Pointee: 759 StructureType os/exec.wrappedError
     - __kind: PointerType
@@ -13753,7 +13753,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.239584e+06
+      GoRuntimeType: 1239584
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -13781,7 +13781,7 @@ Types:
       ID: 791
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.116448e+06
+      GoRuntimeType: 1116448
       GoKind: 22
       Pointee: 792 StructureType runtime.errorAddressString
     - __kind: PointerType
@@ -13840,14 +13840,14 @@ Types:
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 1.9264e+06
+      GoRuntimeType: 1926400
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.435584e+06
+      GoRuntimeType: 1435584
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -13873,7 +13873,7 @@ Types:
       ID: 1014
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.823488e+06
+      GoRuntimeType: 1823488
       GoKind: 22
       Pointee: 1015 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
@@ -13899,28 +13899,28 @@ Types:
       ID: 843
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.240704e+06
+      GoRuntimeType: 1240704
       GoKind: 22
       Pointee: 842 BaseType syscall.Errno
     - __kind: PointerType
       ID: 1047
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.027808e+06
+      GoRuntimeType: 2027808
       GoKind: 22
       Pointee: 1048 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 784
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.051904e+06
+      GoRuntimeType: 1051904
       GoKind: 22
       Pointee: 785 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 859
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.441152e+06
+      GoRuntimeType: 1441152
       GoKind: 22
       Pointee: 860 UnresolvedPointeeType time.Location
     - __kind: PointerType
@@ -13988,7 +13988,7 @@ Types:
       ID: 1010
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
-      GoRuntimeType: 1.780512e+06
+      GoRuntimeType: 1780512
       GoKind: 22
       Pointee: 1011 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
@@ -14002,7 +14002,7 @@ Types:
       ID: 1039
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.004384e+06
+      GoRuntimeType: 2004384
       GoKind: 22
       Pointee: 1040 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -14023,14 +14023,14 @@ Types:
       ID: 763
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.009792e+06
+      GoRuntimeType: 1009792
       GoKind: 22
       Pointee: 764 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 765
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.00992e+06
+      GoRuntimeType: 1009920
       GoKind: 22
       Pointee: 718 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -16598,14 +16598,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16620,14 +16620,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 25
           Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22361,14 +22361,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22394,14 +22394,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 66
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -24378,7 +24378,7 @@ Types:
     - __kind: StructureType
       ID: 916
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.083904e+06
+      GoRuntimeType: 1083904
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24389,7 +24389,7 @@ Types:
       ID: 942
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.383296e+06
+      GoRuntimeType: 1383296
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -24992,7 +24992,7 @@ Types:
     - __kind: StructureType
       ID: 822
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.303392e+06
+      GoRuntimeType: 1303392
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25055,7 +25055,7 @@ Types:
       ID: 593
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.613856e+06
+      GoRuntimeType: 1613856
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25093,7 +25093,7 @@ Types:
       ID: 667
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.616928e+06
+      GoRuntimeType: 1616928
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25108,14 +25108,14 @@ Types:
     - __kind: StructureType
       ID: 661
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.081216e+06
+      GoRuntimeType: 1081216
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 663
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.415648e+06
+      GoRuntimeType: 1415648
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -25140,7 +25140,7 @@ Types:
       ID: 767
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.379616e+06
+      GoRuntimeType: 1379616
       GoKind: 25
       RawFields:
         - Name: Err
@@ -25149,14 +25149,14 @@ Types:
     - __kind: StructureType
       ID: 669
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.081472e+06
+      GoRuntimeType: 1081472
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 665
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.616736e+06
+      GoRuntimeType: 1616736
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25172,7 +25172,7 @@ Types:
       ID: 682
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.259584e+06
+      GoRuntimeType: 1259584
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25182,7 +25182,7 @@ Types:
       ID: 686
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.259744e+06
+      GoRuntimeType: 1259744
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25240,7 +25240,7 @@ Types:
       ID: 556
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.244224e+06
+      GoRuntimeType: 1244224
       GoKind: 25
       RawFields:
         - Name: error
@@ -25383,7 +25383,7 @@ Types:
       ID: 565
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.612128e+06
+      GoRuntimeType: 1612128
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25406,7 +25406,7 @@ Types:
     - __kind: StructureType
       ID: 571
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.077632e+06
+      GoRuntimeType: 1077632
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25436,7 +25436,7 @@ Types:
       ID: 880
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.083648e+06
+      GoRuntimeType: 2083648
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25552,7 +25552,7 @@ Types:
     - __kind: StructureType
       ID: 611
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.080448e+06
+      GoRuntimeType: 1080448
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25564,14 +25564,14 @@ Types:
     - __kind: StructureType
       ID: 609
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.08032e+06
+      GoRuntimeType: 1080320
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 607
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.413728e+06
+      GoRuntimeType: 1413728
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25584,7 +25584,7 @@ Types:
       ID: 627
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.414528e+06
+      GoRuntimeType: 1414528
       GoKind: 25
       RawFields:
         - Name: File
@@ -25597,7 +25597,7 @@ Types:
       ID: 631
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.61616e+06
+      GoRuntimeType: 1616160
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25613,7 +25613,7 @@ Types:
       ID: 629
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.253984e+06
+      GoRuntimeType: 1253984
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25623,7 +25623,7 @@ Types:
       ID: 625
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.253664e+06
+      GoRuntimeType: 1253664
       GoKind: 25
       RawFields:
         - Name: File
@@ -25633,14 +25633,14 @@ Types:
       ID: 866
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.140896e+06
+      GoRuntimeType: 1140896
       GoKind: 21
       HeaderType: 868 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 889
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.013504e+06
+      GoRuntimeType: 1013504
       GoKind: 23
       RawFields:
         - Name: array
@@ -25663,7 +25663,7 @@ Types:
       ID: 639
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.414848e+06
+      GoRuntimeType: 1414848
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25676,7 +25676,7 @@ Types:
       ID: 633
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.254144e+06
+      GoRuntimeType: 1254144
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25686,7 +25686,7 @@ Types:
       ID: 637
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.616352e+06
+      GoRuntimeType: 1616352
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25702,7 +25702,7 @@ Types:
       ID: 635
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.414688e+06
+      GoRuntimeType: 1414688
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25715,7 +25715,7 @@ Types:
       ID: 641
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.254304e+06
+      GoRuntimeType: 1254304
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25725,7 +25725,7 @@ Types:
       ID: 647
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.415168e+06
+      GoRuntimeType: 1415168
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25738,7 +25738,7 @@ Types:
       ID: 649
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.254624e+06
+      GoRuntimeType: 1254624
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25748,7 +25748,7 @@ Types:
       ID: 645
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.415008e+06
+      GoRuntimeType: 1415008
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25761,7 +25761,7 @@ Types:
       ID: 643
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.254464e+06
+      GoRuntimeType: 1254464
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25771,7 +25771,7 @@ Types:
       ID: 651
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.415328e+06
+      GoRuntimeType: 1415328
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25784,7 +25784,7 @@ Types:
       ID: 573
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.246464e+06
+      GoRuntimeType: 1246464
       GoKind: 25
       RawFields:
         - Name: message
@@ -25798,7 +25798,7 @@ Types:
       ID: 575
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.246624e+06
+      GoRuntimeType: 1246624
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25820,7 +25820,7 @@ Types:
       ID: 579
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.246944e+06
+      GoRuntimeType: 1246944
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25834,7 +25834,7 @@ Types:
       ID: 1035
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 1.97792e+06
+      GoRuntimeType: 1977920
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25847,7 +25847,7 @@ Types:
       ID: 1036
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.001696e+06
+      GoRuntimeType: 2001696
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25867,7 +25867,7 @@ Types:
       ID: 577
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.246784e+06
+      GoRuntimeType: 1246784
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25877,7 +25877,7 @@ Types:
       ID: 581
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.247104e+06
+      GoRuntimeType: 1247104
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25927,7 +25927,7 @@ Types:
       ID: 587
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.248064e+06
+      GoRuntimeType: 1248064
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -25942,7 +25942,7 @@ Types:
       ID: 806
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.72128e+06
+      GoRuntimeType: 1721280
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -25962,7 +25962,7 @@ Types:
       ID: 739
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.517856e+06
+      GoRuntimeType: 1517856
       GoKind: 25
       RawFields:
         - Name: Got
@@ -25975,7 +25975,7 @@ Types:
       ID: 812
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.721728e+06
+      GoRuntimeType: 1721728
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25997,7 +25997,7 @@ Types:
       ID: 804
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.721056e+06
+      GoRuntimeType: 1721056
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -26019,7 +26019,7 @@ Types:
       ID: 802
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.720832e+06
+      GoRuntimeType: 1720832
       GoKind: 25
       RawFields:
         - Name: Method
@@ -26035,7 +26035,7 @@ Types:
       ID: 810
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.639744e+06
+      GoRuntimeType: 1639744
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26048,7 +26048,7 @@ Types:
       ID: 808
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.721504e+06
+      GoRuntimeType: 1721504
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26068,7 +26068,7 @@ Types:
       ID: 816
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.442112e+06
+      GoRuntimeType: 1442112
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -26077,20 +26077,20 @@ Types:
     - __kind: StructureType
       ID: 743
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.200992e+06
+      GoRuntimeType: 1200992
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 741
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.200864e+06
+      GoRuntimeType: 1200864
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 814
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.639936e+06
+      GoRuntimeType: 1639936
       GoKind: 25
       RawFields:
         - Name: cause
@@ -26173,7 +26173,7 @@ Types:
         - Name: X
           Offset: 0
           Type: 9 BaseType int
-        - Name: Y
+        - Name: "Y"
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
@@ -26214,7 +26214,7 @@ Types:
       ID: 783
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.271424e+06
+      GoRuntimeType: 1271424
       GoKind: 25
       RawFields:
         - Name: error
@@ -26224,7 +26224,7 @@ Types:
       ID: 960
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.49472e+06
+      GoRuntimeType: 1494720
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -26238,7 +26238,7 @@ Types:
       ID: 984
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.091328e+06
+      GoRuntimeType: 1091328
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26251,7 +26251,7 @@ Types:
       ID: 946
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.388096e+06
+      GoRuntimeType: 1388096
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -26273,7 +26273,7 @@ Types:
       ID: 841
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.75936e+06
+      GoRuntimeType: 1759360
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26289,7 +26289,7 @@ Types:
       ID: 702
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.422528e+06
+      GoRuntimeType: 1422528
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26382,7 +26382,7 @@ Types:
       ID: 706
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.272064e+06
+      GoRuntimeType: 1272064
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26398,7 +26398,7 @@ Types:
       ID: 694
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.267104e+06
+      GoRuntimeType: 1267104
       GoKind: 25
       RawFields:
         - Name: error
@@ -26412,7 +26412,7 @@ Types:
       ID: 864
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.78512e+06
+      GoRuntimeType: 1785120
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26428,7 +26428,7 @@ Types:
       ID: 696
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.422048e+06
+      GoRuntimeType: 1422048
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26441,7 +26441,7 @@ Types:
       ID: 1007
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.838592e+06
+      GoRuntimeType: 1838592
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26458,7 +26458,7 @@ Types:
       ID: 781
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.385696e+06
+      GoRuntimeType: 1385696
       GoKind: 25
       RawFields:
         - Name: error
@@ -26483,14 +26483,14 @@ Types:
     - __kind: StructureType
       ID: 835
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.332512e+06
+      GoRuntimeType: 1332512
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 688
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.260384e+06
+      GoRuntimeType: 1260384
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26500,7 +26500,7 @@ Types:
       ID: 690
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.260544e+06
+      GoRuntimeType: 1260544
       GoKind: 25
       RawFields:
         - Name: Line
@@ -27487,7 +27487,7 @@ Types:
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.729344e+06
+      GoRuntimeType: 1729344
       GoKind: 25
       RawFields:
         - Name: buf
@@ -27499,7 +27499,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -27520,7 +27520,7 @@ Types:
     - __kind: StructureType
       ID: 796
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.300352e+06
+      GoRuntimeType: 1300352
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27531,7 +27531,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.133088e+06
+      GoRuntimeType: 1133088
       GoKind: 25
       RawFields:
         - Name: u
@@ -27541,7 +27541,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.45632e+06
+      GoRuntimeType: 1456320
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27557,7 +27557,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.313632e+06
+      GoRuntimeType: 1313632
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27570,7 +27570,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.313472e+06
+      GoRuntimeType: 1313472
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27583,7 +27583,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.313792e+06
+      GoRuntimeType: 1313792
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27612,7 +27612,7 @@ Types:
       ID: 991
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.109408e+06
+      GoRuntimeType: 1109408
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27638,7 +27638,7 @@ Types:
       ID: 979
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.074048e+06
+      GoRuntimeType: 1074048
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27663,7 +27663,7 @@ Types:
     - __kind: StructureType
       ID: 948
       Name: io.discard
-      GoRuntimeType: 1.287712e+06
+      GoRuntimeType: 1287712
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27746,7 +27746,7 @@ Types:
       ID: 121
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.428864e+06
+      GoRuntimeType: 1428864
       GoKind: 25
       RawFields:
         - Name: x
@@ -27762,7 +27762,7 @@ Types:
       ID: 136
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.105696e+06
+      GoRuntimeType: 1105696
       GoKind: 25
       RawFields:
         - Name: a
@@ -27772,7 +27772,7 @@ Types:
       ID: 368
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.105568e+06
+      GoRuntimeType: 1105568
       GoKind: 25
       RawFields:
         - Name: a
@@ -27786,7 +27786,7 @@ Types:
       ID: 145
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.104928e+06
+      GoRuntimeType: 1104928
       GoKind: 25
       RawFields:
         - Name: a
@@ -27796,7 +27796,7 @@ Types:
       ID: 1153
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.1048e+06
+      GoRuntimeType: 1104800
       GoKind: 25
       RawFields:
         - Name: a
@@ -27806,7 +27806,7 @@ Types:
       ID: 1162
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.104672e+06
+      GoRuntimeType: 1104672
       GoKind: 25
       RawFields:
         - Name: a
@@ -27816,7 +27816,7 @@ Types:
       ID: 125
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.106848e+06
+      GoRuntimeType: 1106848
       GoKind: 25
       RawFields:
         - Name: a
@@ -27826,7 +27826,7 @@ Types:
       ID: 127
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.10672e+06
+      GoRuntimeType: 1106720
       GoKind: 25
       RawFields:
         - Name: a
@@ -27840,7 +27840,7 @@ Types:
       ID: 129
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.10608e+06
+      GoRuntimeType: 1106080
       GoKind: 25
       RawFields:
         - Name: a
@@ -27850,7 +27850,7 @@ Types:
       ID: 1128
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.105952e+06
+      GoRuntimeType: 1105952
       GoKind: 25
       RawFields:
         - Name: a
@@ -27860,7 +27860,7 @@ Types:
       ID: 1130
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.105824e+06
+      GoRuntimeType: 1105824
       GoKind: 25
       RawFields:
         - Name: a
@@ -27870,7 +27870,7 @@ Types:
       ID: 130
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.108e+06
+      GoRuntimeType: 1108000
       GoKind: 25
       RawFields:
         - Name: a
@@ -27880,7 +27880,7 @@ Types:
       ID: 361
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.107872e+06
+      GoRuntimeType: 1107872
       GoKind: 25
       RawFields:
         - Name: a
@@ -27894,7 +27894,7 @@ Types:
       ID: 135
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.107232e+06
+      GoRuntimeType: 1107232
       GoKind: 25
       RawFields:
         - Name: a
@@ -27904,7 +27904,7 @@ Types:
       ID: 1134
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.107104e+06
+      GoRuntimeType: 1107104
       GoKind: 25
       RawFields:
         - Name: a
@@ -27914,7 +27914,7 @@ Types:
       ID: 1140
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.106976e+06
+      GoRuntimeType: 1106976
       GoKind: 25
       RawFields:
         - Name: a
@@ -27929,7 +27929,7 @@ Types:
       ID: 159
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.71344e+06
+      GoRuntimeType: 1713440
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27951,7 +27951,7 @@ Types:
       ID: 154
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.839904e+06
+      GoRuntimeType: 1839904
       GoKind: 25
       RawFields:
         - Name: _
@@ -27979,7 +27979,7 @@ Types:
       ID: 352
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.237504e+06
+      GoRuntimeType: 1237504
       GoKind: 25
       RawFields:
         - Name: s
@@ -28322,7 +28322,7 @@ Types:
       ID: 116
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.286752e+06
+      GoRuntimeType: 1286752
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -28335,7 +28335,7 @@ Types:
       ID: 245
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.286432e+06
+      GoRuntimeType: 1286432
       GoKind: 25
       RawFields:
         - Name: val
@@ -28369,7 +28369,7 @@ Types:
       ID: 1108
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.237664e+06
+      GoRuntimeType: 1237664
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 9 BaseType int}]
     - __kind: GoInterfaceType
@@ -28429,7 +28429,7 @@ Types:
       ID: 163
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.104416e+06
+      GoRuntimeType: 1104416
       GoKind: 25
       RawFields:
         - Name: a
@@ -28499,7 +28499,7 @@ Types:
       ID: 164
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.104544e+06
+      GoRuntimeType: 1104544
       GoKind: 25
       RawFields:
         - Name: m
@@ -28844,7 +28844,7 @@ Types:
       ID: 623
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.253344e+06
+      GoRuntimeType: 1253344
       GoKind: 25
       RawFields:
         - Name: msg
@@ -28854,7 +28854,7 @@ Types:
       ID: 912
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.250144e+06
+      GoRuntimeType: 1250144
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -28868,7 +28868,7 @@ Types:
       ID: 888
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.412448e+06
+      GoRuntimeType: 1412448
       GoKind: 20
       RawFields:
         - Name: tab
@@ -28909,7 +28909,7 @@ Types:
       ID: 786
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.077248e+06
+      GoRuntimeType: 1077248
       GoKind: 24
       RawFields:
         - Name: str
@@ -28927,7 +28927,7 @@ Types:
     - __kind: StructureType
       ID: 755
       Name: net.canceledError
-      GoRuntimeType: 1.201888e+06
+      GoRuntimeType: 1201888
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28938,7 +28938,7 @@ Types:
       ID: 893
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 1.977216e+06
+      GoRuntimeType: 1977216
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -28960,13 +28960,13 @@ Types:
     - __kind: StructureType
       ID: 1066
       Name: net.noReadFrom
-      GoRuntimeType: 1.077504e+06
+      GoRuntimeType: 1077504
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1065
       Name: net.noWriteTo
-      GoRuntimeType: 1.077376e+06
+      GoRuntimeType: 1077376
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28977,7 +28977,7 @@ Types:
       ID: 560
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.611936e+06
+      GoRuntimeType: 1611936
       GoKind: 25
       RawFields:
         - Name: p
@@ -28993,7 +28993,7 @@ Types:
       ID: 1054
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.153536e+06
+      GoRuntimeType: 2153536
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29006,7 +29006,7 @@ Types:
       ID: 1052
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.152992e+06
+      GoRuntimeType: 2152992
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29031,7 +29031,7 @@ Types:
       ID: 906
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.241664e+06
+      GoRuntimeType: 1241664
       GoKind: 25
       RawFields:
         - Name: w
@@ -29053,7 +29053,7 @@ Types:
       ID: 536
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.610016e+06
+      GoRuntimeType: 1610016
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -29069,7 +29069,7 @@ Types:
       ID: 845
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.775392e+06
+      GoRuntimeType: 1775392
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -29085,7 +29085,7 @@ Types:
       ID: 540
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.411968e+06
+      GoRuntimeType: 1411968
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29162,7 +29162,7 @@ Types:
     - __kind: StructureType
       ID: 751
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.201248e+06
+      GoRuntimeType: 1201248
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29192,7 +29192,7 @@ Types:
       ID: 908
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
-      GoRuntimeType: 1.610784e+06
+      GoRuntimeType: 1610784
       GoKind: 25
       RawFields:
         - Name: conn
@@ -29215,7 +29215,7 @@ Types:
       ID: 747
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.373856e+06
+      GoRuntimeType: 1373856
       GoKind: 25
       RawFields:
         - Name: error
@@ -29229,7 +29229,7 @@ Types:
       ID: 926
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.373696e+06
+      GoRuntimeType: 1373696
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29239,7 +29239,7 @@ Types:
       ID: 952
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.68208e+06
+      GoRuntimeType: 1682080
       GoKind: 25
       RawFields:
         - Name: _
@@ -29255,7 +29255,7 @@ Types:
       ID: 544
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.242624e+06
+      GoRuntimeType: 1242624
       GoKind: 25
       RawFields:
         - Name: error
@@ -29268,14 +29268,14 @@ Types:
     - __kind: StructureType
       ID: 818
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.303072e+06
+      GoRuntimeType: 1303072
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 749
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.374016e+06
+      GoRuntimeType: 1374016
       GoKind: 25
       RawFields:
         - Name: err
@@ -29289,7 +29289,7 @@ Types:
       ID: 1021
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 1.913632e+06
+      GoRuntimeType: 1913632
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29303,7 +29303,7 @@ Types:
       ID: 615
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.615776e+06
+      GoRuntimeType: 1615776
       GoKind: 25
       RawFields:
         - Name: in
@@ -29319,7 +29319,7 @@ Types:
       ID: 613
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.413888e+06
+      GoRuntimeType: 1413888
       GoKind: 25
       RawFields:
         - Name: in
@@ -29336,7 +29336,7 @@ Types:
       ID: 938
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.415808e+06
+      GoRuntimeType: 1415808
       GoKind: 25
       RawFields:
         - Name: c
@@ -29430,7 +29430,7 @@ Types:
       ID: 1076
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.221728e+06
+      GoRuntimeType: 2221728
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29443,7 +29443,7 @@ Types:
       ID: 1074
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.220928e+06
+      GoRuntimeType: 2220928
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29455,13 +29455,13 @@ Types:
     - __kind: StructureType
       ID: 1082
       Name: os.noReadFrom
-      GoRuntimeType: 1.075072e+06
+      GoRuntimeType: 1075072
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1081
       Name: os.noWriteTo
-      GoRuntimeType: 1.074944e+06
+      GoRuntimeType: 1074944
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29480,7 +29480,7 @@ Types:
       ID: 759
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.518432e+06
+      GoRuntimeType: 1518432
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -29542,13 +29542,13 @@ Types:
       ID: 733
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.76496e+06
+      GoRuntimeType: 1764960
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
           Type: 13 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 9 BaseType int
         - Name: signed
@@ -29581,7 +29581,7 @@ Types:
       ID: 792
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.635904e+06
+      GoRuntimeType: 1635904
       GoKind: 25
       RawFields:
         - Name: msg
@@ -29613,7 +29613,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 2.26496e+06
+      GoRuntimeType: 2264960
       GoKind: 25
       RawFields:
         - Name: stack
@@ -29788,7 +29788,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.116192e+06
+      GoRuntimeType: 1116192
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -29798,7 +29798,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.842208e+06
+      GoRuntimeType: 1842208
       GoKind: 25
       RawFields:
         - Name: sp
@@ -29826,7 +29826,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.295392e+06
+      GoRuntimeType: 1295392
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -29839,7 +29839,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.634944e+06
+      GoRuntimeType: 1634944
       GoKind: 25
       RawFields:
         - Name: stack
@@ -29864,7 +29864,7 @@ Types:
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.295232e+06
+      GoRuntimeType: 1295232
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -29877,13 +29877,13 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.790464e+06
+      GoRuntimeType: 1790464
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -29908,7 +29908,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 2.271072e+06
+      GoRuntimeType: 2271072
       GoKind: 25
       RawFields:
         - Name: g0
@@ -30128,7 +30128,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.790208e+06
+      GoRuntimeType: 1790208
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -30153,7 +30153,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 1.435968e+06
+      GoRuntimeType: 1435968
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -30169,7 +30169,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 1.435776e+06
+      GoRuntimeType: 1435776
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -30195,14 +30195,14 @@ Types:
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.115808e+06
+      GoRuntimeType: 1115808
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.295072e+06
+      GoRuntimeType: 1295072
       GoKind: 25
       RawFields:
         - Name: entries
@@ -30215,13 +30215,13 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.635712e+06
+      GoRuntimeType: 1635712
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -30268,7 +30268,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.293472e+06
+      GoRuntimeType: 1293472
       GoKind: 25
       RawFields:
         - Name: lo
@@ -30305,7 +30305,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.294432e+06
+      GoRuntimeType: 1294432
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -30318,7 +30318,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.075456e+06
+      GoRuntimeType: 1075456
       GoKind: 8
     - __kind: StructureType
       ID: 75
@@ -30361,7 +30361,7 @@ Types:
       ID: 920
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.279232e+06
+      GoRuntimeType: 1279232
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -30377,7 +30377,7 @@ Types:
       ID: 1097
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.288672e+06
+      GoRuntimeType: 1288672
       GoKind: 25
       RawFields:
         - Name: state
@@ -30390,7 +30390,7 @@ Types:
       ID: 1098
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.289792e+06
+      GoRuntimeType: 1289792
       GoKind: 25
       RawFields:
         - Name: done
@@ -30403,7 +30403,7 @@ Types:
       ID: 1101
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.430592e+06
+      GoRuntimeType: 1430592
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -30425,7 +30425,7 @@ Types:
       ID: 1105
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.290112e+06
+      GoRuntimeType: 1290112
       GoKind: 25
       RawFields:
         - Name: _
@@ -30438,7 +30438,7 @@ Types:
       ID: 1099
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.290272e+06
+      GoRuntimeType: 1290272
       GoKind: 25
       RawFields:
         - Name: _
@@ -30451,7 +30451,7 @@ Types:
       ID: 1103
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.430976e+06
+      GoRuntimeType: 1430976
       GoKind: 25
       RawFields:
         - Name: _
@@ -30479,7 +30479,7 @@ Types:
       ID: 842
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.20048e+06
+      GoRuntimeType: 1200480
       GoKind: 12
     - __kind: UnresolvedPointeeType
       ID: 1048
@@ -30489,7 +30489,7 @@ Types:
       ID: 785
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.522848e+06
+      GoRuntimeType: 1522848
       GoKind: 25
       RawFields:
         - Name: Name
@@ -30502,7 +30502,7 @@ Types:
       ID: 987
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.791232e+06
+      GoRuntimeType: 1791232
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 860
@@ -30516,7 +30516,7 @@ Types:
       ID: 858
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.233952e+06
+      GoRuntimeType: 2233952
       GoKind: 25
       RawFields:
         - Name: wall
@@ -30597,7 +30597,7 @@ Types:
       ID: 876
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 1.93536e+06
+      GoRuntimeType: 1935360
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30609,7 +30609,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 878 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 9 BaseType int
         - Name: index
@@ -30637,7 +30637,7 @@ Types:
       ID: 877
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.801728e+06
+      GoRuntimeType: 1801728
       GoKind: 25
       RawFields:
         - Name: id
@@ -30676,7 +30676,7 @@ Types:
       ID: 601
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.250464e+06
+      GoRuntimeType: 1250464
       GoKind: 25
       RawFields:
         - Name: Err
@@ -30692,7 +30692,7 @@ Types:
       ID: 764
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.518624e+06
+      GoRuntimeType: 1518624
       GoKind: 25
       RawFields:
         - Name: label

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -576,8 +576,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 86}
@@ -600,7 +600,7 @@ Probes:
                   EventExpressionIndex: 1
                 - ', '
                 - Error: failed to resolve reference "y"
-                  DSL: y
+                  DSL: "y"
     - id: testConflictingReturn
       version: 0
       type: LOG_PROBE
@@ -1713,8 +1713,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 53}
@@ -1735,8 +1735,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
     - id: testInlinedBBA
@@ -5475,8 +5475,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
         - ', '
         - json: {ref: z}
           dsl: z
@@ -5496,8 +5496,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
                 - ', '
@@ -6832,7 +6832,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 7 BaseType int
           Locations:
             - Range: 0xcd9960..0xcd9987
@@ -7371,7 +7371,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 17 BaseType float32
           Locations:
             - Range: 0xcdc240..0xcdc241
@@ -7402,7 +7402,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 17 BaseType float32
           Locations:
             - Range: 0xcdc280..0xcdc281
@@ -9580,7 +9580,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcdfc20..0xcdfc21
@@ -11349,7 +11349,7 @@ Types:
       ID: 1173
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.987584e+06
+      GoRuntimeType: 1987584
       GoKind: 22
       Pointee: 1174 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
@@ -11368,7 +11368,7 @@ Types:
       ID: 1108
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.438816e+06
+      GoRuntimeType: 1438816
       GoKind: 22
       Pointee: 1109 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
@@ -11389,21 +11389,21 @@ Types:
       ID: 1156
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.907264e+06
+      GoRuntimeType: 1907264
       GoKind: 22
       Pointee: 1157 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 1084
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.058528e+06
+      GoRuntimeType: 1058528
       GoKind: 22
       Pointee: 1085 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 1086
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.058784e+06
+      GoRuntimeType: 1058784
       GoKind: 22
       Pointee: 1087 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
@@ -11417,21 +11417,21 @@ Types:
       ID: 1131
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.176416e+06
+      GoRuntimeType: 2176416
       GoKind: 22
       Pointee: 1132 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1162
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.952288e+06
+      GoRuntimeType: 1952288
       GoKind: 22
       Pointee: 1163 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1211
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.273696e+06
+      GoRuntimeType: 2273696
       GoKind: 22
       Pointee: 1212 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -11457,7 +11457,7 @@ Types:
       ID: 1106
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.428256e+06
+      GoRuntimeType: 1428256
       GoKind: 22
       Pointee: 1107 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
@@ -11471,14 +11471,14 @@ Types:
       ID: 1128
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.729024e+06
+      GoRuntimeType: 1729024
       GoKind: 22
       Pointee: 1129 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 958
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.206272e+06
+      GoRuntimeType: 1206272
       GoKind: 22
       Pointee: 959 StructureType context.deadlineExceededError
     - __kind: PointerType
@@ -11506,42 +11506,42 @@ Types:
       ID: 1118
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
-      GoRuntimeType: 1.569856e+06
+      GoRuntimeType: 1569856
       GoKind: 22
       Pointee: 1119 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
       ID: 1152
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.865696e+06
+      GoRuntimeType: 1865696
       GoKind: 22
       Pointee: 1153 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
       ID: 1184
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
-      GoRuntimeType: 2.123744e+06
+      GoRuntimeType: 2123744
       GoKind: 22
       Pointee: 1185 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
       ID: 1158
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.907776e+06
+      GoRuntimeType: 1907776
       GoKind: 22
       Pointee: 1159 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
       ID: 1154
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.866368e+06
+      GoRuntimeType: 1866368
       GoKind: 22
       Pointee: 1155 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
       ID: 1150
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.858528e+06
+      GoRuntimeType: 1858528
       GoKind: 22
       Pointee: 1151 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
@@ -11555,14 +11555,14 @@ Types:
       ID: 1168
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 1.957152e+06
+      GoRuntimeType: 1957152
       GoKind: 22
       Pointee: 1169 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1140
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
-      GoRuntimeType: 1.812512e+06
+      GoRuntimeType: 1812512
       GoKind: 22
       Pointee: 1141 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
@@ -11576,14 +11576,14 @@ Types:
       ID: 898
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.047136e+06
+      GoRuntimeType: 1047136
       GoKind: 22
       Pointee: 899 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1237
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.385568e+06
+      GoRuntimeType: 2385568
       GoKind: 22
       Pointee: 1238 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
@@ -11604,35 +11604,35 @@ Types:
       ID: 897
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.045472e+06
+      GoRuntimeType: 1045472
       GoKind: 22
       Pointee: 854 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 1116
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.562816e+06
+      GoRuntimeType: 1562816
       GoKind: 22
       Pointee: 1117 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
       ID: 1123
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.64672e+06
+      GoRuntimeType: 1646720
       GoKind: 22
       Pointee: 1124 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 993
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.428576e+06
+      GoRuntimeType: 1428576
       GoKind: 22
       Pointee: 994 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 1008
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.045632e+06
+      GoRuntimeType: 2045632
       GoKind: 22
       Pointee: 1009 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
@@ -11667,7 +11667,7 @@ Types:
       ID: 903
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.052896e+06
+      GoRuntimeType: 1052896
       GoKind: 22
       Pointee: 904 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
@@ -11716,7 +11716,7 @@ Types:
       ID: 1074
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.04304e+06
+      GoRuntimeType: 1043040
       GoKind: 22
       Pointee: 1075 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -11737,7 +11737,7 @@ Types:
       ID: 889
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.039328e+06
+      GoRuntimeType: 1039328
       GoKind: 22
       Pointee: 890 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
@@ -11772,7 +11772,7 @@ Types:
       ID: 1217
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.29872e+06
+      GoRuntimeType: 2298720
       GoKind: 22
       Pointee: 1218 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
@@ -11786,7 +11786,7 @@ Types:
       ID: 1082
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.055456e+06
+      GoRuntimeType: 1055456
       GoKind: 22
       Pointee: 1083 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
@@ -11826,7 +11826,7 @@ Types:
       ID: 1195
       Name: '*encoding/xml.printer'
       ByteSize: 8
-      GoRuntimeType: 2.162176e+06
+      GoRuntimeType: 2162176
       GoKind: 22
       Pointee: 1196 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
@@ -11847,7 +11847,7 @@ Types:
       ID: 856
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1.02384e+06
+      GoRuntimeType: 1023840
       GoKind: 22
       Pointee: 857 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -11868,21 +11868,21 @@ Types:
       ID: 1205
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.266016e+06
+      GoRuntimeType: 2266016
       GoKind: 22
       Pointee: 1206 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 858
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.023968e+06
+      GoRuntimeType: 1023968
       GoKind: 22
       Pointee: 859 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 860
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.024096e+06
+      GoRuntimeType: 1024096
       GoKind: 22
       Pointee: 861 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -11967,14 +11967,14 @@ Types:
       ID: 1096
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.211776e+06
+      GoRuntimeType: 1211776
       GoKind: 22
       Pointee: 1097 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1181
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 2.06096e+06
+      GoRuntimeType: 2060960
       GoKind: 22
       Pointee: 1182 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
@@ -11988,14 +11988,14 @@ Types:
       ID: 967
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.21536e+06
+      GoRuntimeType: 1215360
       GoKind: 22
       Pointee: 968 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1213
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.275744e+06
+      GoRuntimeType: 2275744
       GoKind: 22
       Pointee: 1214 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
@@ -12147,7 +12147,7 @@ Types:
       ID: 1134
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.80512e+06
+      GoRuntimeType: 1805120
       GoKind: 22
       Pointee: 1135 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
@@ -12161,21 +12161,21 @@ Types:
       ID: 1114
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.561696e+06
+      GoRuntimeType: 1561696
       GoKind: 22
       Pointee: 1115 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 1070
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.042016e+06
+      GoRuntimeType: 1042016
       GoKind: 22
       Pointee: 1071 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1104
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.426336e+06
+      GoRuntimeType: 1426336
       GoKind: 22
       Pointee: 1105 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
@@ -12189,28 +12189,28 @@ Types:
       ID: 1171
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.977792e+06
+      GoRuntimeType: 1977792
       GoKind: 22
       Pointee: 1172 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1188
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.135712e+06
+      GoRuntimeType: 2135712
       GoKind: 22
       Pointee: 1183 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1187
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.135328e+06
+      GoRuntimeType: 2135328
       GoKind: 22
       Pointee: 1186 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 1072
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.042144e+06
+      GoRuntimeType: 1042144
       GoKind: 22
       Pointee: 1073 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
@@ -12231,70 +12231,70 @@ Types:
       ID: 1136
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.806912e+06
+      GoRuntimeType: 1806912
       GoKind: 22
       Pointee: 1137 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1177
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.01424e+06
+      GoRuntimeType: 2014240
       GoKind: 22
       Pointee: 1178 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1179
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.045312e+06
+      GoRuntimeType: 2045312
       GoKind: 22
       Pointee: 1180 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 998
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.441216e+06
+      GoRuntimeType: 1441216
       GoKind: 22
       Pointee: 999 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 911
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.066976e+06
+      GoRuntimeType: 1066976
       GoKind: 22
       Pointee: 912 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 909
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.066848e+06
+      GoRuntimeType: 1066848
       GoKind: 22
       Pointee: 910 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 913
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.070944e+06
+      GoRuntimeType: 1070944
       GoKind: 22
       Pointee: 914 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 915
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.071072e+06
+      GoRuntimeType: 1071072
       GoKind: 22
       Pointee: 916 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 1125
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.673792e+06
+      GoRuntimeType: 1673792
       GoKind: 22
       Pointee: 1126 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 905
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.053536e+06
+      GoRuntimeType: 1053536
       GoKind: 22
       Pointee: 906 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
@@ -12308,112 +12308,112 @@ Types:
       ID: 1229
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.361792e+06
+      GoRuntimeType: 2361792
       GoKind: 22
       Pointee: 1230 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 969
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.223808e+06
+      GoRuntimeType: 1223808
       GoKind: 22
       Pointee: 970 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 942
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.20256e+06
+      GoRuntimeType: 1202560
       GoKind: 22
       Pointee: 943 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 936
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.202176e+06
+      GoRuntimeType: 1202176
       GoKind: 22
       Pointee: 937 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 875
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.033312e+06
+      GoRuntimeType: 1033312
       GoKind: 22
       Pointee: 876 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 948
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.202944e+06
+      GoRuntimeType: 1202944
       GoKind: 22
       Pointee: 949 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 874
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1.033184e+06
+      GoRuntimeType: 1033184
       GoKind: 22
       Pointee: 853 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 940
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.202432e+06
+      GoRuntimeType: 1202432
       GoKind: 22
       Pointee: 941 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 938
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.202304e+06
+      GoRuntimeType: 1202304
       GoKind: 22
       Pointee: 939 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 946
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.202816e+06
+      GoRuntimeType: 1202816
       GoKind: 22
       Pointee: 947 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 944
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.202688e+06
+      GoRuntimeType: 1202688
       GoKind: 22
       Pointee: 945 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1233
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.3736e+06
+      GoRuntimeType: 2373600
       GoKind: 22
       Pointee: 1234 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 952
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.203328e+06
+      GoRuntimeType: 1203328
       GoKind: 22
       Pointee: 953 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 879
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1.033568e+06
+      GoRuntimeType: 1033568
       GoKind: 22
       Pointee: 880 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 877
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1.03344e+06
+      GoRuntimeType: 1033440
       GoKind: 22
       Pointee: 878 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 950
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.2032e+06
+      GoRuntimeType: 1203200
       GoKind: 22
       Pointee: 951 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -12476,35 +12476,35 @@ Types:
       ID: 1011
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.672256e+06
+      GoRuntimeType: 1672256
       GoKind: 22
       Pointee: 1012 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 919
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.085792e+06
+      GoRuntimeType: 1085792
       GoKind: 22
       Pointee: 920 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 1102
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.26336e+06
+      GoRuntimeType: 1263360
       GoKind: 22
       Pointee: 1103 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1193
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.150304e+06
+      GoRuntimeType: 2150304
       GoKind: 22
       Pointee: 1194 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 1088
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.088096e+06
+      GoRuntimeType: 1088096
       GoKind: 22
       Pointee: 1089 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
@@ -12518,7 +12518,7 @@ Types:
       ID: 977
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.265024e+06
+      GoRuntimeType: 1265024
       GoKind: 22
       Pointee: 978 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
@@ -12580,7 +12580,7 @@ Types:
       ID: 1191
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.148384e+06
+      GoRuntimeType: 2148384
       GoKind: 22
       Pointee: 1192 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -12608,14 +12608,14 @@ Types:
       ID: 975
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.26208e+06
+      GoRuntimeType: 1262080
       GoKind: 22
       Pointee: 976 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 1000
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.448576e+06
+      GoRuntimeType: 1448576
       GoKind: 22
       Pointee: 1001 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
@@ -12629,21 +12629,21 @@ Types:
       ID: 1142
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.81296e+06
+      GoRuntimeType: 1812960
       GoKind: 22
       Pointee: 1143 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 1100
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.258624e+06
+      GoRuntimeType: 1258624
       GoKind: 22
       Pointee: 1101 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 917
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.080032e+06
+      GoRuntimeType: 1080032
       GoKind: 22
       Pointee: 918 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
@@ -12664,21 +12664,21 @@ Types:
       ID: 907
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.056864e+06
+      GoRuntimeType: 1056864
       GoKind: 22
       Pointee: 908 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 973
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.23008e+06
+      GoRuntimeType: 1230080
       GoKind: 22
       Pointee: 974 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 971
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.229824e+06
+      GoRuntimeType: 1229824
       GoKind: 22
       Pointee: 972 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
@@ -12706,7 +12706,7 @@ Types:
       ID: 1148
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.8536e+06
+      GoRuntimeType: 1853600
       GoKind: 22
       Pointee: 1149 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
@@ -12783,21 +12783,21 @@ Types:
       ID: 934
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.201408e+06
+      GoRuntimeType: 1201408
       GoKind: 22
       Pointee: 935 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1235
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.379232e+06
+      GoRuntimeType: 2379232
       GoKind: 22
       Pointee: 1236 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 932
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.20128e+06
+      GoRuntimeType: 1201280
       GoKind: 22
       Pointee: 933 StructureType internal/poll.errNetClosing
     - __kind: PointerType
@@ -12811,35 +12811,35 @@ Types:
       ID: 1092
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.193088e+06
+      GoRuntimeType: 1193088
       GoKind: 22
       Pointee: 1093 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1090
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.192704e+06
+      GoRuntimeType: 1192704
       GoKind: 22
       Pointee: 1091 StructureType io.discard
     - __kind: PointerType
       ID: 1064
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.024864e+06
+      GoRuntimeType: 1024864
       GoKind: 22
       Pointee: 1065 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 930
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.201024e+06
+      GoRuntimeType: 1201024
       GoKind: 22
       Pointee: 931 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 1138
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.807136e+06
+      GoRuntimeType: 1807136
       GoKind: 22
       Pointee: 1139 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13246,63 +13246,63 @@ Types:
       ID: 961
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.2096e+06
+      GoRuntimeType: 1209600
       GoKind: 22
       Pointee: 962 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 987
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.424576e+06
+      GoRuntimeType: 1424576
       GoKind: 22
       Pointee: 988 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1199
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.237312e+06
+      GoRuntimeType: 2237312
       GoKind: 22
       Pointee: 1200 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 985
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.424256e+06
+      GoRuntimeType: 1424256
       GoKind: 22
       Pointee: 986 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 963
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.209728e+06
+      GoRuntimeType: 1209728
       GoKind: 22
       Pointee: 964 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1209
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.26704e+06
+      GoRuntimeType: 2267040
       GoKind: 22
       Pointee: 1210 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1219
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.312032e+06
+      GoRuntimeType: 2312032
       GoKind: 22
       Pointee: 1220 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1207
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.266528e+06
+      GoRuntimeType: 2266528
       GoKind: 22
       Pointee: 1208 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 960
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.208832e+06
+      GoRuntimeType: 1208832
       GoKind: 22
       Pointee: 923 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13314,28 +13314,28 @@ Types:
       ID: 891
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.040224e+06
+      GoRuntimeType: 1040224
       GoKind: 22
       Pointee: 892 StructureType net.canceledError
     - __kind: PointerType
       ID: 1175
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2.01136e+06
+      GoRuntimeType: 2011360
       GoKind: 22
       Pointee: 1176 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1029
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.849344e+06
+      GoRuntimeType: 1849344
       GoKind: 22
       Pointee: 1030 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1221
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.316288e+06
+      GoRuntimeType: 2316288
       GoKind: 22
       Pointee: 1222 UnresolvedPointeeType net.netFD
     - __kind: PointerType
@@ -13356,35 +13356,35 @@ Types:
       ID: 1203
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.253056e+06
+      GoRuntimeType: 2253056
       GoKind: 22
       Pointee: 1204 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1201
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.252576e+06
+      GoRuntimeType: 2252576
       GoKind: 22
       Pointee: 1202 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 965
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.210368e+06
+      GoRuntimeType: 1210368
       GoKind: 22
       Pointee: 966 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 989
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.424736e+06
+      GoRuntimeType: 1424736
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 881
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1.036e+06
+      GoRuntimeType: 1036000
       GoKind: 22
       Pointee: 882 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
@@ -13412,7 +13412,7 @@ Types:
       ID: 981
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.420416e+06
+      GoRuntimeType: 1420416
       GoKind: 22
       Pointee: 982 StructureType net/http.http2StreamError
     - __kind: PointerType
@@ -13426,7 +13426,7 @@ Types:
       ID: 1110
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.558176e+06
+      GoRuntimeType: 1558176
       GoKind: 22
       Pointee: 1111 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
@@ -13469,21 +13469,21 @@ Types:
       ID: 956
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.205376e+06
+      GoRuntimeType: 1205376
       GoKind: 22
       Pointee: 957 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 887
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1.03664e+06
+      GoRuntimeType: 1036640
       GoKind: 22
       Pointee: 888 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1164
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.953824e+06
+      GoRuntimeType: 1953824
       GoKind: 22
       Pointee: 1165 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
@@ -13509,28 +13509,28 @@ Types:
       ID: 883
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1.036256e+06
+      GoRuntimeType: 1036256
       GoKind: 22
       Pointee: 884 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1112
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.17808e+06
+      GoRuntimeType: 2178080
       GoKind: 22
       Pointee: 1113 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1068
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1.036128e+06
+      GoRuntimeType: 1036128
       GoKind: 22
       Pointee: 1069 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 1094
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.20448e+06
+      GoRuntimeType: 1204480
       GoKind: 22
       Pointee: 1095 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
@@ -13544,28 +13544,28 @@ Types:
       ID: 983
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.421536e+06
+      GoRuntimeType: 1421536
       GoKind: 22
       Pointee: 984 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 954
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.205248e+06
+      GoRuntimeType: 1205248
       GoKind: 22
       Pointee: 955 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 885
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1.036384e+06
+      GoRuntimeType: 1036384
       GoKind: 22
       Pointee: 886 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1146
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1.845984e+06
+      GoRuntimeType: 1845984
       GoKind: 22
       Pointee: 1147 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
@@ -13579,14 +13579,14 @@ Types:
       ID: 1166
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.95536e+06
+      GoRuntimeType: 1955360
       GoKind: 22
       Pointee: 1167 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 1078
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.048288e+06
+      GoRuntimeType: 1048288
       GoKind: 22
       Pointee: 1079 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
@@ -13607,14 +13607,14 @@ Types:
       ID: 1120
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 2.122336e+06
+      GoRuntimeType: 2122336
       GoKind: 22
       Pointee: 1121 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 1080
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.053152e+06
+      GoRuntimeType: 1053152
       GoKind: 22
       Pointee: 1081 StructureType net/smtp.dataCloser
     - __kind: PointerType
@@ -13640,14 +13640,14 @@ Types:
       ID: 1076
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.04752e+06
+      GoRuntimeType: 1047520
       GoKind: 22
       Pointee: 1077 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 991
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.425056e+06
+      GoRuntimeType: 1425056
       GoKind: 22
       Pointee: 992 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
@@ -13813,63 +13813,63 @@ Types:
       ID: 1227
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.354944e+06
+      GoRuntimeType: 2354944
       GoKind: 22
       Pointee: 1228 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 864
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 1.027552e+06
+      GoRuntimeType: 1027552
       GoKind: 22
       Pointee: 865 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 926
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.194496e+06
+      GoRuntimeType: 1194496
       GoKind: 22
       Pointee: 927 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1225
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.351264e+06
+      GoRuntimeType: 2351264
       GoKind: 22
       Pointee: 1226 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1223
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.350528e+06
+      GoRuntimeType: 2350528
       GoKind: 22
       Pointee: 1224 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 893
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.044192e+06
+      GoRuntimeType: 1044192
       GoKind: 22
       Pointee: 894 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 1032
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 2.091488e+06
+      GoRuntimeType: 2091488
       GoKind: 22
       Pointee: 1033 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 1098
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.21664e+06
+      GoRuntimeType: 1216640
       GoKind: 22
       Pointee: 1099 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 895
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.04432e+06
+      GoRuntimeType: 1044320
       GoKind: 22
       Pointee: 896 StructureType os/exec.wrappedError
     - __kind: PointerType
@@ -13909,14 +13909,14 @@ Types:
       ID: 868
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1.029088e+06
+      GoRuntimeType: 1029088
       GoKind: 22
       Pointee: 869 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 872
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1.03088e+06
+      GoRuntimeType: 1030880
       GoKind: 22
       Pointee: 873 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
@@ -13930,14 +13930,14 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.418496e+06
+      GoRuntimeType: 1418496
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 870
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1.029216e+06
+      GoRuntimeType: 1029216
       GoKind: 22
       Pointee: 871 StructureType runtime.boundsError
     - __kind: PointerType
@@ -13958,14 +13958,14 @@ Types:
       ID: 928
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.199872e+06
+      GoRuntimeType: 1199872
       GoKind: 22
       Pointee: 929 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 866
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1.028704e+06
+      GoRuntimeType: 1028704
       GoKind: 22
       Pointee: 847 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -13984,14 +13984,14 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.030368e+06
+      GoRuntimeType: 1030368
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 867
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1.028832e+06
+      GoRuntimeType: 1028832
       GoKind: 22
       Pointee: 850 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14010,28 +14010,28 @@ Types:
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 1.555936e+06
+      GoRuntimeType: 1555936
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.05776e+06
+      GoRuntimeType: 2057760
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.624064e+06
+      GoRuntimeType: 1624064
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 862
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 1.0264e+06
+      GoRuntimeType: 1026400
       GoKind: 22
       Pointee: 863 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
@@ -14050,14 +14050,14 @@ Types:
       ID: 1160
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.951776e+06
+      GoRuntimeType: 1951776
       GoKind: 22
       Pointee: 1161 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 1066
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 1.026528e+06
+      GoRuntimeType: 1026528
       GoKind: 22
       Pointee: 1067 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
@@ -14076,7 +14076,7 @@ Types:
       ID: 980
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.419776e+06
+      GoRuntimeType: 1419776
       GoKind: 22
       Pointee: 979 BaseType syscall.Errno
     - __kind: PointerType
@@ -14218,21 +14218,21 @@ Types:
       ID: 1197
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.16256e+06
+      GoRuntimeType: 2162560
       GoKind: 22
       Pointee: 1198 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 921
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.089632e+06
+      GoRuntimeType: 1089632
       GoKind: 22
       Pointee: 922 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 996
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.629056e+06
+      GoRuntimeType: 1629056
       GoKind: 22
       Pointee: 997 UnresolvedPointeeType time.Location
     - __kind: PointerType
@@ -14307,7 +14307,7 @@ Types:
       ID: 1189
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.138016e+06
+      GoRuntimeType: 2138016
       GoKind: 22
       Pointee: 1190 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -14328,14 +14328,14 @@ Types:
       ID: 900
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.048032e+06
+      GoRuntimeType: 1048032
       GoKind: 22
       Pointee: 901 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 902
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.04816e+06
+      GoRuntimeType: 1048160
       GoKind: 22
       Pointee: 855 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -16903,14 +16903,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16925,14 +16925,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 25
           Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22666,14 +22666,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22699,14 +22699,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -24656,7 +24656,7 @@ Types:
     - __kind: StructureType
       ID: 1059
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.121664e+06
+      GoRuntimeType: 1121664
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24667,7 +24667,7 @@ Types:
       ID: 1085
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.568736e+06
+      GoRuntimeType: 1568736
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -24757,7 +24757,7 @@ Types:
     - __kind: StructureType
       ID: 959
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.483296e+06
+      GoRuntimeType: 1483296
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -24838,7 +24838,7 @@ Types:
       ID: 729
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.733632e+06
+      GoRuntimeType: 1733632
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24876,7 +24876,7 @@ Types:
       ID: 803
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.736512e+06
+      GoRuntimeType: 1736512
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -24891,14 +24891,14 @@ Types:
     - __kind: StructureType
       ID: 797
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.119232e+06
+      GoRuntimeType: 1119232
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 799
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.603456e+06
+      GoRuntimeType: 1603456
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -24923,7 +24923,7 @@ Types:
       ID: 904
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.564736e+06
+      GoRuntimeType: 1564736
       GoKind: 25
       RawFields:
         - Name: Err
@@ -24932,14 +24932,14 @@ Types:
     - __kind: StructureType
       ID: 805
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.119488e+06
+      GoRuntimeType: 1119488
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 801
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.73632e+06
+      GoRuntimeType: 1736320
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -24955,7 +24955,7 @@ Types:
       ID: 819
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.439456e+06
+      GoRuntimeType: 1439456
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24965,7 +24965,7 @@ Types:
       ID: 823
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.439616e+06
+      GoRuntimeType: 1439616
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25023,7 +25023,7 @@ Types:
       ID: 690
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.423296e+06
+      GoRuntimeType: 1423296
       GoKind: 25
       RawFields:
         - Name: error
@@ -25072,7 +25072,7 @@ Types:
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.028576e+06
+      GoRuntimeType: 1028576
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25166,7 +25166,7 @@ Types:
       ID: 699
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.73248e+06
+      GoRuntimeType: 1732480
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25189,7 +25189,7 @@ Types:
     - __kind: StructureType
       ID: 705
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.11552e+06
+      GoRuntimeType: 1115520
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25219,7 +25219,7 @@ Types:
       ID: 1017
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.222368e+06
+      GoRuntimeType: 2222368
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25335,7 +25335,7 @@ Types:
     - __kind: StructureType
       ID: 747
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.118464e+06
+      GoRuntimeType: 1118464
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25347,14 +25347,14 @@ Types:
     - __kind: StructureType
       ID: 745
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.118336e+06
+      GoRuntimeType: 1118336
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 743
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.601536e+06
+      GoRuntimeType: 1601536
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25367,7 +25367,7 @@ Types:
       ID: 763
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.602336e+06
+      GoRuntimeType: 1602336
       GoKind: 25
       RawFields:
         - Name: File
@@ -25380,7 +25380,7 @@ Types:
       ID: 767
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.735744e+06
+      GoRuntimeType: 1735744
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25396,7 +25396,7 @@ Types:
       ID: 765
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.433056e+06
+      GoRuntimeType: 1433056
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25406,7 +25406,7 @@ Types:
       ID: 761
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.432736e+06
+      GoRuntimeType: 1432736
       GoKind: 25
       RawFields:
         - Name: File
@@ -25416,14 +25416,14 @@ Types:
       ID: 1003
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.503776e+06
+      GoRuntimeType: 1503776
       GoKind: 21
       HeaderType: 1005 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 1026
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.051616e+06
+      GoRuntimeType: 1051616
       GoKind: 23
       RawFields:
         - Name: array
@@ -25446,7 +25446,7 @@ Types:
       ID: 775
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.602656e+06
+      GoRuntimeType: 1602656
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25459,7 +25459,7 @@ Types:
       ID: 769
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.433216e+06
+      GoRuntimeType: 1433216
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25469,7 +25469,7 @@ Types:
       ID: 773
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.735936e+06
+      GoRuntimeType: 1735936
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25485,7 +25485,7 @@ Types:
       ID: 771
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.602496e+06
+      GoRuntimeType: 1602496
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25498,7 +25498,7 @@ Types:
       ID: 777
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.433376e+06
+      GoRuntimeType: 1433376
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25508,7 +25508,7 @@ Types:
       ID: 783
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.602976e+06
+      GoRuntimeType: 1602976
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25521,7 +25521,7 @@ Types:
       ID: 785
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.433696e+06
+      GoRuntimeType: 1433696
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25531,7 +25531,7 @@ Types:
       ID: 781
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.602816e+06
+      GoRuntimeType: 1602816
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25544,7 +25544,7 @@ Types:
       ID: 779
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.433536e+06
+      GoRuntimeType: 1433536
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25554,7 +25554,7 @@ Types:
       ID: 787
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.603136e+06
+      GoRuntimeType: 1603136
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25567,7 +25567,7 @@ Types:
       ID: 707
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.425536e+06
+      GoRuntimeType: 1425536
       GoKind: 25
       RawFields:
         - Name: message
@@ -25581,7 +25581,7 @@ Types:
       ID: 709
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.425696e+06
+      GoRuntimeType: 1425696
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25603,7 +25603,7 @@ Types:
       ID: 713
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.426016e+06
+      GoRuntimeType: 1426016
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25617,7 +25617,7 @@ Types:
       ID: 1183
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 2.110752e+06
+      GoRuntimeType: 2110752
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25630,7 +25630,7 @@ Types:
       ID: 1186
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.134944e+06
+      GoRuntimeType: 2134944
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25650,7 +25650,7 @@ Types:
       ID: 711
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.425856e+06
+      GoRuntimeType: 1425856
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25660,7 +25660,7 @@ Types:
       ID: 715
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.426176e+06
+      GoRuntimeType: 1426176
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25710,7 +25710,7 @@ Types:
       ID: 721
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.427136e+06
+      GoRuntimeType: 1427136
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -25725,7 +25725,7 @@ Types:
       ID: 943
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.844192e+06
+      GoRuntimeType: 1844192
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -25745,7 +25745,7 @@ Types:
       ID: 876
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.706528e+06
+      GoRuntimeType: 1706528
       GoKind: 25
       RawFields:
         - Name: Got
@@ -25758,7 +25758,7 @@ Types:
       ID: 949
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.84464e+06
+      GoRuntimeType: 1844640
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25780,7 +25780,7 @@ Types:
       ID: 941
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.843968e+06
+      GoRuntimeType: 1843968
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -25802,7 +25802,7 @@ Types:
       ID: 939
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.843744e+06
+      GoRuntimeType: 1843744
       GoKind: 25
       RawFields:
         - Name: Method
@@ -25818,7 +25818,7 @@ Types:
       ID: 947
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.758752e+06
+      GoRuntimeType: 1758752
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25831,7 +25831,7 @@ Types:
       ID: 945
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.844416e+06
+      GoRuntimeType: 1844416
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25851,7 +25851,7 @@ Types:
       ID: 953
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.630016e+06
+      GoRuntimeType: 1630016
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -25860,20 +25860,20 @@ Types:
     - __kind: StructureType
       ID: 880
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.285824e+06
+      GoRuntimeType: 1285824
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 878
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.285696e+06
+      GoRuntimeType: 1285696
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 951
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.758944e+06
+      GoRuntimeType: 1758944
       GoKind: 25
       RawFields:
         - Name: cause
@@ -25956,7 +25956,7 @@ Types:
         - Name: X
           Offset: 0
           Type: 7 BaseType int
-        - Name: Y
+        - Name: "Y"
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
@@ -25997,7 +25997,7 @@ Types:
       ID: 920
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.451296e+06
+      GoRuntimeType: 1451296
       GoKind: 25
       RawFields:
         - Name: error
@@ -26007,7 +26007,7 @@ Types:
       ID: 1103
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.682624e+06
+      GoRuntimeType: 1682624
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -26021,7 +26021,7 @@ Types:
       ID: 1127
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.129216e+06
+      GoRuntimeType: 1129216
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26034,7 +26034,7 @@ Types:
       ID: 1089
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.573696e+06
+      GoRuntimeType: 1573696
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -26050,13 +26050,13 @@ Types:
       ID: 1010
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.004704e+06
+      GoRuntimeType: 1004704
       GoKind: 10
     - __kind: StructureType
       ID: 978
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.882944e+06
+      GoRuntimeType: 1882944
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26072,7 +26072,7 @@ Types:
       ID: 839
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.610176e+06
+      GoRuntimeType: 1610176
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26165,7 +26165,7 @@ Types:
       ID: 843
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.451936e+06
+      GoRuntimeType: 1451936
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26181,7 +26181,7 @@ Types:
       ID: 831
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.446976e+06
+      GoRuntimeType: 1446976
       GoKind: 25
       RawFields:
         - Name: error
@@ -26195,7 +26195,7 @@ Types:
       ID: 1001
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.910848e+06
+      GoRuntimeType: 1910848
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26211,7 +26211,7 @@ Types:
       ID: 833
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.609696e+06
+      GoRuntimeType: 1609696
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26224,7 +26224,7 @@ Types:
       ID: 1143
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.968416e+06
+      GoRuntimeType: 1968416
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26241,7 +26241,7 @@ Types:
       ID: 918
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.571296e+06
+      GoRuntimeType: 1571296
       GoKind: 25
       RawFields:
         - Name: error
@@ -26266,14 +26266,14 @@ Types:
     - __kind: StructureType
       ID: 972
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.514336e+06
+      GoRuntimeType: 1514336
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 825
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.440256e+06
+      GoRuntimeType: 1440256
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26283,7 +26283,7 @@ Types:
       ID: 827
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.440416e+06
+      GoRuntimeType: 1440416
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26730,7 +26730,7 @@ Types:
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.85248e+06
+      GoRuntimeType: 1852480
       GoKind: 25
       RawFields:
         - Name: buf
@@ -26742,7 +26742,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -26767,7 +26767,7 @@ Types:
     - __kind: StructureType
       ID: 933
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.480096e+06
+      GoRuntimeType: 1480096
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -26778,7 +26778,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.216128e+06
+      GoRuntimeType: 1216128
       GoKind: 25
       RawFields:
         - Name: u
@@ -26788,7 +26788,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.644608e+06
+      GoRuntimeType: 1644608
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26804,7 +26804,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.493856e+06
+      GoRuntimeType: 1493856
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26817,7 +26817,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.493696e+06
+      GoRuntimeType: 1493696
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26830,7 +26830,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.494016e+06
+      GoRuntimeType: 1494016
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26855,7 +26855,7 @@ Types:
       ID: 1249
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.477536e+06
+      GoRuntimeType: 1477536
       GoKind: 25
       RawFields:
         - Name: state
@@ -26872,7 +26872,7 @@ Types:
       ID: 1133
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.192832e+06
+      GoRuntimeType: 1192832
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26885,7 +26885,7 @@ Types:
       ID: 1170
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.024992e+06
+      GoRuntimeType: 1024992
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26898,7 +26898,7 @@ Types:
       ID: 1122
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.111808e+06
+      GoRuntimeType: 1111808
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26911,7 +26911,7 @@ Types:
       ID: 129
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.024736e+06
+      GoRuntimeType: 1024736
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26923,7 +26923,7 @@ Types:
     - __kind: StructureType
       ID: 1091
       Name: io.discard
-      GoRuntimeType: 1.467456e+06
+      GoRuntimeType: 1467456
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -26993,7 +26993,7 @@ Types:
       ID: 164
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.023584e+06
+      GoRuntimeType: 1023584
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27006,7 +27006,7 @@ Types:
       ID: 126
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.617152e+06
+      GoRuntimeType: 1617152
       GoKind: 25
       RawFields:
         - Name: x
@@ -27022,7 +27022,7 @@ Types:
       ID: 141
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.18912e+06
+      GoRuntimeType: 1189120
       GoKind: 25
       RawFields:
         - Name: a
@@ -27032,7 +27032,7 @@ Types:
       ID: 374
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.188992e+06
+      GoRuntimeType: 1188992
       GoKind: 25
       RawFields:
         - Name: a
@@ -27046,7 +27046,7 @@ Types:
       ID: 148
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.188352e+06
+      GoRuntimeType: 1188352
       GoKind: 25
       RawFields:
         - Name: a
@@ -27056,7 +27056,7 @@ Types:
       ID: 1315
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.188224e+06
+      GoRuntimeType: 1188224
       GoKind: 25
       RawFields:
         - Name: a
@@ -27066,7 +27066,7 @@ Types:
       ID: 1330
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.188096e+06
+      GoRuntimeType: 1188096
       GoKind: 25
       RawFields:
         - Name: a
@@ -27076,7 +27076,7 @@ Types:
       ID: 130
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.190272e+06
+      GoRuntimeType: 1190272
       GoKind: 25
       RawFields:
         - Name: a
@@ -27086,7 +27086,7 @@ Types:
       ID: 132
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.190144e+06
+      GoRuntimeType: 1190144
       GoKind: 25
       RawFields:
         - Name: a
@@ -27100,7 +27100,7 @@ Types:
       ID: 134
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.189504e+06
+      GoRuntimeType: 1189504
       GoKind: 25
       RawFields:
         - Name: a
@@ -27110,7 +27110,7 @@ Types:
       ID: 1285
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.189376e+06
+      GoRuntimeType: 1189376
       GoKind: 25
       RawFields:
         - Name: a
@@ -27120,7 +27120,7 @@ Types:
       ID: 1287
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.189248e+06
+      GoRuntimeType: 1189248
       GoKind: 25
       RawFields:
         - Name: a
@@ -27130,7 +27130,7 @@ Types:
       ID: 135
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.191424e+06
+      GoRuntimeType: 1191424
       GoKind: 25
       RawFields:
         - Name: a
@@ -27140,7 +27140,7 @@ Types:
       ID: 364
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.191296e+06
+      GoRuntimeType: 1191296
       GoKind: 25
       RawFields:
         - Name: a
@@ -27154,7 +27154,7 @@ Types:
       ID: 140
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.190656e+06
+      GoRuntimeType: 1190656
       GoKind: 25
       RawFields:
         - Name: a
@@ -27164,7 +27164,7 @@ Types:
       ID: 1291
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.190528e+06
+      GoRuntimeType: 1190528
       GoKind: 25
       RawFields:
         - Name: a
@@ -27174,7 +27174,7 @@ Types:
       ID: 1297
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.1904e+06
+      GoRuntimeType: 1190400
       GoKind: 25
       RawFields:
         - Name: a
@@ -27189,7 +27189,7 @@ Types:
       ID: 162
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.835904e+06
+      GoRuntimeType: 1835904
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27211,7 +27211,7 @@ Types:
       ID: 157
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.969728e+06
+      GoRuntimeType: 1969728
       GoKind: 25
       RawFields:
         - Name: _
@@ -27239,7 +27239,7 @@ Types:
       ID: 355
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.416416e+06
+      GoRuntimeType: 1416416
       GoKind: 25
       RawFields:
         - Name: s
@@ -27582,7 +27582,7 @@ Types:
       ID: 121
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.466496e+06
+      GoRuntimeType: 1466496
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -27595,7 +27595,7 @@ Types:
       ID: 248
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.466176e+06
+      GoRuntimeType: 1466176
       GoKind: 25
       RawFields:
         - Name: val
@@ -27629,14 +27629,14 @@ Types:
       ID: 1259
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.416576e+06
+      GoRuntimeType: 1416576
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 160
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.023712e+06
+      GoRuntimeType: 1023712
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27689,7 +27689,7 @@ Types:
       ID: 166
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.18784e+06
+      GoRuntimeType: 1187840
       GoKind: 25
       RawFields:
         - Name: a
@@ -27759,7 +27759,7 @@ Types:
       ID: 167
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.187968e+06
+      GoRuntimeType: 1187968
       GoKind: 25
       RawFields:
         - Name: m
@@ -28792,119 +28792,119 @@ Types:
       ID: 225
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.131264e+06
+      GoRuntimeType: 1131264
       GoKind: 21
       HeaderType: 227 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 220
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.131392e+06
+      GoRuntimeType: 1131392
       GoKind: 21
       HeaderType: 222 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 188
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.13152e+06
+      GoRuntimeType: 1131520
       GoKind: 21
       HeaderType: 190 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 200
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.131648e+06
+      GoRuntimeType: 1131648
       GoKind: 21
       HeaderType: 202 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 142
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.131136e+06
+      GoRuntimeType: 1131136
       GoKind: 21
       HeaderType: 144 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1269
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.131008e+06
+      GoRuntimeType: 1131008
       GoKind: 21
       HeaderType: 1271 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1303
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.130368e+06
+      GoRuntimeType: 1130368
       GoKind: 21
       HeaderType: 1305 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1318
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.13024e+06
+      GoRuntimeType: 1130240
       GoKind: 21
       HeaderType: 1320 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 168
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.1296e+06
+      GoRuntimeType: 1129600
       GoKind: 21
       HeaderType: 170 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 1333
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.130112e+06
+      GoRuntimeType: 1130112
       GoKind: 21
       HeaderType: 1335 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 235
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.131776e+06
+      GoRuntimeType: 1131776
       GoKind: 21
       HeaderType: 237 GoSwissMapHeaderType map<int,struct {}>
     - __kind: GoMapType
       ID: 205
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.131904e+06
+      GoRuntimeType: 1131904
       GoKind: 21
       HeaderType: 207 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 195
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.132032e+06
+      GoRuntimeType: 1132032
       GoKind: 21
       HeaderType: 197 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 183
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.13216e+06
+      GoRuntimeType: 1132160
       GoKind: 21
       HeaderType: 185 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 178
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.132288e+06
+      GoRuntimeType: 1132288
       GoKind: 21
       HeaderType: 180 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 173
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.132416e+06
+      GoRuntimeType: 1132416
       GoKind: 21
       HeaderType: 175 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 230
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 1.132544e+06
+      GoRuntimeType: 1132544
       GoKind: 21
       HeaderType: 232 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
@@ -28947,28 +28947,28 @@ Types:
       ID: 240
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.132672e+06
+      GoRuntimeType: 1132672
       GoKind: 21
       HeaderType: 242 GoSwissMapHeaderType map<struct {},struct {}>
     - __kind: GoMapType
       ID: 215
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.1328e+06
+      GoRuntimeType: 1132800
       GoKind: 21
       HeaderType: 217 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 210
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.132928e+06
+      GoRuntimeType: 1132928
       GoKind: 21
       HeaderType: 212 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
       ID: 759
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.432416e+06
+      GoRuntimeType: 1432416
       GoKind: 25
       RawFields:
         - Name: msg
@@ -28978,7 +28978,7 @@ Types:
       ID: 1055
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.429216e+06
+      GoRuntimeType: 1429216
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -28992,7 +28992,7 @@ Types:
       ID: 1025
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.600256e+06
+      GoRuntimeType: 1600256
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29033,7 +29033,7 @@ Types:
       ID: 923
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.115136e+06
+      GoRuntimeType: 1115136
       GoKind: 24
       RawFields:
         - Name: str
@@ -29051,7 +29051,7 @@ Types:
     - __kind: StructureType
       ID: 892
       Name: net.canceledError
-      GoRuntimeType: 1.286848e+06
+      GoRuntimeType: 1286848
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29062,7 +29062,7 @@ Types:
       ID: 1030
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 2.110048e+06
+      GoRuntimeType: 2110048
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29084,13 +29084,13 @@ Types:
     - __kind: StructureType
       ID: 1216
       Name: net.noReadFrom
-      GoRuntimeType: 1.115392e+06
+      GoRuntimeType: 1115392
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1215
       Name: net.noWriteTo
-      GoRuntimeType: 1.115264e+06
+      GoRuntimeType: 1115264
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29101,7 +29101,7 @@ Types:
       ID: 694
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.732288e+06
+      GoRuntimeType: 1732288
       GoKind: 25
       RawFields:
         - Name: p
@@ -29117,7 +29117,7 @@ Types:
       ID: 1204
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.294784e+06
+      GoRuntimeType: 2294784
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29130,7 +29130,7 @@ Types:
       ID: 1202
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.29424e+06
+      GoRuntimeType: 2294240
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29155,7 +29155,7 @@ Types:
       ID: 1049
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.420736e+06
+      GoRuntimeType: 1420736
       GoKind: 25
       RawFields:
         - Name: w
@@ -29177,7 +29177,7 @@ Types:
       ID: 670
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.73056e+06
+      GoRuntimeType: 1730560
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -29193,7 +29193,7 @@ Types:
       ID: 982
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.902144e+06
+      GoRuntimeType: 1902144
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -29209,7 +29209,7 @@ Types:
       ID: 674
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.599776e+06
+      GoRuntimeType: 1599776
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29286,7 +29286,7 @@ Types:
     - __kind: StructureType
       ID: 888
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.28608e+06
+      GoRuntimeType: 1286080
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29316,7 +29316,7 @@ Types:
       ID: 1051
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
-      GoRuntimeType: 1.826432e+06
+      GoRuntimeType: 1826432
       GoKind: 25
       RawFields:
         - Name: group
@@ -29335,7 +29335,7 @@ Types:
       ID: 1144
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
-      GoRuntimeType: 1.420096e+06
+      GoRuntimeType: 1420096
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29355,7 +29355,7 @@ Types:
       ID: 884
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.558816e+06
+      GoRuntimeType: 1558816
       GoKind: 25
       RawFields:
         - Name: error
@@ -29369,7 +29369,7 @@ Types:
       ID: 1069
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.558656e+06
+      GoRuntimeType: 1558656
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29379,7 +29379,7 @@ Types:
       ID: 1095
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.802432e+06
+      GoRuntimeType: 1802432
       GoKind: 25
       RawFields:
         - Name: _
@@ -29395,7 +29395,7 @@ Types:
       ID: 678
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.421696e+06
+      GoRuntimeType: 1421696
       GoKind: 25
       RawFields:
         - Name: error
@@ -29408,14 +29408,14 @@ Types:
     - __kind: StructureType
       ID: 955
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.482976e+06
+      GoRuntimeType: 1482976
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 886
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.558976e+06
+      GoRuntimeType: 1558976
       GoKind: 25
       RawFields:
         - Name: err
@@ -29425,7 +29425,7 @@ Types:
       ID: 1147
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2.02832e+06
+      GoRuntimeType: 2028320
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29442,7 +29442,7 @@ Types:
       ID: 1167
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 2.044352e+06
+      GoRuntimeType: 2044352
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29456,7 +29456,7 @@ Types:
       ID: 751
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.73536e+06
+      GoRuntimeType: 1735360
       GoKind: 25
       RawFields:
         - Name: in
@@ -29472,7 +29472,7 @@ Types:
       ID: 749
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.601696e+06
+      GoRuntimeType: 1601696
       GoKind: 25
       RawFields:
         - Name: in
@@ -29489,7 +29489,7 @@ Types:
       ID: 1081
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.603616e+06
+      GoRuntimeType: 1603616
       GoKind: 25
       RawFields:
         - Name: c
@@ -29807,7 +29807,7 @@ Types:
       ID: 474
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.298112e+06
+      GoRuntimeType: 1298112
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29820,7 +29820,7 @@ Types:
       ID: 466
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.298368e+06
+      GoRuntimeType: 1298368
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29833,7 +29833,7 @@ Types:
       ID: 414
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.298624e+06
+      GoRuntimeType: 1298624
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29846,7 +29846,7 @@ Types:
       ID: 433
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.29888e+06
+      GoRuntimeType: 1298880
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29859,7 +29859,7 @@ Types:
       ID: 370
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.297856e+06
+      GoRuntimeType: 1297856
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29872,7 +29872,7 @@ Types:
       ID: 1277
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.2976e+06
+      GoRuntimeType: 1297600
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29885,7 +29885,7 @@ Types:
       ID: 1311
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.29632e+06
+      GoRuntimeType: 1296320
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29898,7 +29898,7 @@ Types:
       ID: 1326
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.296064e+06
+      GoRuntimeType: 1296064
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29911,7 +29911,7 @@ Types:
       ID: 382
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.294784e+06
+      GoRuntimeType: 1294784
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29924,7 +29924,7 @@ Types:
       ID: 1341
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.295808e+06
+      GoRuntimeType: 1295808
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29937,7 +29937,7 @@ Types:
       ID: 490
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
-      GoRuntimeType: 1.299136e+06
+      GoRuntimeType: 1299136
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29950,7 +29950,7 @@ Types:
       ID: 441
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.299392e+06
+      GoRuntimeType: 1299392
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29963,7 +29963,7 @@ Types:
       ID: 423
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.299648e+06
+      GoRuntimeType: 1299648
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29976,7 +29976,7 @@ Types:
       ID: 406
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.299904e+06
+      GoRuntimeType: 1299904
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29989,7 +29989,7 @@ Types:
       ID: 1037
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
-      GoRuntimeType: 1.3616e+06
+      GoRuntimeType: 1361600
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30002,7 +30002,7 @@ Types:
       ID: 398
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.30016e+06
+      GoRuntimeType: 1300160
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30015,7 +30015,7 @@ Types:
       ID: 390
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.300416e+06
+      GoRuntimeType: 1300416
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30028,7 +30028,7 @@ Types:
       ID: 482
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
-      GoRuntimeType: 1.300672e+06
+      GoRuntimeType: 1300672
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30113,7 +30113,7 @@ Types:
       ID: 498
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
-      GoRuntimeType: 1.300928e+06
+      GoRuntimeType: 1300928
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30126,7 +30126,7 @@ Types:
       ID: 457
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.301184e+06
+      GoRuntimeType: 1301184
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30139,7 +30139,7 @@ Types:
       ID: 449
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.30144e+06
+      GoRuntimeType: 1301440
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30152,7 +30152,7 @@ Types:
       ID: 476
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.297984e+06
+      GoRuntimeType: 1297984
       GoKind: 25
       RawFields:
         - Name: key
@@ -30165,7 +30165,7 @@ Types:
       ID: 468
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.29824e+06
+      GoRuntimeType: 1298240
       GoKind: 25
       RawFields:
         - Name: key
@@ -30178,7 +30178,7 @@ Types:
       ID: 416
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.298496e+06
+      GoRuntimeType: 1298496
       GoKind: 25
       RawFields:
         - Name: key
@@ -30191,7 +30191,7 @@ Types:
       ID: 435
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.298752e+06
+      GoRuntimeType: 1298752
       GoKind: 25
       RawFields:
         - Name: key
@@ -30204,7 +30204,7 @@ Types:
       ID: 372
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.297728e+06
+      GoRuntimeType: 1297728
       GoKind: 25
       RawFields:
         - Name: key
@@ -30217,7 +30217,7 @@ Types:
       ID: 1279
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.297472e+06
+      GoRuntimeType: 1297472
       GoKind: 25
       RawFields:
         - Name: key
@@ -30230,7 +30230,7 @@ Types:
       ID: 1313
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.296192e+06
+      GoRuntimeType: 1296192
       GoKind: 25
       RawFields:
         - Name: key
@@ -30243,7 +30243,7 @@ Types:
       ID: 1328
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.295936e+06
+      GoRuntimeType: 1295936
       GoKind: 25
       RawFields:
         - Name: key
@@ -30256,7 +30256,7 @@ Types:
       ID: 384
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.294656e+06
+      GoRuntimeType: 1294656
       GoKind: 25
       RawFields:
         - Name: key
@@ -30269,7 +30269,7 @@ Types:
       ID: 1343
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.29568e+06
+      GoRuntimeType: 1295680
       GoKind: 25
       RawFields:
         - Name: key
@@ -30282,7 +30282,7 @@ Types:
       ID: 492
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
-      GoRuntimeType: 1.299008e+06
+      GoRuntimeType: 1299008
       GoKind: 25
       RawFields:
         - Name: key
@@ -30295,7 +30295,7 @@ Types:
       ID: 443
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.299264e+06
+      GoRuntimeType: 1299264
       GoKind: 25
       RawFields:
         - Name: key
@@ -30308,7 +30308,7 @@ Types:
       ID: 425
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.29952e+06
+      GoRuntimeType: 1299520
       GoKind: 25
       RawFields:
         - Name: key
@@ -30321,7 +30321,7 @@ Types:
       ID: 408
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.299776e+06
+      GoRuntimeType: 1299776
       GoKind: 25
       RawFields:
         - Name: key
@@ -30334,7 +30334,7 @@ Types:
       ID: 1039
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
-      GoRuntimeType: 1.361472e+06
+      GoRuntimeType: 1361472
       GoKind: 25
       RawFields:
         - Name: key
@@ -30347,7 +30347,7 @@ Types:
       ID: 400
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.300032e+06
+      GoRuntimeType: 1300032
       GoKind: 25
       RawFields:
         - Name: key
@@ -30360,7 +30360,7 @@ Types:
       ID: 392
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.300288e+06
+      GoRuntimeType: 1300288
       GoKind: 25
       RawFields:
         - Name: key
@@ -30373,7 +30373,7 @@ Types:
       ID: 484
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
-      GoRuntimeType: 1.300544e+06
+      GoRuntimeType: 1300544
       GoKind: 25
       RawFields:
         - Name: key
@@ -30457,7 +30457,7 @@ Types:
     - __kind: StructureType
       ID: 500
       Name: noalg.struct { key struct {}; elem struct {} }
-      GoRuntimeType: 1.3008e+06
+      GoRuntimeType: 1300800
       GoKind: 25
       RawFields:
         - Name: key
@@ -30470,7 +30470,7 @@ Types:
       ID: 459
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.301056e+06
+      GoRuntimeType: 1301056
       GoKind: 25
       RawFields:
         - Name: key
@@ -30483,7 +30483,7 @@ Types:
       ID: 451
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.301312e+06
+      GoRuntimeType: 1301312
       GoKind: 25
       RawFields:
         - Name: key
@@ -30508,7 +30508,7 @@ Types:
       ID: 1226
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.363392e+06
+      GoRuntimeType: 2363392
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -30521,7 +30521,7 @@ Types:
       ID: 1224
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.362592e+06
+      GoRuntimeType: 2362592
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -30533,13 +30533,13 @@ Types:
     - __kind: StructureType
       ID: 1232
       Name: os.noReadFrom
-      GoRuntimeType: 1.112832e+06
+      GoRuntimeType: 1112832
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1231
       Name: os.noWriteTo
-      GoRuntimeType: 1.112704e+06
+      GoRuntimeType: 1112704
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -30558,7 +30558,7 @@ Types:
       ID: 896
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.707104e+06
+      GoRuntimeType: 1707104
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -30620,13 +30620,13 @@ Types:
       ID: 871
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.89056e+06
+      GoRuntimeType: 1890560
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
           Type: 12 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -30659,7 +30659,7 @@ Types:
       ID: 929
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.754912e+06
+      GoRuntimeType: 1754912
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30691,7 +30691,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.41168e+06
+      GoRuntimeType: 2411680
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30872,7 +30872,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.199616e+06
+      GoRuntimeType: 1199616
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -30882,7 +30882,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.972032e+06
+      GoRuntimeType: 1972032
       GoKind: 25
       RawFields:
         - Name: sp
@@ -30910,7 +30910,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.474976e+06
+      GoRuntimeType: 1474976
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -30923,7 +30923,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.753952e+06
+      GoRuntimeType: 1753952
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30948,7 +30948,7 @@ Types:
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.474816e+06
+      GoRuntimeType: 1474816
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -30961,13 +30961,13 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.915936e+06
+      GoRuntimeType: 1915936
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -30992,7 +30992,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 2.416736e+06
+      GoRuntimeType: 2416736
       GoKind: 25
       RawFields:
         - Name: g0
@@ -31215,7 +31215,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.97232e+06
+      GoRuntimeType: 1972320
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31243,7 +31243,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.84128e+06
+      GoRuntimeType: 1841280
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31265,7 +31265,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.841056e+06
+      GoRuntimeType: 1841056
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -31287,7 +31287,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 1.19936e+06
+      GoRuntimeType: 1199360
       GoKind: 25
       RawFields:
         - Name: next
@@ -31303,14 +31303,14 @@ Types:
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.199232e+06
+      GoRuntimeType: 1199232
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.474656e+06
+      GoRuntimeType: 1474656
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31323,13 +31323,13 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.75472e+06
+      GoRuntimeType: 1754720
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -31376,7 +31376,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.473056e+06
+      GoRuntimeType: 1473056
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31417,7 +31417,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.474016e+06
+      GoRuntimeType: 1474016
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -31430,7 +31430,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.285056e+06
+      GoRuntimeType: 1285056
       GoKind: 8
     - __kind: StructureType
       ID: 79
@@ -31473,7 +31473,7 @@ Types:
       ID: 1063
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.459136e+06
+      GoRuntimeType: 1459136
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -31489,7 +31489,7 @@ Types:
       ID: 1247
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.468416e+06
+      GoRuntimeType: 1468416
       GoKind: 25
       RawFields:
         - Name: _
@@ -31502,7 +31502,7 @@ Types:
       ID: 1250
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.61888e+06
+      GoRuntimeType: 1618880
       GoKind: 25
       RawFields:
         - Name: _
@@ -31518,7 +31518,7 @@ Types:
       ID: 1253
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.619072e+06
+      GoRuntimeType: 1619072
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31540,7 +31540,7 @@ Types:
       ID: 1256
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.469696e+06
+      GoRuntimeType: 1469696
       GoKind: 25
       RawFields:
         - Name: _
@@ -31553,7 +31553,7 @@ Types:
       ID: 1251
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.469856e+06
+      GoRuntimeType: 1469856
       GoKind: 25
       RawFields:
         - Name: _
@@ -31566,7 +31566,7 @@ Types:
       ID: 1254
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.619456e+06
+      GoRuntimeType: 1619456
       GoKind: 25
       RawFields:
         - Name: _
@@ -31594,7 +31594,7 @@ Types:
       ID: 979
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.28544e+06
+      GoRuntimeType: 1285440
       GoKind: 12
     - __kind: StructureType
       ID: 471
@@ -32252,7 +32252,7 @@ Types:
       ID: 922
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.71152e+06
+      GoRuntimeType: 1711520
       GoKind: 25
       RawFields:
         - Name: Name
@@ -32265,7 +32265,7 @@ Types:
       ID: 1145
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.916704e+06
+      GoRuntimeType: 1916704
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 997
@@ -32279,7 +32279,7 @@ Types:
       ID: 995
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.378272e+06
+      GoRuntimeType: 2378272
       GoKind: 25
       RawFields:
         - Name: wall
@@ -32356,7 +32356,7 @@ Types:
       ID: 1013
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 2.06576e+06
+      GoRuntimeType: 2065760
       GoKind: 25
       RawFields:
         - Name: msg
@@ -32368,7 +32368,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 1015 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 7 BaseType int
         - Name: index
@@ -32396,7 +32396,7 @@ Types:
       ID: 1014
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.927456e+06
+      GoRuntimeType: 1927456
       GoKind: 25
       RawFields:
         - Name: id
@@ -32435,7 +32435,7 @@ Types:
       ID: 737
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.429536e+06
+      GoRuntimeType: 1429536
       GoKind: 25
       RawFields:
         - Name: Err
@@ -32451,7 +32451,7 @@ Types:
       ID: 901
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.707296e+06
+      GoRuntimeType: 1707296
       GoKind: 25
       RawFields:
         - Name: label

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -576,8 +576,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 86}
@@ -600,7 +600,7 @@ Probes:
                   EventExpressionIndex: 1
                 - ', '
                 - Error: failed to resolve reference "y"
-                  DSL: y
+                  DSL: "y"
     - id: testConflictingReturn
       version: 0
       type: LOG_PROBE
@@ -1713,8 +1713,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 53}
@@ -1735,8 +1735,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
     - id: testInlinedBBA
@@ -5475,8 +5475,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
         - ', '
         - json: {ref: z}
           dsl: z
@@ -5496,8 +5496,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
                 - ', '
@@ -6828,7 +6828,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 7 BaseType int
           Locations:
             - Range: 0xcde1c0..0xcde1e7
@@ -7367,7 +7367,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 18 BaseType float32
           Locations:
             - Range: 0xce0a40..0xce0a41
@@ -7398,7 +7398,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 18 BaseType float32
           Locations:
             - Range: 0xce0a80..0xce0a81
@@ -9576,7 +9576,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xce43c0..0xce43c1
@@ -11350,7 +11350,7 @@ Types:
       ID: 1192
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.996576e+06
+      GoRuntimeType: 1996576
       GoKind: 22
       Pointee: 1193 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
@@ -11369,7 +11369,7 @@ Types:
       ID: 1127
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.443104e+06
+      GoRuntimeType: 1443104
       GoKind: 22
       Pointee: 1128 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
@@ -11390,21 +11390,21 @@ Types:
       ID: 1171
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.91472e+06
+      GoRuntimeType: 1914720
       GoKind: 22
       Pointee: 1172 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 1103
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.063008e+06
+      GoRuntimeType: 1063008
       GoKind: 22
       Pointee: 1104 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 1105
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.063264e+06
+      GoRuntimeType: 1063264
       GoKind: 22
       Pointee: 1106 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
@@ -11418,21 +11418,21 @@ Types:
       ID: 1150
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.185376e+06
+      GoRuntimeType: 2185376
       GoKind: 22
       Pointee: 1151 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1181
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.959968e+06
+      GoRuntimeType: 1959968
       GoKind: 22
       Pointee: 1182 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1230
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.27824e+06
+      GoRuntimeType: 2278240
       GoKind: 22
       Pointee: 1231 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -11458,7 +11458,7 @@ Types:
       ID: 1125
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.432704e+06
+      GoRuntimeType: 1432704
       GoKind: 22
       Pointee: 1126 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
@@ -11472,14 +11472,14 @@ Types:
       ID: 1147
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.736e+06
+      GoRuntimeType: 1736000
       GoKind: 22
       Pointee: 1148 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 975
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.21008e+06
+      GoRuntimeType: 1210080
       GoKind: 22
       Pointee: 976 StructureType context.deadlineExceededError
     - __kind: PointerType
@@ -11507,49 +11507,49 @@ Types:
       ID: 1142
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
-      GoRuntimeType: 1.676736e+06
+      GoRuntimeType: 1676736
       GoKind: 22
       Pointee: 1143 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
       ID: 924
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
-      GoRuntimeType: 1.070816e+06
+      GoRuntimeType: 1070816
       GoKind: 22
       Pointee: 925 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
       ID: 1173
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.915232e+06
+      GoRuntimeType: 1915232
       GoKind: 22
       Pointee: 1174 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
       ID: 1203
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
-      GoRuntimeType: 2.130528e+06
+      GoRuntimeType: 2130528
       GoKind: 22
       Pointee: 1204 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
       ID: 1177
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.915744e+06
+      GoRuntimeType: 1915744
       GoKind: 22
       Pointee: 1178 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
       ID: 1175
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.915488e+06
+      GoRuntimeType: 1915488
       GoKind: 22
       Pointee: 1176 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
       ID: 1169
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.912928e+06
+      GoRuntimeType: 1912928
       GoKind: 22
       Pointee: 1170 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
@@ -11563,14 +11563,14 @@ Types:
       ID: 1190
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 1.993696e+06
+      GoRuntimeType: 1993696
       GoKind: 22
       Pointee: 1191 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1165
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
-      GoRuntimeType: 1.882304e+06
+      GoRuntimeType: 1882304
       GoKind: 22
       Pointee: 1166 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
@@ -11584,14 +11584,14 @@ Types:
       ID: 913
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.051616e+06
+      GoRuntimeType: 1051616
       GoKind: 22
       Pointee: 914 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1256
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.38976e+06
+      GoRuntimeType: 2389760
       GoKind: 22
       Pointee: 1257 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
@@ -11612,14 +11612,14 @@ Types:
       ID: 912
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.049952e+06
+      GoRuntimeType: 1049952
       GoKind: 22
       Pointee: 867 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 1135
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.568128e+06
+      GoRuntimeType: 1568128
       GoKind: 22
       Pointee: 1136 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
@@ -11633,21 +11633,21 @@ Types:
       ID: 1140
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.651776e+06
+      GoRuntimeType: 1651776
       GoKind: 22
       Pointee: 1141 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 1010
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.433184e+06
+      GoRuntimeType: 1433184
       GoKind: 22
       Pointee: 1011 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 1027
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.052864e+06
+      GoRuntimeType: 2052864
       GoKind: 22
       Pointee: 1028 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
@@ -11682,7 +11682,7 @@ Types:
       ID: 918
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.057376e+06
+      GoRuntimeType: 1057376
       GoKind: 22
       Pointee: 919 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
@@ -11731,7 +11731,7 @@ Types:
       ID: 1093
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.047392e+06
+      GoRuntimeType: 1047392
       GoKind: 22
       Pointee: 1094 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -11752,7 +11752,7 @@ Types:
       ID: 902
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.043552e+06
+      GoRuntimeType: 1043552
       GoKind: 22
       Pointee: 903 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
@@ -11787,7 +11787,7 @@ Types:
       ID: 1236
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.303776e+06
+      GoRuntimeType: 2303776
       GoKind: 22
       Pointee: 1237 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
@@ -11801,7 +11801,7 @@ Types:
       ID: 1101
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.059936e+06
+      GoRuntimeType: 1059936
       GoKind: 22
       Pointee: 1102 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
@@ -11841,7 +11841,7 @@ Types:
       ID: 1214
       Name: '*encoding/xml.printer'
       ByteSize: 8
-      GoRuntimeType: 2.170368e+06
+      GoRuntimeType: 2170368
       GoKind: 22
       Pointee: 1215 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
@@ -11862,7 +11862,7 @@ Types:
       ID: 869
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1.028064e+06
+      GoRuntimeType: 1028064
       GoKind: 22
       Pointee: 870 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -11883,21 +11883,21 @@ Types:
       ID: 1224
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.27056e+06
+      GoRuntimeType: 2270560
       GoKind: 22
       Pointee: 1225 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 871
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.028192e+06
+      GoRuntimeType: 1028192
       GoKind: 22
       Pointee: 872 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 873
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.02832e+06
+      GoRuntimeType: 1028320
       GoKind: 22
       Pointee: 874 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -11982,14 +11982,14 @@ Types:
       ID: 1113
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.215584e+06
+      GoRuntimeType: 1215584
       GoKind: 22
       Pointee: 1114 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1200
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 2.068192e+06
+      GoRuntimeType: 2068192
       GoKind: 22
       Pointee: 1201 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
@@ -12003,14 +12003,14 @@ Types:
       ID: 984
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.219168e+06
+      GoRuntimeType: 1219168
       GoKind: 22
       Pointee: 985 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1232
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.280288e+06
+      GoRuntimeType: 2280288
       GoKind: 22
       Pointee: 1233 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
@@ -12162,7 +12162,7 @@ Types:
       ID: 1153
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.812864e+06
+      GoRuntimeType: 1812864
       GoKind: 22
       Pointee: 1154 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
@@ -12176,21 +12176,21 @@ Types:
       ID: 1133
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.566848e+06
+      GoRuntimeType: 1566848
       GoKind: 22
       Pointee: 1134 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 1089
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.04624e+06
+      GoRuntimeType: 1046240
       GoKind: 22
       Pointee: 1090 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1123
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.430784e+06
+      GoRuntimeType: 1430784
       GoKind: 22
       Pointee: 1124 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
@@ -12204,28 +12204,28 @@ Types:
       ID: 1188
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.986208e+06
+      GoRuntimeType: 1986208
       GoKind: 22
       Pointee: 1189 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1207
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.143552e+06
+      GoRuntimeType: 2143552
       GoKind: 22
       Pointee: 1202 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1206
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.143168e+06
+      GoRuntimeType: 2143168
       GoKind: 22
       Pointee: 1205 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 1091
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.046368e+06
+      GoRuntimeType: 1046368
       GoKind: 22
       Pointee: 1092 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
@@ -12246,70 +12246,70 @@ Types:
       ID: 1155
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.814656e+06
+      GoRuntimeType: 1814656
       GoKind: 22
       Pointee: 1156 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1196
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.022048e+06
+      GoRuntimeType: 2022048
       GoKind: 22
       Pointee: 1197 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1198
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.052544e+06
+      GoRuntimeType: 2052544
       GoKind: 22
       Pointee: 1199 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 1015
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.445504e+06
+      GoRuntimeType: 1445504
       GoKind: 22
       Pointee: 1016 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 928
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.071584e+06
+      GoRuntimeType: 1071584
       GoKind: 22
       Pointee: 929 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 926
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.071456e+06
+      GoRuntimeType: 1071456
       GoKind: 22
       Pointee: 927 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 930
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.075552e+06
+      GoRuntimeType: 1075552
       GoKind: 22
       Pointee: 931 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 932
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.07568e+06
+      GoRuntimeType: 1075680
       GoKind: 22
       Pointee: 933 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 1144
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.67904e+06
+      GoRuntimeType: 1679040
       GoKind: 22
       Pointee: 1145 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 920
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.058016e+06
+      GoRuntimeType: 1058016
       GoKind: 22
       Pointee: 921 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
@@ -12323,112 +12323,112 @@ Types:
       ID: 1248
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.366208e+06
+      GoRuntimeType: 2366208
       GoKind: 22
       Pointee: 1249 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 986
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.227744e+06
+      GoRuntimeType: 1227744
       GoKind: 22
       Pointee: 987 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 959
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.206624e+06
+      GoRuntimeType: 1206624
       GoKind: 22
       Pointee: 960 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 953
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.20624e+06
+      GoRuntimeType: 1206240
       GoKind: 22
       Pointee: 954 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 888
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.037536e+06
+      GoRuntimeType: 1037536
       GoKind: 22
       Pointee: 889 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 965
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.207008e+06
+      GoRuntimeType: 1207008
       GoKind: 22
       Pointee: 966 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 887
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1.037408e+06
+      GoRuntimeType: 1037408
       GoKind: 22
       Pointee: 866 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 957
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.206496e+06
+      GoRuntimeType: 1206496
       GoKind: 22
       Pointee: 958 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 955
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.206368e+06
+      GoRuntimeType: 1206368
       GoKind: 22
       Pointee: 956 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 963
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.20688e+06
+      GoRuntimeType: 1206880
       GoKind: 22
       Pointee: 964 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 961
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.206752e+06
+      GoRuntimeType: 1206752
       GoKind: 22
       Pointee: 962 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1252
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.378816e+06
+      GoRuntimeType: 2378816
       GoKind: 22
       Pointee: 1253 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 969
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.207392e+06
+      GoRuntimeType: 1207392
       GoKind: 22
       Pointee: 970 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 892
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1.037792e+06
+      GoRuntimeType: 1037792
       GoKind: 22
       Pointee: 893 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 890
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1.037664e+06
+      GoRuntimeType: 1037664
       GoKind: 22
       Pointee: 891 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 967
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.207264e+06
+      GoRuntimeType: 1207264
       GoKind: 22
       Pointee: 968 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -12491,35 +12491,35 @@ Types:
       ID: 1030
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.677504e+06
+      GoRuntimeType: 1677504
       GoKind: 22
       Pointee: 1031 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 936
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.0904e+06
+      GoRuntimeType: 1090400
       GoKind: 22
       Pointee: 937 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 1119
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.267552e+06
+      GoRuntimeType: 1267552
       GoKind: 22
       Pointee: 1120 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1212
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.158528e+06
+      GoRuntimeType: 2158528
       GoKind: 22
       Pointee: 1213 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 1107
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.092704e+06
+      GoRuntimeType: 1092704
       GoKind: 22
       Pointee: 1108 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
@@ -12533,7 +12533,7 @@ Types:
       ID: 994
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.269216e+06
+      GoRuntimeType: 1269216
       GoKind: 22
       Pointee: 995 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
@@ -12595,7 +12595,7 @@ Types:
       ID: 1210
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.156608e+06
+      GoRuntimeType: 2156608
       GoKind: 22
       Pointee: 1211 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -12623,14 +12623,14 @@ Types:
       ID: 992
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.266272e+06
+      GoRuntimeType: 1266272
       GoKind: 22
       Pointee: 993 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 1017
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.452864e+06
+      GoRuntimeType: 1452864
       GoKind: 22
       Pointee: 1018 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
@@ -12644,21 +12644,21 @@ Types:
       ID: 1159
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.820256e+06
+      GoRuntimeType: 1820256
       GoKind: 22
       Pointee: 1160 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 1117
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.262816e+06
+      GoRuntimeType: 1262816
       GoKind: 22
       Pointee: 1118 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 934
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.08464e+06
+      GoRuntimeType: 1084640
       GoKind: 22
       Pointee: 935 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
@@ -12679,21 +12679,21 @@ Types:
       ID: 922
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.061344e+06
+      GoRuntimeType: 1061344
       GoKind: 22
       Pointee: 923 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 990
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.234144e+06
+      GoRuntimeType: 1234144
       GoKind: 22
       Pointee: 991 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 988
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.233888e+06
+      GoRuntimeType: 1233888
       GoKind: 22
       Pointee: 989 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
@@ -12721,7 +12721,7 @@ Types:
       ID: 1167
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.91088e+06
+      GoRuntimeType: 1910880
       GoKind: 22
       Pointee: 1168 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
@@ -12777,7 +12777,7 @@ Types:
       ID: 1019
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 2.22288e+06
+      GoRuntimeType: 2222880
       GoKind: 22
       Pointee: 1020 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
@@ -12805,21 +12805,21 @@ Types:
       ID: 951
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.205472e+06
+      GoRuntimeType: 1205472
       GoKind: 22
       Pointee: 952 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1254
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.38448e+06
+      GoRuntimeType: 2384480
       GoKind: 22
       Pointee: 1255 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 949
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.205344e+06
+      GoRuntimeType: 1205344
       GoKind: 22
       Pointee: 950 StructureType internal/poll.errNetClosing
     - __kind: PointerType
@@ -12845,42 +12845,42 @@ Types:
       ID: 906
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.048288e+06
+      GoRuntimeType: 1048288
       GoKind: 22
       Pointee: 907 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
       ID: 1111
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.197024e+06
+      GoRuntimeType: 1197024
       GoKind: 22
       Pointee: 1112 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1109
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.19664e+06
+      GoRuntimeType: 1196640
       GoKind: 22
       Pointee: 1110 StructureType io.discard
     - __kind: PointerType
       ID: 1083
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.029088e+06
+      GoRuntimeType: 1029088
       GoKind: 22
       Pointee: 1084 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 947
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.204832e+06
+      GoRuntimeType: 1204832
       GoKind: 22
       Pointee: 948 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 1157
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.81488e+06
+      GoRuntimeType: 1814880
       GoKind: 22
       Pointee: 1158 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13287,63 +13287,63 @@ Types:
       ID: 978
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.213408e+06
+      GoRuntimeType: 1213408
       GoKind: 22
       Pointee: 979 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1004
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.429024e+06
+      GoRuntimeType: 1429024
       GoKind: 22
       Pointee: 1005 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1218
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.243712e+06
+      GoRuntimeType: 2243712
       GoKind: 22
       Pointee: 1219 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 1002
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.428704e+06
+      GoRuntimeType: 1428704
       GoKind: 22
       Pointee: 1003 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 980
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.213536e+06
+      GoRuntimeType: 1213536
       GoKind: 22
       Pointee: 981 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1228
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.271584e+06
+      GoRuntimeType: 2271584
       GoKind: 22
       Pointee: 1229 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1238
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.317088e+06
+      GoRuntimeType: 2317088
       GoKind: 22
       Pointee: 1239 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1226
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.271072e+06
+      GoRuntimeType: 2271072
       GoKind: 22
       Pointee: 1227 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 977
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.21264e+06
+      GoRuntimeType: 1212640
       GoKind: 22
       Pointee: 940 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13355,28 +13355,28 @@ Types:
       ID: 904
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.044448e+06
+      GoRuntimeType: 1044448
       GoKind: 22
       Pointee: 905 StructureType net.canceledError
     - __kind: PointerType
       ID: 1194
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2.019456e+06
+      GoRuntimeType: 2019456
       GoKind: 22
       Pointee: 1195 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1048
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.858112e+06
+      GoRuntimeType: 1858112
       GoKind: 22
       Pointee: 1049 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1240
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.321344e+06
+      GoRuntimeType: 2321344
       GoKind: 22
       Pointee: 1241 UnresolvedPointeeType net.netFD
     - __kind: PointerType
@@ -13397,35 +13397,35 @@ Types:
       ID: 1222
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.2576e+06
+      GoRuntimeType: 2257600
       GoKind: 22
       Pointee: 1223 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1220
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.25712e+06
+      GoRuntimeType: 2257120
       GoKind: 22
       Pointee: 1221 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 982
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.214176e+06
+      GoRuntimeType: 1214176
       GoKind: 22
       Pointee: 983 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1006
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.429184e+06
+      GoRuntimeType: 1429184
       GoKind: 22
       Pointee: 1007 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 894
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1.040224e+06
+      GoRuntimeType: 1040224
       GoKind: 22
       Pointee: 895 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
@@ -13453,7 +13453,7 @@ Types:
       ID: 998
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.424704e+06
+      GoRuntimeType: 1424704
       GoKind: 22
       Pointee: 999 StructureType net/http.http2StreamError
     - __kind: PointerType
@@ -13467,7 +13467,7 @@ Types:
       ID: 1129
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.563328e+06
+      GoRuntimeType: 1563328
       GoKind: 22
       Pointee: 1130 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
@@ -13510,21 +13510,21 @@ Types:
       ID: 973
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.209312e+06
+      GoRuntimeType: 1209312
       GoKind: 22
       Pointee: 974 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 900
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1.040864e+06
+      GoRuntimeType: 1040864
       GoKind: 22
       Pointee: 901 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1183
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.96176e+06
+      GoRuntimeType: 1961760
       GoKind: 22
       Pointee: 1184 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
@@ -13550,28 +13550,28 @@ Types:
       ID: 896
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1.04048e+06
+      GoRuntimeType: 1040480
       GoKind: 22
       Pointee: 897 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1131
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.18704e+06
+      GoRuntimeType: 2187040
       GoKind: 22
       Pointee: 1132 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1087
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1.040352e+06
+      GoRuntimeType: 1040352
       GoKind: 22
       Pointee: 1088 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 1121
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.424864e+06
+      GoRuntimeType: 1424864
       GoKind: 22
       Pointee: 1122 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
@@ -13585,28 +13585,28 @@ Types:
       ID: 1000
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.425984e+06
+      GoRuntimeType: 1425984
       GoKind: 22
       Pointee: 1001 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 971
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.209184e+06
+      GoRuntimeType: 1209184
       GoKind: 22
       Pointee: 972 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 898
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1.040608e+06
+      GoRuntimeType: 1040608
       GoKind: 22
       Pointee: 899 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1163
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1.854752e+06
+      GoRuntimeType: 1854752
       GoKind: 22
       Pointee: 1164 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
@@ -13620,14 +13620,14 @@ Types:
       ID: 1185
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.963552e+06
+      GoRuntimeType: 1963552
       GoKind: 22
       Pointee: 1186 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 1097
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.052768e+06
+      GoRuntimeType: 1052768
       GoKind: 22
       Pointee: 1098 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
@@ -13648,14 +13648,14 @@ Types:
       ID: 1137
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 2.12912e+06
+      GoRuntimeType: 2129120
       GoKind: 22
       Pointee: 1138 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 1099
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.057632e+06
+      GoRuntimeType: 1057632
       GoKind: 22
       Pointee: 1100 StructureType net/smtp.dataCloser
     - __kind: PointerType
@@ -13681,14 +13681,14 @@ Types:
       ID: 1095
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.052e+06
+      GoRuntimeType: 1052000
       GoKind: 22
       Pointee: 1096 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 1008
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.429504e+06
+      GoRuntimeType: 1429504
       GoKind: 22
       Pointee: 1009 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
@@ -13854,63 +13854,63 @@ Types:
       ID: 1246
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.360832e+06
+      GoRuntimeType: 2360832
       GoKind: 22
       Pointee: 1247 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 877
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 1.031776e+06
+      GoRuntimeType: 1031776
       GoKind: 22
       Pointee: 878 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 943
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.198304e+06
+      GoRuntimeType: 1198304
       GoKind: 22
       Pointee: 944 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1244
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.35936e+06
+      GoRuntimeType: 2359360
       GoKind: 22
       Pointee: 1245 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1242
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.358624e+06
+      GoRuntimeType: 2358624
       GoKind: 22
       Pointee: 1243 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 908
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.048672e+06
+      GoRuntimeType: 1048672
       GoKind: 22
       Pointee: 909 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 1051
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 2.09968e+06
+      GoRuntimeType: 2099680
       GoKind: 22
       Pointee: 1052 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 1115
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.220448e+06
+      GoRuntimeType: 1220448
       GoKind: 22
       Pointee: 1116 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 910
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.0488e+06
+      GoRuntimeType: 1048800
       GoKind: 22
       Pointee: 911 StructureType os/exec.wrappedError
     - __kind: PointerType
@@ -13950,14 +13950,14 @@ Types:
       ID: 881
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1.033312e+06
+      GoRuntimeType: 1033312
       GoKind: 22
       Pointee: 882 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 885
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1.035104e+06
+      GoRuntimeType: 1035104
       GoKind: 22
       Pointee: 886 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
@@ -13971,14 +13971,14 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.422464e+06
+      GoRuntimeType: 1422464
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 883
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1.03344e+06
+      GoRuntimeType: 1033440
       GoKind: 22
       Pointee: 884 StructureType runtime.boundsError
     - __kind: PointerType
@@ -13999,14 +13999,14 @@ Types:
       ID: 945
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.203808e+06
+      GoRuntimeType: 1203808
       GoKind: 22
       Pointee: 946 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 879
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1.032928e+06
+      GoRuntimeType: 1032928
       GoKind: 22
       Pointee: 860 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14025,21 +14025,21 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.423104e+06
+      GoRuntimeType: 1423104
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.034464e+06
+      GoRuntimeType: 1034464
       GoKind: 22
       Pointee: 364 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 880
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1.033056e+06
+      GoRuntimeType: 1033056
       GoKind: 22
       Pointee: 863 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14058,7 +14058,7 @@ Types:
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.561088e+06
+      GoRuntimeType: 1561088
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
@@ -14072,21 +14072,21 @@ Types:
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.064672e+06
+      GoRuntimeType: 2064672
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.62912e+06
+      GoRuntimeType: 1629120
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 875
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 1.030624e+06
+      GoRuntimeType: 1030624
       GoKind: 22
       Pointee: 876 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
@@ -14105,14 +14105,14 @@ Types:
       ID: 1179
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.959456e+06
+      GoRuntimeType: 1959456
       GoKind: 22
       Pointee: 1180 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 1085
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 1.030752e+06
+      GoRuntimeType: 1030752
       GoKind: 22
       Pointee: 1086 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
@@ -14133,7 +14133,7 @@ Types:
       ID: 997
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.424064e+06
+      GoRuntimeType: 1424064
       GoKind: 22
       Pointee: 996 BaseType syscall.Errno
     - __kind: PointerType
@@ -14275,21 +14275,21 @@ Types:
       ID: 1216
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.170752e+06
+      GoRuntimeType: 2170752
       GoKind: 22
       Pointee: 1217 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 938
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.09424e+06
+      GoRuntimeType: 1094240
       GoKind: 22
       Pointee: 939 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 1013
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.634112e+06
+      GoRuntimeType: 1634112
       GoKind: 22
       Pointee: 1014 UnresolvedPointeeType time.Location
     - __kind: PointerType
@@ -14364,7 +14364,7 @@ Types:
       ID: 1208
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.14624e+06
+      GoRuntimeType: 2146240
       GoKind: 22
       Pointee: 1209 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -14385,14 +14385,14 @@ Types:
       ID: 915
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.052512e+06
+      GoRuntimeType: 1052512
       GoKind: 22
       Pointee: 916 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 917
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.05264e+06
+      GoRuntimeType: 1052640
       GoKind: 22
       Pointee: 868 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -16960,14 +16960,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16982,14 +16982,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 25
           Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22723,14 +22723,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22756,14 +22756,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -24729,7 +24729,7 @@ Types:
     - __kind: StructureType
       ID: 1078
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.126432e+06
+      GoRuntimeType: 1126432
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24740,7 +24740,7 @@ Types:
       ID: 1104
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.574048e+06
+      GoRuntimeType: 1574048
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -24830,7 +24830,7 @@ Types:
     - __kind: StructureType
       ID: 976
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.488608e+06
+      GoRuntimeType: 1488608
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -24858,7 +24858,7 @@ Types:
     - __kind: StructureType
       ID: 925
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
-      GoRuntimeType: 1.296288e+06
+      GoRuntimeType: 1296288
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24917,7 +24917,7 @@ Types:
       ID: 740
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.740608e+06
+      GoRuntimeType: 1740608
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24959,7 +24959,7 @@ Types:
       ID: 816
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.743488e+06
+      GoRuntimeType: 1743488
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -24974,14 +24974,14 @@ Types:
     - __kind: StructureType
       ID: 810
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.124e+06
+      GoRuntimeType: 1124000
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 812
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.60816e+06
+      GoRuntimeType: 1608160
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -25006,7 +25006,7 @@ Types:
       ID: 919
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.570048e+06
+      GoRuntimeType: 1570048
       GoKind: 25
       RawFields:
         - Name: Err
@@ -25015,14 +25015,14 @@ Types:
     - __kind: StructureType
       ID: 818
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.124256e+06
+      GoRuntimeType: 1124256
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 814
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.743296e+06
+      GoRuntimeType: 1743296
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25038,7 +25038,7 @@ Types:
       ID: 832
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.443744e+06
+      GoRuntimeType: 1443744
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25048,7 +25048,7 @@ Types:
       ID: 836
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.443904e+06
+      GoRuntimeType: 1443904
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25106,7 +25106,7 @@ Types:
       ID: 700
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.427744e+06
+      GoRuntimeType: 1427744
       GoKind: 25
       RawFields:
         - Name: error
@@ -25155,7 +25155,7 @@ Types:
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.0328e+06
+      GoRuntimeType: 1032800
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25249,7 +25249,7 @@ Types:
       ID: 709
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.739456e+06
+      GoRuntimeType: 1739456
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25272,7 +25272,7 @@ Types:
     - __kind: StructureType
       ID: 715
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.120288e+06
+      GoRuntimeType: 1120288
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25302,7 +25302,7 @@ Types:
       ID: 1036
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.230048e+06
+      GoRuntimeType: 2230048
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25418,7 +25418,7 @@ Types:
     - __kind: StructureType
       ID: 760
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.123232e+06
+      GoRuntimeType: 1123232
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25430,14 +25430,14 @@ Types:
     - __kind: StructureType
       ID: 758
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.123104e+06
+      GoRuntimeType: 1123104
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 756
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.60624e+06
+      GoRuntimeType: 1606240
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25450,7 +25450,7 @@ Types:
       ID: 776
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.60704e+06
+      GoRuntimeType: 1607040
       GoKind: 25
       RawFields:
         - Name: File
@@ -25463,7 +25463,7 @@ Types:
       ID: 780
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.74272e+06
+      GoRuntimeType: 1742720
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25479,7 +25479,7 @@ Types:
       ID: 778
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.437664e+06
+      GoRuntimeType: 1437664
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25489,7 +25489,7 @@ Types:
       ID: 774
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.437344e+06
+      GoRuntimeType: 1437344
       GoKind: 25
       RawFields:
         - Name: File
@@ -25499,14 +25499,14 @@ Types:
       ID: 1022
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.508928e+06
+      GoRuntimeType: 1508928
       GoKind: 21
       HeaderType: 1024 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 1045
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.056096e+06
+      GoRuntimeType: 1056096
       GoKind: 23
       RawFields:
         - Name: array
@@ -25529,7 +25529,7 @@ Types:
       ID: 788
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.60736e+06
+      GoRuntimeType: 1607360
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25542,7 +25542,7 @@ Types:
       ID: 782
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.437824e+06
+      GoRuntimeType: 1437824
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25552,7 +25552,7 @@ Types:
       ID: 786
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.742912e+06
+      GoRuntimeType: 1742912
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25568,7 +25568,7 @@ Types:
       ID: 784
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.6072e+06
+      GoRuntimeType: 1607200
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25581,7 +25581,7 @@ Types:
       ID: 790
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.437984e+06
+      GoRuntimeType: 1437984
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25591,7 +25591,7 @@ Types:
       ID: 796
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.60768e+06
+      GoRuntimeType: 1607680
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25604,7 +25604,7 @@ Types:
       ID: 798
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.438304e+06
+      GoRuntimeType: 1438304
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25614,7 +25614,7 @@ Types:
       ID: 794
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.60752e+06
+      GoRuntimeType: 1607520
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25627,7 +25627,7 @@ Types:
       ID: 792
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.438144e+06
+      GoRuntimeType: 1438144
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25637,7 +25637,7 @@ Types:
       ID: 800
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.60784e+06
+      GoRuntimeType: 1607840
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25650,7 +25650,7 @@ Types:
       ID: 717
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.429984e+06
+      GoRuntimeType: 1429984
       GoKind: 25
       RawFields:
         - Name: message
@@ -25664,7 +25664,7 @@ Types:
       ID: 719
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.430144e+06
+      GoRuntimeType: 1430144
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25686,7 +25686,7 @@ Types:
       ID: 723
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.430464e+06
+      GoRuntimeType: 1430464
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25700,7 +25700,7 @@ Types:
       ID: 1202
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 2.117536e+06
+      GoRuntimeType: 2117536
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25713,7 +25713,7 @@ Types:
       ID: 1205
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.142784e+06
+      GoRuntimeType: 2142784
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25733,7 +25733,7 @@ Types:
       ID: 721
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.430304e+06
+      GoRuntimeType: 1430304
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25743,7 +25743,7 @@ Types:
       ID: 725
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.430624e+06
+      GoRuntimeType: 1430624
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25793,7 +25793,7 @@ Types:
       ID: 731
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.431584e+06
+      GoRuntimeType: 1431584
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -25808,7 +25808,7 @@ Types:
       ID: 960
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.85296e+06
+      GoRuntimeType: 1852960
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -25828,7 +25828,7 @@ Types:
       ID: 889
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.71216e+06
+      GoRuntimeType: 1712160
       GoKind: 25
       RawFields:
         - Name: Got
@@ -25841,7 +25841,7 @@ Types:
       ID: 966
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.853408e+06
+      GoRuntimeType: 1853408
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25863,7 +25863,7 @@ Types:
       ID: 958
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.852736e+06
+      GoRuntimeType: 1852736
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -25885,7 +25885,7 @@ Types:
       ID: 956
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.852512e+06
+      GoRuntimeType: 1852512
       GoKind: 25
       RawFields:
         - Name: Method
@@ -25901,7 +25901,7 @@ Types:
       ID: 964
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.76688e+06
+      GoRuntimeType: 1766880
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25914,7 +25914,7 @@ Types:
       ID: 962
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.853184e+06
+      GoRuntimeType: 1853184
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25934,7 +25934,7 @@ Types:
       ID: 970
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.635072e+06
+      GoRuntimeType: 1635072
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -25943,20 +25943,20 @@ Types:
     - __kind: StructureType
       ID: 893
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.290272e+06
+      GoRuntimeType: 1290272
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 891
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.290144e+06
+      GoRuntimeType: 1290144
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 968
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.767072e+06
+      GoRuntimeType: 1767072
       GoKind: 25
       RawFields:
         - Name: cause
@@ -26039,7 +26039,7 @@ Types:
         - Name: X
           Offset: 0
           Type: 7 BaseType int
-        - Name: Y
+        - Name: "Y"
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
@@ -26080,7 +26080,7 @@ Types:
       ID: 937
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.455584e+06
+      GoRuntimeType: 1455584
       GoKind: 25
       RawFields:
         - Name: error
@@ -26090,7 +26090,7 @@ Types:
       ID: 1120
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.687872e+06
+      GoRuntimeType: 1687872
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -26104,7 +26104,7 @@ Types:
       ID: 1146
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.133984e+06
+      GoRuntimeType: 1133984
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26117,7 +26117,7 @@ Types:
       ID: 1108
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.578848e+06
+      GoRuntimeType: 1578848
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -26133,13 +26133,13 @@ Types:
       ID: 1029
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.009152e+06
+      GoRuntimeType: 1009152
       GoKind: 10
     - __kind: StructureType
       ID: 995
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.89104e+06
+      GoRuntimeType: 1891040
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26155,7 +26155,7 @@ Types:
       ID: 852
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.61488e+06
+      GoRuntimeType: 1614880
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26248,7 +26248,7 @@ Types:
       ID: 856
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.456224e+06
+      GoRuntimeType: 1456224
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26264,7 +26264,7 @@ Types:
       ID: 844
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.451264e+06
+      GoRuntimeType: 1451264
       GoKind: 25
       RawFields:
         - Name: error
@@ -26278,7 +26278,7 @@ Types:
       ID: 1018
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.918816e+06
+      GoRuntimeType: 1918816
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26294,7 +26294,7 @@ Types:
       ID: 846
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.6144e+06
+      GoRuntimeType: 1614400
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26307,7 +26307,7 @@ Types:
       ID: 1160
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.976864e+06
+      GoRuntimeType: 1976864
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26324,7 +26324,7 @@ Types:
       ID: 935
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.576448e+06
+      GoRuntimeType: 1576448
       GoKind: 25
       RawFields:
         - Name: error
@@ -26349,14 +26349,14 @@ Types:
     - __kind: StructureType
       ID: 989
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.519648e+06
+      GoRuntimeType: 1519648
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 838
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.444544e+06
+      GoRuntimeType: 1444544
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26366,7 +26366,7 @@ Types:
       ID: 840
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.444704e+06
+      GoRuntimeType: 1444704
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26817,7 +26817,7 @@ Types:
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.861024e+06
+      GoRuntimeType: 1861024
       GoKind: 25
       RawFields:
         - Name: buf
@@ -26829,7 +26829,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -26854,7 +26854,7 @@ Types:
     - __kind: StructureType
       ID: 950
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.485408e+06
+      GoRuntimeType: 1485408
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -26865,7 +26865,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.219936e+06
+      GoRuntimeType: 1219936
       GoKind: 25
       RawFields:
         - Name: u
@@ -26875,7 +26875,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.649664e+06
+      GoRuntimeType: 1649664
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26891,7 +26891,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.499168e+06
+      GoRuntimeType: 1499168
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26904,7 +26904,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.499008e+06
+      GoRuntimeType: 1499008
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26917,7 +26917,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.499328e+06
+      GoRuntimeType: 1499328
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26961,7 +26961,7 @@ Types:
       ID: 907
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
-      GoRuntimeType: 1.567808e+06
+      GoRuntimeType: 1567808
       GoKind: 25
       RawFields:
         - Name: typ
@@ -26971,7 +26971,7 @@ Types:
       ID: 1268
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.482848e+06
+      GoRuntimeType: 1482848
       GoKind: 25
       RawFields:
         - Name: state
@@ -26988,7 +26988,7 @@ Types:
       ID: 1152
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.196768e+06
+      GoRuntimeType: 1196768
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27001,7 +27001,7 @@ Types:
       ID: 1187
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.029216e+06
+      GoRuntimeType: 1029216
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27014,7 +27014,7 @@ Types:
       ID: 1139
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.116576e+06
+      GoRuntimeType: 1116576
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27027,7 +27027,7 @@ Types:
       ID: 131
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.02896e+06
+      GoRuntimeType: 1028960
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27039,7 +27039,7 @@ Types:
     - __kind: StructureType
       ID: 1110
       Name: io.discard
-      GoRuntimeType: 1.471968e+06
+      GoRuntimeType: 1471968
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27109,7 +27109,7 @@ Types:
       ID: 166
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.027808e+06
+      GoRuntimeType: 1027808
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27122,7 +27122,7 @@ Types:
       ID: 128
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.622016e+06
+      GoRuntimeType: 1622016
       GoKind: 25
       RawFields:
         - Name: x
@@ -27138,7 +27138,7 @@ Types:
       ID: 143
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.193056e+06
+      GoRuntimeType: 1193056
       GoKind: 25
       RawFields:
         - Name: a
@@ -27148,7 +27148,7 @@ Types:
       ID: 379
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.192928e+06
+      GoRuntimeType: 1192928
       GoKind: 25
       RawFields:
         - Name: a
@@ -27162,7 +27162,7 @@ Types:
       ID: 150
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.192288e+06
+      GoRuntimeType: 1192288
       GoKind: 25
       RawFields:
         - Name: a
@@ -27172,7 +27172,7 @@ Types:
       ID: 1334
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.19216e+06
+      GoRuntimeType: 1192160
       GoKind: 25
       RawFields:
         - Name: a
@@ -27182,7 +27182,7 @@ Types:
       ID: 1349
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.192032e+06
+      GoRuntimeType: 1192032
       GoKind: 25
       RawFields:
         - Name: a
@@ -27192,7 +27192,7 @@ Types:
       ID: 132
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.194208e+06
+      GoRuntimeType: 1194208
       GoKind: 25
       RawFields:
         - Name: a
@@ -27202,7 +27202,7 @@ Types:
       ID: 134
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.19408e+06
+      GoRuntimeType: 1194080
       GoKind: 25
       RawFields:
         - Name: a
@@ -27216,7 +27216,7 @@ Types:
       ID: 136
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.19344e+06
+      GoRuntimeType: 1193440
       GoKind: 25
       RawFields:
         - Name: a
@@ -27226,7 +27226,7 @@ Types:
       ID: 1304
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.193312e+06
+      GoRuntimeType: 1193312
       GoKind: 25
       RawFields:
         - Name: a
@@ -27236,7 +27236,7 @@ Types:
       ID: 1306
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.193184e+06
+      GoRuntimeType: 1193184
       GoKind: 25
       RawFields:
         - Name: a
@@ -27246,7 +27246,7 @@ Types:
       ID: 137
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.19536e+06
+      GoRuntimeType: 1195360
       GoKind: 25
       RawFields:
         - Name: a
@@ -27256,7 +27256,7 @@ Types:
       ID: 369
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.195232e+06
+      GoRuntimeType: 1195232
       GoKind: 25
       RawFields:
         - Name: a
@@ -27270,7 +27270,7 @@ Types:
       ID: 142
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.194592e+06
+      GoRuntimeType: 1194592
       GoKind: 25
       RawFields:
         - Name: a
@@ -27280,7 +27280,7 @@ Types:
       ID: 1310
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.194464e+06
+      GoRuntimeType: 1194464
       GoKind: 25
       RawFields:
         - Name: a
@@ -27290,7 +27290,7 @@ Types:
       ID: 1316
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.194336e+06
+      GoRuntimeType: 1194336
       GoKind: 25
       RawFields:
         - Name: a
@@ -27305,7 +27305,7 @@ Types:
       ID: 164
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.84512e+06
+      GoRuntimeType: 1845120
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27327,7 +27327,7 @@ Types:
       ID: 159
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.978432e+06
+      GoRuntimeType: 1978432
       GoKind: 25
       RawFields:
         - Name: _
@@ -27355,7 +27355,7 @@ Types:
       ID: 357
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.420224e+06
+      GoRuntimeType: 1420224
       GoKind: 25
       RawFields:
         - Name: s
@@ -27698,7 +27698,7 @@ Types:
       ID: 123
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.471008e+06
+      GoRuntimeType: 1471008
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -27711,7 +27711,7 @@ Types:
       ID: 250
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.470688e+06
+      GoRuntimeType: 1470688
       GoKind: 25
       RawFields:
         - Name: val
@@ -27745,14 +27745,14 @@ Types:
       ID: 1278
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.420384e+06
+      GoRuntimeType: 1420384
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 162
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.027936e+06
+      GoRuntimeType: 1027936
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27805,7 +27805,7 @@ Types:
       ID: 168
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.191776e+06
+      GoRuntimeType: 1191776
       GoKind: 25
       RawFields:
         - Name: a
@@ -27875,7 +27875,7 @@ Types:
       ID: 169
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.191904e+06
+      GoRuntimeType: 1191904
       GoKind: 25
       RawFields:
         - Name: m
@@ -28989,119 +28989,119 @@ Types:
       ID: 227
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.136032e+06
+      GoRuntimeType: 1136032
       GoKind: 21
       HeaderType: 229 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 222
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.13616e+06
+      GoRuntimeType: 1136160
       GoKind: 21
       HeaderType: 224 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 190
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.136288e+06
+      GoRuntimeType: 1136288
       GoKind: 21
       HeaderType: 192 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 202
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.136416e+06
+      GoRuntimeType: 1136416
       GoKind: 21
       HeaderType: 204 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 144
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.135904e+06
+      GoRuntimeType: 1135904
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1288
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.135776e+06
+      GoRuntimeType: 1135776
       GoKind: 21
       HeaderType: 1290 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1322
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.135136e+06
+      GoRuntimeType: 1135136
       GoKind: 21
       HeaderType: 1324 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1337
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.135008e+06
+      GoRuntimeType: 1135008
       GoKind: 21
       HeaderType: 1339 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 170
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.134368e+06
+      GoRuntimeType: 1134368
       GoKind: 21
       HeaderType: 172 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 1352
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.13488e+06
+      GoRuntimeType: 1134880
       GoKind: 21
       HeaderType: 1354 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 237
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.136544e+06
+      GoRuntimeType: 1136544
       GoKind: 21
       HeaderType: 239 GoSwissMapHeaderType map<int,struct {}>
     - __kind: GoMapType
       ID: 207
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.136672e+06
+      GoRuntimeType: 1136672
       GoKind: 21
       HeaderType: 209 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 197
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.1368e+06
+      GoRuntimeType: 1136800
       GoKind: 21
       HeaderType: 199 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 185
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.136928e+06
+      GoRuntimeType: 1136928
       GoKind: 21
       HeaderType: 187 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 180
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.137056e+06
+      GoRuntimeType: 1137056
       GoKind: 21
       HeaderType: 182 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 175
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.137184e+06
+      GoRuntimeType: 1137184
       GoKind: 21
       HeaderType: 177 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 232
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 1.137312e+06
+      GoRuntimeType: 1137312
       GoKind: 21
       HeaderType: 234 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
@@ -29144,28 +29144,28 @@ Types:
       ID: 242
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.13744e+06
+      GoRuntimeType: 1137440
       GoKind: 21
       HeaderType: 244 GoSwissMapHeaderType map<struct {},struct {}>
     - __kind: GoMapType
       ID: 217
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.137568e+06
+      GoRuntimeType: 1137568
       GoKind: 21
       HeaderType: 219 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 212
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.137696e+06
+      GoRuntimeType: 1137696
       GoKind: 21
       HeaderType: 214 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
       ID: 772
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.436864e+06
+      GoRuntimeType: 1436864
       GoKind: 25
       RawFields:
         - Name: msg
@@ -29175,7 +29175,7 @@ Types:
       ID: 1074
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.433664e+06
+      GoRuntimeType: 1433664
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29189,7 +29189,7 @@ Types:
       ID: 1044
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.60496e+06
+      GoRuntimeType: 1604960
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29230,7 +29230,7 @@ Types:
       ID: 940
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.119904e+06
+      GoRuntimeType: 1119904
       GoKind: 24
       RawFields:
         - Name: str
@@ -29248,7 +29248,7 @@ Types:
     - __kind: StructureType
       ID: 905
       Name: net.canceledError
-      GoRuntimeType: 1.291296e+06
+      GoRuntimeType: 1291296
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29259,7 +29259,7 @@ Types:
       ID: 1049
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 2.116832e+06
+      GoRuntimeType: 2116832
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29281,13 +29281,13 @@ Types:
     - __kind: StructureType
       ID: 1235
       Name: net.noReadFrom
-      GoRuntimeType: 1.12016e+06
+      GoRuntimeType: 1120160
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1234
       Name: net.noWriteTo
-      GoRuntimeType: 1.120032e+06
+      GoRuntimeType: 1120032
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29298,7 +29298,7 @@ Types:
       ID: 704
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.739264e+06
+      GoRuntimeType: 1739264
       GoKind: 25
       RawFields:
         - Name: p
@@ -29314,7 +29314,7 @@ Types:
       ID: 1223
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.29984e+06
+      GoRuntimeType: 2299840
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29327,7 +29327,7 @@ Types:
       ID: 1221
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.299296e+06
+      GoRuntimeType: 2299296
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29352,7 +29352,7 @@ Types:
       ID: 1068
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.425184e+06
+      GoRuntimeType: 1425184
       GoKind: 25
       RawFields:
         - Name: w
@@ -29374,7 +29374,7 @@ Types:
       ID: 680
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.737536e+06
+      GoRuntimeType: 1737536
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -29390,7 +29390,7 @@ Types:
       ID: 999
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.909344e+06
+      GoRuntimeType: 1909344
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -29406,7 +29406,7 @@ Types:
       ID: 684
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.60448e+06
+      GoRuntimeType: 1604480
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29483,7 +29483,7 @@ Types:
     - __kind: StructureType
       ID: 901
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.290528e+06
+      GoRuntimeType: 1290528
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29513,7 +29513,7 @@ Types:
       ID: 1070
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
-      GoRuntimeType: 1.8352e+06
+      GoRuntimeType: 1835200
       GoKind: 25
       RawFields:
         - Name: group
@@ -29532,7 +29532,7 @@ Types:
       ID: 1161
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
-      GoRuntimeType: 1.424384e+06
+      GoRuntimeType: 1424384
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29552,7 +29552,7 @@ Types:
       ID: 897
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.563968e+06
+      GoRuntimeType: 1563968
       GoKind: 25
       RawFields:
         - Name: error
@@ -29566,7 +29566,7 @@ Types:
       ID: 1088
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.563808e+06
+      GoRuntimeType: 1563808
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29576,7 +29576,7 @@ Types:
       ID: 1122
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.810176e+06
+      GoRuntimeType: 1810176
       GoKind: 25
       RawFields:
         - Name: _
@@ -29592,7 +29592,7 @@ Types:
       ID: 688
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.426144e+06
+      GoRuntimeType: 1426144
       GoKind: 25
       RawFields:
         - Name: error
@@ -29605,14 +29605,14 @@ Types:
     - __kind: StructureType
       ID: 972
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.488288e+06
+      GoRuntimeType: 1488288
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 899
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.564128e+06
+      GoRuntimeType: 1564128
       GoKind: 25
       RawFields:
         - Name: err
@@ -29622,7 +29622,7 @@ Types:
       ID: 1164
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2.03584e+06
+      GoRuntimeType: 2035840
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29639,7 +29639,7 @@ Types:
       ID: 1186
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 2.051584e+06
+      GoRuntimeType: 2051584
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29653,7 +29653,7 @@ Types:
       ID: 764
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.742336e+06
+      GoRuntimeType: 1742336
       GoKind: 25
       RawFields:
         - Name: in
@@ -29669,7 +29669,7 @@ Types:
       ID: 762
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.6064e+06
+      GoRuntimeType: 1606400
       GoKind: 25
       RawFields:
         - Name: in
@@ -29686,7 +29686,7 @@ Types:
       ID: 1100
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.60832e+06
+      GoRuntimeType: 1608320
       GoKind: 25
       RawFields:
         - Name: c
@@ -30004,7 +30004,7 @@ Types:
       ID: 479
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.30256e+06
+      GoRuntimeType: 1302560
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30017,7 +30017,7 @@ Types:
       ID: 471
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.302816e+06
+      GoRuntimeType: 1302816
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30030,7 +30030,7 @@ Types:
       ID: 419
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.303072e+06
+      GoRuntimeType: 1303072
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30043,7 +30043,7 @@ Types:
       ID: 438
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.303328e+06
+      GoRuntimeType: 1303328
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30056,7 +30056,7 @@ Types:
       ID: 375
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.302304e+06
+      GoRuntimeType: 1302304
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30069,7 +30069,7 @@ Types:
       ID: 1296
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.302048e+06
+      GoRuntimeType: 1302048
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30082,7 +30082,7 @@ Types:
       ID: 1330
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.300768e+06
+      GoRuntimeType: 1300768
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30095,7 +30095,7 @@ Types:
       ID: 1345
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.300512e+06
+      GoRuntimeType: 1300512
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30108,7 +30108,7 @@ Types:
       ID: 387
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.299232e+06
+      GoRuntimeType: 1299232
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30121,7 +30121,7 @@ Types:
       ID: 1360
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.300256e+06
+      GoRuntimeType: 1300256
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30134,7 +30134,7 @@ Types:
       ID: 495
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
-      GoRuntimeType: 1.303584e+06
+      GoRuntimeType: 1303584
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30147,7 +30147,7 @@ Types:
       ID: 446
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.30384e+06
+      GoRuntimeType: 1303840
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30160,7 +30160,7 @@ Types:
       ID: 428
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.304096e+06
+      GoRuntimeType: 1304096
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30173,7 +30173,7 @@ Types:
       ID: 411
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.304352e+06
+      GoRuntimeType: 1304352
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30186,7 +30186,7 @@ Types:
       ID: 1056
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
-      GoRuntimeType: 1.365792e+06
+      GoRuntimeType: 1365792
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30199,7 +30199,7 @@ Types:
       ID: 403
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.304608e+06
+      GoRuntimeType: 1304608
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30212,7 +30212,7 @@ Types:
       ID: 395
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.304864e+06
+      GoRuntimeType: 1304864
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30225,7 +30225,7 @@ Types:
       ID: 487
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
-      GoRuntimeType: 1.30512e+06
+      GoRuntimeType: 1305120
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30310,7 +30310,7 @@ Types:
       ID: 503
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
-      GoRuntimeType: 1.305376e+06
+      GoRuntimeType: 1305376
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30323,7 +30323,7 @@ Types:
       ID: 462
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.305632e+06
+      GoRuntimeType: 1305632
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30336,7 +30336,7 @@ Types:
       ID: 454
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.305888e+06
+      GoRuntimeType: 1305888
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30349,7 +30349,7 @@ Types:
       ID: 481
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.302432e+06
+      GoRuntimeType: 1302432
       GoKind: 25
       RawFields:
         - Name: key
@@ -30362,7 +30362,7 @@ Types:
       ID: 473
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.302688e+06
+      GoRuntimeType: 1302688
       GoKind: 25
       RawFields:
         - Name: key
@@ -30375,7 +30375,7 @@ Types:
       ID: 421
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.302944e+06
+      GoRuntimeType: 1302944
       GoKind: 25
       RawFields:
         - Name: key
@@ -30388,7 +30388,7 @@ Types:
       ID: 440
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.3032e+06
+      GoRuntimeType: 1303200
       GoKind: 25
       RawFields:
         - Name: key
@@ -30401,7 +30401,7 @@ Types:
       ID: 377
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.302176e+06
+      GoRuntimeType: 1302176
       GoKind: 25
       RawFields:
         - Name: key
@@ -30414,7 +30414,7 @@ Types:
       ID: 1298
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.30192e+06
+      GoRuntimeType: 1301920
       GoKind: 25
       RawFields:
         - Name: key
@@ -30427,7 +30427,7 @@ Types:
       ID: 1332
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.30064e+06
+      GoRuntimeType: 1300640
       GoKind: 25
       RawFields:
         - Name: key
@@ -30440,7 +30440,7 @@ Types:
       ID: 1347
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.300384e+06
+      GoRuntimeType: 1300384
       GoKind: 25
       RawFields:
         - Name: key
@@ -30453,7 +30453,7 @@ Types:
       ID: 389
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.299104e+06
+      GoRuntimeType: 1299104
       GoKind: 25
       RawFields:
         - Name: key
@@ -30466,7 +30466,7 @@ Types:
       ID: 1362
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.300128e+06
+      GoRuntimeType: 1300128
       GoKind: 25
       RawFields:
         - Name: key
@@ -30479,7 +30479,7 @@ Types:
       ID: 497
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
-      GoRuntimeType: 1.303456e+06
+      GoRuntimeType: 1303456
       GoKind: 25
       RawFields:
         - Name: key
@@ -30492,7 +30492,7 @@ Types:
       ID: 448
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.303712e+06
+      GoRuntimeType: 1303712
       GoKind: 25
       RawFields:
         - Name: key
@@ -30505,7 +30505,7 @@ Types:
       ID: 430
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.303968e+06
+      GoRuntimeType: 1303968
       GoKind: 25
       RawFields:
         - Name: key
@@ -30518,7 +30518,7 @@ Types:
       ID: 413
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.304224e+06
+      GoRuntimeType: 1304224
       GoKind: 25
       RawFields:
         - Name: key
@@ -30531,7 +30531,7 @@ Types:
       ID: 1058
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
-      GoRuntimeType: 1.365664e+06
+      GoRuntimeType: 1365664
       GoKind: 25
       RawFields:
         - Name: key
@@ -30544,7 +30544,7 @@ Types:
       ID: 405
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.30448e+06
+      GoRuntimeType: 1304480
       GoKind: 25
       RawFields:
         - Name: key
@@ -30557,7 +30557,7 @@ Types:
       ID: 397
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.304736e+06
+      GoRuntimeType: 1304736
       GoKind: 25
       RawFields:
         - Name: key
@@ -30570,7 +30570,7 @@ Types:
       ID: 489
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
-      GoRuntimeType: 1.304992e+06
+      GoRuntimeType: 1304992
       GoKind: 25
       RawFields:
         - Name: key
@@ -30654,7 +30654,7 @@ Types:
     - __kind: StructureType
       ID: 505
       Name: noalg.struct { key struct {}; elem struct {} }
-      GoRuntimeType: 1.305248e+06
+      GoRuntimeType: 1305248
       GoKind: 25
       RawFields:
         - Name: key
@@ -30667,7 +30667,7 @@ Types:
       ID: 464
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.305504e+06
+      GoRuntimeType: 1305504
       GoKind: 25
       RawFields:
         - Name: key
@@ -30680,7 +30680,7 @@ Types:
       ID: 456
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.30576e+06
+      GoRuntimeType: 1305760
       GoKind: 25
       RawFields:
         - Name: key
@@ -30705,7 +30705,7 @@ Types:
       ID: 1245
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.370208e+06
+      GoRuntimeType: 2370208
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -30718,7 +30718,7 @@ Types:
       ID: 1243
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.369408e+06
+      GoRuntimeType: 2369408
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -30730,13 +30730,13 @@ Types:
     - __kind: StructureType
       ID: 1251
       Name: os.noReadFrom
-      GoRuntimeType: 1.1176e+06
+      GoRuntimeType: 1117600
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1250
       Name: os.noWriteTo
-      GoRuntimeType: 1.117472e+06
+      GoRuntimeType: 1117472
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -30755,7 +30755,7 @@ Types:
       ID: 911
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.712736e+06
+      GoRuntimeType: 1712736
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -30817,13 +30817,13 @@ Types:
       ID: 884
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.898208e+06
+      GoRuntimeType: 1898208
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
           Type: 12 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -30856,7 +30856,7 @@ Types:
       ID: 946
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.76304e+06
+      GoRuntimeType: 1763040
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30888,7 +30888,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.417024e+06
+      GoRuntimeType: 2417024
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31078,7 +31078,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.203552e+06
+      GoRuntimeType: 1203552
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -31088,7 +31088,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.924128e+06
+      GoRuntimeType: 1924128
       GoKind: 25
       RawFields:
         - Name: sp
@@ -31113,7 +31113,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.479968e+06
+      GoRuntimeType: 1479968
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31126,7 +31126,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.761888e+06
+      GoRuntimeType: 1761888
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31151,7 +31151,7 @@ Types:
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.479808e+06
+      GoRuntimeType: 1479808
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -31164,13 +31164,13 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.924896e+06
+      GoRuntimeType: 1924896
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -31195,7 +31195,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 2.42032e+06
+      GoRuntimeType: 2420320
       GoKind: 25
       RawFields:
         - Name: g0
@@ -31415,7 +31415,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.92464e+06
+      GoRuntimeType: 1924640
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31440,7 +31440,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.850048e+06
+      GoRuntimeType: 1850048
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31462,7 +31462,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.849824e+06
+      GoRuntimeType: 1849824
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -31484,7 +31484,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.479488e+06
+      GoRuntimeType: 1479488
       GoKind: 25
       RawFields:
         - Name: next
@@ -31503,7 +31503,7 @@ Types:
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.203296e+06
+      GoRuntimeType: 1203296
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -31514,7 +31514,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.479648e+06
+      GoRuntimeType: 1479648
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31527,13 +31527,13 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.762848e+06
+      GoRuntimeType: 1762848
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -31580,7 +31580,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.477728e+06
+      GoRuntimeType: 1477728
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31601,7 +31601,7 @@ Types:
       ID: 668
       Name: runtime.synctestDeadlockError
       ByteSize: 24
-      GoRuntimeType: 1.60416e+06
+      GoRuntimeType: 1604160
       GoKind: 25
       RawFields:
         - Name: reason
@@ -31634,7 +31634,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.478688e+06
+      GoRuntimeType: 1478688
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -31647,7 +31647,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.289504e+06
+      GoRuntimeType: 1289504
       GoKind: 8
     - __kind: StructureType
       ID: 82
@@ -31690,7 +31690,7 @@ Types:
       ID: 1082
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.463584e+06
+      GoRuntimeType: 1463584
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -31706,7 +31706,7 @@ Types:
       ID: 1266
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.472928e+06
+      GoRuntimeType: 1472928
       GoKind: 25
       RawFields:
         - Name: _
@@ -31719,7 +31719,7 @@ Types:
       ID: 1269
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.623936e+06
+      GoRuntimeType: 1623936
       GoKind: 25
       RawFields:
         - Name: _
@@ -31735,7 +31735,7 @@ Types:
       ID: 1272
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.623744e+06
+      GoRuntimeType: 1623744
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31757,7 +31757,7 @@ Types:
       ID: 1270
       Name: sync/atomic.Bool
       ByteSize: 4
-      GoRuntimeType: 1.474048e+06
+      GoRuntimeType: 1474048
       GoKind: 25
       RawFields:
         - Name: _
@@ -31770,7 +31770,7 @@ Types:
       ID: 1275
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.474208e+06
+      GoRuntimeType: 1474208
       GoKind: 25
       RawFields:
         - Name: _
@@ -31783,7 +31783,7 @@ Types:
       ID: 1273
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.62432e+06
+      GoRuntimeType: 1624320
       GoKind: 25
       RawFields:
         - Name: _
@@ -31811,7 +31811,7 @@ Types:
       ID: 996
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.289888e+06
+      GoRuntimeType: 1289888
       GoKind: 12
     - __kind: StructureType
       ID: 476
@@ -32469,7 +32469,7 @@ Types:
       ID: 939
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.717152e+06
+      GoRuntimeType: 1717152
       GoKind: 25
       RawFields:
         - Name: Name
@@ -32482,7 +32482,7 @@ Types:
       ID: 1162
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.925664e+06
+      GoRuntimeType: 1925664
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1014
@@ -32496,7 +32496,7 @@ Types:
       ID: 1012
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.38352e+06
+      GoRuntimeType: 2383520
       GoKind: 25
       RawFields:
         - Name: wall
@@ -32573,7 +32573,7 @@ Types:
       ID: 1032
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 2.073312e+06
+      GoRuntimeType: 2073312
       GoKind: 25
       RawFields:
         - Name: msg
@@ -32585,7 +32585,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 1034 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 7 BaseType int
         - Name: index
@@ -32607,13 +32607,13 @@ Types:
       ID: 1035
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
-      GoRuntimeType: 1.00032e+06
+      GoRuntimeType: 1000320
       GoKind: 9
     - __kind: StructureType
       ID: 1033
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.936672e+06
+      GoRuntimeType: 1936672
       GoKind: 25
       RawFields:
         - Name: id
@@ -32652,7 +32652,7 @@ Types:
       ID: 750
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.433984e+06
+      GoRuntimeType: 1433984
       GoKind: 25
       RawFields:
         - Name: Err
@@ -32668,7 +32668,7 @@ Types:
       ID: 916
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.712928e+06
+      GoRuntimeType: 1712928
       GoKind: 25
       RawFields:
         - Name: label

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -568,8 +568,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 86}
@@ -592,7 +592,7 @@ Probes:
                   EventExpressionIndex: 1
                 - ', '
                 - Error: failed to resolve reference "y"
-                  DSL: y
+                  DSL: "y"
     - id: testConflictingReturn
       version: 0
       type: LOG_PROBE
@@ -1705,8 +1705,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 53}
@@ -1727,8 +1727,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
     - id: testInlinedBBA
@@ -5459,8 +5459,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
         - ', '
         - json: {ref: z}
           dsl: z
@@ -5480,8 +5480,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
                 - ', '
@@ -6806,7 +6806,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 7 BaseType int
           Locations:
             - Range: 0xcea680..0xcea6a7
@@ -7345,7 +7345,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 17 BaseType float32
           Locations:
             - Range: 0xcecea0..0xcecea1
@@ -7376,7 +7376,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 17 BaseType float32
           Locations:
             - Range: 0xcecee0..0xcecee1
@@ -9554,7 +9554,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcf0860..0xcf0861
@@ -11344,7 +11344,7 @@ Types:
       ID: 1195
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.017568e+06
+      GoRuntimeType: 2017568
       GoKind: 22
       Pointee: 1196 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
@@ -11363,7 +11363,7 @@ Types:
       ID: 1129
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.45424e+06
+      GoRuntimeType: 1454240
       GoKind: 22
       Pointee: 1130 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
@@ -11384,21 +11384,21 @@ Types:
       ID: 1172
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.9336e+06
+      GoRuntimeType: 1933600
       GoKind: 22
       Pointee: 1173 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 1105
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.071488e+06
+      GoRuntimeType: 1071488
       GoKind: 22
       Pointee: 1106 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 1107
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.071744e+06
+      GoRuntimeType: 1071744
       GoKind: 22
       Pointee: 1108 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
@@ -11412,21 +11412,21 @@ Types:
       ID: 1153
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.207648e+06
+      GoRuntimeType: 2207648
       GoKind: 22
       Pointee: 1154 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1184
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.980128e+06
+      GoRuntimeType: 1980128
       GoKind: 22
       Pointee: 1185 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1231
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.309632e+06
+      GoRuntimeType: 2309632
       GoKind: 22
       Pointee: 1232 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -11459,7 +11459,7 @@ Types:
       ID: 1127
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.44304e+06
+      GoRuntimeType: 1443040
       GoKind: 22
       Pointee: 1128 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
@@ -11473,14 +11473,14 @@ Types:
       ID: 1149
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.752736e+06
+      GoRuntimeType: 1752736
       GoKind: 22
       Pointee: 1150 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 977
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.218304e+06
+      GoRuntimeType: 1218304
       GoKind: 22
       Pointee: 978 StructureType context.deadlineExceededError
     - __kind: PointerType
@@ -11508,49 +11508,49 @@ Types:
       ID: 1144
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
-      GoRuntimeType: 1.69328e+06
+      GoRuntimeType: 1693280
       GoKind: 22
       Pointee: 1145 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
       ID: 926
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
-      GoRuntimeType: 1.079296e+06
+      GoRuntimeType: 1079296
       GoKind: 22
       Pointee: 927 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
       ID: 1174
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.934112e+06
+      GoRuntimeType: 1934112
       GoKind: 22
       Pointee: 1175 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
       ID: 1206
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
-      GoRuntimeType: 2.151648e+06
+      GoRuntimeType: 2151648
       GoKind: 22
       Pointee: 1207 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
       ID: 1180
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.93488e+06
+      GoRuntimeType: 1934880
       GoKind: 22
       Pointee: 1181 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
       ID: 1176
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.934368e+06
+      GoRuntimeType: 1934368
       GoKind: 22
       Pointee: 1177 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
       ID: 1170
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.931552e+06
+      GoRuntimeType: 1931552
       GoKind: 22
       Pointee: 1171 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
@@ -11564,21 +11564,21 @@ Types:
       ID: 1193
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 2.015264e+06
+      GoRuntimeType: 2015264
       GoKind: 22
       Pointee: 1194 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1178
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
-      GoRuntimeType: 1.934624e+06
+      GoRuntimeType: 1934624
       GoKind: 22
       Pointee: 1179 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
       ID: 1162
       Name: '*crypto/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.836288e+06
+      GoRuntimeType: 1836288
       GoKind: 22
       Pointee: 1163 UnresolvedPointeeType crypto/sha3.SHAKE
     - __kind: PointerType
@@ -11592,14 +11592,14 @@ Types:
       ID: 915
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.060736e+06
+      GoRuntimeType: 1060736
       GoKind: 22
       Pointee: 916 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1257
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.412352e+06
+      GoRuntimeType: 2412352
       GoKind: 22
       Pointee: 1258 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
@@ -11620,14 +11620,14 @@ Types:
       ID: 914
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.059072e+06
+      GoRuntimeType: 1059072
       GoKind: 22
       Pointee: 869 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 1137
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.582112e+06
+      GoRuntimeType: 1582112
       GoKind: 22
       Pointee: 1138 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
@@ -11641,21 +11641,21 @@ Types:
       ID: 1142
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.66736e+06
+      GoRuntimeType: 1667360
       GoKind: 22
       Pointee: 1143 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 1012
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.44352e+06
+      GoRuntimeType: 1443520
       GoKind: 22
       Pointee: 1013 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 1029
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.043904e+06
+      GoRuntimeType: 2043904
       GoKind: 22
       Pointee: 1030 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
@@ -11690,7 +11690,7 @@ Types:
       ID: 920
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.065984e+06
+      GoRuntimeType: 1065984
       GoKind: 22
       Pointee: 921 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
@@ -11739,7 +11739,7 @@ Types:
       ID: 1095
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.056512e+06
+      GoRuntimeType: 1056512
       GoKind: 22
       Pointee: 1096 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -11760,7 +11760,7 @@ Types:
       ID: 904
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.052672e+06
+      GoRuntimeType: 1052672
       GoKind: 22
       Pointee: 905 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
@@ -11795,7 +11795,7 @@ Types:
       ID: 1237
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.330752e+06
+      GoRuntimeType: 2330752
       GoKind: 22
       Pointee: 1238 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
@@ -11809,7 +11809,7 @@ Types:
       ID: 1103
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.068288e+06
+      GoRuntimeType: 1068288
       GoKind: 22
       Pointee: 1104 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
@@ -11837,7 +11837,7 @@ Types:
       ID: 871
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1.036928e+06
+      GoRuntimeType: 1036928
       GoKind: 22
       Pointee: 872 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -11858,21 +11858,21 @@ Types:
       ID: 1225
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.292192e+06
+      GoRuntimeType: 2292192
       GoKind: 22
       Pointee: 1226 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 873
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.037056e+06
+      GoRuntimeType: 1037056
       GoKind: 22
       Pointee: 874 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 875
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.037184e+06
+      GoRuntimeType: 1037184
       GoKind: 22
       Pointee: 876 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -11957,14 +11957,14 @@ Types:
       ID: 1115
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.223808e+06
+      GoRuntimeType: 1223808
       GoKind: 22
       Pointee: 1116 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1203
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 2.089376e+06
+      GoRuntimeType: 2089376
       GoKind: 22
       Pointee: 1204 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
@@ -11978,14 +11978,14 @@ Types:
       ID: 986
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.227264e+06
+      GoRuntimeType: 1227264
       GoKind: 22
       Pointee: 987 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1233
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.31072e+06
+      GoRuntimeType: 2310720
       GoKind: 22
       Pointee: 1234 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
@@ -12137,7 +12137,7 @@ Types:
       ID: 1156
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.830912e+06
+      GoRuntimeType: 1830912
       GoKind: 22
       Pointee: 1157 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
@@ -12151,21 +12151,21 @@ Types:
       ID: 1135
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.580832e+06
+      GoRuntimeType: 1580832
       GoKind: 22
       Pointee: 1136 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 1091
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.05536e+06
+      GoRuntimeType: 1055360
       GoKind: 22
       Pointee: 1092 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1125
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.44112e+06
+      GoRuntimeType: 1441120
       GoKind: 22
       Pointee: 1126 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
@@ -12179,28 +12179,28 @@ Types:
       ID: 1191
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 2.007488e+06
+      GoRuntimeType: 2007488
       GoKind: 22
       Pointee: 1192 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1210
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.165824e+06
+      GoRuntimeType: 2165824
       GoKind: 22
       Pointee: 1205 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1209
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.16544e+06
+      GoRuntimeType: 2165440
       GoKind: 22
       Pointee: 1208 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 1093
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.055488e+06
+      GoRuntimeType: 1055488
       GoKind: 22
       Pointee: 1094 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
@@ -12221,70 +12221,70 @@ Types:
       ID: 1158
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.832704e+06
+      GoRuntimeType: 1832704
       GoKind: 22
       Pointee: 1159 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1199
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.043616e+06
+      GoRuntimeType: 2043616
       GoKind: 22
       Pointee: 1200 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1201
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.074688e+06
+      GoRuntimeType: 2074688
       GoKind: 22
       Pointee: 1202 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 1017
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.45664e+06
+      GoRuntimeType: 1456640
       GoKind: 22
       Pointee: 1018 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 930
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.080064e+06
+      GoRuntimeType: 1080064
       GoKind: 22
       Pointee: 931 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 928
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.079936e+06
+      GoRuntimeType: 1079936
       GoKind: 22
       Pointee: 929 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 932
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.084032e+06
+      GoRuntimeType: 1084032
       GoKind: 22
       Pointee: 933 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 934
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.08416e+06
+      GoRuntimeType: 1084160
       GoKind: 22
       Pointee: 935 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 1146
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.69616e+06
+      GoRuntimeType: 1696160
       GoKind: 22
       Pointee: 1147 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 922
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.066496e+06
+      GoRuntimeType: 1066496
       GoKind: 22
       Pointee: 923 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
@@ -12298,112 +12298,112 @@ Types:
       ID: 1249
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.38608e+06
+      GoRuntimeType: 2386080
       GoKind: 22
       Pointee: 1250 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 988
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.236352e+06
+      GoRuntimeType: 1236352
       GoKind: 22
       Pointee: 989 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 961
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.214848e+06
+      GoRuntimeType: 1214848
       GoKind: 22
       Pointee: 962 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 955
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.214464e+06
+      GoRuntimeType: 1214464
       GoKind: 22
       Pointee: 956 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 890
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.046528e+06
+      GoRuntimeType: 1046528
       GoKind: 22
       Pointee: 891 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 967
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.215232e+06
+      GoRuntimeType: 1215232
       GoKind: 22
       Pointee: 968 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 889
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1.0464e+06
+      GoRuntimeType: 1046400
       GoKind: 22
       Pointee: 868 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 959
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.21472e+06
+      GoRuntimeType: 1214720
       GoKind: 22
       Pointee: 960 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 957
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.214592e+06
+      GoRuntimeType: 1214592
       GoKind: 22
       Pointee: 958 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 965
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.215104e+06
+      GoRuntimeType: 1215104
       GoKind: 22
       Pointee: 966 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 963
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.214976e+06
+      GoRuntimeType: 1214976
       GoKind: 22
       Pointee: 964 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1253
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.40032e+06
+      GoRuntimeType: 2400320
       GoKind: 22
       Pointee: 1254 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 971
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.215616e+06
+      GoRuntimeType: 1215616
       GoKind: 22
       Pointee: 972 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 894
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1.046784e+06
+      GoRuntimeType: 1046784
       GoKind: 22
       Pointee: 895 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 892
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1.046656e+06
+      GoRuntimeType: 1046656
       GoKind: 22
       Pointee: 893 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 969
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.215488e+06
+      GoRuntimeType: 1215488
       GoKind: 22
       Pointee: 970 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -12466,35 +12466,35 @@ Types:
       ID: 1032
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.694624e+06
+      GoRuntimeType: 1694624
       GoKind: 22
       Pointee: 1033 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 938
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.09888e+06
+      GoRuntimeType: 1098880
       GoKind: 22
       Pointee: 939 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 1121
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.277184e+06
+      GoRuntimeType: 1277184
       GoKind: 22
       Pointee: 1122 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1215
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.180416e+06
+      GoRuntimeType: 2180416
       GoKind: 22
       Pointee: 1216 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 1109
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.101184e+06
+      GoRuntimeType: 1101184
       GoKind: 22
       Pointee: 1110 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
@@ -12508,7 +12508,7 @@ Types:
       ID: 996
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.278848e+06
+      GoRuntimeType: 1278848
       GoKind: 22
       Pointee: 997 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
@@ -12570,7 +12570,7 @@ Types:
       ID: 1213
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.178496e+06
+      GoRuntimeType: 2178496
       GoKind: 22
       Pointee: 1214 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -12598,14 +12598,14 @@ Types:
       ID: 994
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.275904e+06
+      GoRuntimeType: 1275904
       GoKind: 22
       Pointee: 995 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 1019
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.464e+06
+      GoRuntimeType: 1464000
       GoKind: 22
       Pointee: 1020 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
@@ -12619,21 +12619,21 @@ Types:
       ID: 1164
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.838528e+06
+      GoRuntimeType: 1838528
       GoKind: 22
       Pointee: 1165 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 1119
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.272448e+06
+      GoRuntimeType: 1272448
       GoKind: 22
       Pointee: 1120 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 936
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.09312e+06
+      GoRuntimeType: 1093120
       GoKind: 22
       Pointee: 937 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
@@ -12654,21 +12654,21 @@ Types:
       ID: 924
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.069824e+06
+      GoRuntimeType: 1069824
       GoKind: 22
       Pointee: 925 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 992
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.243136e+06
+      GoRuntimeType: 1243136
       GoKind: 22
       Pointee: 993 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 990
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.24288e+06
+      GoRuntimeType: 1242880
       GoKind: 22
       Pointee: 991 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
@@ -12696,7 +12696,7 @@ Types:
       ID: 1168
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.929504e+06
+      GoRuntimeType: 1929504
       GoKind: 22
       Pointee: 1169 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
@@ -12752,7 +12752,7 @@ Types:
       ID: 1021
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 2.227584e+06
+      GoRuntimeType: 2227584
       GoKind: 22
       Pointee: 1022 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
@@ -12780,21 +12780,21 @@ Types:
       ID: 953
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.213696e+06
+      GoRuntimeType: 1213696
       GoKind: 22
       Pointee: 954 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1255
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.405984e+06
+      GoRuntimeType: 2405984
       GoKind: 22
       Pointee: 1256 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 951
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.213568e+06
+      GoRuntimeType: 1213568
       GoKind: 22
       Pointee: 952 StructureType internal/poll.errNetClosing
     - __kind: PointerType
@@ -12808,7 +12808,7 @@ Types:
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
       ByteSize: 8
-      GoRuntimeType: 1.596512e+06
+      GoRuntimeType: 1596512
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
@@ -12827,7 +12827,7 @@ Types:
       ID: 908
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.057408e+06
+      GoRuntimeType: 1057408
       GoKind: 22
       Pointee: 909 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
@@ -12841,35 +12841,35 @@ Types:
       ID: 1113
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.204864e+06
+      GoRuntimeType: 1204864
       GoKind: 22
       Pointee: 1114 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1111
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.20448e+06
+      GoRuntimeType: 1204480
       GoKind: 22
       Pointee: 1112 StructureType io.discard
     - __kind: PointerType
       ID: 1085
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.037952e+06
+      GoRuntimeType: 1037952
       GoKind: 22
       Pointee: 1086 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 949
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.213056e+06
+      GoRuntimeType: 1213056
       GoKind: 22
       Pointee: 950 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 1160
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.832928e+06
+      GoRuntimeType: 1832928
       GoKind: 22
       Pointee: 1161 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13276,63 +13276,63 @@ Types:
       ID: 980
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.221632e+06
+      GoRuntimeType: 1221632
       GoKind: 22
       Pointee: 981 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1006
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.43936e+06
+      GoRuntimeType: 1439360
       GoKind: 22
       Pointee: 1007 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1219
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.266304e+06
+      GoRuntimeType: 2266304
       GoKind: 22
       Pointee: 1220 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 1004
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.43904e+06
+      GoRuntimeType: 1439040
       GoKind: 22
       Pointee: 1005 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 982
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.22176e+06
+      GoRuntimeType: 1221760
       GoKind: 22
       Pointee: 983 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1229
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.293216e+06
+      GoRuntimeType: 2293216
       GoKind: 22
       Pointee: 1230 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1239
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.338336e+06
+      GoRuntimeType: 2338336
       GoKind: 22
       Pointee: 1240 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1227
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.292704e+06
+      GoRuntimeType: 2292704
       GoKind: 22
       Pointee: 1228 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 979
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.220864e+06
+      GoRuntimeType: 1220864
       GoKind: 22
       Pointee: 942 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13344,28 +13344,28 @@ Types:
       ID: 906
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.053568e+06
+      GoRuntimeType: 1053568
       GoKind: 22
       Pointee: 907 StructureType net.canceledError
     - __kind: PointerType
       ID: 1197
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2.040736e+06
+      GoRuntimeType: 2040736
       GoKind: 22
       Pointee: 1198 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1050
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.876608e+06
+      GoRuntimeType: 1876608
       GoKind: 22
       Pointee: 1051 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1241
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.342592e+06
+      GoRuntimeType: 2342592
       GoKind: 22
       Pointee: 1242 UnresolvedPointeeType net.netFD
     - __kind: PointerType
@@ -13386,35 +13386,35 @@ Types:
       ID: 1223
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.279232e+06
+      GoRuntimeType: 2279232
       GoKind: 22
       Pointee: 1224 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1221
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.278752e+06
+      GoRuntimeType: 2278752
       GoKind: 22
       Pointee: 1222 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 984
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.2224e+06
+      GoRuntimeType: 1222400
       GoKind: 22
       Pointee: 985 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1008
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.43952e+06
+      GoRuntimeType: 1439520
       GoKind: 22
       Pointee: 1009 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 896
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1.049344e+06
+      GoRuntimeType: 1049344
       GoKind: 22
       Pointee: 897 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
@@ -13442,7 +13442,7 @@ Types:
       ID: 1000
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.43504e+06
+      GoRuntimeType: 1435040
       GoKind: 22
       Pointee: 1001 StructureType net/http.http2StreamError
     - __kind: PointerType
@@ -13456,7 +13456,7 @@ Types:
       ID: 1131
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.576992e+06
+      GoRuntimeType: 1576992
       GoKind: 22
       Pointee: 1132 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
@@ -13499,21 +13499,21 @@ Types:
       ID: 975
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.217536e+06
+      GoRuntimeType: 1217536
       GoKind: 22
       Pointee: 976 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 902
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1.049856e+06
+      GoRuntimeType: 1049856
       GoKind: 22
       Pointee: 903 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1186
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.98192e+06
+      GoRuntimeType: 1981920
       GoKind: 22
       Pointee: 1187 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
@@ -13539,28 +13539,28 @@ Types:
       ID: 898
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1.0496e+06
+      GoRuntimeType: 1049600
       GoKind: 22
       Pointee: 899 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1133
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.228416e+06
+      GoRuntimeType: 2228416
       GoKind: 22
       Pointee: 1134 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1089
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1.049472e+06
+      GoRuntimeType: 1049472
       GoKind: 22
       Pointee: 1090 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 1123
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.4352e+06
+      GoRuntimeType: 1435200
       GoKind: 22
       Pointee: 1124 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
@@ -13574,28 +13574,28 @@ Types:
       ID: 1002
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.43632e+06
+      GoRuntimeType: 1436320
       GoKind: 22
       Pointee: 1003 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 973
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.217408e+06
+      GoRuntimeType: 1217408
       GoKind: 22
       Pointee: 974 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 900
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1.049728e+06
+      GoRuntimeType: 1049728
       GoKind: 22
       Pointee: 901 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1166
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1.8728e+06
+      GoRuntimeType: 1872800
       GoKind: 22
       Pointee: 1167 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
@@ -13609,14 +13609,14 @@ Types:
       ID: 1188
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.983712e+06
+      GoRuntimeType: 1983712
       GoKind: 22
       Pointee: 1189 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 1099
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.06176e+06
+      GoRuntimeType: 1061760
       GoKind: 22
       Pointee: 1100 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
@@ -13637,14 +13637,14 @@ Types:
       ID: 1139
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 2.15024e+06
+      GoRuntimeType: 2150240
       GoKind: 22
       Pointee: 1140 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 1101
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.066112e+06
+      GoRuntimeType: 1066112
       GoKind: 22
       Pointee: 1102 StructureType net/smtp.dataCloser
     - __kind: PointerType
@@ -13670,14 +13670,14 @@ Types:
       ID: 1097
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.061248e+06
+      GoRuntimeType: 1061248
       GoKind: 22
       Pointee: 1098 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 1010
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.43984e+06
+      GoRuntimeType: 1439840
       GoKind: 22
       Pointee: 1011 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
@@ -13843,63 +13843,63 @@ Types:
       ID: 1247
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.380704e+06
+      GoRuntimeType: 2380704
       GoKind: 22
       Pointee: 1248 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 879
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 1.04064e+06
+      GoRuntimeType: 1040640
       GoKind: 22
       Pointee: 880 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 945
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.206144e+06
+      GoRuntimeType: 1206144
       GoKind: 22
       Pointee: 946 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1245
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.379968e+06
+      GoRuntimeType: 2379968
       GoKind: 22
       Pointee: 1246 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1243
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.379232e+06
+      GoRuntimeType: 2379232
       GoKind: 22
       Pointee: 1244 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 910
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.057792e+06
+      GoRuntimeType: 1057792
       GoKind: 22
       Pointee: 911 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 1053
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 2.121152e+06
+      GoRuntimeType: 2121152
       GoKind: 22
       Pointee: 1054 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 1117
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.228672e+06
+      GoRuntimeType: 1228672
       GoKind: 22
       Pointee: 1118 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 912
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.05792e+06
+      GoRuntimeType: 1057920
       GoKind: 22
       Pointee: 913 StructureType os/exec.wrappedError
     - __kind: PointerType
@@ -13939,14 +13939,14 @@ Types:
       ID: 883
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1.043456e+06
+      GoRuntimeType: 1043456
       GoKind: 22
       Pointee: 884 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 887
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1.044096e+06
+      GoRuntimeType: 1044096
       GoKind: 22
       Pointee: 888 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
@@ -13960,14 +13960,14 @@ Types:
       ID: 25
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.43296e+06
+      GoRuntimeType: 1432960
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 885
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1.043584e+06
+      GoRuntimeType: 1043584
       GoKind: 22
       Pointee: 886 StructureType runtime.boundsError
     - __kind: PointerType
@@ -13988,14 +13988,14 @@ Types:
       ID: 947
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.212032e+06
+      GoRuntimeType: 1212032
       GoKind: 22
       Pointee: 948 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 881
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1.041792e+06
+      GoRuntimeType: 1041792
       GoKind: 22
       Pointee: 862 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14007,28 +14007,28 @@ Types:
       ID: 59
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 1.210752e+06
+      GoRuntimeType: 1210752
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.4336e+06
+      GoRuntimeType: 1433600
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 68
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.0432e+06
+      GoRuntimeType: 1043200
       GoKind: 22
       Pointee: 370 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 882
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1.04192e+06
+      GoRuntimeType: 1041920
       GoKind: 22
       Pointee: 865 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14047,7 +14047,7 @@ Types:
       ID: 50
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.574272e+06
+      GoRuntimeType: 1574272
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
@@ -14061,14 +14061,14 @@ Types:
       ID: 45
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.086176e+06
+      GoRuntimeType: 2086176
       GoKind: 22
       Pointee: 46 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 83
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.645472e+06
+      GoRuntimeType: 1645472
       GoKind: 22
       Pointee: 84 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -14082,7 +14082,7 @@ Types:
       ID: 877
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 1.039488e+06
+      GoRuntimeType: 1039488
       GoKind: 22
       Pointee: 878 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
@@ -14101,14 +14101,14 @@ Types:
       ID: 1182
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.979616e+06
+      GoRuntimeType: 1979616
       GoKind: 22
       Pointee: 1183 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 1087
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 1.039616e+06
+      GoRuntimeType: 1039616
       GoKind: 22
       Pointee: 1088 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
@@ -14129,7 +14129,7 @@ Types:
       ID: 999
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.43456e+06
+      GoRuntimeType: 1434560
       GoKind: 22
       Pointee: 998 BaseType syscall.Errno
     - __kind: PointerType
@@ -14271,21 +14271,21 @@ Types:
       ID: 1217
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.19264e+06
+      GoRuntimeType: 2192640
       GoKind: 22
       Pointee: 1218 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 940
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.10272e+06
+      GoRuntimeType: 1102720
       GoKind: 22
       Pointee: 941 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 1015
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.65008e+06
+      GoRuntimeType: 1650080
       GoKind: 22
       Pointee: 1016 UnresolvedPointeeType time.Location
     - __kind: PointerType
@@ -14367,7 +14367,7 @@ Types:
       ID: 1211
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.168128e+06
+      GoRuntimeType: 2168128
       GoKind: 22
       Pointee: 1212 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -14388,14 +14388,14 @@ Types:
       ID: 917
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.061504e+06
+      GoRuntimeType: 1061504
       GoKind: 22
       Pointee: 918 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 919
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.061632e+06
+      GoRuntimeType: 1061632
       GoKind: 22
       Pointee: 870 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -16960,14 +16960,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16982,14 +16982,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 25
           Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22730,14 +22730,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22763,14 +22763,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -24736,7 +24736,7 @@ Types:
     - __kind: StructureType
       ID: 1080
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.134848e+06
+      GoRuntimeType: 1134848
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24747,7 +24747,7 @@ Types:
       ID: 1106
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.588192e+06
+      GoRuntimeType: 1588192
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -24837,7 +24837,7 @@ Types:
     - __kind: StructureType
       ID: 978
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.500672e+06
+      GoRuntimeType: 1500672
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -24865,7 +24865,7 @@ Types:
     - __kind: StructureType
       ID: 927
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
-      GoRuntimeType: 1.306816e+06
+      GoRuntimeType: 1306816
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24928,7 +24928,7 @@ Types:
       ID: 747
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.758112e+06
+      GoRuntimeType: 1758112
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -24944,7 +24944,7 @@ Types:
       ID: 869
       Name: crypto/tls.alert
       ByteSize: 1
-      GoRuntimeType: 1.007744e+06
+      GoRuntimeType: 1007744
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1138
@@ -24970,7 +24970,7 @@ Types:
       ID: 818
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.760992e+06
+      GoRuntimeType: 1760992
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -24985,14 +24985,14 @@ Types:
     - __kind: StructureType
       ID: 812
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.132288e+06
+      GoRuntimeType: 1132288
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 814
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.623424e+06
+      GoRuntimeType: 1623424
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -25017,7 +25017,7 @@ Types:
       ID: 921
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.584032e+06
+      GoRuntimeType: 1584032
       GoKind: 25
       RawFields:
         - Name: Err
@@ -25026,14 +25026,14 @@ Types:
     - __kind: StructureType
       ID: 820
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.132544e+06
+      GoRuntimeType: 1132544
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 816
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.7608e+06
+      GoRuntimeType: 1760800
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25049,7 +25049,7 @@ Types:
       ID: 834
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.45488e+06
+      GoRuntimeType: 1454880
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25059,7 +25059,7 @@ Types:
       ID: 838
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.45504e+06
+      GoRuntimeType: 1455040
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25117,7 +25117,7 @@ Types:
       ID: 707
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.43808e+06
+      GoRuntimeType: 1438080
       GoKind: 25
       RawFields:
         - Name: error
@@ -25135,7 +25135,7 @@ Types:
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.041664e+06
+      GoRuntimeType: 1041664
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25229,7 +25229,7 @@ Types:
       ID: 716
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.75696e+06
+      GoRuntimeType: 1756960
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25252,7 +25252,7 @@ Types:
     - __kind: StructureType
       ID: 722
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.128576e+06
+      GoRuntimeType: 1128576
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25282,7 +25282,7 @@ Types:
       ID: 1038
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.252672e+06
+      GoRuntimeType: 2252672
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25398,7 +25398,7 @@ Types:
     - __kind: StructureType
       ID: 767
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.13152e+06
+      GoRuntimeType: 1131520
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25410,14 +25410,14 @@ Types:
     - __kind: StructureType
       ID: 765
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.131392e+06
+      GoRuntimeType: 1131392
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 763
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.621344e+06
+      GoRuntimeType: 1621344
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25430,7 +25430,7 @@ Types:
       ID: 783
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.622144e+06
+      GoRuntimeType: 1622144
       GoKind: 25
       RawFields:
         - Name: File
@@ -25443,7 +25443,7 @@ Types:
       ID: 787
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.760224e+06
+      GoRuntimeType: 1760224
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25459,7 +25459,7 @@ Types:
       ID: 785
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.44784e+06
+      GoRuntimeType: 1447840
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25469,7 +25469,7 @@ Types:
       ID: 781
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.44752e+06
+      GoRuntimeType: 1447520
       GoKind: 25
       RawFields:
         - Name: File
@@ -25479,14 +25479,14 @@ Types:
       ID: 1024
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.521472e+06
+      GoRuntimeType: 1521472
       GoKind: 21
       HeaderType: 1026 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 1047
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.065088e+06
+      GoRuntimeType: 1065088
       GoKind: 23
       RawFields:
         - Name: array
@@ -25509,7 +25509,7 @@ Types:
       ID: 795
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.622464e+06
+      GoRuntimeType: 1622464
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25522,7 +25522,7 @@ Types:
       ID: 789
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.448e+06
+      GoRuntimeType: 1448000
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25532,7 +25532,7 @@ Types:
       ID: 793
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.760416e+06
+      GoRuntimeType: 1760416
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25548,7 +25548,7 @@ Types:
       ID: 791
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.622304e+06
+      GoRuntimeType: 1622304
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25561,7 +25561,7 @@ Types:
       ID: 797
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.44816e+06
+      GoRuntimeType: 1448160
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25571,7 +25571,7 @@ Types:
       ID: 803
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.622784e+06
+      GoRuntimeType: 1622784
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25584,7 +25584,7 @@ Types:
       ID: 805
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.44848e+06
+      GoRuntimeType: 1448480
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25594,7 +25594,7 @@ Types:
       ID: 801
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.622624e+06
+      GoRuntimeType: 1622624
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25607,7 +25607,7 @@ Types:
       ID: 799
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.44832e+06
+      GoRuntimeType: 1448320
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25617,7 +25617,7 @@ Types:
       ID: 807
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.622944e+06
+      GoRuntimeType: 1622944
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25630,7 +25630,7 @@ Types:
       ID: 724
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.44032e+06
+      GoRuntimeType: 1440320
       GoKind: 25
       RawFields:
         - Name: message
@@ -25644,7 +25644,7 @@ Types:
       ID: 726
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.44048e+06
+      GoRuntimeType: 1440480
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25666,7 +25666,7 @@ Types:
       ID: 730
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.4408e+06
+      GoRuntimeType: 1440800
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25680,7 +25680,7 @@ Types:
       ID: 1205
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 2.139008e+06
+      GoRuntimeType: 2139008
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25693,7 +25693,7 @@ Types:
       ID: 1208
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.165056e+06
+      GoRuntimeType: 2165056
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25713,7 +25713,7 @@ Types:
       ID: 728
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.44064e+06
+      GoRuntimeType: 1440640
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25723,7 +25723,7 @@ Types:
       ID: 732
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.44096e+06
+      GoRuntimeType: 1440960
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25773,7 +25773,7 @@ Types:
       ID: 738
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.44192e+06
+      GoRuntimeType: 1441920
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -25788,7 +25788,7 @@ Types:
       ID: 962
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.871008e+06
+      GoRuntimeType: 1871008
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -25808,7 +25808,7 @@ Types:
       ID: 891
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.729664e+06
+      GoRuntimeType: 1729664
       GoKind: 25
       RawFields:
         - Name: Got
@@ -25821,7 +25821,7 @@ Types:
       ID: 968
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.871456e+06
+      GoRuntimeType: 1871456
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25837,13 +25837,13 @@ Types:
       ID: 868
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 1.005056e+06
+      GoRuntimeType: 1005056
       GoKind: 8
     - __kind: StructureType
       ID: 960
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.870784e+06
+      GoRuntimeType: 1870784
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -25865,7 +25865,7 @@ Types:
       ID: 958
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.87056e+06
+      GoRuntimeType: 1870560
       GoKind: 25
       RawFields:
         - Name: Method
@@ -25881,7 +25881,7 @@ Types:
       ID: 966
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.78512e+06
+      GoRuntimeType: 1785120
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25894,7 +25894,7 @@ Types:
       ID: 964
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.871232e+06
+      GoRuntimeType: 1871232
       GoKind: 25
       RawFields:
         - Name: Value
@@ -25914,7 +25914,7 @@ Types:
       ID: 972
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.65104e+06
+      GoRuntimeType: 1651040
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -25923,20 +25923,20 @@ Types:
     - __kind: StructureType
       ID: 895
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.300288e+06
+      GoRuntimeType: 1300288
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 893
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.30016e+06
+      GoRuntimeType: 1300160
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 970
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.785312e+06
+      GoRuntimeType: 1785312
       GoKind: 25
       RawFields:
         - Name: cause
@@ -26019,7 +26019,7 @@ Types:
         - Name: X
           Offset: 0
           Type: 7 BaseType int
-        - Name: Y
+        - Name: "Y"
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
@@ -26060,7 +26060,7 @@ Types:
       ID: 939
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.46672e+06
+      GoRuntimeType: 1466720
       GoKind: 25
       RawFields:
         - Name: error
@@ -26070,7 +26070,7 @@ Types:
       ID: 1122
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.704992e+06
+      GoRuntimeType: 1704992
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -26084,7 +26084,7 @@ Types:
       ID: 1148
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.1424e+06
+      GoRuntimeType: 1142400
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26097,7 +26097,7 @@ Types:
       ID: 1110
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.593312e+06
+      GoRuntimeType: 1593312
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -26113,13 +26113,13 @@ Types:
       ID: 1031
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.018304e+06
+      GoRuntimeType: 1018304
       GoKind: 10
     - __kind: StructureType
       ID: 997
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.909088e+06
+      GoRuntimeType: 1909088
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26135,7 +26135,7 @@ Types:
       ID: 854
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.630464e+06
+      GoRuntimeType: 1630464
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26228,7 +26228,7 @@ Types:
       ID: 858
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.46736e+06
+      GoRuntimeType: 1467360
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26244,7 +26244,7 @@ Types:
       ID: 846
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.4624e+06
+      GoRuntimeType: 1462400
       GoKind: 25
       RawFields:
         - Name: error
@@ -26258,7 +26258,7 @@ Types:
       ID: 1020
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.937952e+06
+      GoRuntimeType: 1937952
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26274,7 +26274,7 @@ Types:
       ID: 848
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.629984e+06
+      GoRuntimeType: 1629984
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26287,7 +26287,7 @@ Types:
       ID: 1165
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.99728e+06
+      GoRuntimeType: 1997280
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26304,7 +26304,7 @@ Types:
       ID: 937
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.590912e+06
+      GoRuntimeType: 1590912
       GoKind: 25
       RawFields:
         - Name: error
@@ -26329,14 +26329,14 @@ Types:
     - __kind: StructureType
       ID: 991
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.532992e+06
+      GoRuntimeType: 1532992
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 840
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.45568e+06
+      GoRuntimeType: 1455680
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26346,7 +26346,7 @@ Types:
       ID: 842
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.45584e+06
+      GoRuntimeType: 1455840
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26803,7 +26803,7 @@ Types:
       ID: 92
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.87952e+06
+      GoRuntimeType: 1879520
       GoKind: 25
       RawFields:
         - Name: buf
@@ -26815,7 +26815,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -26840,7 +26840,7 @@ Types:
     - __kind: StructureType
       ID: 952
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.497472e+06
+      GoRuntimeType: 1497472
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -26851,7 +26851,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.228032e+06
+      GoRuntimeType: 1228032
       GoKind: 25
       RawFields:
         - Name: u
@@ -26861,7 +26861,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.66544e+06
+      GoRuntimeType: 1665440
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26881,7 +26881,7 @@ Types:
       ID: 33
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.511232e+06
+      GoRuntimeType: 1511232
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26894,7 +26894,7 @@ Types:
       ID: 37
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.511072e+06
+      GoRuntimeType: 1511072
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -26906,13 +26906,13 @@ Types:
     - __kind: StructureType
       ID: 77
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 1.007456e+06
+      GoRuntimeType: 1007456
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 34
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 1.00736e+06
+      GoRuntimeType: 1007360
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
@@ -26938,7 +26938,7 @@ Types:
       ID: 909
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
-      GoRuntimeType: 1.581792e+06
+      GoRuntimeType: 1581792
       GoKind: 25
       RawFields:
         - Name: typ
@@ -26954,7 +26954,7 @@ Types:
       ID: 1269
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.494912e+06
+      GoRuntimeType: 1494912
       GoKind: 25
       RawFields:
         - Name: state
@@ -26971,7 +26971,7 @@ Types:
       ID: 1155
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.204608e+06
+      GoRuntimeType: 1204608
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26984,7 +26984,7 @@ Types:
       ID: 1190
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.03808e+06
+      GoRuntimeType: 1038080
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26997,7 +26997,7 @@ Types:
       ID: 1141
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.124864e+06
+      GoRuntimeType: 1124864
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27010,7 +27010,7 @@ Types:
       ID: 137
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.037824e+06
+      GoRuntimeType: 1037824
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27022,7 +27022,7 @@ Types:
     - __kind: StructureType
       ID: 1112
       Name: io.discard
-      GoRuntimeType: 1.483232e+06
+      GoRuntimeType: 1483232
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27092,7 +27092,7 @@ Types:
       ID: 172
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.036672e+06
+      GoRuntimeType: 1036672
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27105,7 +27105,7 @@ Types:
       ID: 134
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.6376e+06
+      GoRuntimeType: 1637600
       GoKind: 25
       RawFields:
         - Name: x
@@ -27121,7 +27121,7 @@ Types:
       ID: 149
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.200896e+06
+      GoRuntimeType: 1200896
       GoKind: 25
       RawFields:
         - Name: a
@@ -27131,7 +27131,7 @@ Types:
       ID: 385
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.200768e+06
+      GoRuntimeType: 1200768
       GoKind: 25
       RawFields:
         - Name: a
@@ -27145,7 +27145,7 @@ Types:
       ID: 156
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.200128e+06
+      GoRuntimeType: 1200128
       GoKind: 25
       RawFields:
         - Name: a
@@ -27155,7 +27155,7 @@ Types:
       ID: 1335
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.2e+06
+      GoRuntimeType: 1200000
       GoKind: 25
       RawFields:
         - Name: a
@@ -27165,7 +27165,7 @@ Types:
       ID: 1350
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.199872e+06
+      GoRuntimeType: 1199872
       GoKind: 25
       RawFields:
         - Name: a
@@ -27175,7 +27175,7 @@ Types:
       ID: 138
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.202048e+06
+      GoRuntimeType: 1202048
       GoKind: 25
       RawFields:
         - Name: a
@@ -27185,7 +27185,7 @@ Types:
       ID: 140
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.20192e+06
+      GoRuntimeType: 1201920
       GoKind: 25
       RawFields:
         - Name: a
@@ -27199,7 +27199,7 @@ Types:
       ID: 142
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.20128e+06
+      GoRuntimeType: 1201280
       GoKind: 25
       RawFields:
         - Name: a
@@ -27209,7 +27209,7 @@ Types:
       ID: 1305
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.201152e+06
+      GoRuntimeType: 1201152
       GoKind: 25
       RawFields:
         - Name: a
@@ -27219,7 +27219,7 @@ Types:
       ID: 1307
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.201024e+06
+      GoRuntimeType: 1201024
       GoKind: 25
       RawFields:
         - Name: a
@@ -27229,7 +27229,7 @@ Types:
       ID: 143
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.2032e+06
+      GoRuntimeType: 1203200
       GoKind: 25
       RawFields:
         - Name: a
@@ -27239,7 +27239,7 @@ Types:
       ID: 375
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.203072e+06
+      GoRuntimeType: 1203072
       GoKind: 25
       RawFields:
         - Name: a
@@ -27253,7 +27253,7 @@ Types:
       ID: 148
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.202432e+06
+      GoRuntimeType: 1202432
       GoKind: 25
       RawFields:
         - Name: a
@@ -27263,7 +27263,7 @@ Types:
       ID: 1311
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.202304e+06
+      GoRuntimeType: 1202304
       GoKind: 25
       RawFields:
         - Name: a
@@ -27273,7 +27273,7 @@ Types:
       ID: 1317
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.202176e+06
+      GoRuntimeType: 1202176
       GoKind: 25
       RawFields:
         - Name: a
@@ -27288,7 +27288,7 @@ Types:
       ID: 170
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.863168e+06
+      GoRuntimeType: 1863168
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27310,7 +27310,7 @@ Types:
       ID: 165
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.998848e+06
+      GoRuntimeType: 1998848
       GoKind: 25
       RawFields:
         - Name: _
@@ -27338,7 +27338,7 @@ Types:
       ID: 363
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.43088e+06
+      GoRuntimeType: 1430880
       GoKind: 25
       RawFields:
         - Name: s
@@ -27681,7 +27681,7 @@ Types:
       ID: 129
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.482272e+06
+      GoRuntimeType: 1482272
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -27694,7 +27694,7 @@ Types:
       ID: 256
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.481952e+06
+      GoRuntimeType: 1481952
       GoKind: 25
       RawFields:
         - Name: val
@@ -27728,14 +27728,14 @@ Types:
       ID: 1279
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.43104e+06
+      GoRuntimeType: 1431040
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 168
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.0368e+06
+      GoRuntimeType: 1036800
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27788,7 +27788,7 @@ Types:
       ID: 174
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.199616e+06
+      GoRuntimeType: 1199616
       GoKind: 25
       RawFields:
         - Name: a
@@ -27858,7 +27858,7 @@ Types:
       ID: 175
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.199744e+06
+      GoRuntimeType: 1199744
       GoKind: 25
       RawFields:
         - Name: m
@@ -28972,119 +28972,119 @@ Types:
       ID: 233
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.144448e+06
+      GoRuntimeType: 1144448
       GoKind: 21
       HeaderType: 235 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 228
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.144576e+06
+      GoRuntimeType: 1144576
       GoKind: 21
       HeaderType: 230 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 196
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.144704e+06
+      GoRuntimeType: 1144704
       GoKind: 21
       HeaderType: 198 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 208
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.144832e+06
+      GoRuntimeType: 1144832
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 150
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.14432e+06
+      GoRuntimeType: 1144320
       GoKind: 21
       HeaderType: 152 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1289
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.144192e+06
+      GoRuntimeType: 1144192
       GoKind: 21
       HeaderType: 1291 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1323
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.143552e+06
+      GoRuntimeType: 1143552
       GoKind: 21
       HeaderType: 1325 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1338
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.143424e+06
+      GoRuntimeType: 1143424
       GoKind: 21
       HeaderType: 1340 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 176
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.142784e+06
+      GoRuntimeType: 1142784
       GoKind: 21
       HeaderType: 178 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 1353
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.143296e+06
+      GoRuntimeType: 1143296
       GoKind: 21
       HeaderType: 1355 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 243
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.14496e+06
+      GoRuntimeType: 1144960
       GoKind: 21
       HeaderType: 245 GoSwissMapHeaderType map<int,struct {}>
     - __kind: GoMapType
       ID: 213
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.145088e+06
+      GoRuntimeType: 1145088
       GoKind: 21
       HeaderType: 215 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 203
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.145216e+06
+      GoRuntimeType: 1145216
       GoKind: 21
       HeaderType: 205 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 191
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.145344e+06
+      GoRuntimeType: 1145344
       GoKind: 21
       HeaderType: 193 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 186
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.145472e+06
+      GoRuntimeType: 1145472
       GoKind: 21
       HeaderType: 188 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 181
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.1456e+06
+      GoRuntimeType: 1145600
       GoKind: 21
       HeaderType: 183 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 238
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 1.145728e+06
+      GoRuntimeType: 1145728
       GoKind: 21
       HeaderType: 240 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
@@ -29127,28 +29127,28 @@ Types:
       ID: 248
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.145856e+06
+      GoRuntimeType: 1145856
       GoKind: 21
       HeaderType: 250 GoSwissMapHeaderType map<struct {},struct {}>
     - __kind: GoMapType
       ID: 223
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.145984e+06
+      GoRuntimeType: 1145984
       GoKind: 21
       HeaderType: 225 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 218
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.146112e+06
+      GoRuntimeType: 1146112
       GoKind: 21
       HeaderType: 220 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
       ID: 779
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.44704e+06
+      GoRuntimeType: 1447040
       GoKind: 25
       RawFields:
         - Name: msg
@@ -29158,7 +29158,7 @@ Types:
       ID: 1076
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.444e+06
+      GoRuntimeType: 1444000
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29172,7 +29172,7 @@ Types:
       ID: 1046
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.620064e+06
+      GoRuntimeType: 1620064
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29213,7 +29213,7 @@ Types:
       ID: 942
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.128192e+06
+      GoRuntimeType: 1128192
       GoKind: 24
       RawFields:
         - Name: str
@@ -29231,7 +29231,7 @@ Types:
     - __kind: StructureType
       ID: 907
       Name: net.canceledError
-      GoRuntimeType: 1.301568e+06
+      GoRuntimeType: 1301568
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29242,7 +29242,7 @@ Types:
       ID: 1051
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 2.138304e+06
+      GoRuntimeType: 2138304
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29264,13 +29264,13 @@ Types:
     - __kind: StructureType
       ID: 1236
       Name: net.noReadFrom
-      GoRuntimeType: 1.128448e+06
+      GoRuntimeType: 1128448
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1235
       Name: net.noWriteTo
-      GoRuntimeType: 1.12832e+06
+      GoRuntimeType: 1128320
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29281,7 +29281,7 @@ Types:
       ID: 711
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.756768e+06
+      GoRuntimeType: 1756768
       GoKind: 25
       RawFields:
         - Name: p
@@ -29297,7 +29297,7 @@ Types:
       ID: 1224
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.32048e+06
+      GoRuntimeType: 2320480
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29310,7 +29310,7 @@ Types:
       ID: 1222
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.319936e+06
+      GoRuntimeType: 2319936
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29335,7 +29335,7 @@ Types:
       ID: 1070
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.43552e+06
+      GoRuntimeType: 1435520
       GoKind: 25
       RawFields:
         - Name: w
@@ -29351,13 +29351,13 @@ Types:
       ID: 1023
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.005152e+06
+      GoRuntimeType: 1005152
       GoKind: 10
     - __kind: StructureType
       ID: 687
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.754272e+06
+      GoRuntimeType: 1754272
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -29373,7 +29373,7 @@ Types:
       ID: 1001
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.9272e+06
+      GoRuntimeType: 1927200
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -29389,7 +29389,7 @@ Types:
       ID: 691
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.619584e+06
+      GoRuntimeType: 1619584
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29466,7 +29466,7 @@ Types:
     - __kind: StructureType
       ID: 903
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.3008e+06
+      GoRuntimeType: 1300800
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29496,7 +29496,7 @@ Types:
       ID: 1072
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
-      GoRuntimeType: 1.75504e+06
+      GoRuntimeType: 1755040
       GoKind: 25
       RawFields:
         - Name: conn
@@ -29519,7 +29519,7 @@ Types:
       ID: 899
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.577792e+06
+      GoRuntimeType: 1577792
       GoKind: 25
       RawFields:
         - Name: error
@@ -29533,7 +29533,7 @@ Types:
       ID: 1090
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.577632e+06
+      GoRuntimeType: 1577632
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29543,7 +29543,7 @@ Types:
       ID: 1124
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.828448e+06
+      GoRuntimeType: 1828448
       GoKind: 25
       RawFields:
         - Name: _
@@ -29559,7 +29559,7 @@ Types:
       ID: 695
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.43648e+06
+      GoRuntimeType: 1436480
       GoKind: 25
       RawFields:
         - Name: error
@@ -29572,14 +29572,14 @@ Types:
     - __kind: StructureType
       ID: 974
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.500352e+06
+      GoRuntimeType: 1500352
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 901
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.577952e+06
+      GoRuntimeType: 1577952
       GoKind: 25
       RawFields:
         - Name: err
@@ -29589,7 +29589,7 @@ Types:
       ID: 1167
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2.057984e+06
+      GoRuntimeType: 2057984
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29606,7 +29606,7 @@ Types:
       ID: 1189
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 2.073728e+06
+      GoRuntimeType: 2073728
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29620,7 +29620,7 @@ Types:
       ID: 771
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.75984e+06
+      GoRuntimeType: 1759840
       GoKind: 25
       RawFields:
         - Name: in
@@ -29636,7 +29636,7 @@ Types:
       ID: 769
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.621504e+06
+      GoRuntimeType: 1621504
       GoKind: 25
       RawFields:
         - Name: in
@@ -29653,7 +29653,7 @@ Types:
       ID: 1102
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.623744e+06
+      GoRuntimeType: 1623744
       GoKind: 25
       RawFields:
         - Name: c
@@ -29971,7 +29971,7 @@ Types:
       ID: 485
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.313088e+06
+      GoRuntimeType: 1313088
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29984,7 +29984,7 @@ Types:
       ID: 477
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.313344e+06
+      GoRuntimeType: 1313344
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -29997,7 +29997,7 @@ Types:
       ID: 425
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.3136e+06
+      GoRuntimeType: 1313600
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30010,7 +30010,7 @@ Types:
       ID: 444
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.313856e+06
+      GoRuntimeType: 1313856
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30023,7 +30023,7 @@ Types:
       ID: 381
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.312832e+06
+      GoRuntimeType: 1312832
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30036,7 +30036,7 @@ Types:
       ID: 1297
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.312576e+06
+      GoRuntimeType: 1312576
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30049,7 +30049,7 @@ Types:
       ID: 1331
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.311296e+06
+      GoRuntimeType: 1311296
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30062,7 +30062,7 @@ Types:
       ID: 1346
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.31104e+06
+      GoRuntimeType: 1311040
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30075,7 +30075,7 @@ Types:
       ID: 393
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.30976e+06
+      GoRuntimeType: 1309760
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30088,7 +30088,7 @@ Types:
       ID: 1361
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.310784e+06
+      GoRuntimeType: 1310784
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30101,7 +30101,7 @@ Types:
       ID: 501
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
-      GoRuntimeType: 1.314112e+06
+      GoRuntimeType: 1314112
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30114,7 +30114,7 @@ Types:
       ID: 452
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.314368e+06
+      GoRuntimeType: 1314368
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30127,7 +30127,7 @@ Types:
       ID: 434
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.314624e+06
+      GoRuntimeType: 1314624
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30140,7 +30140,7 @@ Types:
       ID: 417
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.31488e+06
+      GoRuntimeType: 1314880
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30153,7 +30153,7 @@ Types:
       ID: 1058
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
-      GoRuntimeType: 1.37632e+06
+      GoRuntimeType: 1376320
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30166,7 +30166,7 @@ Types:
       ID: 409
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.315136e+06
+      GoRuntimeType: 1315136
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30179,7 +30179,7 @@ Types:
       ID: 401
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.315392e+06
+      GoRuntimeType: 1315392
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30192,7 +30192,7 @@ Types:
       ID: 493
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
-      GoRuntimeType: 1.315648e+06
+      GoRuntimeType: 1315648
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30277,7 +30277,7 @@ Types:
       ID: 509
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
-      GoRuntimeType: 1.315904e+06
+      GoRuntimeType: 1315904
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30290,7 +30290,7 @@ Types:
       ID: 468
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.31616e+06
+      GoRuntimeType: 1316160
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30303,7 +30303,7 @@ Types:
       ID: 460
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.316416e+06
+      GoRuntimeType: 1316416
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30316,7 +30316,7 @@ Types:
       ID: 487
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.31296e+06
+      GoRuntimeType: 1312960
       GoKind: 25
       RawFields:
         - Name: key
@@ -30329,7 +30329,7 @@ Types:
       ID: 479
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.313216e+06
+      GoRuntimeType: 1313216
       GoKind: 25
       RawFields:
         - Name: key
@@ -30342,7 +30342,7 @@ Types:
       ID: 427
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.313472e+06
+      GoRuntimeType: 1313472
       GoKind: 25
       RawFields:
         - Name: key
@@ -30355,7 +30355,7 @@ Types:
       ID: 446
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.313728e+06
+      GoRuntimeType: 1313728
       GoKind: 25
       RawFields:
         - Name: key
@@ -30368,7 +30368,7 @@ Types:
       ID: 383
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.312704e+06
+      GoRuntimeType: 1312704
       GoKind: 25
       RawFields:
         - Name: key
@@ -30381,7 +30381,7 @@ Types:
       ID: 1299
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.312448e+06
+      GoRuntimeType: 1312448
       GoKind: 25
       RawFields:
         - Name: key
@@ -30394,7 +30394,7 @@ Types:
       ID: 1333
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.311168e+06
+      GoRuntimeType: 1311168
       GoKind: 25
       RawFields:
         - Name: key
@@ -30407,7 +30407,7 @@ Types:
       ID: 1348
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.310912e+06
+      GoRuntimeType: 1310912
       GoKind: 25
       RawFields:
         - Name: key
@@ -30420,7 +30420,7 @@ Types:
       ID: 395
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.309632e+06
+      GoRuntimeType: 1309632
       GoKind: 25
       RawFields:
         - Name: key
@@ -30433,7 +30433,7 @@ Types:
       ID: 1363
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.310656e+06
+      GoRuntimeType: 1310656
       GoKind: 25
       RawFields:
         - Name: key
@@ -30446,7 +30446,7 @@ Types:
       ID: 503
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
-      GoRuntimeType: 1.313984e+06
+      GoRuntimeType: 1313984
       GoKind: 25
       RawFields:
         - Name: key
@@ -30459,7 +30459,7 @@ Types:
       ID: 454
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.31424e+06
+      GoRuntimeType: 1314240
       GoKind: 25
       RawFields:
         - Name: key
@@ -30472,7 +30472,7 @@ Types:
       ID: 436
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.314496e+06
+      GoRuntimeType: 1314496
       GoKind: 25
       RawFields:
         - Name: key
@@ -30485,7 +30485,7 @@ Types:
       ID: 419
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.314752e+06
+      GoRuntimeType: 1314752
       GoKind: 25
       RawFields:
         - Name: key
@@ -30498,7 +30498,7 @@ Types:
       ID: 1060
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
-      GoRuntimeType: 1.376192e+06
+      GoRuntimeType: 1376192
       GoKind: 25
       RawFields:
         - Name: key
@@ -30511,7 +30511,7 @@ Types:
       ID: 411
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.315008e+06
+      GoRuntimeType: 1315008
       GoKind: 25
       RawFields:
         - Name: key
@@ -30524,7 +30524,7 @@ Types:
       ID: 403
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.315264e+06
+      GoRuntimeType: 1315264
       GoKind: 25
       RawFields:
         - Name: key
@@ -30537,7 +30537,7 @@ Types:
       ID: 495
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
-      GoRuntimeType: 1.31552e+06
+      GoRuntimeType: 1315520
       GoKind: 25
       RawFields:
         - Name: key
@@ -30621,7 +30621,7 @@ Types:
     - __kind: StructureType
       ID: 511
       Name: noalg.struct { key struct {}; elem struct {} }
-      GoRuntimeType: 1.315776e+06
+      GoRuntimeType: 1315776
       GoKind: 25
       RawFields:
         - Name: key
@@ -30634,7 +30634,7 @@ Types:
       ID: 470
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.316032e+06
+      GoRuntimeType: 1316032
       GoKind: 25
       RawFields:
         - Name: key
@@ -30647,7 +30647,7 @@ Types:
       ID: 462
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.316288e+06
+      GoRuntimeType: 1316288
       GoKind: 25
       RawFields:
         - Name: key
@@ -30672,7 +30672,7 @@ Types:
       ID: 1246
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.39088e+06
+      GoRuntimeType: 2390880
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -30685,7 +30685,7 @@ Types:
       ID: 1244
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.39008e+06
+      GoRuntimeType: 2390080
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -30697,13 +30697,13 @@ Types:
     - __kind: StructureType
       ID: 1252
       Name: os.noReadFrom
-      GoRuntimeType: 1.125888e+06
+      GoRuntimeType: 1125888
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1251
       Name: os.noWriteTo
-      GoRuntimeType: 1.12576e+06
+      GoRuntimeType: 1125760
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -30722,7 +30722,7 @@ Types:
       ID: 913
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.73024e+06
+      GoRuntimeType: 1730240
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -30784,13 +30784,13 @@ Types:
       ID: 886
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.916256e+06
+      GoRuntimeType: 1916256
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
           Type: 12 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -30810,14 +30810,14 @@ Types:
     - __kind: StructureType
       ID: 90
       Name: runtime.dlogPerM
-      GoRuntimeType: 1.004288e+06
+      GoRuntimeType: 1004288
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 948
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.781088e+06
+      GoRuntimeType: 1781088
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30830,7 +30830,7 @@ Types:
       ID: 862
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 1.003712e+06
+      GoRuntimeType: 1003712
       GoKind: 24
       RawFields:
         - Name: str
@@ -30849,7 +30849,7 @@ Types:
       ID: 23
       Name: runtime.g
       ByteSize: 456
-      GoRuntimeType: 2.439808e+06
+      GoRuntimeType: 2439808
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31051,7 +31051,7 @@ Types:
       ID: 55
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.210624e+06
+      GoRuntimeType: 1210624
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -31061,7 +31061,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.943008e+06
+      GoRuntimeType: 1943008
       GoKind: 25
       RawFields:
         - Name: sp
@@ -31086,7 +31086,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.489472e+06
+      GoRuntimeType: 1489472
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31099,7 +31099,7 @@ Types:
       ID: 60
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.779936e+06
+      GoRuntimeType: 1779936
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31124,7 +31124,7 @@ Types:
       ID: 96
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.491872e+06
+      GoRuntimeType: 1491872
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -31137,7 +31137,7 @@ Types:
       ID: 72
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 1.491072e+06
+      GoRuntimeType: 1491072
       GoKind: 25
       RawFields:
         - Name: prev
@@ -31156,7 +31156,7 @@ Types:
       ID: 30
       Name: runtime.m
       ByteSize: 1824
-      GoRuntimeType: 2.445088e+06
+      GoRuntimeType: 2445088
       GoKind: 25
       RawFields:
         - Name: g0
@@ -31385,7 +31385,7 @@ Types:
       ID: 75
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.94352e+06
+      GoRuntimeType: 1943520
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31410,7 +31410,7 @@ Types:
       ID: 91
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.868544e+06
+      GoRuntimeType: 1868544
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31432,7 +31432,7 @@ Types:
       ID: 80
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 1.943776e+06
+      GoRuntimeType: 1943776
       GoKind: 25
       RawFields:
         - Name: writing
@@ -31457,7 +31457,7 @@ Types:
       ID: 74
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.491552e+06
+      GoRuntimeType: 1491552
       GoKind: 25
       RawFields:
         - Name: next
@@ -31470,7 +31470,7 @@ Types:
       ID: 98
       Name: runtime.mWeakPointer
       ByteSize: 8
-      GoRuntimeType: 1.574752e+06
+      GoRuntimeType: 1574752
       GoKind: 25
       RawFields:
         - Name: m
@@ -31486,7 +31486,7 @@ Types:
       ID: 71
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.211648e+06
+      GoRuntimeType: 1211648
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -31497,7 +31497,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.491712e+06
+      GoRuntimeType: 1491712
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31510,13 +31510,13 @@ Types:
       ID: 89
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.780896e+06
+      GoRuntimeType: 1780896
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -31529,7 +31529,7 @@ Types:
       ID: 865
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 1.003808e+06
+      GoRuntimeType: 1003808
       GoKind: 24
       RawFields:
         - Name: str
@@ -31563,7 +31563,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.488192e+06
+      GoRuntimeType: 1488192
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31584,7 +31584,7 @@ Types:
       ID: 672
       Name: runtime.synctestDeadlockError
       ByteSize: 24
-      GoRuntimeType: 1.619264e+06
+      GoRuntimeType: 1619264
       GoKind: 25
       RawFields:
         - Name: reason
@@ -31617,7 +31617,7 @@ Types:
       ID: 56
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.489792e+06
+      GoRuntimeType: 1489792
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -31630,19 +31630,19 @@ Types:
       ID: 35
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.618944e+06
+      GoRuntimeType: 1618944
       GoKind: 8
     - __kind: StructureType
       ID: 85
       Name: runtime.winlibcall
-      GoRuntimeType: 1.004192e+06
+      GoRuntimeType: 1004192
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 52
       Name: runtime.xRegPerG
       ByteSize: 8
-      GoRuntimeType: 1.210496e+06
+      GoRuntimeType: 1210496
       GoKind: 25
       RawFields:
         - Name: state
@@ -31687,7 +31687,7 @@ Types:
       ID: 1084
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.47472e+06
+      GoRuntimeType: 1474720
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -31703,7 +31703,7 @@ Types:
       ID: 1267
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.484192e+06
+      GoRuntimeType: 1484192
       GoKind: 25
       RawFields:
         - Name: _
@@ -31716,7 +31716,7 @@ Types:
       ID: 1270
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.63952e+06
+      GoRuntimeType: 1639520
       GoKind: 25
       RawFields:
         - Name: _
@@ -31732,7 +31732,7 @@ Types:
       ID: 1273
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.639328e+06
+      GoRuntimeType: 1639328
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31747,14 +31747,14 @@ Types:
     - __kind: StructureType
       ID: 1268
       Name: sync.noCopy
-      GoRuntimeType: 1.002656e+06
+      GoRuntimeType: 1002656
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1271
       Name: sync/atomic.Bool
       ByteSize: 4
-      GoRuntimeType: 1.485312e+06
+      GoRuntimeType: 1485312
       GoKind: 25
       RawFields:
         - Name: _
@@ -31767,7 +31767,7 @@ Types:
       ID: 1276
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.485472e+06
+      GoRuntimeType: 1485472
       GoKind: 25
       RawFields:
         - Name: _
@@ -31780,7 +31780,7 @@ Types:
       ID: 1274
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.639904e+06
+      GoRuntimeType: 1639904
       GoKind: 25
       RawFields:
         - Name: _
@@ -31795,20 +31795,20 @@ Types:
     - __kind: StructureType
       ID: 1275
       Name: sync/atomic.align64
-      GoRuntimeType: 1.002848e+06
+      GoRuntimeType: 1002848
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1272
       Name: sync/atomic.noCopy
-      GoRuntimeType: 1.002752e+06
+      GoRuntimeType: 1002752
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 998
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.299904e+06
+      GoRuntimeType: 1299904
       GoKind: 12
     - __kind: StructureType
       ID: 482
@@ -32466,7 +32466,7 @@ Types:
       ID: 941
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.734656e+06
+      GoRuntimeType: 1734656
       GoKind: 25
       RawFields:
         - Name: Name
@@ -32479,7 +32479,7 @@ Types:
       ID: 1151
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.944544e+06
+      GoRuntimeType: 1944544
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1016
@@ -32493,7 +32493,7 @@ Types:
       ID: 1014
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.405024e+06
+      GoRuntimeType: 2405024
       GoKind: 25
       RawFields:
         - Name: wall
@@ -32574,7 +32574,7 @@ Types:
       ID: 1034
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 2.094496e+06
+      GoRuntimeType: 2094496
       GoKind: 25
       RawFields:
         - Name: msg
@@ -32586,7 +32586,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 1036 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 7 BaseType int
         - Name: index
@@ -32608,13 +32608,13 @@ Types:
       ID: 1037
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
-      GoRuntimeType: 1.009376e+06
+      GoRuntimeType: 1009376
       GoKind: 9
     - __kind: StructureType
       ID: 1035
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.955808e+06
+      GoRuntimeType: 1955808
       GoKind: 25
       RawFields:
         - Name: id
@@ -32653,7 +32653,7 @@ Types:
       ID: 757
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.44416e+06
+      GoRuntimeType: 1444160
       GoKind: 25
       RawFields:
         - Name: Err
@@ -32669,7 +32669,7 @@ Types:
       ID: 918
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.730432e+06
+      GoRuntimeType: 1730432
       GoKind: 25
       RawFields:
         - Name: label
@@ -32682,7 +32682,7 @@ Types:
       ID: 870
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
-      GoRuntimeType: 1.008224e+06
+      GoRuntimeType: 1008224
       GoKind: 5
 MaxTypeID: 1690
 Issues:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -576,8 +576,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 86}
@@ -600,7 +600,7 @@ Probes:
                   EventExpressionIndex: 1
                 - ', '
                 - Error: failed to resolve reference "y"
-                  DSL: y
+                  DSL: "y"
     - id: testConflictingReturn
       version: 0
       type: LOG_PROBE
@@ -1713,8 +1713,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 53}
@@ -1735,8 +1735,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
     - id: testInlinedBBA
@@ -5475,8 +5475,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
         - ', '
         - json: {ref: z}
           dsl: z
@@ -5496,8 +5496,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
                 - ', '
@@ -6832,7 +6832,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 9 BaseType int
           Locations:
             - Range: 0x8910b0..0x8910dc
@@ -7373,7 +7373,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 16 BaseType float32
           Locations:
             - Range: 0x893160..0x893170
@@ -7404,7 +7404,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 16 BaseType float32
           Locations:
             - Range: 0x893180..0x893190
@@ -9818,7 +9818,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x8965b0..0x8965c0
@@ -11499,7 +11499,7 @@ Types:
       ID: 1025
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.858304e+06
+      GoRuntimeType: 1858304
       GoKind: 22
       Pointee: 1026 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
@@ -11518,7 +11518,7 @@ Types:
       ID: 965
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.259136e+06
+      GoRuntimeType: 1259136
       GoKind: 22
       Pointee: 966 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
@@ -11539,21 +11539,21 @@ Types:
       ID: 1012
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.782592e+06
+      GoRuntimeType: 1782592
       GoKind: 22
       Pointee: 1013 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 941
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.021376e+06
+      GoRuntimeType: 1021376
       GoKind: 22
       Pointee: 942 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 943
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.021632e+06
+      GoRuntimeType: 1021632
       GoKind: 22
       Pointee: 944 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
@@ -11702,21 +11702,21 @@ Types:
       ID: 989
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.039488e+06
+      GoRuntimeType: 2039488
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1016
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.824544e+06
+      GoRuntimeType: 1824544
       GoKind: 22
       Pointee: 1017 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1061
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.132448e+06
+      GoRuntimeType: 2132448
       GoKind: 22
       Pointee: 1062 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -11742,7 +11742,7 @@ Types:
       ID: 963
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.249376e+06
+      GoRuntimeType: 1249376
       GoKind: 22
       Pointee: 964 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
@@ -11756,14 +11756,14 @@ Types:
       ID: 985
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.609216e+06
+      GoRuntimeType: 1609216
       GoKind: 22
       Pointee: 986 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 821
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.123552e+06
+      GoRuntimeType: 1123552
       GoKind: 22
       Pointee: 822 StructureType context.deadlineExceededError
     - __kind: PointerType
@@ -11784,14 +11784,14 @@ Types:
       ID: 975
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
-      GoRuntimeType: 1.380928e+06
+      GoRuntimeType: 1380928
       GoKind: 22
       Pointee: 976 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
       ID: 1000
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.688224e+06
+      GoRuntimeType: 1688224
       GoKind: 22
       Pointee: 1001 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
@@ -11805,21 +11805,21 @@ Types:
       ID: 1008
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 1.779776e+06
+      GoRuntimeType: 1779776
       GoKind: 22
       Pointee: 1009 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1002
       Name: '*crypto/sha256.digest'
       ByteSize: 8
-      GoRuntimeType: 1.688672e+06
+      GoRuntimeType: 1688672
       GoKind: 22
       Pointee: 1003 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
       ID: 1004
       Name: '*crypto/sha512.digest'
       ByteSize: 8
-      GoRuntimeType: 1.68912e+06
+      GoRuntimeType: 1689120
       GoKind: 22
       Pointee: 1005 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
@@ -11833,14 +11833,14 @@ Types:
       ID: 761
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.009216e+06
+      GoRuntimeType: 1009216
       GoKind: 22
       Pointee: 762 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1087
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.241568e+06
+      GoRuntimeType: 2241568
       GoKind: 22
       Pointee: 1088 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
@@ -11861,35 +11861,35 @@ Types:
       ID: 760
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.007552e+06
+      GoRuntimeType: 1007552
       GoKind: 22
       Pointee: 717 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 973
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.378048e+06
+      GoRuntimeType: 1378048
       GoKind: 22
       Pointee: 974 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
       ID: 980
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.458592e+06
+      GoRuntimeType: 1458592
       GoKind: 22
       Pointee: 981 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 856
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.249696e+06
+      GoRuntimeType: 1249696
       GoKind: 22
       Pointee: 857 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 871
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 1.915456e+06
+      GoRuntimeType: 1915456
       GoKind: 22
       Pointee: 872 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
@@ -11924,7 +11924,7 @@ Types:
       ID: 766
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.015104e+06
+      GoRuntimeType: 1015104
       GoKind: 22
       Pointee: 767 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
@@ -11973,7 +11973,7 @@ Types:
       ID: 931
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.004736e+06
+      GoRuntimeType: 1004736
       GoKind: 22
       Pointee: 932 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -11994,7 +11994,7 @@ Types:
       ID: 752
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.000384e+06
+      GoRuntimeType: 1000384
       GoKind: 22
       Pointee: 753 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
@@ -12029,7 +12029,7 @@ Types:
       ID: 1067
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.158016e+06
+      GoRuntimeType: 2158016
       GoKind: 22
       Pointee: 1068 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
@@ -12043,7 +12043,7 @@ Types:
       ID: 939
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.01792e+06
+      GoRuntimeType: 1017920
       GoKind: 22
       Pointee: 940 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
@@ -12083,7 +12083,7 @@ Types:
       ID: 1045
       Name: '*encoding/xml.printer'
       ByteSize: 8
-      GoRuntimeType: 2.027968e+06
+      GoRuntimeType: 2027968
       GoKind: 22
       Pointee: 1046 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
@@ -12125,7 +12125,7 @@ Types:
       ID: 1055
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.123744e+06
+      GoRuntimeType: 2123744
       GoKind: 22
       Pointee: 1056 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
@@ -12224,14 +12224,14 @@ Types:
       ID: 953
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.129312e+06
+      GoRuntimeType: 1129312
       GoKind: 22
       Pointee: 954 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1033
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 1.930784e+06
+      GoRuntimeType: 1930784
       GoKind: 22
       Pointee: 1034 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
@@ -12245,14 +12245,14 @@ Types:
       ID: 830
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.13264e+06
+      GoRuntimeType: 1132640
       GoKind: 22
       Pointee: 831 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1063
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.133984e+06
+      GoRuntimeType: 2133984
       GoKind: 22
       Pointee: 1064 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
@@ -12404,7 +12404,7 @@ Types:
       ID: 992
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.685312e+06
+      GoRuntimeType: 1685312
       GoKind: 22
       Pointee: 993 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
@@ -12418,21 +12418,21 @@ Types:
       ID: 971
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.376928e+06
+      GoRuntimeType: 1376928
       GoKind: 22
       Pointee: 972 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 927
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.003712e+06
+      GoRuntimeType: 1003712
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 961
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.247456e+06
+      GoRuntimeType: 1247456
       GoKind: 22
       Pointee: 962 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
@@ -12446,28 +12446,28 @@ Types:
       ID: 1023
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.8488e+06
+      GoRuntimeType: 1848800
       GoKind: 22
       Pointee: 1024 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1038
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.003008e+06
+      GoRuntimeType: 2003008
       GoKind: 22
       Pointee: 1035 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1037
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.002624e+06
+      GoRuntimeType: 2002624
       GoKind: 22
       Pointee: 1036 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 929
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.00384e+06
+      GoRuntimeType: 1003840
       GoKind: 22
       Pointee: 930 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
@@ -12488,70 +12488,70 @@ Types:
       ID: 996
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.68688e+06
+      GoRuntimeType: 1686880
       GoKind: 22
       Pointee: 997 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1029
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.884384e+06
+      GoRuntimeType: 1884384
       GoKind: 22
       Pointee: 1030 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1031
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.915136e+06
+      GoRuntimeType: 1915136
       GoKind: 22
       Pointee: 1032 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 861
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.261536e+06
+      GoRuntimeType: 1261536
       GoKind: 22
       Pointee: 862 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 774
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.029312e+06
+      GoRuntimeType: 1029312
       GoKind: 22
       Pointee: 775 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 772
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.029184e+06
+      GoRuntimeType: 1029184
       GoKind: 22
       Pointee: 773 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 776
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.03328e+06
+      GoRuntimeType: 1033280
       GoKind: 22
       Pointee: 777 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 778
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.033408e+06
+      GoRuntimeType: 1033408
       GoKind: 22
       Pointee: 779 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 982
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.48624e+06
+      GoRuntimeType: 1486240
       GoKind: 22
       Pointee: 983 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 768
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.015872e+06
+      GoRuntimeType: 1015872
       GoKind: 22
       Pointee: 769 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
@@ -12565,28 +12565,28 @@ Types:
       ID: 1079
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.220672e+06
+      GoRuntimeType: 2220672
       GoKind: 22
       Pointee: 1080 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 832
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.140832e+06
+      GoRuntimeType: 1140832
       GoKind: 22
       Pointee: 833 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 805
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.119712e+06
+      GoRuntimeType: 1119712
       GoKind: 22
       Pointee: 806 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 799
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.119328e+06
+      GoRuntimeType: 1119328
       GoKind: 22
       Pointee: 800 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
@@ -12600,7 +12600,7 @@ Types:
       ID: 811
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.120096e+06
+      GoRuntimeType: 1120096
       GoKind: 22
       Pointee: 812 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
@@ -12614,42 +12614,42 @@ Types:
       ID: 803
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.119584e+06
+      GoRuntimeType: 1119584
       GoKind: 22
       Pointee: 804 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 801
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.119456e+06
+      GoRuntimeType: 1119456
       GoKind: 22
       Pointee: 802 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 809
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.119968e+06
+      GoRuntimeType: 1119968
       GoKind: 22
       Pointee: 810 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 807
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.11984e+06
+      GoRuntimeType: 1119840
       GoKind: 22
       Pointee: 808 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1083
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.231712e+06
+      GoRuntimeType: 2231712
       GoKind: 22
       Pointee: 1084 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 815
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.12048e+06
+      GoRuntimeType: 1120480
       GoKind: 22
       Pointee: 816 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
@@ -12670,7 +12670,7 @@ Types:
       ID: 813
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.120352e+06
+      GoRuntimeType: 1120352
       GoKind: 22
       Pointee: 814 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -12733,35 +12733,35 @@ Types:
       ID: 874
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.484704e+06
+      GoRuntimeType: 1484704
       GoKind: 22
       Pointee: 875 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 782
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.048256e+06
+      GoRuntimeType: 1048256
       GoKind: 22
       Pointee: 783 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 959
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.179744e+06
+      GoRuntimeType: 1179744
       GoKind: 22
       Pointee: 960 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1043
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.0176e+06
+      GoRuntimeType: 2017600
       GoKind: 22
       Pointee: 1044 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 945
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.05056e+06
+      GoRuntimeType: 1050560
       GoKind: 22
       Pointee: 946 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
@@ -12775,7 +12775,7 @@ Types:
       ID: 840
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.181408e+06
+      GoRuntimeType: 1181408
       GoKind: 22
       Pointee: 841 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
@@ -12837,7 +12837,7 @@ Types:
       ID: 1041
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.01568e+06
+      GoRuntimeType: 2015680
       GoKind: 22
       Pointee: 1042 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -12865,14 +12865,14 @@ Types:
       ID: 838
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.178336e+06
+      GoRuntimeType: 1178336
       GoKind: 22
       Pointee: 839 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 863
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.268896e+06
+      GoRuntimeType: 1268896
       GoKind: 22
       Pointee: 864 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
@@ -12886,21 +12886,21 @@ Types:
       ID: 1006
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.6936e+06
+      GoRuntimeType: 1693600
       GoKind: 22
       Pointee: 1007 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 957
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.17488e+06
+      GoRuntimeType: 1174880
       GoKind: 22
       Pointee: 958 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 780
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.042496e+06
+      GoRuntimeType: 1042496
       GoKind: 22
       Pointee: 781 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
@@ -12921,21 +12921,21 @@ Types:
       ID: 770
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.019328e+06
+      GoRuntimeType: 1019328
       GoKind: 22
       Pointee: 771 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 836
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.146592e+06
+      GoRuntimeType: 1146592
       GoKind: 22
       Pointee: 837 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 834
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.146336e+06
+      GoRuntimeType: 1146336
       GoKind: 22
       Pointee: 835 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
@@ -12963,7 +12963,7 @@ Types:
       ID: 994
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.685984e+06
+      GoRuntimeType: 1685984
       GoKind: 22
       Pointee: 995 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
@@ -13168,21 +13168,21 @@ Types:
       ID: 797
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.11856e+06
+      GoRuntimeType: 1118560
       GoKind: 22
       Pointee: 798 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1085
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.236384e+06
+      GoRuntimeType: 2236384
       GoKind: 22
       Pointee: 1086 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 795
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.118432e+06
+      GoRuntimeType: 1118432
       GoKind: 22
       Pointee: 796 StructureType internal/poll.errNetClosing
     - __kind: PointerType
@@ -13196,14 +13196,14 @@ Types:
       ID: 949
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.109856e+06
+      GoRuntimeType: 1109856
       GoKind: 22
       Pointee: 950 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 947
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.109472e+06
+      GoRuntimeType: 1109472
       GoKind: 22
       Pointee: 948 StructureType io.discard
     - __kind: PointerType
@@ -13217,14 +13217,14 @@ Types:
       ID: 793
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.118176e+06
+      GoRuntimeType: 1118176
       GoKind: 22
       Pointee: 794 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 998
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.687104e+06
+      GoRuntimeType: 1687104
       GoKind: 22
       Pointee: 999 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13496,63 +13496,63 @@ Types:
       ID: 824
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.12688e+06
+      GoRuntimeType: 1126880
       GoKind: 22
       Pointee: 825 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 850
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.245696e+06
+      GoRuntimeType: 1245696
       GoKind: 22
       Pointee: 851 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1049
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.095936e+06
+      GoRuntimeType: 2095936
       GoKind: 22
       Pointee: 1050 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 848
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.245376e+06
+      GoRuntimeType: 1245376
       GoKind: 22
       Pointee: 849 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 826
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.127008e+06
+      GoRuntimeType: 1127008
       GoKind: 22
       Pointee: 827 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1059
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.125792e+06
+      GoRuntimeType: 2125792
       GoKind: 22
       Pointee: 1060 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1069
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.170752e+06
+      GoRuntimeType: 2170752
       GoKind: 22
       Pointee: 1070 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1057
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.12528e+06
+      GoRuntimeType: 2125280
       GoKind: 22
       Pointee: 1058 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 823
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.126112e+06
+      GoRuntimeType: 1126112
       GoKind: 22
       Pointee: 786 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13564,28 +13564,28 @@ Types:
       ID: 754
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.001152e+06
+      GoRuntimeType: 1001152
       GoKind: 22
       Pointee: 755 StructureType net.canceledError
     - __kind: PointerType
       ID: 1027
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 1.88208e+06
+      GoRuntimeType: 1882080
       GoKind: 22
       Pointee: 1028 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 892
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.726752e+06
+      GoRuntimeType: 1726752
       GoKind: 22
       Pointee: 893 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1071
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.175008e+06
+      GoRuntimeType: 2175008
       GoKind: 22
       Pointee: 1072 UnresolvedPointeeType net.netFD
     - __kind: PointerType
@@ -13606,28 +13606,28 @@ Types:
       ID: 1053
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.110304e+06
+      GoRuntimeType: 2110304
       GoKind: 22
       Pointee: 1054 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1051
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.109824e+06
+      GoRuntimeType: 2109824
       GoKind: 22
       Pointee: 1052 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 828
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.127648e+06
+      GoRuntimeType: 1127648
       GoKind: 22
       Pointee: 829 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 852
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.245856e+06
+      GoRuntimeType: 1245856
       GoKind: 22
       Pointee: 853 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
@@ -13662,7 +13662,7 @@ Types:
       ID: 844
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.241536e+06
+      GoRuntimeType: 1241536
       GoKind: 22
       Pointee: 845 StructureType net/http.http2StreamError
     - __kind: PointerType
@@ -13676,7 +13676,7 @@ Types:
       ID: 967
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.373568e+06
+      GoRuntimeType: 1373568
       GoKind: 22
       Pointee: 968 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
@@ -13719,7 +13719,7 @@ Types:
       ID: 819
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.122656e+06
+      GoRuntimeType: 1122656
       GoKind: 22
       Pointee: 820 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
@@ -13733,7 +13733,7 @@ Types:
       ID: 1018
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.82608e+06
+      GoRuntimeType: 1826080
       GoKind: 22
       Pointee: 1019 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
@@ -13766,7 +13766,7 @@ Types:
       ID: 969
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.041152e+06
+      GoRuntimeType: 2041152
       GoKind: 22
       Pointee: 970 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
@@ -13780,7 +13780,7 @@ Types:
       ID: 951
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.121632e+06
+      GoRuntimeType: 1121632
       GoKind: 22
       Pointee: 952 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
@@ -13794,14 +13794,14 @@ Types:
       ID: 846
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.242656e+06
+      GoRuntimeType: 1242656
       GoKind: 22
       Pointee: 847 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 817
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.122528e+06
+      GoRuntimeType: 1122528
       GoKind: 22
       Pointee: 818 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
@@ -13822,14 +13822,14 @@ Types:
       ID: 1020
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.827616e+06
+      GoRuntimeType: 1827616
       GoKind: 22
       Pointee: 1021 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 935
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.01024e+06
+      GoRuntimeType: 1010240
       GoKind: 22
       Pointee: 936 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
@@ -13850,14 +13850,14 @@ Types:
       ID: 977
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 1.9904e+06
+      GoRuntimeType: 1990400
       GoKind: 22
       Pointee: 978 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 937
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.01536e+06
+      GoRuntimeType: 1015360
       GoKind: 22
       Pointee: 938 StructureType net/smtp.dataCloser
     - __kind: PointerType
@@ -13883,14 +13883,14 @@ Types:
       ID: 933
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.0096e+06
+      GoRuntimeType: 1009600
       GoKind: 22
       Pointee: 934 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 854
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.246176e+06
+      GoRuntimeType: 1246176
       GoKind: 22
       Pointee: 855 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
@@ -13921,7 +13921,7 @@ Types:
       ID: 1077
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.212256e+06
+      GoRuntimeType: 2212256
       GoKind: 22
       Pointee: 1078 UnresolvedPointeeType os.File
     - __kind: PointerType
@@ -13935,49 +13935,49 @@ Types:
       ID: 789
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.111264e+06
+      GoRuntimeType: 1111264
       GoKind: 22
       Pointee: 790 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1075
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.209312e+06
+      GoRuntimeType: 2209312
       GoKind: 22
       Pointee: 1076 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1073
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.208576e+06
+      GoRuntimeType: 2208576
       GoKind: 22
       Pointee: 1074 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 756
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.006272e+06
+      GoRuntimeType: 1006272
       GoKind: 22
       Pointee: 757 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 895
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 1.961664e+06
+      GoRuntimeType: 1961664
       GoKind: 22
       Pointee: 896 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 955
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.133664e+06
+      GoRuntimeType: 1133664
       GoKind: 22
       Pointee: 956 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 758
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.0064e+06
+      GoRuntimeType: 1006400
       GoKind: 22
       Pointee: 759 StructureType os/exec.wrappedError
     - __kind: PointerType
@@ -14038,7 +14038,7 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.239776e+06
+      GoRuntimeType: 1239776
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
@@ -14066,7 +14066,7 @@ Types:
       ID: 791
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.11664e+06
+      GoRuntimeType: 1116640
       GoKind: 22
       Pointee: 792 StructureType runtime.errorAddressString
     - __kind: PointerType
@@ -14125,14 +14125,14 @@ Types:
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 1.926944e+06
+      GoRuntimeType: 1926944
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.435936e+06
+      GoRuntimeType: 1435936
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -14158,7 +14158,7 @@ Types:
       ID: 1014
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.824032e+06
+      GoRuntimeType: 1824032
       GoKind: 22
       Pointee: 1015 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
@@ -14184,28 +14184,28 @@ Types:
       ID: 843
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.240896e+06
+      GoRuntimeType: 1240896
       GoKind: 22
       Pointee: 842 BaseType syscall.Errno
     - __kind: PointerType
       ID: 1047
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.028352e+06
+      GoRuntimeType: 2028352
       GoKind: 22
       Pointee: 1048 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 784
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.052096e+06
+      GoRuntimeType: 1052096
       GoKind: 22
       Pointee: 785 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 859
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.441504e+06
+      GoRuntimeType: 1441504
       GoKind: 22
       Pointee: 860 UnresolvedPointeeType time.Location
     - __kind: PointerType
@@ -14273,7 +14273,7 @@ Types:
       ID: 1010
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
-      GoRuntimeType: 1.781056e+06
+      GoRuntimeType: 1781056
       GoKind: 22
       Pointee: 1011 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
@@ -14287,7 +14287,7 @@ Types:
       ID: 1039
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.004928e+06
+      GoRuntimeType: 2004928
       GoKind: 22
       Pointee: 1040 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -14308,14 +14308,14 @@ Types:
       ID: 763
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.009984e+06
+      GoRuntimeType: 1009984
       GoKind: 22
       Pointee: 764 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 765
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.010112e+06
+      GoRuntimeType: 1010112
       GoKind: 22
       Pointee: 718 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -16883,14 +16883,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16905,14 +16905,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 25
           Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22646,14 +22646,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22679,14 +22679,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 66
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -24663,7 +24663,7 @@ Types:
     - __kind: StructureType
       ID: 916
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.084096e+06
+      GoRuntimeType: 1084096
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24674,7 +24674,7 @@ Types:
       ID: 942
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.383648e+06
+      GoRuntimeType: 1383648
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -25277,7 +25277,7 @@ Types:
     - __kind: StructureType
       ID: 822
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.303584e+06
+      GoRuntimeType: 1303584
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25340,7 +25340,7 @@ Types:
       ID: 593
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.6144e+06
+      GoRuntimeType: 1614400
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25378,7 +25378,7 @@ Types:
       ID: 667
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.617472e+06
+      GoRuntimeType: 1617472
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25393,14 +25393,14 @@ Types:
     - __kind: StructureType
       ID: 661
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.081408e+06
+      GoRuntimeType: 1081408
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 663
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.416e+06
+      GoRuntimeType: 1416000
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -25425,7 +25425,7 @@ Types:
       ID: 767
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.379968e+06
+      GoRuntimeType: 1379968
       GoKind: 25
       RawFields:
         - Name: Err
@@ -25434,14 +25434,14 @@ Types:
     - __kind: StructureType
       ID: 669
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.081664e+06
+      GoRuntimeType: 1081664
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 665
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.61728e+06
+      GoRuntimeType: 1617280
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25457,7 +25457,7 @@ Types:
       ID: 682
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.259776e+06
+      GoRuntimeType: 1259776
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25467,7 +25467,7 @@ Types:
       ID: 686
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.259936e+06
+      GoRuntimeType: 1259936
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25525,7 +25525,7 @@ Types:
       ID: 556
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.244416e+06
+      GoRuntimeType: 1244416
       GoKind: 25
       RawFields:
         - Name: error
@@ -25668,7 +25668,7 @@ Types:
       ID: 565
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.612672e+06
+      GoRuntimeType: 1612672
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25691,7 +25691,7 @@ Types:
     - __kind: StructureType
       ID: 571
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.077824e+06
+      GoRuntimeType: 1077824
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25721,7 +25721,7 @@ Types:
       ID: 880
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.084192e+06
+      GoRuntimeType: 2084192
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25837,7 +25837,7 @@ Types:
     - __kind: StructureType
       ID: 611
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.08064e+06
+      GoRuntimeType: 1080640
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25849,14 +25849,14 @@ Types:
     - __kind: StructureType
       ID: 609
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.080512e+06
+      GoRuntimeType: 1080512
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 607
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.41408e+06
+      GoRuntimeType: 1414080
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25869,7 +25869,7 @@ Types:
       ID: 627
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.41488e+06
+      GoRuntimeType: 1414880
       GoKind: 25
       RawFields:
         - Name: File
@@ -25882,7 +25882,7 @@ Types:
       ID: 631
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.616704e+06
+      GoRuntimeType: 1616704
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25898,7 +25898,7 @@ Types:
       ID: 629
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.254176e+06
+      GoRuntimeType: 1254176
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25908,7 +25908,7 @@ Types:
       ID: 625
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.253856e+06
+      GoRuntimeType: 1253856
       GoKind: 25
       RawFields:
         - Name: File
@@ -25918,14 +25918,14 @@ Types:
       ID: 866
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.141088e+06
+      GoRuntimeType: 1141088
       GoKind: 21
       HeaderType: 868 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 889
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.013696e+06
+      GoRuntimeType: 1013696
       GoKind: 23
       RawFields:
         - Name: array
@@ -25948,7 +25948,7 @@ Types:
       ID: 639
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.4152e+06
+      GoRuntimeType: 1415200
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25961,7 +25961,7 @@ Types:
       ID: 633
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.254336e+06
+      GoRuntimeType: 1254336
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25971,7 +25971,7 @@ Types:
       ID: 637
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.616896e+06
+      GoRuntimeType: 1616896
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25987,7 +25987,7 @@ Types:
       ID: 635
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.41504e+06
+      GoRuntimeType: 1415040
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -26000,7 +26000,7 @@ Types:
       ID: 641
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.254496e+06
+      GoRuntimeType: 1254496
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -26010,7 +26010,7 @@ Types:
       ID: 647
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.41552e+06
+      GoRuntimeType: 1415520
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -26023,7 +26023,7 @@ Types:
       ID: 649
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.254816e+06
+      GoRuntimeType: 1254816
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -26033,7 +26033,7 @@ Types:
       ID: 645
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.41536e+06
+      GoRuntimeType: 1415360
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -26046,7 +26046,7 @@ Types:
       ID: 643
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.254656e+06
+      GoRuntimeType: 1254656
       GoKind: 25
       RawFields:
         - Name: Role
@@ -26056,7 +26056,7 @@ Types:
       ID: 651
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.41568e+06
+      GoRuntimeType: 1415680
       GoKind: 25
       RawFields:
         - Name: Given
@@ -26069,7 +26069,7 @@ Types:
       ID: 573
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.246656e+06
+      GoRuntimeType: 1246656
       GoKind: 25
       RawFields:
         - Name: message
@@ -26083,7 +26083,7 @@ Types:
       ID: 575
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.246816e+06
+      GoRuntimeType: 1246816
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -26105,7 +26105,7 @@ Types:
       ID: 579
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.247136e+06
+      GoRuntimeType: 1247136
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -26119,7 +26119,7 @@ Types:
       ID: 1035
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 1.978464e+06
+      GoRuntimeType: 1978464
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -26132,7 +26132,7 @@ Types:
       ID: 1036
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.00224e+06
+      GoRuntimeType: 2002240
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -26152,7 +26152,7 @@ Types:
       ID: 577
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.246976e+06
+      GoRuntimeType: 1246976
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -26162,7 +26162,7 @@ Types:
       ID: 581
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.247296e+06
+      GoRuntimeType: 1247296
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -26212,7 +26212,7 @@ Types:
       ID: 587
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.248256e+06
+      GoRuntimeType: 1248256
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -26227,7 +26227,7 @@ Types:
       ID: 806
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.721824e+06
+      GoRuntimeType: 1721824
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -26247,7 +26247,7 @@ Types:
       ID: 739
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.518208e+06
+      GoRuntimeType: 1518208
       GoKind: 25
       RawFields:
         - Name: Got
@@ -26260,7 +26260,7 @@ Types:
       ID: 812
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.722272e+06
+      GoRuntimeType: 1722272
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26282,7 +26282,7 @@ Types:
       ID: 804
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.7216e+06
+      GoRuntimeType: 1721600
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -26304,7 +26304,7 @@ Types:
       ID: 802
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.721376e+06
+      GoRuntimeType: 1721376
       GoKind: 25
       RawFields:
         - Name: Method
@@ -26320,7 +26320,7 @@ Types:
       ID: 810
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.640288e+06
+      GoRuntimeType: 1640288
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26333,7 +26333,7 @@ Types:
       ID: 808
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.722048e+06
+      GoRuntimeType: 1722048
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26353,7 +26353,7 @@ Types:
       ID: 816
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.442464e+06
+      GoRuntimeType: 1442464
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -26362,20 +26362,20 @@ Types:
     - __kind: StructureType
       ID: 743
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.201184e+06
+      GoRuntimeType: 1201184
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 741
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.201056e+06
+      GoRuntimeType: 1201056
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 814
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.64048e+06
+      GoRuntimeType: 1640480
       GoKind: 25
       RawFields:
         - Name: cause
@@ -26458,7 +26458,7 @@ Types:
         - Name: X
           Offset: 0
           Type: 9 BaseType int
-        - Name: Y
+        - Name: "Y"
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
@@ -26499,7 +26499,7 @@ Types:
       ID: 783
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.271616e+06
+      GoRuntimeType: 1271616
       GoKind: 25
       RawFields:
         - Name: error
@@ -26509,7 +26509,7 @@ Types:
       ID: 960
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.495072e+06
+      GoRuntimeType: 1495072
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -26523,7 +26523,7 @@ Types:
       ID: 984
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.09152e+06
+      GoRuntimeType: 1091520
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26536,7 +26536,7 @@ Types:
       ID: 946
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.388448e+06
+      GoRuntimeType: 1388448
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -26558,7 +26558,7 @@ Types:
       ID: 841
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.759904e+06
+      GoRuntimeType: 1759904
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26574,7 +26574,7 @@ Types:
       ID: 702
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.42288e+06
+      GoRuntimeType: 1422880
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26667,7 +26667,7 @@ Types:
       ID: 706
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.272256e+06
+      GoRuntimeType: 1272256
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26683,7 +26683,7 @@ Types:
       ID: 694
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.267296e+06
+      GoRuntimeType: 1267296
       GoKind: 25
       RawFields:
         - Name: error
@@ -26697,7 +26697,7 @@ Types:
       ID: 864
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.785664e+06
+      GoRuntimeType: 1785664
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26713,7 +26713,7 @@ Types:
       ID: 696
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.4224e+06
+      GoRuntimeType: 1422400
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26726,7 +26726,7 @@ Types:
       ID: 1007
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.839136e+06
+      GoRuntimeType: 1839136
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26743,7 +26743,7 @@ Types:
       ID: 781
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.386048e+06
+      GoRuntimeType: 1386048
       GoKind: 25
       RawFields:
         - Name: error
@@ -26768,14 +26768,14 @@ Types:
     - __kind: StructureType
       ID: 835
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.332864e+06
+      GoRuntimeType: 1332864
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 688
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.260576e+06
+      GoRuntimeType: 1260576
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26785,7 +26785,7 @@ Types:
       ID: 690
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.260736e+06
+      GoRuntimeType: 1260736
       GoKind: 25
       RawFields:
         - Name: Line
@@ -27772,7 +27772,7 @@ Types:
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.729888e+06
+      GoRuntimeType: 1729888
       GoKind: 25
       RawFields:
         - Name: buf
@@ -27784,7 +27784,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -27805,7 +27805,7 @@ Types:
     - __kind: StructureType
       ID: 796
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.300544e+06
+      GoRuntimeType: 1300544
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27816,7 +27816,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.13328e+06
+      GoRuntimeType: 1133280
       GoKind: 25
       RawFields:
         - Name: u
@@ -27826,7 +27826,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.456672e+06
+      GoRuntimeType: 1456672
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27842,7 +27842,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.313824e+06
+      GoRuntimeType: 1313824
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27855,7 +27855,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.313664e+06
+      GoRuntimeType: 1313664
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27868,7 +27868,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.313984e+06
+      GoRuntimeType: 1313984
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27897,7 +27897,7 @@ Types:
       ID: 991
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.1096e+06
+      GoRuntimeType: 1109600
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27923,7 +27923,7 @@ Types:
       ID: 979
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.07424e+06
+      GoRuntimeType: 1074240
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27948,7 +27948,7 @@ Types:
     - __kind: StructureType
       ID: 948
       Name: io.discard
-      GoRuntimeType: 1.287904e+06
+      GoRuntimeType: 1287904
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -28031,7 +28031,7 @@ Types:
       ID: 121
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.429216e+06
+      GoRuntimeType: 1429216
       GoKind: 25
       RawFields:
         - Name: x
@@ -28047,7 +28047,7 @@ Types:
       ID: 136
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.105888e+06
+      GoRuntimeType: 1105888
       GoKind: 25
       RawFields:
         - Name: a
@@ -28057,7 +28057,7 @@ Types:
       ID: 368
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.10576e+06
+      GoRuntimeType: 1105760
       GoKind: 25
       RawFields:
         - Name: a
@@ -28071,7 +28071,7 @@ Types:
       ID: 145
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.10512e+06
+      GoRuntimeType: 1105120
       GoKind: 25
       RawFields:
         - Name: a
@@ -28081,7 +28081,7 @@ Types:
       ID: 1153
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.104992e+06
+      GoRuntimeType: 1104992
       GoKind: 25
       RawFields:
         - Name: a
@@ -28091,7 +28091,7 @@ Types:
       ID: 1162
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.104864e+06
+      GoRuntimeType: 1104864
       GoKind: 25
       RawFields:
         - Name: a
@@ -28101,7 +28101,7 @@ Types:
       ID: 125
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.10704e+06
+      GoRuntimeType: 1107040
       GoKind: 25
       RawFields:
         - Name: a
@@ -28111,7 +28111,7 @@ Types:
       ID: 127
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.106912e+06
+      GoRuntimeType: 1106912
       GoKind: 25
       RawFields:
         - Name: a
@@ -28125,7 +28125,7 @@ Types:
       ID: 129
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.106272e+06
+      GoRuntimeType: 1106272
       GoKind: 25
       RawFields:
         - Name: a
@@ -28135,7 +28135,7 @@ Types:
       ID: 1128
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.106144e+06
+      GoRuntimeType: 1106144
       GoKind: 25
       RawFields:
         - Name: a
@@ -28145,7 +28145,7 @@ Types:
       ID: 1130
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.106016e+06
+      GoRuntimeType: 1106016
       GoKind: 25
       RawFields:
         - Name: a
@@ -28155,7 +28155,7 @@ Types:
       ID: 130
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.108192e+06
+      GoRuntimeType: 1108192
       GoKind: 25
       RawFields:
         - Name: a
@@ -28165,7 +28165,7 @@ Types:
       ID: 361
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.108064e+06
+      GoRuntimeType: 1108064
       GoKind: 25
       RawFields:
         - Name: a
@@ -28179,7 +28179,7 @@ Types:
       ID: 135
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.107424e+06
+      GoRuntimeType: 1107424
       GoKind: 25
       RawFields:
         - Name: a
@@ -28189,7 +28189,7 @@ Types:
       ID: 1134
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.107296e+06
+      GoRuntimeType: 1107296
       GoKind: 25
       RawFields:
         - Name: a
@@ -28199,7 +28199,7 @@ Types:
       ID: 1140
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.107168e+06
+      GoRuntimeType: 1107168
       GoKind: 25
       RawFields:
         - Name: a
@@ -28214,7 +28214,7 @@ Types:
       ID: 159
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.713984e+06
+      GoRuntimeType: 1713984
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -28236,7 +28236,7 @@ Types:
       ID: 154
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.840448e+06
+      GoRuntimeType: 1840448
       GoKind: 25
       RawFields:
         - Name: _
@@ -28264,7 +28264,7 @@ Types:
       ID: 352
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.237696e+06
+      GoRuntimeType: 1237696
       GoKind: 25
       RawFields:
         - Name: s
@@ -28607,7 +28607,7 @@ Types:
       ID: 116
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.286944e+06
+      GoRuntimeType: 1286944
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -28620,7 +28620,7 @@ Types:
       ID: 245
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.286624e+06
+      GoRuntimeType: 1286624
       GoKind: 25
       RawFields:
         - Name: val
@@ -28654,7 +28654,7 @@ Types:
       ID: 1108
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.237856e+06
+      GoRuntimeType: 1237856
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 9 BaseType int}]
     - __kind: GoInterfaceType
@@ -28714,7 +28714,7 @@ Types:
       ID: 163
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.104608e+06
+      GoRuntimeType: 1104608
       GoKind: 25
       RawFields:
         - Name: a
@@ -28784,7 +28784,7 @@ Types:
       ID: 164
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.104736e+06
+      GoRuntimeType: 1104736
       GoKind: 25
       RawFields:
         - Name: m
@@ -29129,7 +29129,7 @@ Types:
       ID: 623
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.253536e+06
+      GoRuntimeType: 1253536
       GoKind: 25
       RawFields:
         - Name: msg
@@ -29139,7 +29139,7 @@ Types:
       ID: 912
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.250336e+06
+      GoRuntimeType: 1250336
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29153,7 +29153,7 @@ Types:
       ID: 888
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.4128e+06
+      GoRuntimeType: 1412800
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29194,7 +29194,7 @@ Types:
       ID: 786
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.07744e+06
+      GoRuntimeType: 1077440
       GoKind: 24
       RawFields:
         - Name: str
@@ -29212,7 +29212,7 @@ Types:
     - __kind: StructureType
       ID: 755
       Name: net.canceledError
-      GoRuntimeType: 1.20208e+06
+      GoRuntimeType: 1202080
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29223,7 +29223,7 @@ Types:
       ID: 893
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 1.97776e+06
+      GoRuntimeType: 1977760
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29245,13 +29245,13 @@ Types:
     - __kind: StructureType
       ID: 1066
       Name: net.noReadFrom
-      GoRuntimeType: 1.077696e+06
+      GoRuntimeType: 1077696
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1065
       Name: net.noWriteTo
-      GoRuntimeType: 1.077568e+06
+      GoRuntimeType: 1077568
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29262,7 +29262,7 @@ Types:
       ID: 560
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.61248e+06
+      GoRuntimeType: 1612480
       GoKind: 25
       RawFields:
         - Name: p
@@ -29278,7 +29278,7 @@ Types:
       ID: 1054
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.15408e+06
+      GoRuntimeType: 2154080
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29291,7 +29291,7 @@ Types:
       ID: 1052
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.153536e+06
+      GoRuntimeType: 2153536
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29316,7 +29316,7 @@ Types:
       ID: 906
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.241856e+06
+      GoRuntimeType: 1241856
       GoKind: 25
       RawFields:
         - Name: w
@@ -29338,7 +29338,7 @@ Types:
       ID: 536
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.61056e+06
+      GoRuntimeType: 1610560
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -29354,7 +29354,7 @@ Types:
       ID: 845
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.775936e+06
+      GoRuntimeType: 1775936
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -29370,7 +29370,7 @@ Types:
       ID: 540
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.41232e+06
+      GoRuntimeType: 1412320
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29447,7 +29447,7 @@ Types:
     - __kind: StructureType
       ID: 751
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.20144e+06
+      GoRuntimeType: 1201440
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29477,7 +29477,7 @@ Types:
       ID: 908
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
-      GoRuntimeType: 1.611328e+06
+      GoRuntimeType: 1611328
       GoKind: 25
       RawFields:
         - Name: conn
@@ -29500,7 +29500,7 @@ Types:
       ID: 747
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.374208e+06
+      GoRuntimeType: 1374208
       GoKind: 25
       RawFields:
         - Name: error
@@ -29514,7 +29514,7 @@ Types:
       ID: 926
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.374048e+06
+      GoRuntimeType: 1374048
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29524,7 +29524,7 @@ Types:
       ID: 952
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.682624e+06
+      GoRuntimeType: 1682624
       GoKind: 25
       RawFields:
         - Name: _
@@ -29540,7 +29540,7 @@ Types:
       ID: 544
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.242816e+06
+      GoRuntimeType: 1242816
       GoKind: 25
       RawFields:
         - Name: error
@@ -29553,14 +29553,14 @@ Types:
     - __kind: StructureType
       ID: 818
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.303264e+06
+      GoRuntimeType: 1303264
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 749
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.374368e+06
+      GoRuntimeType: 1374368
       GoKind: 25
       RawFields:
         - Name: err
@@ -29574,7 +29574,7 @@ Types:
       ID: 1021
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 1.914176e+06
+      GoRuntimeType: 1914176
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29588,7 +29588,7 @@ Types:
       ID: 615
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.61632e+06
+      GoRuntimeType: 1616320
       GoKind: 25
       RawFields:
         - Name: in
@@ -29604,7 +29604,7 @@ Types:
       ID: 613
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.41424e+06
+      GoRuntimeType: 1414240
       GoKind: 25
       RawFields:
         - Name: in
@@ -29621,7 +29621,7 @@ Types:
       ID: 938
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.41616e+06
+      GoRuntimeType: 1416160
       GoKind: 25
       RawFields:
         - Name: c
@@ -29715,7 +29715,7 @@ Types:
       ID: 1076
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.222272e+06
+      GoRuntimeType: 2222272
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29728,7 +29728,7 @@ Types:
       ID: 1074
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.221472e+06
+      GoRuntimeType: 2221472
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29740,13 +29740,13 @@ Types:
     - __kind: StructureType
       ID: 1082
       Name: os.noReadFrom
-      GoRuntimeType: 1.075264e+06
+      GoRuntimeType: 1075264
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1081
       Name: os.noWriteTo
-      GoRuntimeType: 1.075136e+06
+      GoRuntimeType: 1075136
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29765,7 +29765,7 @@ Types:
       ID: 759
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.518784e+06
+      GoRuntimeType: 1518784
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -29827,13 +29827,13 @@ Types:
       ID: 733
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.765504e+06
+      GoRuntimeType: 1765504
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
           Type: 14 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 9 BaseType int
         - Name: signed
@@ -29866,7 +29866,7 @@ Types:
       ID: 792
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.636448e+06
+      GoRuntimeType: 1636448
       GoKind: 25
       RawFields:
         - Name: msg
@@ -29898,7 +29898,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 2.265504e+06
+      GoRuntimeType: 2265504
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30073,7 +30073,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.116384e+06
+      GoRuntimeType: 1116384
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -30083,7 +30083,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.842752e+06
+      GoRuntimeType: 1842752
       GoKind: 25
       RawFields:
         - Name: sp
@@ -30111,7 +30111,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.295584e+06
+      GoRuntimeType: 1295584
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -30124,7 +30124,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.635488e+06
+      GoRuntimeType: 1635488
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30149,7 +30149,7 @@ Types:
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.295424e+06
+      GoRuntimeType: 1295424
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -30162,13 +30162,13 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.791008e+06
+      GoRuntimeType: 1791008
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -30193,7 +30193,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 2.271616e+06
+      GoRuntimeType: 2271616
       GoKind: 25
       RawFields:
         - Name: g0
@@ -30413,7 +30413,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.790752e+06
+      GoRuntimeType: 1790752
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -30438,7 +30438,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 1.43632e+06
+      GoRuntimeType: 1436320
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -30454,7 +30454,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 1.436128e+06
+      GoRuntimeType: 1436128
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -30480,14 +30480,14 @@ Types:
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.116e+06
+      GoRuntimeType: 1116000
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.295264e+06
+      GoRuntimeType: 1295264
       GoKind: 25
       RawFields:
         - Name: entries
@@ -30500,13 +30500,13 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.636256e+06
+      GoRuntimeType: 1636256
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -30553,7 +30553,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.293664e+06
+      GoRuntimeType: 1293664
       GoKind: 25
       RawFields:
         - Name: lo
@@ -30590,7 +30590,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.294624e+06
+      GoRuntimeType: 1294624
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -30603,7 +30603,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.075648e+06
+      GoRuntimeType: 1075648
       GoKind: 8
     - __kind: StructureType
       ID: 75
@@ -30646,7 +30646,7 @@ Types:
       ID: 920
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.279424e+06
+      GoRuntimeType: 1279424
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -30662,7 +30662,7 @@ Types:
       ID: 1097
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.288864e+06
+      GoRuntimeType: 1288864
       GoKind: 25
       RawFields:
         - Name: state
@@ -30675,7 +30675,7 @@ Types:
       ID: 1098
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.289984e+06
+      GoRuntimeType: 1289984
       GoKind: 25
       RawFields:
         - Name: done
@@ -30688,7 +30688,7 @@ Types:
       ID: 1101
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.430944e+06
+      GoRuntimeType: 1430944
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -30710,7 +30710,7 @@ Types:
       ID: 1105
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.290304e+06
+      GoRuntimeType: 1290304
       GoKind: 25
       RawFields:
         - Name: _
@@ -30723,7 +30723,7 @@ Types:
       ID: 1099
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.290464e+06
+      GoRuntimeType: 1290464
       GoKind: 25
       RawFields:
         - Name: _
@@ -30736,7 +30736,7 @@ Types:
       ID: 1103
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.431328e+06
+      GoRuntimeType: 1431328
       GoKind: 25
       RawFields:
         - Name: _
@@ -30764,7 +30764,7 @@ Types:
       ID: 842
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.200672e+06
+      GoRuntimeType: 1200672
       GoKind: 12
     - __kind: UnresolvedPointeeType
       ID: 1048
@@ -30774,7 +30774,7 @@ Types:
       ID: 785
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.5232e+06
+      GoRuntimeType: 1523200
       GoKind: 25
       RawFields:
         - Name: Name
@@ -30787,7 +30787,7 @@ Types:
       ID: 987
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.791776e+06
+      GoRuntimeType: 1791776
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 860
@@ -30801,7 +30801,7 @@ Types:
       ID: 858
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.234496e+06
+      GoRuntimeType: 2234496
       GoKind: 25
       RawFields:
         - Name: wall
@@ -30882,7 +30882,7 @@ Types:
       ID: 876
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 1.935904e+06
+      GoRuntimeType: 1935904
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30894,7 +30894,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 878 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 9 BaseType int
         - Name: index
@@ -30922,7 +30922,7 @@ Types:
       ID: 877
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.802272e+06
+      GoRuntimeType: 1802272
       GoKind: 25
       RawFields:
         - Name: id
@@ -30961,7 +30961,7 @@ Types:
       ID: 601
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.250656e+06
+      GoRuntimeType: 1250656
       GoKind: 25
       RawFields:
         - Name: Err
@@ -30977,7 +30977,7 @@ Types:
       ID: 764
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.518976e+06
+      GoRuntimeType: 1518976
       GoKind: 25
       RawFields:
         - Name: label

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -576,8 +576,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 86}
@@ -600,7 +600,7 @@ Probes:
                   EventExpressionIndex: 1
                 - ', '
                 - Error: failed to resolve reference "y"
-                  DSL: y
+                  DSL: "y"
     - id: testConflictingReturn
       version: 0
       type: LOG_PROBE
@@ -1713,8 +1713,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 53}
@@ -1735,8 +1735,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
     - id: testInlinedBBA
@@ -5475,8 +5475,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
         - ', '
         - json: {ref: z}
           dsl: z
@@ -5496,8 +5496,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
                 - ', '
@@ -6832,7 +6832,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 7 BaseType int
           Locations:
             - Range: 0x84e740..0x84e76c
@@ -7373,7 +7373,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 17 BaseType float32
           Locations:
             - Range: 0x850880..0x850890
@@ -7404,7 +7404,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 17 BaseType float32
           Locations:
             - Range: 0x8508a0..0x8508b0
@@ -9818,7 +9818,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x853b20..0x853b30
@@ -11634,7 +11634,7 @@ Types:
       ID: 1173
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.986848e+06
+      GoRuntimeType: 1986848
       GoKind: 22
       Pointee: 1174 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
@@ -11653,7 +11653,7 @@ Types:
       ID: 1108
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.438144e+06
+      GoRuntimeType: 1438144
       GoKind: 22
       Pointee: 1109 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
@@ -11674,21 +11674,21 @@ Types:
       ID: 1156
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.906528e+06
+      GoRuntimeType: 1906528
       GoKind: 22
       Pointee: 1157 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 1084
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.057856e+06
+      GoRuntimeType: 1057856
       GoKind: 22
       Pointee: 1085 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 1086
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.058112e+06
+      GoRuntimeType: 1058112
       GoKind: 22
       Pointee: 1087 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
@@ -11702,21 +11702,21 @@ Types:
       ID: 1131
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.17568e+06
+      GoRuntimeType: 2175680
       GoKind: 22
       Pointee: 1132 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1162
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.951552e+06
+      GoRuntimeType: 1951552
       GoKind: 22
       Pointee: 1163 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1211
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.27296e+06
+      GoRuntimeType: 2272960
       GoKind: 22
       Pointee: 1212 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -11742,7 +11742,7 @@ Types:
       ID: 1106
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.427584e+06
+      GoRuntimeType: 1427584
       GoKind: 22
       Pointee: 1107 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
@@ -11756,14 +11756,14 @@ Types:
       ID: 1128
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.728512e+06
+      GoRuntimeType: 1728512
       GoKind: 22
       Pointee: 1129 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 958
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.2056e+06
+      GoRuntimeType: 1205600
       GoKind: 22
       Pointee: 959 StructureType context.deadlineExceededError
     - __kind: PointerType
@@ -11791,42 +11791,42 @@ Types:
       ID: 1118
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
-      GoRuntimeType: 1.569344e+06
+      GoRuntimeType: 1569344
       GoKind: 22
       Pointee: 1119 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
       ID: 1152
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.865184e+06
+      GoRuntimeType: 1865184
       GoKind: 22
       Pointee: 1153 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
       ID: 1184
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
-      GoRuntimeType: 2.123008e+06
+      GoRuntimeType: 2123008
       GoKind: 22
       Pointee: 1185 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
       ID: 1158
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.90704e+06
+      GoRuntimeType: 1907040
       GoKind: 22
       Pointee: 1159 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
       ID: 1154
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.865632e+06
+      GoRuntimeType: 1865632
       GoKind: 22
       Pointee: 1155 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
       ID: 1150
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.858016e+06
+      GoRuntimeType: 1858016
       GoKind: 22
       Pointee: 1151 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
@@ -11840,14 +11840,14 @@ Types:
       ID: 1168
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 1.956416e+06
+      GoRuntimeType: 1956416
       GoKind: 22
       Pointee: 1169 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1140
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
-      GoRuntimeType: 1.812e+06
+      GoRuntimeType: 1812000
       GoKind: 22
       Pointee: 1141 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
@@ -11861,14 +11861,14 @@ Types:
       ID: 898
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.046464e+06
+      GoRuntimeType: 1046464
       GoKind: 22
       Pointee: 899 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1237
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.384832e+06
+      GoRuntimeType: 2384832
       GoKind: 22
       Pointee: 1238 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
@@ -11889,35 +11889,35 @@ Types:
       ID: 897
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.0448e+06
+      GoRuntimeType: 1044800
       GoKind: 22
       Pointee: 854 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 1116
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.562304e+06
+      GoRuntimeType: 1562304
       GoKind: 22
       Pointee: 1117 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
       ID: 1123
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.646208e+06
+      GoRuntimeType: 1646208
       GoKind: 22
       Pointee: 1124 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 993
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.427904e+06
+      GoRuntimeType: 1427904
       GoKind: 22
       Pointee: 994 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 1008
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.044896e+06
+      GoRuntimeType: 2044896
       GoKind: 22
       Pointee: 1009 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
@@ -11952,7 +11952,7 @@ Types:
       ID: 903
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.052224e+06
+      GoRuntimeType: 1052224
       GoKind: 22
       Pointee: 904 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
@@ -12001,7 +12001,7 @@ Types:
       ID: 1074
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.042368e+06
+      GoRuntimeType: 1042368
       GoKind: 22
       Pointee: 1075 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -12022,7 +12022,7 @@ Types:
       ID: 889
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.038656e+06
+      GoRuntimeType: 1038656
       GoKind: 22
       Pointee: 890 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
@@ -12057,7 +12057,7 @@ Types:
       ID: 1217
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.297984e+06
+      GoRuntimeType: 2297984
       GoKind: 22
       Pointee: 1218 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
@@ -12071,7 +12071,7 @@ Types:
       ID: 1082
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.054784e+06
+      GoRuntimeType: 1054784
       GoKind: 22
       Pointee: 1083 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
@@ -12111,7 +12111,7 @@ Types:
       ID: 1195
       Name: '*encoding/xml.printer'
       ByteSize: 8
-      GoRuntimeType: 2.16144e+06
+      GoRuntimeType: 2161440
       GoKind: 22
       Pointee: 1196 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
@@ -12132,7 +12132,7 @@ Types:
       ID: 856
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1.023168e+06
+      GoRuntimeType: 1023168
       GoKind: 22
       Pointee: 857 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -12153,21 +12153,21 @@ Types:
       ID: 1205
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.26528e+06
+      GoRuntimeType: 2265280
       GoKind: 22
       Pointee: 1206 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 858
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.023296e+06
+      GoRuntimeType: 1023296
       GoKind: 22
       Pointee: 859 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 860
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.023424e+06
+      GoRuntimeType: 1023424
       GoKind: 22
       Pointee: 861 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -12252,14 +12252,14 @@ Types:
       ID: 1096
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.211104e+06
+      GoRuntimeType: 1211104
       GoKind: 22
       Pointee: 1097 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1181
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 2.060224e+06
+      GoRuntimeType: 2060224
       GoKind: 22
       Pointee: 1182 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
@@ -12273,14 +12273,14 @@ Types:
       ID: 967
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.214688e+06
+      GoRuntimeType: 1214688
       GoKind: 22
       Pointee: 968 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1213
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.275008e+06
+      GoRuntimeType: 2275008
       GoKind: 22
       Pointee: 1214 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
@@ -12432,7 +12432,7 @@ Types:
       ID: 1134
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.804608e+06
+      GoRuntimeType: 1804608
       GoKind: 22
       Pointee: 1135 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
@@ -12446,21 +12446,21 @@ Types:
       ID: 1114
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.561184e+06
+      GoRuntimeType: 1561184
       GoKind: 22
       Pointee: 1115 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 1070
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.041344e+06
+      GoRuntimeType: 1041344
       GoKind: 22
       Pointee: 1071 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1104
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.425664e+06
+      GoRuntimeType: 1425664
       GoKind: 22
       Pointee: 1105 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
@@ -12474,28 +12474,28 @@ Types:
       ID: 1171
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.977056e+06
+      GoRuntimeType: 1977056
       GoKind: 22
       Pointee: 1172 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1188
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.134976e+06
+      GoRuntimeType: 2134976
       GoKind: 22
       Pointee: 1183 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1187
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.134592e+06
+      GoRuntimeType: 2134592
       GoKind: 22
       Pointee: 1186 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 1072
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.041472e+06
+      GoRuntimeType: 1041472
       GoKind: 22
       Pointee: 1073 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
@@ -12516,70 +12516,70 @@ Types:
       ID: 1136
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.8064e+06
+      GoRuntimeType: 1806400
       GoKind: 22
       Pointee: 1137 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1177
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.013504e+06
+      GoRuntimeType: 2013504
       GoKind: 22
       Pointee: 1178 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1179
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.044576e+06
+      GoRuntimeType: 2044576
       GoKind: 22
       Pointee: 1180 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 998
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.440544e+06
+      GoRuntimeType: 1440544
       GoKind: 22
       Pointee: 999 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 911
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.066304e+06
+      GoRuntimeType: 1066304
       GoKind: 22
       Pointee: 912 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 909
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.066176e+06
+      GoRuntimeType: 1066176
       GoKind: 22
       Pointee: 910 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 913
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.070272e+06
+      GoRuntimeType: 1070272
       GoKind: 22
       Pointee: 914 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 915
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.0704e+06
+      GoRuntimeType: 1070400
       GoKind: 22
       Pointee: 916 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 1125
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.67328e+06
+      GoRuntimeType: 1673280
       GoKind: 22
       Pointee: 1126 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 905
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.052864e+06
+      GoRuntimeType: 1052864
       GoKind: 22
       Pointee: 906 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
@@ -12593,112 +12593,112 @@ Types:
       ID: 1229
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.361056e+06
+      GoRuntimeType: 2361056
       GoKind: 22
       Pointee: 1230 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 969
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.223136e+06
+      GoRuntimeType: 1223136
       GoKind: 22
       Pointee: 970 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 942
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.201888e+06
+      GoRuntimeType: 1201888
       GoKind: 22
       Pointee: 943 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 936
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.201504e+06
+      GoRuntimeType: 1201504
       GoKind: 22
       Pointee: 937 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 875
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.03264e+06
+      GoRuntimeType: 1032640
       GoKind: 22
       Pointee: 876 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 948
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.202272e+06
+      GoRuntimeType: 1202272
       GoKind: 22
       Pointee: 949 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 874
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1.032512e+06
+      GoRuntimeType: 1032512
       GoKind: 22
       Pointee: 853 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 940
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.20176e+06
+      GoRuntimeType: 1201760
       GoKind: 22
       Pointee: 941 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 938
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.201632e+06
+      GoRuntimeType: 1201632
       GoKind: 22
       Pointee: 939 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 946
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.202144e+06
+      GoRuntimeType: 1202144
       GoKind: 22
       Pointee: 947 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 944
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.202016e+06
+      GoRuntimeType: 1202016
       GoKind: 22
       Pointee: 945 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1233
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.372864e+06
+      GoRuntimeType: 2372864
       GoKind: 22
       Pointee: 1234 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 952
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.202656e+06
+      GoRuntimeType: 1202656
       GoKind: 22
       Pointee: 953 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 879
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1.032896e+06
+      GoRuntimeType: 1032896
       GoKind: 22
       Pointee: 880 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 877
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1.032768e+06
+      GoRuntimeType: 1032768
       GoKind: 22
       Pointee: 878 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 950
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.202528e+06
+      GoRuntimeType: 1202528
       GoKind: 22
       Pointee: 951 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -12761,35 +12761,35 @@ Types:
       ID: 1011
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.671744e+06
+      GoRuntimeType: 1671744
       GoKind: 22
       Pointee: 1012 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 919
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.08512e+06
+      GoRuntimeType: 1085120
       GoKind: 22
       Pointee: 920 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 1102
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.262688e+06
+      GoRuntimeType: 1262688
       GoKind: 22
       Pointee: 1103 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1193
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.149568e+06
+      GoRuntimeType: 2149568
       GoKind: 22
       Pointee: 1194 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 1088
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.087424e+06
+      GoRuntimeType: 1087424
       GoKind: 22
       Pointee: 1089 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
@@ -12803,7 +12803,7 @@ Types:
       ID: 977
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.264352e+06
+      GoRuntimeType: 1264352
       GoKind: 22
       Pointee: 978 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
@@ -12865,7 +12865,7 @@ Types:
       ID: 1191
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.147648e+06
+      GoRuntimeType: 2147648
       GoKind: 22
       Pointee: 1192 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -12893,14 +12893,14 @@ Types:
       ID: 975
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.261408e+06
+      GoRuntimeType: 1261408
       GoKind: 22
       Pointee: 976 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 1000
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.447904e+06
+      GoRuntimeType: 1447904
       GoKind: 22
       Pointee: 1001 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
@@ -12914,21 +12914,21 @@ Types:
       ID: 1142
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.812448e+06
+      GoRuntimeType: 1812448
       GoKind: 22
       Pointee: 1143 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 1100
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.257952e+06
+      GoRuntimeType: 1257952
       GoKind: 22
       Pointee: 1101 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 917
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.07936e+06
+      GoRuntimeType: 1079360
       GoKind: 22
       Pointee: 918 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
@@ -12949,21 +12949,21 @@ Types:
       ID: 907
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.056192e+06
+      GoRuntimeType: 1056192
       GoKind: 22
       Pointee: 908 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 973
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.229408e+06
+      GoRuntimeType: 1229408
       GoKind: 22
       Pointee: 974 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 971
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.229152e+06
+      GoRuntimeType: 1229152
       GoKind: 22
       Pointee: 972 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
@@ -12991,7 +12991,7 @@ Types:
       ID: 1148
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.853088e+06
+      GoRuntimeType: 1853088
       GoKind: 22
       Pointee: 1149 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
@@ -13068,21 +13068,21 @@ Types:
       ID: 934
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.200736e+06
+      GoRuntimeType: 1200736
       GoKind: 22
       Pointee: 935 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1235
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.378496e+06
+      GoRuntimeType: 2378496
       GoKind: 22
       Pointee: 1236 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 932
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.200608e+06
+      GoRuntimeType: 1200608
       GoKind: 22
       Pointee: 933 StructureType internal/poll.errNetClosing
     - __kind: PointerType
@@ -13096,35 +13096,35 @@ Types:
       ID: 1092
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.192416e+06
+      GoRuntimeType: 1192416
       GoKind: 22
       Pointee: 1093 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1090
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.192032e+06
+      GoRuntimeType: 1192032
       GoKind: 22
       Pointee: 1091 StructureType io.discard
     - __kind: PointerType
       ID: 1064
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.024192e+06
+      GoRuntimeType: 1024192
       GoKind: 22
       Pointee: 1065 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 930
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.200352e+06
+      GoRuntimeType: 1200352
       GoKind: 22
       Pointee: 931 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 1138
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.806624e+06
+      GoRuntimeType: 1806624
       GoKind: 22
       Pointee: 1139 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13531,63 +13531,63 @@ Types:
       ID: 961
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.208928e+06
+      GoRuntimeType: 1208928
       GoKind: 22
       Pointee: 962 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 987
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.423904e+06
+      GoRuntimeType: 1423904
       GoKind: 22
       Pointee: 988 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1199
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.236096e+06
+      GoRuntimeType: 2236096
       GoKind: 22
       Pointee: 1200 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 985
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.423584e+06
+      GoRuntimeType: 1423584
       GoKind: 22
       Pointee: 986 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 963
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.209056e+06
+      GoRuntimeType: 1209056
       GoKind: 22
       Pointee: 964 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1209
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.266304e+06
+      GoRuntimeType: 2266304
       GoKind: 22
       Pointee: 1210 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1219
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.311296e+06
+      GoRuntimeType: 2311296
       GoKind: 22
       Pointee: 1220 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1207
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.265792e+06
+      GoRuntimeType: 2265792
       GoKind: 22
       Pointee: 1208 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 960
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.20816e+06
+      GoRuntimeType: 1208160
       GoKind: 22
       Pointee: 923 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13599,28 +13599,28 @@ Types:
       ID: 891
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.039552e+06
+      GoRuntimeType: 1039552
       GoKind: 22
       Pointee: 892 StructureType net.canceledError
     - __kind: PointerType
       ID: 1175
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2.010624e+06
+      GoRuntimeType: 2010624
       GoKind: 22
       Pointee: 1176 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1029
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.848832e+06
+      GoRuntimeType: 1848832
       GoKind: 22
       Pointee: 1030 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1221
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.315552e+06
+      GoRuntimeType: 2315552
       GoKind: 22
       Pointee: 1222 UnresolvedPointeeType net.netFD
     - __kind: PointerType
@@ -13641,35 +13641,35 @@ Types:
       ID: 1203
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.25184e+06
+      GoRuntimeType: 2251840
       GoKind: 22
       Pointee: 1204 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1201
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.25136e+06
+      GoRuntimeType: 2251360
       GoKind: 22
       Pointee: 1202 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 965
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.209696e+06
+      GoRuntimeType: 1209696
       GoKind: 22
       Pointee: 966 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 989
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.424064e+06
+      GoRuntimeType: 1424064
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 881
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1.035328e+06
+      GoRuntimeType: 1035328
       GoKind: 22
       Pointee: 882 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
@@ -13697,7 +13697,7 @@ Types:
       ID: 981
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.419744e+06
+      GoRuntimeType: 1419744
       GoKind: 22
       Pointee: 982 StructureType net/http.http2StreamError
     - __kind: PointerType
@@ -13711,7 +13711,7 @@ Types:
       ID: 1110
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.557664e+06
+      GoRuntimeType: 1557664
       GoKind: 22
       Pointee: 1111 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
@@ -13754,21 +13754,21 @@ Types:
       ID: 956
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.204704e+06
+      GoRuntimeType: 1204704
       GoKind: 22
       Pointee: 957 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 887
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1.035968e+06
+      GoRuntimeType: 1035968
       GoKind: 22
       Pointee: 888 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1164
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.953088e+06
+      GoRuntimeType: 1953088
       GoKind: 22
       Pointee: 1165 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
@@ -13794,28 +13794,28 @@ Types:
       ID: 883
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1.035584e+06
+      GoRuntimeType: 1035584
       GoKind: 22
       Pointee: 884 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1112
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.177344e+06
+      GoRuntimeType: 2177344
       GoKind: 22
       Pointee: 1113 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1068
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1.035456e+06
+      GoRuntimeType: 1035456
       GoKind: 22
       Pointee: 1069 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 1094
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.203808e+06
+      GoRuntimeType: 1203808
       GoKind: 22
       Pointee: 1095 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
@@ -13829,28 +13829,28 @@ Types:
       ID: 983
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.420864e+06
+      GoRuntimeType: 1420864
       GoKind: 22
       Pointee: 984 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 954
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.204576e+06
+      GoRuntimeType: 1204576
       GoKind: 22
       Pointee: 955 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 885
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1.035712e+06
+      GoRuntimeType: 1035712
       GoKind: 22
       Pointee: 886 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1146
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1.845472e+06
+      GoRuntimeType: 1845472
       GoKind: 22
       Pointee: 1147 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
@@ -13864,14 +13864,14 @@ Types:
       ID: 1166
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.954624e+06
+      GoRuntimeType: 1954624
       GoKind: 22
       Pointee: 1167 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 1078
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.047616e+06
+      GoRuntimeType: 1047616
       GoKind: 22
       Pointee: 1079 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
@@ -13892,14 +13892,14 @@ Types:
       ID: 1120
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 2.1216e+06
+      GoRuntimeType: 2121600
       GoKind: 22
       Pointee: 1121 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 1080
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.05248e+06
+      GoRuntimeType: 1052480
       GoKind: 22
       Pointee: 1081 StructureType net/smtp.dataCloser
     - __kind: PointerType
@@ -13925,14 +13925,14 @@ Types:
       ID: 1076
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.046848e+06
+      GoRuntimeType: 1046848
       GoKind: 22
       Pointee: 1077 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 991
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.424384e+06
+      GoRuntimeType: 1424384
       GoKind: 22
       Pointee: 992 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
@@ -14098,63 +14098,63 @@ Types:
       ID: 1227
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.354208e+06
+      GoRuntimeType: 2354208
       GoKind: 22
       Pointee: 1228 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 864
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 1.02688e+06
+      GoRuntimeType: 1026880
       GoKind: 22
       Pointee: 865 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 926
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.193824e+06
+      GoRuntimeType: 1193824
       GoKind: 22
       Pointee: 927 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1225
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.350528e+06
+      GoRuntimeType: 2350528
       GoKind: 22
       Pointee: 1226 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1223
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.349792e+06
+      GoRuntimeType: 2349792
       GoKind: 22
       Pointee: 1224 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 893
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.04352e+06
+      GoRuntimeType: 1043520
       GoKind: 22
       Pointee: 894 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 1032
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 2.090752e+06
+      GoRuntimeType: 2090752
       GoKind: 22
       Pointee: 1033 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 1098
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.215968e+06
+      GoRuntimeType: 1215968
       GoKind: 22
       Pointee: 1099 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 895
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.043648e+06
+      GoRuntimeType: 1043648
       GoKind: 22
       Pointee: 896 StructureType os/exec.wrappedError
     - __kind: PointerType
@@ -14194,14 +14194,14 @@ Types:
       ID: 868
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1.028416e+06
+      GoRuntimeType: 1028416
       GoKind: 22
       Pointee: 869 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 872
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1.030208e+06
+      GoRuntimeType: 1030208
       GoKind: 22
       Pointee: 873 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
@@ -14215,14 +14215,14 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.417824e+06
+      GoRuntimeType: 1417824
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 870
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1.028544e+06
+      GoRuntimeType: 1028544
       GoKind: 22
       Pointee: 871 StructureType runtime.boundsError
     - __kind: PointerType
@@ -14243,14 +14243,14 @@ Types:
       ID: 928
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.1992e+06
+      GoRuntimeType: 1199200
       GoKind: 22
       Pointee: 929 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 866
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1.028032e+06
+      GoRuntimeType: 1028032
       GoKind: 22
       Pointee: 847 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14269,14 +14269,14 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.029696e+06
+      GoRuntimeType: 1029696
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 867
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1.02816e+06
+      GoRuntimeType: 1028160
       GoKind: 22
       Pointee: 850 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14295,28 +14295,28 @@ Types:
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 1.555424e+06
+      GoRuntimeType: 1555424
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.057024e+06
+      GoRuntimeType: 2057024
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.623552e+06
+      GoRuntimeType: 1623552
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 862
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 1.025728e+06
+      GoRuntimeType: 1025728
       GoKind: 22
       Pointee: 863 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
@@ -14335,14 +14335,14 @@ Types:
       ID: 1160
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.95104e+06
+      GoRuntimeType: 1951040
       GoKind: 22
       Pointee: 1161 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 1066
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 1.025856e+06
+      GoRuntimeType: 1025856
       GoKind: 22
       Pointee: 1067 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
@@ -14361,7 +14361,7 @@ Types:
       ID: 980
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.419104e+06
+      GoRuntimeType: 1419104
       GoKind: 22
       Pointee: 979 BaseType syscall.Errno
     - __kind: PointerType
@@ -14503,21 +14503,21 @@ Types:
       ID: 1197
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.161824e+06
+      GoRuntimeType: 2161824
       GoKind: 22
       Pointee: 1198 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 921
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.08896e+06
+      GoRuntimeType: 1088960
       GoKind: 22
       Pointee: 922 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 996
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.628544e+06
+      GoRuntimeType: 1628544
       GoKind: 22
       Pointee: 997 UnresolvedPointeeType time.Location
     - __kind: PointerType
@@ -14592,7 +14592,7 @@ Types:
       ID: 1189
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.13728e+06
+      GoRuntimeType: 2137280
       GoKind: 22
       Pointee: 1190 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -14613,14 +14613,14 @@ Types:
       ID: 900
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.04736e+06
+      GoRuntimeType: 1047360
       GoKind: 22
       Pointee: 901 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 902
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.047488e+06
+      GoRuntimeType: 1047488
       GoKind: 22
       Pointee: 855 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -17188,14 +17188,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17210,14 +17210,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 25
           Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22951,14 +22951,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22984,14 +22984,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -24941,7 +24941,7 @@ Types:
     - __kind: StructureType
       ID: 1059
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.120992e+06
+      GoRuntimeType: 1120992
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -24952,7 +24952,7 @@ Types:
       ID: 1085
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.568224e+06
+      GoRuntimeType: 1568224
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -25042,7 +25042,7 @@ Types:
     - __kind: StructureType
       ID: 959
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.482624e+06
+      GoRuntimeType: 1482624
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25123,7 +25123,7 @@ Types:
       ID: 729
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.73312e+06
+      GoRuntimeType: 1733120
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25161,7 +25161,7 @@ Types:
       ID: 803
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.736e+06
+      GoRuntimeType: 1736000
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25176,14 +25176,14 @@ Types:
     - __kind: StructureType
       ID: 797
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.11856e+06
+      GoRuntimeType: 1118560
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 799
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.602944e+06
+      GoRuntimeType: 1602944
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -25208,7 +25208,7 @@ Types:
       ID: 904
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.564224e+06
+      GoRuntimeType: 1564224
       GoKind: 25
       RawFields:
         - Name: Err
@@ -25217,14 +25217,14 @@ Types:
     - __kind: StructureType
       ID: 805
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.118816e+06
+      GoRuntimeType: 1118816
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 801
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.735808e+06
+      GoRuntimeType: 1735808
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25240,7 +25240,7 @@ Types:
       ID: 819
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.438784e+06
+      GoRuntimeType: 1438784
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25250,7 +25250,7 @@ Types:
       ID: 823
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.438944e+06
+      GoRuntimeType: 1438944
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25308,7 +25308,7 @@ Types:
       ID: 690
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.422624e+06
+      GoRuntimeType: 1422624
       GoKind: 25
       RawFields:
         - Name: error
@@ -25357,7 +25357,7 @@ Types:
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.027904e+06
+      GoRuntimeType: 1027904
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25451,7 +25451,7 @@ Types:
       ID: 699
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.731968e+06
+      GoRuntimeType: 1731968
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25474,7 +25474,7 @@ Types:
     - __kind: StructureType
       ID: 705
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.114848e+06
+      GoRuntimeType: 1114848
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25504,7 +25504,7 @@ Types:
       ID: 1017
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.221632e+06
+      GoRuntimeType: 2221632
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25620,7 +25620,7 @@ Types:
     - __kind: StructureType
       ID: 747
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.117792e+06
+      GoRuntimeType: 1117792
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25632,14 +25632,14 @@ Types:
     - __kind: StructureType
       ID: 745
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.117664e+06
+      GoRuntimeType: 1117664
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 743
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.601024e+06
+      GoRuntimeType: 1601024
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25652,7 +25652,7 @@ Types:
       ID: 763
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.601824e+06
+      GoRuntimeType: 1601824
       GoKind: 25
       RawFields:
         - Name: File
@@ -25665,7 +25665,7 @@ Types:
       ID: 767
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.735232e+06
+      GoRuntimeType: 1735232
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25681,7 +25681,7 @@ Types:
       ID: 765
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.432384e+06
+      GoRuntimeType: 1432384
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25691,7 +25691,7 @@ Types:
       ID: 761
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.432064e+06
+      GoRuntimeType: 1432064
       GoKind: 25
       RawFields:
         - Name: File
@@ -25701,14 +25701,14 @@ Types:
       ID: 1003
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.503264e+06
+      GoRuntimeType: 1503264
       GoKind: 21
       HeaderType: 1005 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 1026
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.050944e+06
+      GoRuntimeType: 1050944
       GoKind: 23
       RawFields:
         - Name: array
@@ -25731,7 +25731,7 @@ Types:
       ID: 775
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.602144e+06
+      GoRuntimeType: 1602144
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25744,7 +25744,7 @@ Types:
       ID: 769
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.432544e+06
+      GoRuntimeType: 1432544
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25754,7 +25754,7 @@ Types:
       ID: 773
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.735424e+06
+      GoRuntimeType: 1735424
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25770,7 +25770,7 @@ Types:
       ID: 771
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.601984e+06
+      GoRuntimeType: 1601984
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25783,7 +25783,7 @@ Types:
       ID: 777
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.432704e+06
+      GoRuntimeType: 1432704
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25793,7 +25793,7 @@ Types:
       ID: 783
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.602464e+06
+      GoRuntimeType: 1602464
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25806,7 +25806,7 @@ Types:
       ID: 785
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.433024e+06
+      GoRuntimeType: 1433024
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25816,7 +25816,7 @@ Types:
       ID: 781
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.602304e+06
+      GoRuntimeType: 1602304
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25829,7 +25829,7 @@ Types:
       ID: 779
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.432864e+06
+      GoRuntimeType: 1432864
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25839,7 +25839,7 @@ Types:
       ID: 787
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.602624e+06
+      GoRuntimeType: 1602624
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25852,7 +25852,7 @@ Types:
       ID: 707
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.424864e+06
+      GoRuntimeType: 1424864
       GoKind: 25
       RawFields:
         - Name: message
@@ -25866,7 +25866,7 @@ Types:
       ID: 709
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.425024e+06
+      GoRuntimeType: 1425024
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25888,7 +25888,7 @@ Types:
       ID: 713
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.425344e+06
+      GoRuntimeType: 1425344
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25902,7 +25902,7 @@ Types:
       ID: 1183
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 2.110016e+06
+      GoRuntimeType: 2110016
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25915,7 +25915,7 @@ Types:
       ID: 1186
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.134208e+06
+      GoRuntimeType: 2134208
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -25935,7 +25935,7 @@ Types:
       ID: 711
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.425184e+06
+      GoRuntimeType: 1425184
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25945,7 +25945,7 @@ Types:
       ID: 715
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.425504e+06
+      GoRuntimeType: 1425504
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25995,7 +25995,7 @@ Types:
       ID: 721
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.426464e+06
+      GoRuntimeType: 1426464
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -26010,7 +26010,7 @@ Types:
       ID: 943
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.84368e+06
+      GoRuntimeType: 1843680
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -26030,7 +26030,7 @@ Types:
       ID: 876
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.706016e+06
+      GoRuntimeType: 1706016
       GoKind: 25
       RawFields:
         - Name: Got
@@ -26043,7 +26043,7 @@ Types:
       ID: 949
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.844128e+06
+      GoRuntimeType: 1844128
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26065,7 +26065,7 @@ Types:
       ID: 941
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.843456e+06
+      GoRuntimeType: 1843456
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -26087,7 +26087,7 @@ Types:
       ID: 939
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.843232e+06
+      GoRuntimeType: 1843232
       GoKind: 25
       RawFields:
         - Name: Method
@@ -26103,7 +26103,7 @@ Types:
       ID: 947
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.75824e+06
+      GoRuntimeType: 1758240
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26116,7 +26116,7 @@ Types:
       ID: 945
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.843904e+06
+      GoRuntimeType: 1843904
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26136,7 +26136,7 @@ Types:
       ID: 953
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.629504e+06
+      GoRuntimeType: 1629504
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -26145,20 +26145,20 @@ Types:
     - __kind: StructureType
       ID: 880
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.285152e+06
+      GoRuntimeType: 1285152
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 878
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.285024e+06
+      GoRuntimeType: 1285024
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 951
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.758432e+06
+      GoRuntimeType: 1758432
       GoKind: 25
       RawFields:
         - Name: cause
@@ -26241,7 +26241,7 @@ Types:
         - Name: X
           Offset: 0
           Type: 7 BaseType int
-        - Name: Y
+        - Name: "Y"
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
@@ -26282,7 +26282,7 @@ Types:
       ID: 920
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.450624e+06
+      GoRuntimeType: 1450624
       GoKind: 25
       RawFields:
         - Name: error
@@ -26292,7 +26292,7 @@ Types:
       ID: 1103
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.682112e+06
+      GoRuntimeType: 1682112
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -26306,7 +26306,7 @@ Types:
       ID: 1127
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.128544e+06
+      GoRuntimeType: 1128544
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26319,7 +26319,7 @@ Types:
       ID: 1089
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.573184e+06
+      GoRuntimeType: 1573184
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -26335,13 +26335,13 @@ Types:
       ID: 1010
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.004032e+06
+      GoRuntimeType: 1004032
       GoKind: 10
     - __kind: StructureType
       ID: 978
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.882208e+06
+      GoRuntimeType: 1882208
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26357,7 +26357,7 @@ Types:
       ID: 839
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.609664e+06
+      GoRuntimeType: 1609664
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26450,7 +26450,7 @@ Types:
       ID: 843
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.451264e+06
+      GoRuntimeType: 1451264
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26466,7 +26466,7 @@ Types:
       ID: 831
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.446304e+06
+      GoRuntimeType: 1446304
       GoKind: 25
       RawFields:
         - Name: error
@@ -26480,7 +26480,7 @@ Types:
       ID: 1001
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.910112e+06
+      GoRuntimeType: 1910112
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26496,7 +26496,7 @@ Types:
       ID: 833
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.609184e+06
+      GoRuntimeType: 1609184
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26509,7 +26509,7 @@ Types:
       ID: 1143
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.96768e+06
+      GoRuntimeType: 1967680
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26526,7 +26526,7 @@ Types:
       ID: 918
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.570784e+06
+      GoRuntimeType: 1570784
       GoKind: 25
       RawFields:
         - Name: error
@@ -26551,14 +26551,14 @@ Types:
     - __kind: StructureType
       ID: 972
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.513824e+06
+      GoRuntimeType: 1513824
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 825
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.439584e+06
+      GoRuntimeType: 1439584
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26568,7 +26568,7 @@ Types:
       ID: 827
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.439744e+06
+      GoRuntimeType: 1439744
       GoKind: 25
       RawFields:
         - Name: Line
@@ -27015,7 +27015,7 @@ Types:
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.851968e+06
+      GoRuntimeType: 1851968
       GoKind: 25
       RawFields:
         - Name: buf
@@ -27027,7 +27027,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -27052,7 +27052,7 @@ Types:
     - __kind: StructureType
       ID: 933
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.479424e+06
+      GoRuntimeType: 1479424
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27063,7 +27063,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.215456e+06
+      GoRuntimeType: 1215456
       GoKind: 25
       RawFields:
         - Name: u
@@ -27073,7 +27073,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.644096e+06
+      GoRuntimeType: 1644096
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27089,7 +27089,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.493184e+06
+      GoRuntimeType: 1493184
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27102,7 +27102,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.493024e+06
+      GoRuntimeType: 1493024
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27115,7 +27115,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.493344e+06
+      GoRuntimeType: 1493344
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27140,7 +27140,7 @@ Types:
       ID: 1249
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.476864e+06
+      GoRuntimeType: 1476864
       GoKind: 25
       RawFields:
         - Name: state
@@ -27157,7 +27157,7 @@ Types:
       ID: 1133
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.19216e+06
+      GoRuntimeType: 1192160
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27170,7 +27170,7 @@ Types:
       ID: 1170
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.02432e+06
+      GoRuntimeType: 1024320
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27183,7 +27183,7 @@ Types:
       ID: 1122
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.111136e+06
+      GoRuntimeType: 1111136
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27196,7 +27196,7 @@ Types:
       ID: 129
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.024064e+06
+      GoRuntimeType: 1024064
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27208,7 +27208,7 @@ Types:
     - __kind: StructureType
       ID: 1091
       Name: io.discard
-      GoRuntimeType: 1.466784e+06
+      GoRuntimeType: 1466784
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27278,7 +27278,7 @@ Types:
       ID: 164
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.022912e+06
+      GoRuntimeType: 1022912
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27291,7 +27291,7 @@ Types:
       ID: 126
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.61664e+06
+      GoRuntimeType: 1616640
       GoKind: 25
       RawFields:
         - Name: x
@@ -27307,7 +27307,7 @@ Types:
       ID: 141
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.188448e+06
+      GoRuntimeType: 1188448
       GoKind: 25
       RawFields:
         - Name: a
@@ -27317,7 +27317,7 @@ Types:
       ID: 374
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.18832e+06
+      GoRuntimeType: 1188320
       GoKind: 25
       RawFields:
         - Name: a
@@ -27331,7 +27331,7 @@ Types:
       ID: 148
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.18768e+06
+      GoRuntimeType: 1187680
       GoKind: 25
       RawFields:
         - Name: a
@@ -27341,7 +27341,7 @@ Types:
       ID: 1315
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.187552e+06
+      GoRuntimeType: 1187552
       GoKind: 25
       RawFields:
         - Name: a
@@ -27351,7 +27351,7 @@ Types:
       ID: 1330
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.187424e+06
+      GoRuntimeType: 1187424
       GoKind: 25
       RawFields:
         - Name: a
@@ -27361,7 +27361,7 @@ Types:
       ID: 130
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.1896e+06
+      GoRuntimeType: 1189600
       GoKind: 25
       RawFields:
         - Name: a
@@ -27371,7 +27371,7 @@ Types:
       ID: 132
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.189472e+06
+      GoRuntimeType: 1189472
       GoKind: 25
       RawFields:
         - Name: a
@@ -27385,7 +27385,7 @@ Types:
       ID: 134
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.188832e+06
+      GoRuntimeType: 1188832
       GoKind: 25
       RawFields:
         - Name: a
@@ -27395,7 +27395,7 @@ Types:
       ID: 1285
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.188704e+06
+      GoRuntimeType: 1188704
       GoKind: 25
       RawFields:
         - Name: a
@@ -27405,7 +27405,7 @@ Types:
       ID: 1287
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.188576e+06
+      GoRuntimeType: 1188576
       GoKind: 25
       RawFields:
         - Name: a
@@ -27415,7 +27415,7 @@ Types:
       ID: 135
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.190752e+06
+      GoRuntimeType: 1190752
       GoKind: 25
       RawFields:
         - Name: a
@@ -27425,7 +27425,7 @@ Types:
       ID: 364
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.190624e+06
+      GoRuntimeType: 1190624
       GoKind: 25
       RawFields:
         - Name: a
@@ -27439,7 +27439,7 @@ Types:
       ID: 140
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.189984e+06
+      GoRuntimeType: 1189984
       GoKind: 25
       RawFields:
         - Name: a
@@ -27449,7 +27449,7 @@ Types:
       ID: 1291
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.189856e+06
+      GoRuntimeType: 1189856
       GoKind: 25
       RawFields:
         - Name: a
@@ -27459,7 +27459,7 @@ Types:
       ID: 1297
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.189728e+06
+      GoRuntimeType: 1189728
       GoKind: 25
       RawFields:
         - Name: a
@@ -27474,7 +27474,7 @@ Types:
       ID: 162
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.835392e+06
+      GoRuntimeType: 1835392
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27496,7 +27496,7 @@ Types:
       ID: 157
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.968992e+06
+      GoRuntimeType: 1968992
       GoKind: 25
       RawFields:
         - Name: _
@@ -27524,7 +27524,7 @@ Types:
       ID: 355
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.415744e+06
+      GoRuntimeType: 1415744
       GoKind: 25
       RawFields:
         - Name: s
@@ -27867,7 +27867,7 @@ Types:
       ID: 121
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.465824e+06
+      GoRuntimeType: 1465824
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -27880,7 +27880,7 @@ Types:
       ID: 248
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.465504e+06
+      GoRuntimeType: 1465504
       GoKind: 25
       RawFields:
         - Name: val
@@ -27914,14 +27914,14 @@ Types:
       ID: 1259
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.415904e+06
+      GoRuntimeType: 1415904
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 160
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.02304e+06
+      GoRuntimeType: 1023040
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27974,7 +27974,7 @@ Types:
       ID: 166
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.187168e+06
+      GoRuntimeType: 1187168
       GoKind: 25
       RawFields:
         - Name: a
@@ -28044,7 +28044,7 @@ Types:
       ID: 167
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.187296e+06
+      GoRuntimeType: 1187296
       GoKind: 25
       RawFields:
         - Name: m
@@ -29077,119 +29077,119 @@ Types:
       ID: 225
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.130592e+06
+      GoRuntimeType: 1130592
       GoKind: 21
       HeaderType: 227 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 220
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.13072e+06
+      GoRuntimeType: 1130720
       GoKind: 21
       HeaderType: 222 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 188
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.130848e+06
+      GoRuntimeType: 1130848
       GoKind: 21
       HeaderType: 190 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 200
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.130976e+06
+      GoRuntimeType: 1130976
       GoKind: 21
       HeaderType: 202 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 142
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.130464e+06
+      GoRuntimeType: 1130464
       GoKind: 21
       HeaderType: 144 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1269
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.130336e+06
+      GoRuntimeType: 1130336
       GoKind: 21
       HeaderType: 1271 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1303
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.129696e+06
+      GoRuntimeType: 1129696
       GoKind: 21
       HeaderType: 1305 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1318
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.129568e+06
+      GoRuntimeType: 1129568
       GoKind: 21
       HeaderType: 1320 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 168
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.128928e+06
+      GoRuntimeType: 1128928
       GoKind: 21
       HeaderType: 170 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 1333
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.12944e+06
+      GoRuntimeType: 1129440
       GoKind: 21
       HeaderType: 1335 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 235
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.131104e+06
+      GoRuntimeType: 1131104
       GoKind: 21
       HeaderType: 237 GoSwissMapHeaderType map<int,struct {}>
     - __kind: GoMapType
       ID: 205
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.131232e+06
+      GoRuntimeType: 1131232
       GoKind: 21
       HeaderType: 207 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 195
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.13136e+06
+      GoRuntimeType: 1131360
       GoKind: 21
       HeaderType: 197 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 183
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.131488e+06
+      GoRuntimeType: 1131488
       GoKind: 21
       HeaderType: 185 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 178
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.131616e+06
+      GoRuntimeType: 1131616
       GoKind: 21
       HeaderType: 180 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 173
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.131744e+06
+      GoRuntimeType: 1131744
       GoKind: 21
       HeaderType: 175 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 230
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 1.131872e+06
+      GoRuntimeType: 1131872
       GoKind: 21
       HeaderType: 232 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
@@ -29232,28 +29232,28 @@ Types:
       ID: 240
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.132e+06
+      GoRuntimeType: 1132000
       GoKind: 21
       HeaderType: 242 GoSwissMapHeaderType map<struct {},struct {}>
     - __kind: GoMapType
       ID: 215
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.132128e+06
+      GoRuntimeType: 1132128
       GoKind: 21
       HeaderType: 217 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 210
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.132256e+06
+      GoRuntimeType: 1132256
       GoKind: 21
       HeaderType: 212 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
       ID: 759
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.431744e+06
+      GoRuntimeType: 1431744
       GoKind: 25
       RawFields:
         - Name: msg
@@ -29263,7 +29263,7 @@ Types:
       ID: 1055
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.428544e+06
+      GoRuntimeType: 1428544
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29277,7 +29277,7 @@ Types:
       ID: 1025
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.599744e+06
+      GoRuntimeType: 1599744
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29318,7 +29318,7 @@ Types:
       ID: 923
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.114464e+06
+      GoRuntimeType: 1114464
       GoKind: 24
       RawFields:
         - Name: str
@@ -29336,7 +29336,7 @@ Types:
     - __kind: StructureType
       ID: 892
       Name: net.canceledError
-      GoRuntimeType: 1.286176e+06
+      GoRuntimeType: 1286176
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29347,7 +29347,7 @@ Types:
       ID: 1030
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 2.109312e+06
+      GoRuntimeType: 2109312
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29369,13 +29369,13 @@ Types:
     - __kind: StructureType
       ID: 1216
       Name: net.noReadFrom
-      GoRuntimeType: 1.11472e+06
+      GoRuntimeType: 1114720
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1215
       Name: net.noWriteTo
-      GoRuntimeType: 1.114592e+06
+      GoRuntimeType: 1114592
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29386,7 +29386,7 @@ Types:
       ID: 694
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.731776e+06
+      GoRuntimeType: 1731776
       GoKind: 25
       RawFields:
         - Name: p
@@ -29402,7 +29402,7 @@ Types:
       ID: 1204
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.294048e+06
+      GoRuntimeType: 2294048
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29415,7 +29415,7 @@ Types:
       ID: 1202
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.293504e+06
+      GoRuntimeType: 2293504
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29440,7 +29440,7 @@ Types:
       ID: 1049
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.420064e+06
+      GoRuntimeType: 1420064
       GoKind: 25
       RawFields:
         - Name: w
@@ -29462,7 +29462,7 @@ Types:
       ID: 670
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.730048e+06
+      GoRuntimeType: 1730048
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -29478,7 +29478,7 @@ Types:
       ID: 982
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.901408e+06
+      GoRuntimeType: 1901408
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -29494,7 +29494,7 @@ Types:
       ID: 674
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.599264e+06
+      GoRuntimeType: 1599264
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29571,7 +29571,7 @@ Types:
     - __kind: StructureType
       ID: 888
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.285408e+06
+      GoRuntimeType: 1285408
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29601,7 +29601,7 @@ Types:
       ID: 1051
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
-      GoRuntimeType: 1.82592e+06
+      GoRuntimeType: 1825920
       GoKind: 25
       RawFields:
         - Name: group
@@ -29620,7 +29620,7 @@ Types:
       ID: 1144
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
-      GoRuntimeType: 1.419424e+06
+      GoRuntimeType: 1419424
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29640,7 +29640,7 @@ Types:
       ID: 884
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.558304e+06
+      GoRuntimeType: 1558304
       GoKind: 25
       RawFields:
         - Name: error
@@ -29654,7 +29654,7 @@ Types:
       ID: 1069
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.558144e+06
+      GoRuntimeType: 1558144
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29664,7 +29664,7 @@ Types:
       ID: 1095
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.80192e+06
+      GoRuntimeType: 1801920
       GoKind: 25
       RawFields:
         - Name: _
@@ -29680,7 +29680,7 @@ Types:
       ID: 678
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.421024e+06
+      GoRuntimeType: 1421024
       GoKind: 25
       RawFields:
         - Name: error
@@ -29693,14 +29693,14 @@ Types:
     - __kind: StructureType
       ID: 955
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.482304e+06
+      GoRuntimeType: 1482304
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 886
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.558464e+06
+      GoRuntimeType: 1558464
       GoKind: 25
       RawFields:
         - Name: err
@@ -29710,7 +29710,7 @@ Types:
       ID: 1147
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2.027584e+06
+      GoRuntimeType: 2027584
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29727,7 +29727,7 @@ Types:
       ID: 1167
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 2.043616e+06
+      GoRuntimeType: 2043616
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29741,7 +29741,7 @@ Types:
       ID: 751
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.734848e+06
+      GoRuntimeType: 1734848
       GoKind: 25
       RawFields:
         - Name: in
@@ -29757,7 +29757,7 @@ Types:
       ID: 749
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.601184e+06
+      GoRuntimeType: 1601184
       GoKind: 25
       RawFields:
         - Name: in
@@ -29774,7 +29774,7 @@ Types:
       ID: 1081
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.603104e+06
+      GoRuntimeType: 1603104
       GoKind: 25
       RawFields:
         - Name: c
@@ -30092,7 +30092,7 @@ Types:
       ID: 474
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.29744e+06
+      GoRuntimeType: 1297440
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30105,7 +30105,7 @@ Types:
       ID: 466
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.297696e+06
+      GoRuntimeType: 1297696
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30118,7 +30118,7 @@ Types:
       ID: 414
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.297952e+06
+      GoRuntimeType: 1297952
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30131,7 +30131,7 @@ Types:
       ID: 433
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.298208e+06
+      GoRuntimeType: 1298208
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30144,7 +30144,7 @@ Types:
       ID: 370
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.297184e+06
+      GoRuntimeType: 1297184
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30157,7 +30157,7 @@ Types:
       ID: 1277
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.296928e+06
+      GoRuntimeType: 1296928
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30170,7 +30170,7 @@ Types:
       ID: 1311
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.295648e+06
+      GoRuntimeType: 1295648
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30183,7 +30183,7 @@ Types:
       ID: 1326
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.295392e+06
+      GoRuntimeType: 1295392
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30196,7 +30196,7 @@ Types:
       ID: 382
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.294112e+06
+      GoRuntimeType: 1294112
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30209,7 +30209,7 @@ Types:
       ID: 1341
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.295136e+06
+      GoRuntimeType: 1295136
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30222,7 +30222,7 @@ Types:
       ID: 490
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
-      GoRuntimeType: 1.298464e+06
+      GoRuntimeType: 1298464
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30235,7 +30235,7 @@ Types:
       ID: 441
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.29872e+06
+      GoRuntimeType: 1298720
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30248,7 +30248,7 @@ Types:
       ID: 423
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.298976e+06
+      GoRuntimeType: 1298976
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30261,7 +30261,7 @@ Types:
       ID: 406
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.299232e+06
+      GoRuntimeType: 1299232
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30274,7 +30274,7 @@ Types:
       ID: 1037
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
-      GoRuntimeType: 1.360928e+06
+      GoRuntimeType: 1360928
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30287,7 +30287,7 @@ Types:
       ID: 398
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.299488e+06
+      GoRuntimeType: 1299488
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30300,7 +30300,7 @@ Types:
       ID: 390
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.299744e+06
+      GoRuntimeType: 1299744
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30313,7 +30313,7 @@ Types:
       ID: 482
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
-      GoRuntimeType: 1.3e+06
+      GoRuntimeType: 1300000
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30398,7 +30398,7 @@ Types:
       ID: 498
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
-      GoRuntimeType: 1.300256e+06
+      GoRuntimeType: 1300256
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30411,7 +30411,7 @@ Types:
       ID: 457
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.300512e+06
+      GoRuntimeType: 1300512
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30424,7 +30424,7 @@ Types:
       ID: 449
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.300768e+06
+      GoRuntimeType: 1300768
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30437,7 +30437,7 @@ Types:
       ID: 476
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.297312e+06
+      GoRuntimeType: 1297312
       GoKind: 25
       RawFields:
         - Name: key
@@ -30450,7 +30450,7 @@ Types:
       ID: 468
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.297568e+06
+      GoRuntimeType: 1297568
       GoKind: 25
       RawFields:
         - Name: key
@@ -30463,7 +30463,7 @@ Types:
       ID: 416
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.297824e+06
+      GoRuntimeType: 1297824
       GoKind: 25
       RawFields:
         - Name: key
@@ -30476,7 +30476,7 @@ Types:
       ID: 435
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.29808e+06
+      GoRuntimeType: 1298080
       GoKind: 25
       RawFields:
         - Name: key
@@ -30489,7 +30489,7 @@ Types:
       ID: 372
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.297056e+06
+      GoRuntimeType: 1297056
       GoKind: 25
       RawFields:
         - Name: key
@@ -30502,7 +30502,7 @@ Types:
       ID: 1279
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.2968e+06
+      GoRuntimeType: 1296800
       GoKind: 25
       RawFields:
         - Name: key
@@ -30515,7 +30515,7 @@ Types:
       ID: 1313
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.29552e+06
+      GoRuntimeType: 1295520
       GoKind: 25
       RawFields:
         - Name: key
@@ -30528,7 +30528,7 @@ Types:
       ID: 1328
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.295264e+06
+      GoRuntimeType: 1295264
       GoKind: 25
       RawFields:
         - Name: key
@@ -30541,7 +30541,7 @@ Types:
       ID: 384
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.293984e+06
+      GoRuntimeType: 1293984
       GoKind: 25
       RawFields:
         - Name: key
@@ -30554,7 +30554,7 @@ Types:
       ID: 1343
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.295008e+06
+      GoRuntimeType: 1295008
       GoKind: 25
       RawFields:
         - Name: key
@@ -30567,7 +30567,7 @@ Types:
       ID: 492
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
-      GoRuntimeType: 1.298336e+06
+      GoRuntimeType: 1298336
       GoKind: 25
       RawFields:
         - Name: key
@@ -30580,7 +30580,7 @@ Types:
       ID: 443
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.298592e+06
+      GoRuntimeType: 1298592
       GoKind: 25
       RawFields:
         - Name: key
@@ -30593,7 +30593,7 @@ Types:
       ID: 425
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.298848e+06
+      GoRuntimeType: 1298848
       GoKind: 25
       RawFields:
         - Name: key
@@ -30606,7 +30606,7 @@ Types:
       ID: 408
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.299104e+06
+      GoRuntimeType: 1299104
       GoKind: 25
       RawFields:
         - Name: key
@@ -30619,7 +30619,7 @@ Types:
       ID: 1039
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
-      GoRuntimeType: 1.3608e+06
+      GoRuntimeType: 1360800
       GoKind: 25
       RawFields:
         - Name: key
@@ -30632,7 +30632,7 @@ Types:
       ID: 400
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.29936e+06
+      GoRuntimeType: 1299360
       GoKind: 25
       RawFields:
         - Name: key
@@ -30645,7 +30645,7 @@ Types:
       ID: 392
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.299616e+06
+      GoRuntimeType: 1299616
       GoKind: 25
       RawFields:
         - Name: key
@@ -30658,7 +30658,7 @@ Types:
       ID: 484
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
-      GoRuntimeType: 1.299872e+06
+      GoRuntimeType: 1299872
       GoKind: 25
       RawFields:
         - Name: key
@@ -30742,7 +30742,7 @@ Types:
     - __kind: StructureType
       ID: 500
       Name: noalg.struct { key struct {}; elem struct {} }
-      GoRuntimeType: 1.300128e+06
+      GoRuntimeType: 1300128
       GoKind: 25
       RawFields:
         - Name: key
@@ -30755,7 +30755,7 @@ Types:
       ID: 459
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.300384e+06
+      GoRuntimeType: 1300384
       GoKind: 25
       RawFields:
         - Name: key
@@ -30768,7 +30768,7 @@ Types:
       ID: 451
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.30064e+06
+      GoRuntimeType: 1300640
       GoKind: 25
       RawFields:
         - Name: key
@@ -30793,7 +30793,7 @@ Types:
       ID: 1226
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.362656e+06
+      GoRuntimeType: 2362656
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -30806,7 +30806,7 @@ Types:
       ID: 1224
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.361856e+06
+      GoRuntimeType: 2361856
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -30818,13 +30818,13 @@ Types:
     - __kind: StructureType
       ID: 1232
       Name: os.noReadFrom
-      GoRuntimeType: 1.11216e+06
+      GoRuntimeType: 1112160
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1231
       Name: os.noWriteTo
-      GoRuntimeType: 1.112032e+06
+      GoRuntimeType: 1112032
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -30843,7 +30843,7 @@ Types:
       ID: 896
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.706592e+06
+      GoRuntimeType: 1706592
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -30905,13 +30905,13 @@ Types:
       ID: 871
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.889824e+06
+      GoRuntimeType: 1889824
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
           Type: 13 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -30944,7 +30944,7 @@ Types:
       ID: 929
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.7544e+06
+      GoRuntimeType: 1754400
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30976,7 +30976,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.410944e+06
+      GoRuntimeType: 2410944
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31157,7 +31157,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.198944e+06
+      GoRuntimeType: 1198944
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -31167,7 +31167,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1.971296e+06
+      GoRuntimeType: 1971296
       GoKind: 25
       RawFields:
         - Name: sp
@@ -31195,7 +31195,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.474304e+06
+      GoRuntimeType: 1474304
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31208,7 +31208,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.75344e+06
+      GoRuntimeType: 1753440
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31233,7 +31233,7 @@ Types:
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.474144e+06
+      GoRuntimeType: 1474144
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -31246,13 +31246,13 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.9152e+06
+      GoRuntimeType: 1915200
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -31277,7 +31277,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 2.416e+06
+      GoRuntimeType: 2416000
       GoKind: 25
       RawFields:
         - Name: g0
@@ -31500,7 +31500,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1.971584e+06
+      GoRuntimeType: 1971584
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31528,7 +31528,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.840768e+06
+      GoRuntimeType: 1840768
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31550,7 +31550,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.840544e+06
+      GoRuntimeType: 1840544
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -31572,7 +31572,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 1.198688e+06
+      GoRuntimeType: 1198688
       GoKind: 25
       RawFields:
         - Name: next
@@ -31588,14 +31588,14 @@ Types:
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.19856e+06
+      GoRuntimeType: 1198560
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.473984e+06
+      GoRuntimeType: 1473984
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31608,13 +31608,13 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.754208e+06
+      GoRuntimeType: 1754208
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -31661,7 +31661,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.472384e+06
+      GoRuntimeType: 1472384
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31702,7 +31702,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.473344e+06
+      GoRuntimeType: 1473344
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -31715,7 +31715,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.284384e+06
+      GoRuntimeType: 1284384
       GoKind: 8
     - __kind: StructureType
       ID: 79
@@ -31758,7 +31758,7 @@ Types:
       ID: 1063
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.458464e+06
+      GoRuntimeType: 1458464
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -31774,7 +31774,7 @@ Types:
       ID: 1247
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.467744e+06
+      GoRuntimeType: 1467744
       GoKind: 25
       RawFields:
         - Name: _
@@ -31787,7 +31787,7 @@ Types:
       ID: 1250
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.618368e+06
+      GoRuntimeType: 1618368
       GoKind: 25
       RawFields:
         - Name: _
@@ -31803,7 +31803,7 @@ Types:
       ID: 1253
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.61856e+06
+      GoRuntimeType: 1618560
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31825,7 +31825,7 @@ Types:
       ID: 1256
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.469024e+06
+      GoRuntimeType: 1469024
       GoKind: 25
       RawFields:
         - Name: _
@@ -31838,7 +31838,7 @@ Types:
       ID: 1251
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.469184e+06
+      GoRuntimeType: 1469184
       GoKind: 25
       RawFields:
         - Name: _
@@ -31851,7 +31851,7 @@ Types:
       ID: 1254
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.618944e+06
+      GoRuntimeType: 1618944
       GoKind: 25
       RawFields:
         - Name: _
@@ -31879,7 +31879,7 @@ Types:
       ID: 979
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.284768e+06
+      GoRuntimeType: 1284768
       GoKind: 12
     - __kind: StructureType
       ID: 471
@@ -32537,7 +32537,7 @@ Types:
       ID: 922
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.711008e+06
+      GoRuntimeType: 1711008
       GoKind: 25
       RawFields:
         - Name: Name
@@ -32550,7 +32550,7 @@ Types:
       ID: 1145
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.915968e+06
+      GoRuntimeType: 1915968
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 997
@@ -32564,7 +32564,7 @@ Types:
       ID: 995
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.377536e+06
+      GoRuntimeType: 2377536
       GoKind: 25
       RawFields:
         - Name: wall
@@ -32641,7 +32641,7 @@ Types:
       ID: 1013
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 2.065024e+06
+      GoRuntimeType: 2065024
       GoKind: 25
       RawFields:
         - Name: msg
@@ -32653,7 +32653,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 1015 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 7 BaseType int
         - Name: index
@@ -32681,7 +32681,7 @@ Types:
       ID: 1014
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.92672e+06
+      GoRuntimeType: 1926720
       GoKind: 25
       RawFields:
         - Name: id
@@ -32720,7 +32720,7 @@ Types:
       ID: 737
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.428864e+06
+      GoRuntimeType: 1428864
       GoKind: 25
       RawFields:
         - Name: Err
@@ -32736,7 +32736,7 @@ Types:
       ID: 901
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.706784e+06
+      GoRuntimeType: 1706784
       GoKind: 25
       RawFields:
         - Name: label

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -576,8 +576,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 86}
@@ -600,7 +600,7 @@ Probes:
                   EventExpressionIndex: 1
                 - ', '
                 - Error: failed to resolve reference "y"
-                  DSL: y
+                  DSL: "y"
     - id: testConflictingReturn
       version: 0
       type: LOG_PROBE
@@ -1713,8 +1713,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 53}
@@ -1735,8 +1735,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
     - id: testInlinedBBA
@@ -5475,8 +5475,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
         - ', '
         - json: {ref: z}
           dsl: z
@@ -5496,8 +5496,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
                 - ', '
@@ -6830,7 +6830,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 7 BaseType int
           Locations:
             - Range: 0x80aec0..0x80aeec
@@ -7367,7 +7367,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 18 BaseType float32
           Locations:
             - Range: 0x80cee0..0x80cef0
@@ -7398,7 +7398,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 18 BaseType float32
           Locations:
             - Range: 0x80cf00..0x80cf10
@@ -9850,7 +9850,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x80fed0..0x80fee0
@@ -11681,7 +11681,7 @@ Types:
       ID: 1192
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.99584e+06
+      GoRuntimeType: 1995840
       GoKind: 22
       Pointee: 1193 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
@@ -11700,7 +11700,7 @@ Types:
       ID: 1127
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.442432e+06
+      GoRuntimeType: 1442432
       GoKind: 22
       Pointee: 1128 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
@@ -11721,21 +11721,21 @@ Types:
       ID: 1171
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.913984e+06
+      GoRuntimeType: 1913984
       GoKind: 22
       Pointee: 1172 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 1103
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.062336e+06
+      GoRuntimeType: 1062336
       GoKind: 22
       Pointee: 1104 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 1105
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.062592e+06
+      GoRuntimeType: 1062592
       GoKind: 22
       Pointee: 1106 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
@@ -11749,21 +11749,21 @@ Types:
       ID: 1150
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.18464e+06
+      GoRuntimeType: 2184640
       GoKind: 22
       Pointee: 1151 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1181
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.959232e+06
+      GoRuntimeType: 1959232
       GoKind: 22
       Pointee: 1182 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1230
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.277504e+06
+      GoRuntimeType: 2277504
       GoKind: 22
       Pointee: 1231 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -11789,7 +11789,7 @@ Types:
       ID: 1125
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.432032e+06
+      GoRuntimeType: 1432032
       GoKind: 22
       Pointee: 1126 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
@@ -11803,14 +11803,14 @@ Types:
       ID: 1147
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.735488e+06
+      GoRuntimeType: 1735488
       GoKind: 22
       Pointee: 1148 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 975
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.209408e+06
+      GoRuntimeType: 1209408
       GoKind: 22
       Pointee: 976 StructureType context.deadlineExceededError
     - __kind: PointerType
@@ -11838,49 +11838,49 @@ Types:
       ID: 1142
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
-      GoRuntimeType: 1.676224e+06
+      GoRuntimeType: 1676224
       GoKind: 22
       Pointee: 1143 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
       ID: 924
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
-      GoRuntimeType: 1.070144e+06
+      GoRuntimeType: 1070144
       GoKind: 22
       Pointee: 925 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
       ID: 1173
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.914496e+06
+      GoRuntimeType: 1914496
       GoKind: 22
       Pointee: 1174 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
       ID: 1203
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
-      GoRuntimeType: 2.129792e+06
+      GoRuntimeType: 2129792
       GoKind: 22
       Pointee: 1204 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
       ID: 1177
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.915008e+06
+      GoRuntimeType: 1915008
       GoKind: 22
       Pointee: 1178 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
       ID: 1175
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.914752e+06
+      GoRuntimeType: 1914752
       GoKind: 22
       Pointee: 1176 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
       ID: 1169
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.912192e+06
+      GoRuntimeType: 1912192
       GoKind: 22
       Pointee: 1170 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
@@ -11894,14 +11894,14 @@ Types:
       ID: 1190
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 1.99296e+06
+      GoRuntimeType: 1992960
       GoKind: 22
       Pointee: 1191 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1165
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
-      GoRuntimeType: 1.881568e+06
+      GoRuntimeType: 1881568
       GoKind: 22
       Pointee: 1166 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
@@ -11915,14 +11915,14 @@ Types:
       ID: 913
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.050944e+06
+      GoRuntimeType: 1050944
       GoKind: 22
       Pointee: 914 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1256
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.389024e+06
+      GoRuntimeType: 2389024
       GoKind: 22
       Pointee: 1257 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
@@ -11943,14 +11943,14 @@ Types:
       ID: 912
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.04928e+06
+      GoRuntimeType: 1049280
       GoKind: 22
       Pointee: 867 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 1135
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.567616e+06
+      GoRuntimeType: 1567616
       GoKind: 22
       Pointee: 1136 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
@@ -11964,21 +11964,21 @@ Types:
       ID: 1140
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.651264e+06
+      GoRuntimeType: 1651264
       GoKind: 22
       Pointee: 1141 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 1010
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.432512e+06
+      GoRuntimeType: 1432512
       GoKind: 22
       Pointee: 1011 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 1027
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.052128e+06
+      GoRuntimeType: 2052128
       GoKind: 22
       Pointee: 1028 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
@@ -12013,7 +12013,7 @@ Types:
       ID: 918
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.056704e+06
+      GoRuntimeType: 1056704
       GoKind: 22
       Pointee: 919 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
@@ -12062,7 +12062,7 @@ Types:
       ID: 1093
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.04672e+06
+      GoRuntimeType: 1046720
       GoKind: 22
       Pointee: 1094 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -12083,7 +12083,7 @@ Types:
       ID: 902
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.04288e+06
+      GoRuntimeType: 1042880
       GoKind: 22
       Pointee: 903 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
@@ -12118,7 +12118,7 @@ Types:
       ID: 1236
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.30304e+06
+      GoRuntimeType: 2303040
       GoKind: 22
       Pointee: 1237 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
@@ -12132,7 +12132,7 @@ Types:
       ID: 1101
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.059264e+06
+      GoRuntimeType: 1059264
       GoKind: 22
       Pointee: 1102 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
@@ -12172,7 +12172,7 @@ Types:
       ID: 1214
       Name: '*encoding/xml.printer'
       ByteSize: 8
-      GoRuntimeType: 2.169632e+06
+      GoRuntimeType: 2169632
       GoKind: 22
       Pointee: 1215 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
@@ -12193,7 +12193,7 @@ Types:
       ID: 869
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1.027392e+06
+      GoRuntimeType: 1027392
       GoKind: 22
       Pointee: 870 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -12214,21 +12214,21 @@ Types:
       ID: 1224
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.269824e+06
+      GoRuntimeType: 2269824
       GoKind: 22
       Pointee: 1225 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 871
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.02752e+06
+      GoRuntimeType: 1027520
       GoKind: 22
       Pointee: 872 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 873
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.027648e+06
+      GoRuntimeType: 1027648
       GoKind: 22
       Pointee: 874 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -12313,14 +12313,14 @@ Types:
       ID: 1113
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.214912e+06
+      GoRuntimeType: 1214912
       GoKind: 22
       Pointee: 1114 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1200
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 2.067456e+06
+      GoRuntimeType: 2067456
       GoKind: 22
       Pointee: 1201 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
@@ -12334,14 +12334,14 @@ Types:
       ID: 984
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.218496e+06
+      GoRuntimeType: 1218496
       GoKind: 22
       Pointee: 985 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1232
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.279552e+06
+      GoRuntimeType: 2279552
       GoKind: 22
       Pointee: 1233 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
@@ -12493,7 +12493,7 @@ Types:
       ID: 1153
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.812352e+06
+      GoRuntimeType: 1812352
       GoKind: 22
       Pointee: 1154 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
@@ -12507,21 +12507,21 @@ Types:
       ID: 1133
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.566336e+06
+      GoRuntimeType: 1566336
       GoKind: 22
       Pointee: 1134 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 1089
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.045568e+06
+      GoRuntimeType: 1045568
       GoKind: 22
       Pointee: 1090 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1123
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.430112e+06
+      GoRuntimeType: 1430112
       GoKind: 22
       Pointee: 1124 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
@@ -12535,28 +12535,28 @@ Types:
       ID: 1188
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.985472e+06
+      GoRuntimeType: 1985472
       GoKind: 22
       Pointee: 1189 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1207
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.142816e+06
+      GoRuntimeType: 2142816
       GoKind: 22
       Pointee: 1202 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1206
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.142432e+06
+      GoRuntimeType: 2142432
       GoKind: 22
       Pointee: 1205 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 1091
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.045696e+06
+      GoRuntimeType: 1045696
       GoKind: 22
       Pointee: 1092 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
@@ -12577,70 +12577,70 @@ Types:
       ID: 1155
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.814144e+06
+      GoRuntimeType: 1814144
       GoKind: 22
       Pointee: 1156 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1196
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.021312e+06
+      GoRuntimeType: 2021312
       GoKind: 22
       Pointee: 1197 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1198
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.051808e+06
+      GoRuntimeType: 2051808
       GoKind: 22
       Pointee: 1199 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 1015
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.444832e+06
+      GoRuntimeType: 1444832
       GoKind: 22
       Pointee: 1016 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 928
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.070912e+06
+      GoRuntimeType: 1070912
       GoKind: 22
       Pointee: 929 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 926
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.070784e+06
+      GoRuntimeType: 1070784
       GoKind: 22
       Pointee: 927 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 930
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.07488e+06
+      GoRuntimeType: 1074880
       GoKind: 22
       Pointee: 931 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 932
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.075008e+06
+      GoRuntimeType: 1075008
       GoKind: 22
       Pointee: 933 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 1144
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.678528e+06
+      GoRuntimeType: 1678528
       GoKind: 22
       Pointee: 1145 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 920
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.057344e+06
+      GoRuntimeType: 1057344
       GoKind: 22
       Pointee: 921 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
@@ -12654,112 +12654,112 @@ Types:
       ID: 1248
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.365472e+06
+      GoRuntimeType: 2365472
       GoKind: 22
       Pointee: 1249 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 986
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.227072e+06
+      GoRuntimeType: 1227072
       GoKind: 22
       Pointee: 987 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 959
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.205952e+06
+      GoRuntimeType: 1205952
       GoKind: 22
       Pointee: 960 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 953
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.205568e+06
+      GoRuntimeType: 1205568
       GoKind: 22
       Pointee: 954 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 888
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.036864e+06
+      GoRuntimeType: 1036864
       GoKind: 22
       Pointee: 889 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 965
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.206336e+06
+      GoRuntimeType: 1206336
       GoKind: 22
       Pointee: 966 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 887
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1.036736e+06
+      GoRuntimeType: 1036736
       GoKind: 22
       Pointee: 866 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 957
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.205824e+06
+      GoRuntimeType: 1205824
       GoKind: 22
       Pointee: 958 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 955
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.205696e+06
+      GoRuntimeType: 1205696
       GoKind: 22
       Pointee: 956 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 963
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.206208e+06
+      GoRuntimeType: 1206208
       GoKind: 22
       Pointee: 964 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 961
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.20608e+06
+      GoRuntimeType: 1206080
       GoKind: 22
       Pointee: 962 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1252
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.37808e+06
+      GoRuntimeType: 2378080
       GoKind: 22
       Pointee: 1253 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 969
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.20672e+06
+      GoRuntimeType: 1206720
       GoKind: 22
       Pointee: 970 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 892
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1.03712e+06
+      GoRuntimeType: 1037120
       GoKind: 22
       Pointee: 893 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 890
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1.036992e+06
+      GoRuntimeType: 1036992
       GoKind: 22
       Pointee: 891 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 967
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.206592e+06
+      GoRuntimeType: 1206592
       GoKind: 22
       Pointee: 968 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -12822,35 +12822,35 @@ Types:
       ID: 1030
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.676992e+06
+      GoRuntimeType: 1676992
       GoKind: 22
       Pointee: 1031 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 936
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.089728e+06
+      GoRuntimeType: 1089728
       GoKind: 22
       Pointee: 937 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 1119
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.26688e+06
+      GoRuntimeType: 1266880
       GoKind: 22
       Pointee: 1120 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1212
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.157792e+06
+      GoRuntimeType: 2157792
       GoKind: 22
       Pointee: 1213 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 1107
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.092032e+06
+      GoRuntimeType: 1092032
       GoKind: 22
       Pointee: 1108 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
@@ -12864,7 +12864,7 @@ Types:
       ID: 994
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.268544e+06
+      GoRuntimeType: 1268544
       GoKind: 22
       Pointee: 995 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
@@ -12926,7 +12926,7 @@ Types:
       ID: 1210
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.155872e+06
+      GoRuntimeType: 2155872
       GoKind: 22
       Pointee: 1211 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -12954,14 +12954,14 @@ Types:
       ID: 992
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.2656e+06
+      GoRuntimeType: 1265600
       GoKind: 22
       Pointee: 993 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 1017
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.452192e+06
+      GoRuntimeType: 1452192
       GoKind: 22
       Pointee: 1018 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
@@ -12975,21 +12975,21 @@ Types:
       ID: 1159
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.819744e+06
+      GoRuntimeType: 1819744
       GoKind: 22
       Pointee: 1160 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 1117
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.262144e+06
+      GoRuntimeType: 1262144
       GoKind: 22
       Pointee: 1118 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 934
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.083968e+06
+      GoRuntimeType: 1083968
       GoKind: 22
       Pointee: 935 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
@@ -13010,21 +13010,21 @@ Types:
       ID: 922
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.060672e+06
+      GoRuntimeType: 1060672
       GoKind: 22
       Pointee: 923 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 990
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.233472e+06
+      GoRuntimeType: 1233472
       GoKind: 22
       Pointee: 991 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 988
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.233216e+06
+      GoRuntimeType: 1233216
       GoKind: 22
       Pointee: 989 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
@@ -13052,7 +13052,7 @@ Types:
       ID: 1167
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.910144e+06
+      GoRuntimeType: 1910144
       GoKind: 22
       Pointee: 1168 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
@@ -13108,7 +13108,7 @@ Types:
       ID: 1019
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 2.222144e+06
+      GoRuntimeType: 2222144
       GoKind: 22
       Pointee: 1020 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
@@ -13136,21 +13136,21 @@ Types:
       ID: 951
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.2048e+06
+      GoRuntimeType: 1204800
       GoKind: 22
       Pointee: 952 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1254
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.383744e+06
+      GoRuntimeType: 2383744
       GoKind: 22
       Pointee: 1255 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 949
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.204672e+06
+      GoRuntimeType: 1204672
       GoKind: 22
       Pointee: 950 StructureType internal/poll.errNetClosing
     - __kind: PointerType
@@ -13176,42 +13176,42 @@ Types:
       ID: 906
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.047616e+06
+      GoRuntimeType: 1047616
       GoKind: 22
       Pointee: 907 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
       ID: 1111
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.196352e+06
+      GoRuntimeType: 1196352
       GoKind: 22
       Pointee: 1112 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1109
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.195968e+06
+      GoRuntimeType: 1195968
       GoKind: 22
       Pointee: 1110 StructureType io.discard
     - __kind: PointerType
       ID: 1083
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.028416e+06
+      GoRuntimeType: 1028416
       GoKind: 22
       Pointee: 1084 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 947
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.20416e+06
+      GoRuntimeType: 1204160
       GoKind: 22
       Pointee: 948 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 1157
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.814368e+06
+      GoRuntimeType: 1814368
       GoKind: 22
       Pointee: 1158 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13618,63 +13618,63 @@ Types:
       ID: 978
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.212736e+06
+      GoRuntimeType: 1212736
       GoKind: 22
       Pointee: 979 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1004
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.428352e+06
+      GoRuntimeType: 1428352
       GoKind: 22
       Pointee: 1005 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1218
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.242496e+06
+      GoRuntimeType: 2242496
       GoKind: 22
       Pointee: 1219 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 1002
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.428032e+06
+      GoRuntimeType: 1428032
       GoKind: 22
       Pointee: 1003 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 980
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.212864e+06
+      GoRuntimeType: 1212864
       GoKind: 22
       Pointee: 981 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1228
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.270848e+06
+      GoRuntimeType: 2270848
       GoKind: 22
       Pointee: 1229 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1238
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.316352e+06
+      GoRuntimeType: 2316352
       GoKind: 22
       Pointee: 1239 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1226
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.270336e+06
+      GoRuntimeType: 2270336
       GoKind: 22
       Pointee: 1227 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 977
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.211968e+06
+      GoRuntimeType: 1211968
       GoKind: 22
       Pointee: 940 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13686,28 +13686,28 @@ Types:
       ID: 904
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.043776e+06
+      GoRuntimeType: 1043776
       GoKind: 22
       Pointee: 905 StructureType net.canceledError
     - __kind: PointerType
       ID: 1194
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2.01872e+06
+      GoRuntimeType: 2018720
       GoKind: 22
       Pointee: 1195 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1048
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.8576e+06
+      GoRuntimeType: 1857600
       GoKind: 22
       Pointee: 1049 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1240
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.320608e+06
+      GoRuntimeType: 2320608
       GoKind: 22
       Pointee: 1241 UnresolvedPointeeType net.netFD
     - __kind: PointerType
@@ -13728,35 +13728,35 @@ Types:
       ID: 1222
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.256384e+06
+      GoRuntimeType: 2256384
       GoKind: 22
       Pointee: 1223 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1220
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.255904e+06
+      GoRuntimeType: 2255904
       GoKind: 22
       Pointee: 1221 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 982
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.213504e+06
+      GoRuntimeType: 1213504
       GoKind: 22
       Pointee: 983 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1006
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.428512e+06
+      GoRuntimeType: 1428512
       GoKind: 22
       Pointee: 1007 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 894
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1.039552e+06
+      GoRuntimeType: 1039552
       GoKind: 22
       Pointee: 895 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
@@ -13784,7 +13784,7 @@ Types:
       ID: 998
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.424032e+06
+      GoRuntimeType: 1424032
       GoKind: 22
       Pointee: 999 StructureType net/http.http2StreamError
     - __kind: PointerType
@@ -13798,7 +13798,7 @@ Types:
       ID: 1129
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.562816e+06
+      GoRuntimeType: 1562816
       GoKind: 22
       Pointee: 1130 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
@@ -13841,21 +13841,21 @@ Types:
       ID: 973
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.20864e+06
+      GoRuntimeType: 1208640
       GoKind: 22
       Pointee: 974 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 900
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1.040192e+06
+      GoRuntimeType: 1040192
       GoKind: 22
       Pointee: 901 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1183
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.961024e+06
+      GoRuntimeType: 1961024
       GoKind: 22
       Pointee: 1184 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
@@ -13881,28 +13881,28 @@ Types:
       ID: 896
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1.039808e+06
+      GoRuntimeType: 1039808
       GoKind: 22
       Pointee: 897 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1131
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.186304e+06
+      GoRuntimeType: 2186304
       GoKind: 22
       Pointee: 1132 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1087
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1.03968e+06
+      GoRuntimeType: 1039680
       GoKind: 22
       Pointee: 1088 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 1121
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.424192e+06
+      GoRuntimeType: 1424192
       GoKind: 22
       Pointee: 1122 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
@@ -13916,28 +13916,28 @@ Types:
       ID: 1000
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.425312e+06
+      GoRuntimeType: 1425312
       GoKind: 22
       Pointee: 1001 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 971
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.208512e+06
+      GoRuntimeType: 1208512
       GoKind: 22
       Pointee: 972 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 898
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1.039936e+06
+      GoRuntimeType: 1039936
       GoKind: 22
       Pointee: 899 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1163
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1.85424e+06
+      GoRuntimeType: 1854240
       GoKind: 22
       Pointee: 1164 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
@@ -13951,14 +13951,14 @@ Types:
       ID: 1185
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.962816e+06
+      GoRuntimeType: 1962816
       GoKind: 22
       Pointee: 1186 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 1097
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.052096e+06
+      GoRuntimeType: 1052096
       GoKind: 22
       Pointee: 1098 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
@@ -13979,14 +13979,14 @@ Types:
       ID: 1137
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 2.128384e+06
+      GoRuntimeType: 2128384
       GoKind: 22
       Pointee: 1138 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 1099
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.05696e+06
+      GoRuntimeType: 1056960
       GoKind: 22
       Pointee: 1100 StructureType net/smtp.dataCloser
     - __kind: PointerType
@@ -14012,14 +14012,14 @@ Types:
       ID: 1095
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.051328e+06
+      GoRuntimeType: 1051328
       GoKind: 22
       Pointee: 1096 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 1008
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.428832e+06
+      GoRuntimeType: 1428832
       GoKind: 22
       Pointee: 1009 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
@@ -14185,63 +14185,63 @@ Types:
       ID: 1246
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.360096e+06
+      GoRuntimeType: 2360096
       GoKind: 22
       Pointee: 1247 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 877
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 1.031104e+06
+      GoRuntimeType: 1031104
       GoKind: 22
       Pointee: 878 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 943
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.197632e+06
+      GoRuntimeType: 1197632
       GoKind: 22
       Pointee: 944 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1244
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.358624e+06
+      GoRuntimeType: 2358624
       GoKind: 22
       Pointee: 1245 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1242
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.357888e+06
+      GoRuntimeType: 2357888
       GoKind: 22
       Pointee: 1243 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 908
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.048e+06
+      GoRuntimeType: 1048000
       GoKind: 22
       Pointee: 909 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 1051
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 2.098944e+06
+      GoRuntimeType: 2098944
       GoKind: 22
       Pointee: 1052 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 1115
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.219776e+06
+      GoRuntimeType: 1219776
       GoKind: 22
       Pointee: 1116 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 910
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.048128e+06
+      GoRuntimeType: 1048128
       GoKind: 22
       Pointee: 911 StructureType os/exec.wrappedError
     - __kind: PointerType
@@ -14281,14 +14281,14 @@ Types:
       ID: 881
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1.03264e+06
+      GoRuntimeType: 1032640
       GoKind: 22
       Pointee: 882 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 885
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1.034432e+06
+      GoRuntimeType: 1034432
       GoKind: 22
       Pointee: 886 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
@@ -14302,14 +14302,14 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.421792e+06
+      GoRuntimeType: 1421792
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 883
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1.032768e+06
+      GoRuntimeType: 1032768
       GoKind: 22
       Pointee: 884 StructureType runtime.boundsError
     - __kind: PointerType
@@ -14330,14 +14330,14 @@ Types:
       ID: 945
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.203136e+06
+      GoRuntimeType: 1203136
       GoKind: 22
       Pointee: 946 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 879
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1.032256e+06
+      GoRuntimeType: 1032256
       GoKind: 22
       Pointee: 860 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14356,21 +14356,21 @@ Types:
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.422432e+06
+      GoRuntimeType: 1422432
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.033792e+06
+      GoRuntimeType: 1033792
       GoKind: 22
       Pointee: 364 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 880
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1.032384e+06
+      GoRuntimeType: 1032384
       GoKind: 22
       Pointee: 863 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14389,7 +14389,7 @@ Types:
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.560576e+06
+      GoRuntimeType: 1560576
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
@@ -14403,21 +14403,21 @@ Types:
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.063936e+06
+      GoRuntimeType: 2063936
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.628608e+06
+      GoRuntimeType: 1628608
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 875
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 1.029952e+06
+      GoRuntimeType: 1029952
       GoKind: 22
       Pointee: 876 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
@@ -14436,14 +14436,14 @@ Types:
       ID: 1179
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.95872e+06
+      GoRuntimeType: 1958720
       GoKind: 22
       Pointee: 1180 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 1085
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 1.03008e+06
+      GoRuntimeType: 1030080
       GoKind: 22
       Pointee: 1086 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
@@ -14464,7 +14464,7 @@ Types:
       ID: 997
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.423392e+06
+      GoRuntimeType: 1423392
       GoKind: 22
       Pointee: 996 BaseType syscall.Errno
     - __kind: PointerType
@@ -14606,21 +14606,21 @@ Types:
       ID: 1216
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.170016e+06
+      GoRuntimeType: 2170016
       GoKind: 22
       Pointee: 1217 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 938
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.093568e+06
+      GoRuntimeType: 1093568
       GoKind: 22
       Pointee: 939 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 1013
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.6336e+06
+      GoRuntimeType: 1633600
       GoKind: 22
       Pointee: 1014 UnresolvedPointeeType time.Location
     - __kind: PointerType
@@ -14695,7 +14695,7 @@ Types:
       ID: 1208
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.145504e+06
+      GoRuntimeType: 2145504
       GoKind: 22
       Pointee: 1209 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -14716,14 +14716,14 @@ Types:
       ID: 915
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.05184e+06
+      GoRuntimeType: 1051840
       GoKind: 22
       Pointee: 916 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 917
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.051968e+06
+      GoRuntimeType: 1051968
       GoKind: 22
       Pointee: 868 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -17302,14 +17302,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17324,14 +17324,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 25
           Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -23065,14 +23065,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -23098,14 +23098,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -25071,7 +25071,7 @@ Types:
     - __kind: StructureType
       ID: 1078
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.12576e+06
+      GoRuntimeType: 1125760
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25082,7 +25082,7 @@ Types:
       ID: 1104
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.573536e+06
+      GoRuntimeType: 1573536
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -25172,7 +25172,7 @@ Types:
     - __kind: StructureType
       ID: 976
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.487936e+06
+      GoRuntimeType: 1487936
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25200,7 +25200,7 @@ Types:
     - __kind: StructureType
       ID: 925
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
-      GoRuntimeType: 1.295616e+06
+      GoRuntimeType: 1295616
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25259,7 +25259,7 @@ Types:
       ID: 740
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.740096e+06
+      GoRuntimeType: 1740096
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25301,7 +25301,7 @@ Types:
       ID: 816
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.742976e+06
+      GoRuntimeType: 1742976
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25316,14 +25316,14 @@ Types:
     - __kind: StructureType
       ID: 810
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.123328e+06
+      GoRuntimeType: 1123328
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 812
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.607648e+06
+      GoRuntimeType: 1607648
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -25348,7 +25348,7 @@ Types:
       ID: 919
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.569536e+06
+      GoRuntimeType: 1569536
       GoKind: 25
       RawFields:
         - Name: Err
@@ -25357,14 +25357,14 @@ Types:
     - __kind: StructureType
       ID: 818
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.123584e+06
+      GoRuntimeType: 1123584
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 814
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.742784e+06
+      GoRuntimeType: 1742784
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25380,7 +25380,7 @@ Types:
       ID: 832
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.443072e+06
+      GoRuntimeType: 1443072
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25390,7 +25390,7 @@ Types:
       ID: 836
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.443232e+06
+      GoRuntimeType: 1443232
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25448,7 +25448,7 @@ Types:
       ID: 700
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.427072e+06
+      GoRuntimeType: 1427072
       GoKind: 25
       RawFields:
         - Name: error
@@ -25497,7 +25497,7 @@ Types:
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.032128e+06
+      GoRuntimeType: 1032128
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25591,7 +25591,7 @@ Types:
       ID: 709
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.738944e+06
+      GoRuntimeType: 1738944
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25614,7 +25614,7 @@ Types:
     - __kind: StructureType
       ID: 715
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.119616e+06
+      GoRuntimeType: 1119616
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25644,7 +25644,7 @@ Types:
       ID: 1036
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.229312e+06
+      GoRuntimeType: 2229312
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25760,7 +25760,7 @@ Types:
     - __kind: StructureType
       ID: 760
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.12256e+06
+      GoRuntimeType: 1122560
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25772,14 +25772,14 @@ Types:
     - __kind: StructureType
       ID: 758
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.122432e+06
+      GoRuntimeType: 1122432
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 756
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.605728e+06
+      GoRuntimeType: 1605728
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25792,7 +25792,7 @@ Types:
       ID: 776
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.606528e+06
+      GoRuntimeType: 1606528
       GoKind: 25
       RawFields:
         - Name: File
@@ -25805,7 +25805,7 @@ Types:
       ID: 780
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.742208e+06
+      GoRuntimeType: 1742208
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25821,7 +25821,7 @@ Types:
       ID: 778
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.436992e+06
+      GoRuntimeType: 1436992
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25831,7 +25831,7 @@ Types:
       ID: 774
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.436672e+06
+      GoRuntimeType: 1436672
       GoKind: 25
       RawFields:
         - Name: File
@@ -25841,14 +25841,14 @@ Types:
       ID: 1022
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.508416e+06
+      GoRuntimeType: 1508416
       GoKind: 21
       HeaderType: 1024 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 1045
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.055424e+06
+      GoRuntimeType: 1055424
       GoKind: 23
       RawFields:
         - Name: array
@@ -25871,7 +25871,7 @@ Types:
       ID: 788
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.606848e+06
+      GoRuntimeType: 1606848
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25884,7 +25884,7 @@ Types:
       ID: 782
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.437152e+06
+      GoRuntimeType: 1437152
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25894,7 +25894,7 @@ Types:
       ID: 786
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.7424e+06
+      GoRuntimeType: 1742400
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25910,7 +25910,7 @@ Types:
       ID: 784
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.606688e+06
+      GoRuntimeType: 1606688
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25923,7 +25923,7 @@ Types:
       ID: 790
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.437312e+06
+      GoRuntimeType: 1437312
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25933,7 +25933,7 @@ Types:
       ID: 796
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.607168e+06
+      GoRuntimeType: 1607168
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25946,7 +25946,7 @@ Types:
       ID: 798
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.437632e+06
+      GoRuntimeType: 1437632
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25956,7 +25956,7 @@ Types:
       ID: 794
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.607008e+06
+      GoRuntimeType: 1607008
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25969,7 +25969,7 @@ Types:
       ID: 792
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.437472e+06
+      GoRuntimeType: 1437472
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25979,7 +25979,7 @@ Types:
       ID: 800
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.607328e+06
+      GoRuntimeType: 1607328
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25992,7 +25992,7 @@ Types:
       ID: 717
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.429312e+06
+      GoRuntimeType: 1429312
       GoKind: 25
       RawFields:
         - Name: message
@@ -26006,7 +26006,7 @@ Types:
       ID: 719
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.429472e+06
+      GoRuntimeType: 1429472
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -26028,7 +26028,7 @@ Types:
       ID: 723
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.429792e+06
+      GoRuntimeType: 1429792
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -26042,7 +26042,7 @@ Types:
       ID: 1202
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 2.1168e+06
+      GoRuntimeType: 2116800
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -26055,7 +26055,7 @@ Types:
       ID: 1205
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.142048e+06
+      GoRuntimeType: 2142048
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -26075,7 +26075,7 @@ Types:
       ID: 721
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.429632e+06
+      GoRuntimeType: 1429632
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -26085,7 +26085,7 @@ Types:
       ID: 725
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.429952e+06
+      GoRuntimeType: 1429952
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -26135,7 +26135,7 @@ Types:
       ID: 731
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.430912e+06
+      GoRuntimeType: 1430912
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -26150,7 +26150,7 @@ Types:
       ID: 960
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.852448e+06
+      GoRuntimeType: 1852448
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -26170,7 +26170,7 @@ Types:
       ID: 889
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.711648e+06
+      GoRuntimeType: 1711648
       GoKind: 25
       RawFields:
         - Name: Got
@@ -26183,7 +26183,7 @@ Types:
       ID: 966
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.852896e+06
+      GoRuntimeType: 1852896
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26205,7 +26205,7 @@ Types:
       ID: 958
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.852224e+06
+      GoRuntimeType: 1852224
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -26227,7 +26227,7 @@ Types:
       ID: 956
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.852e+06
+      GoRuntimeType: 1852000
       GoKind: 25
       RawFields:
         - Name: Method
@@ -26243,7 +26243,7 @@ Types:
       ID: 964
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.766368e+06
+      GoRuntimeType: 1766368
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26256,7 +26256,7 @@ Types:
       ID: 962
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.852672e+06
+      GoRuntimeType: 1852672
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26276,7 +26276,7 @@ Types:
       ID: 970
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.63456e+06
+      GoRuntimeType: 1634560
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -26285,20 +26285,20 @@ Types:
     - __kind: StructureType
       ID: 893
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.2896e+06
+      GoRuntimeType: 1289600
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 891
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.289472e+06
+      GoRuntimeType: 1289472
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 968
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.76656e+06
+      GoRuntimeType: 1766560
       GoKind: 25
       RawFields:
         - Name: cause
@@ -26381,7 +26381,7 @@ Types:
         - Name: X
           Offset: 0
           Type: 7 BaseType int
-        - Name: Y
+        - Name: "Y"
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
@@ -26422,7 +26422,7 @@ Types:
       ID: 937
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.454912e+06
+      GoRuntimeType: 1454912
       GoKind: 25
       RawFields:
         - Name: error
@@ -26432,7 +26432,7 @@ Types:
       ID: 1120
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.68736e+06
+      GoRuntimeType: 1687360
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -26446,7 +26446,7 @@ Types:
       ID: 1146
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.133312e+06
+      GoRuntimeType: 1133312
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26459,7 +26459,7 @@ Types:
       ID: 1108
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.578336e+06
+      GoRuntimeType: 1578336
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -26475,13 +26475,13 @@ Types:
       ID: 1029
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.00848e+06
+      GoRuntimeType: 1008480
       GoKind: 10
     - __kind: StructureType
       ID: 995
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.890304e+06
+      GoRuntimeType: 1890304
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26497,7 +26497,7 @@ Types:
       ID: 852
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.614368e+06
+      GoRuntimeType: 1614368
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26590,7 +26590,7 @@ Types:
       ID: 856
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.455552e+06
+      GoRuntimeType: 1455552
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26606,7 +26606,7 @@ Types:
       ID: 844
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.450592e+06
+      GoRuntimeType: 1450592
       GoKind: 25
       RawFields:
         - Name: error
@@ -26620,7 +26620,7 @@ Types:
       ID: 1018
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.91808e+06
+      GoRuntimeType: 1918080
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26636,7 +26636,7 @@ Types:
       ID: 846
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.613888e+06
+      GoRuntimeType: 1613888
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26649,7 +26649,7 @@ Types:
       ID: 1160
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.976128e+06
+      GoRuntimeType: 1976128
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26666,7 +26666,7 @@ Types:
       ID: 935
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.575936e+06
+      GoRuntimeType: 1575936
       GoKind: 25
       RawFields:
         - Name: error
@@ -26691,14 +26691,14 @@ Types:
     - __kind: StructureType
       ID: 989
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.519136e+06
+      GoRuntimeType: 1519136
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 838
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.443872e+06
+      GoRuntimeType: 1443872
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26708,7 +26708,7 @@ Types:
       ID: 840
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.444032e+06
+      GoRuntimeType: 1444032
       GoKind: 25
       RawFields:
         - Name: Line
@@ -27159,7 +27159,7 @@ Types:
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.860512e+06
+      GoRuntimeType: 1860512
       GoKind: 25
       RawFields:
         - Name: buf
@@ -27171,7 +27171,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -27196,7 +27196,7 @@ Types:
     - __kind: StructureType
       ID: 950
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.484736e+06
+      GoRuntimeType: 1484736
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27207,7 +27207,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.219264e+06
+      GoRuntimeType: 1219264
       GoKind: 25
       RawFields:
         - Name: u
@@ -27217,7 +27217,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.649152e+06
+      GoRuntimeType: 1649152
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27233,7 +27233,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.498496e+06
+      GoRuntimeType: 1498496
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27246,7 +27246,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.498336e+06
+      GoRuntimeType: 1498336
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27259,7 +27259,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 1.498656e+06
+      GoRuntimeType: 1498656
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27303,7 +27303,7 @@ Types:
       ID: 907
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
-      GoRuntimeType: 1.567296e+06
+      GoRuntimeType: 1567296
       GoKind: 25
       RawFields:
         - Name: typ
@@ -27313,7 +27313,7 @@ Types:
       ID: 1268
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.482176e+06
+      GoRuntimeType: 1482176
       GoKind: 25
       RawFields:
         - Name: state
@@ -27330,7 +27330,7 @@ Types:
       ID: 1152
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.196096e+06
+      GoRuntimeType: 1196096
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27343,7 +27343,7 @@ Types:
       ID: 1187
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.028544e+06
+      GoRuntimeType: 1028544
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27356,7 +27356,7 @@ Types:
       ID: 1139
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.115904e+06
+      GoRuntimeType: 1115904
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27369,7 +27369,7 @@ Types:
       ID: 131
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.028288e+06
+      GoRuntimeType: 1028288
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27381,7 +27381,7 @@ Types:
     - __kind: StructureType
       ID: 1110
       Name: io.discard
-      GoRuntimeType: 1.471296e+06
+      GoRuntimeType: 1471296
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27451,7 +27451,7 @@ Types:
       ID: 166
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.027136e+06
+      GoRuntimeType: 1027136
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27464,7 +27464,7 @@ Types:
       ID: 128
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.621504e+06
+      GoRuntimeType: 1621504
       GoKind: 25
       RawFields:
         - Name: x
@@ -27480,7 +27480,7 @@ Types:
       ID: 143
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.192384e+06
+      GoRuntimeType: 1192384
       GoKind: 25
       RawFields:
         - Name: a
@@ -27490,7 +27490,7 @@ Types:
       ID: 379
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.192256e+06
+      GoRuntimeType: 1192256
       GoKind: 25
       RawFields:
         - Name: a
@@ -27504,7 +27504,7 @@ Types:
       ID: 150
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.191616e+06
+      GoRuntimeType: 1191616
       GoKind: 25
       RawFields:
         - Name: a
@@ -27514,7 +27514,7 @@ Types:
       ID: 1334
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.191488e+06
+      GoRuntimeType: 1191488
       GoKind: 25
       RawFields:
         - Name: a
@@ -27524,7 +27524,7 @@ Types:
       ID: 1349
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.19136e+06
+      GoRuntimeType: 1191360
       GoKind: 25
       RawFields:
         - Name: a
@@ -27534,7 +27534,7 @@ Types:
       ID: 132
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.193536e+06
+      GoRuntimeType: 1193536
       GoKind: 25
       RawFields:
         - Name: a
@@ -27544,7 +27544,7 @@ Types:
       ID: 134
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.193408e+06
+      GoRuntimeType: 1193408
       GoKind: 25
       RawFields:
         - Name: a
@@ -27558,7 +27558,7 @@ Types:
       ID: 136
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.192768e+06
+      GoRuntimeType: 1192768
       GoKind: 25
       RawFields:
         - Name: a
@@ -27568,7 +27568,7 @@ Types:
       ID: 1304
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.19264e+06
+      GoRuntimeType: 1192640
       GoKind: 25
       RawFields:
         - Name: a
@@ -27578,7 +27578,7 @@ Types:
       ID: 1306
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.192512e+06
+      GoRuntimeType: 1192512
       GoKind: 25
       RawFields:
         - Name: a
@@ -27588,7 +27588,7 @@ Types:
       ID: 137
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.194688e+06
+      GoRuntimeType: 1194688
       GoKind: 25
       RawFields:
         - Name: a
@@ -27598,7 +27598,7 @@ Types:
       ID: 369
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.19456e+06
+      GoRuntimeType: 1194560
       GoKind: 25
       RawFields:
         - Name: a
@@ -27612,7 +27612,7 @@ Types:
       ID: 142
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.19392e+06
+      GoRuntimeType: 1193920
       GoKind: 25
       RawFields:
         - Name: a
@@ -27622,7 +27622,7 @@ Types:
       ID: 1310
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.193792e+06
+      GoRuntimeType: 1193792
       GoKind: 25
       RawFields:
         - Name: a
@@ -27632,7 +27632,7 @@ Types:
       ID: 1316
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.193664e+06
+      GoRuntimeType: 1193664
       GoKind: 25
       RawFields:
         - Name: a
@@ -27647,7 +27647,7 @@ Types:
       ID: 164
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.844608e+06
+      GoRuntimeType: 1844608
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27669,7 +27669,7 @@ Types:
       ID: 159
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.977696e+06
+      GoRuntimeType: 1977696
       GoKind: 25
       RawFields:
         - Name: _
@@ -27697,7 +27697,7 @@ Types:
       ID: 357
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.419552e+06
+      GoRuntimeType: 1419552
       GoKind: 25
       RawFields:
         - Name: s
@@ -28040,7 +28040,7 @@ Types:
       ID: 123
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.470336e+06
+      GoRuntimeType: 1470336
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -28053,7 +28053,7 @@ Types:
       ID: 250
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.470016e+06
+      GoRuntimeType: 1470016
       GoKind: 25
       RawFields:
         - Name: val
@@ -28087,14 +28087,14 @@ Types:
       ID: 1278
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.419712e+06
+      GoRuntimeType: 1419712
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 162
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.027264e+06
+      GoRuntimeType: 1027264
       GoKind: 20
       RawFields:
         - Name: tab
@@ -28147,7 +28147,7 @@ Types:
       ID: 168
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.191104e+06
+      GoRuntimeType: 1191104
       GoKind: 25
       RawFields:
         - Name: a
@@ -28217,7 +28217,7 @@ Types:
       ID: 169
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.191232e+06
+      GoRuntimeType: 1191232
       GoKind: 25
       RawFields:
         - Name: m
@@ -29331,119 +29331,119 @@ Types:
       ID: 227
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.13536e+06
+      GoRuntimeType: 1135360
       GoKind: 21
       HeaderType: 229 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 222
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.135488e+06
+      GoRuntimeType: 1135488
       GoKind: 21
       HeaderType: 224 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 190
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.135616e+06
+      GoRuntimeType: 1135616
       GoKind: 21
       HeaderType: 192 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 202
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.135744e+06
+      GoRuntimeType: 1135744
       GoKind: 21
       HeaderType: 204 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 144
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.135232e+06
+      GoRuntimeType: 1135232
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1288
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.135104e+06
+      GoRuntimeType: 1135104
       GoKind: 21
       HeaderType: 1290 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1322
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.134464e+06
+      GoRuntimeType: 1134464
       GoKind: 21
       HeaderType: 1324 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1337
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.134336e+06
+      GoRuntimeType: 1134336
       GoKind: 21
       HeaderType: 1339 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 170
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.133696e+06
+      GoRuntimeType: 1133696
       GoKind: 21
       HeaderType: 172 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 1352
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.134208e+06
+      GoRuntimeType: 1134208
       GoKind: 21
       HeaderType: 1354 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 237
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.135872e+06
+      GoRuntimeType: 1135872
       GoKind: 21
       HeaderType: 239 GoSwissMapHeaderType map<int,struct {}>
     - __kind: GoMapType
       ID: 207
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.136e+06
+      GoRuntimeType: 1136000
       GoKind: 21
       HeaderType: 209 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 197
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.136128e+06
+      GoRuntimeType: 1136128
       GoKind: 21
       HeaderType: 199 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 185
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.136256e+06
+      GoRuntimeType: 1136256
       GoKind: 21
       HeaderType: 187 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 180
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.136384e+06
+      GoRuntimeType: 1136384
       GoKind: 21
       HeaderType: 182 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 175
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.136512e+06
+      GoRuntimeType: 1136512
       GoKind: 21
       HeaderType: 177 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 232
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 1.13664e+06
+      GoRuntimeType: 1136640
       GoKind: 21
       HeaderType: 234 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
@@ -29486,28 +29486,28 @@ Types:
       ID: 242
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.136768e+06
+      GoRuntimeType: 1136768
       GoKind: 21
       HeaderType: 244 GoSwissMapHeaderType map<struct {},struct {}>
     - __kind: GoMapType
       ID: 217
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.136896e+06
+      GoRuntimeType: 1136896
       GoKind: 21
       HeaderType: 219 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 212
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.137024e+06
+      GoRuntimeType: 1137024
       GoKind: 21
       HeaderType: 214 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
       ID: 772
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.436192e+06
+      GoRuntimeType: 1436192
       GoKind: 25
       RawFields:
         - Name: msg
@@ -29517,7 +29517,7 @@ Types:
       ID: 1074
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.432992e+06
+      GoRuntimeType: 1432992
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29531,7 +29531,7 @@ Types:
       ID: 1044
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.604448e+06
+      GoRuntimeType: 1604448
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29572,7 +29572,7 @@ Types:
       ID: 940
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.119232e+06
+      GoRuntimeType: 1119232
       GoKind: 24
       RawFields:
         - Name: str
@@ -29590,7 +29590,7 @@ Types:
     - __kind: StructureType
       ID: 905
       Name: net.canceledError
-      GoRuntimeType: 1.290624e+06
+      GoRuntimeType: 1290624
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29601,7 +29601,7 @@ Types:
       ID: 1049
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 2.116096e+06
+      GoRuntimeType: 2116096
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29623,13 +29623,13 @@ Types:
     - __kind: StructureType
       ID: 1235
       Name: net.noReadFrom
-      GoRuntimeType: 1.119488e+06
+      GoRuntimeType: 1119488
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1234
       Name: net.noWriteTo
-      GoRuntimeType: 1.11936e+06
+      GoRuntimeType: 1119360
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29640,7 +29640,7 @@ Types:
       ID: 704
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.738752e+06
+      GoRuntimeType: 1738752
       GoKind: 25
       RawFields:
         - Name: p
@@ -29656,7 +29656,7 @@ Types:
       ID: 1223
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.299104e+06
+      GoRuntimeType: 2299104
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29669,7 +29669,7 @@ Types:
       ID: 1221
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.29856e+06
+      GoRuntimeType: 2298560
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29694,7 +29694,7 @@ Types:
       ID: 1068
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.424512e+06
+      GoRuntimeType: 1424512
       GoKind: 25
       RawFields:
         - Name: w
@@ -29716,7 +29716,7 @@ Types:
       ID: 680
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.737024e+06
+      GoRuntimeType: 1737024
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -29732,7 +29732,7 @@ Types:
       ID: 999
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.908608e+06
+      GoRuntimeType: 1908608
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -29748,7 +29748,7 @@ Types:
       ID: 684
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.603968e+06
+      GoRuntimeType: 1603968
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29825,7 +29825,7 @@ Types:
     - __kind: StructureType
       ID: 901
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.289856e+06
+      GoRuntimeType: 1289856
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29855,7 +29855,7 @@ Types:
       ID: 1070
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
-      GoRuntimeType: 1.834688e+06
+      GoRuntimeType: 1834688
       GoKind: 25
       RawFields:
         - Name: group
@@ -29874,7 +29874,7 @@ Types:
       ID: 1161
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
-      GoRuntimeType: 1.423712e+06
+      GoRuntimeType: 1423712
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29894,7 +29894,7 @@ Types:
       ID: 897
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.563456e+06
+      GoRuntimeType: 1563456
       GoKind: 25
       RawFields:
         - Name: error
@@ -29908,7 +29908,7 @@ Types:
       ID: 1088
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.563296e+06
+      GoRuntimeType: 1563296
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29918,7 +29918,7 @@ Types:
       ID: 1122
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.809664e+06
+      GoRuntimeType: 1809664
       GoKind: 25
       RawFields:
         - Name: _
@@ -29934,7 +29934,7 @@ Types:
       ID: 688
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.425472e+06
+      GoRuntimeType: 1425472
       GoKind: 25
       RawFields:
         - Name: error
@@ -29947,14 +29947,14 @@ Types:
     - __kind: StructureType
       ID: 972
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.487616e+06
+      GoRuntimeType: 1487616
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 899
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.563616e+06
+      GoRuntimeType: 1563616
       GoKind: 25
       RawFields:
         - Name: err
@@ -29964,7 +29964,7 @@ Types:
       ID: 1164
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2.035104e+06
+      GoRuntimeType: 2035104
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29981,7 +29981,7 @@ Types:
       ID: 1186
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 2.050848e+06
+      GoRuntimeType: 2050848
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29995,7 +29995,7 @@ Types:
       ID: 764
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.741824e+06
+      GoRuntimeType: 1741824
       GoKind: 25
       RawFields:
         - Name: in
@@ -30011,7 +30011,7 @@ Types:
       ID: 762
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.605888e+06
+      GoRuntimeType: 1605888
       GoKind: 25
       RawFields:
         - Name: in
@@ -30028,7 +30028,7 @@ Types:
       ID: 1100
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.607808e+06
+      GoRuntimeType: 1607808
       GoKind: 25
       RawFields:
         - Name: c
@@ -30346,7 +30346,7 @@ Types:
       ID: 479
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.301888e+06
+      GoRuntimeType: 1301888
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30359,7 +30359,7 @@ Types:
       ID: 471
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.302144e+06
+      GoRuntimeType: 1302144
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30372,7 +30372,7 @@ Types:
       ID: 419
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.3024e+06
+      GoRuntimeType: 1302400
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30385,7 +30385,7 @@ Types:
       ID: 438
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.302656e+06
+      GoRuntimeType: 1302656
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30398,7 +30398,7 @@ Types:
       ID: 375
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.301632e+06
+      GoRuntimeType: 1301632
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30411,7 +30411,7 @@ Types:
       ID: 1296
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.301376e+06
+      GoRuntimeType: 1301376
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30424,7 +30424,7 @@ Types:
       ID: 1330
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.300096e+06
+      GoRuntimeType: 1300096
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30437,7 +30437,7 @@ Types:
       ID: 1345
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.29984e+06
+      GoRuntimeType: 1299840
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30450,7 +30450,7 @@ Types:
       ID: 387
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.29856e+06
+      GoRuntimeType: 1298560
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30463,7 +30463,7 @@ Types:
       ID: 1360
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.299584e+06
+      GoRuntimeType: 1299584
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30476,7 +30476,7 @@ Types:
       ID: 495
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
-      GoRuntimeType: 1.302912e+06
+      GoRuntimeType: 1302912
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30489,7 +30489,7 @@ Types:
       ID: 446
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.303168e+06
+      GoRuntimeType: 1303168
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30502,7 +30502,7 @@ Types:
       ID: 428
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.303424e+06
+      GoRuntimeType: 1303424
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30515,7 +30515,7 @@ Types:
       ID: 411
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.30368e+06
+      GoRuntimeType: 1303680
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30528,7 +30528,7 @@ Types:
       ID: 1056
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
-      GoRuntimeType: 1.36512e+06
+      GoRuntimeType: 1365120
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30541,7 +30541,7 @@ Types:
       ID: 403
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.303936e+06
+      GoRuntimeType: 1303936
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30554,7 +30554,7 @@ Types:
       ID: 395
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.304192e+06
+      GoRuntimeType: 1304192
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30567,7 +30567,7 @@ Types:
       ID: 487
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
-      GoRuntimeType: 1.304448e+06
+      GoRuntimeType: 1304448
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30652,7 +30652,7 @@ Types:
       ID: 503
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
-      GoRuntimeType: 1.304704e+06
+      GoRuntimeType: 1304704
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30665,7 +30665,7 @@ Types:
       ID: 462
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.30496e+06
+      GoRuntimeType: 1304960
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30678,7 +30678,7 @@ Types:
       ID: 454
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.305216e+06
+      GoRuntimeType: 1305216
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30691,7 +30691,7 @@ Types:
       ID: 481
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.30176e+06
+      GoRuntimeType: 1301760
       GoKind: 25
       RawFields:
         - Name: key
@@ -30704,7 +30704,7 @@ Types:
       ID: 473
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.302016e+06
+      GoRuntimeType: 1302016
       GoKind: 25
       RawFields:
         - Name: key
@@ -30717,7 +30717,7 @@ Types:
       ID: 421
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.302272e+06
+      GoRuntimeType: 1302272
       GoKind: 25
       RawFields:
         - Name: key
@@ -30730,7 +30730,7 @@ Types:
       ID: 440
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.302528e+06
+      GoRuntimeType: 1302528
       GoKind: 25
       RawFields:
         - Name: key
@@ -30743,7 +30743,7 @@ Types:
       ID: 377
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.301504e+06
+      GoRuntimeType: 1301504
       GoKind: 25
       RawFields:
         - Name: key
@@ -30756,7 +30756,7 @@ Types:
       ID: 1298
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.301248e+06
+      GoRuntimeType: 1301248
       GoKind: 25
       RawFields:
         - Name: key
@@ -30769,7 +30769,7 @@ Types:
       ID: 1332
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.299968e+06
+      GoRuntimeType: 1299968
       GoKind: 25
       RawFields:
         - Name: key
@@ -30782,7 +30782,7 @@ Types:
       ID: 1347
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.299712e+06
+      GoRuntimeType: 1299712
       GoKind: 25
       RawFields:
         - Name: key
@@ -30795,7 +30795,7 @@ Types:
       ID: 389
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.298432e+06
+      GoRuntimeType: 1298432
       GoKind: 25
       RawFields:
         - Name: key
@@ -30808,7 +30808,7 @@ Types:
       ID: 1362
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.299456e+06
+      GoRuntimeType: 1299456
       GoKind: 25
       RawFields:
         - Name: key
@@ -30821,7 +30821,7 @@ Types:
       ID: 497
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
-      GoRuntimeType: 1.302784e+06
+      GoRuntimeType: 1302784
       GoKind: 25
       RawFields:
         - Name: key
@@ -30834,7 +30834,7 @@ Types:
       ID: 448
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.30304e+06
+      GoRuntimeType: 1303040
       GoKind: 25
       RawFields:
         - Name: key
@@ -30847,7 +30847,7 @@ Types:
       ID: 430
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.303296e+06
+      GoRuntimeType: 1303296
       GoKind: 25
       RawFields:
         - Name: key
@@ -30860,7 +30860,7 @@ Types:
       ID: 413
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.303552e+06
+      GoRuntimeType: 1303552
       GoKind: 25
       RawFields:
         - Name: key
@@ -30873,7 +30873,7 @@ Types:
       ID: 1058
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
-      GoRuntimeType: 1.364992e+06
+      GoRuntimeType: 1364992
       GoKind: 25
       RawFields:
         - Name: key
@@ -30886,7 +30886,7 @@ Types:
       ID: 405
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.303808e+06
+      GoRuntimeType: 1303808
       GoKind: 25
       RawFields:
         - Name: key
@@ -30899,7 +30899,7 @@ Types:
       ID: 397
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.304064e+06
+      GoRuntimeType: 1304064
       GoKind: 25
       RawFields:
         - Name: key
@@ -30912,7 +30912,7 @@ Types:
       ID: 489
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
-      GoRuntimeType: 1.30432e+06
+      GoRuntimeType: 1304320
       GoKind: 25
       RawFields:
         - Name: key
@@ -30996,7 +30996,7 @@ Types:
     - __kind: StructureType
       ID: 505
       Name: noalg.struct { key struct {}; elem struct {} }
-      GoRuntimeType: 1.304576e+06
+      GoRuntimeType: 1304576
       GoKind: 25
       RawFields:
         - Name: key
@@ -31009,7 +31009,7 @@ Types:
       ID: 464
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.304832e+06
+      GoRuntimeType: 1304832
       GoKind: 25
       RawFields:
         - Name: key
@@ -31022,7 +31022,7 @@ Types:
       ID: 456
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.305088e+06
+      GoRuntimeType: 1305088
       GoKind: 25
       RawFields:
         - Name: key
@@ -31047,7 +31047,7 @@ Types:
       ID: 1245
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.369472e+06
+      GoRuntimeType: 2369472
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -31060,7 +31060,7 @@ Types:
       ID: 1243
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.368672e+06
+      GoRuntimeType: 2368672
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -31072,13 +31072,13 @@ Types:
     - __kind: StructureType
       ID: 1251
       Name: os.noReadFrom
-      GoRuntimeType: 1.116928e+06
+      GoRuntimeType: 1116928
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1250
       Name: os.noWriteTo
-      GoRuntimeType: 1.1168e+06
+      GoRuntimeType: 1116800
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -31097,7 +31097,7 @@ Types:
       ID: 911
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.712224e+06
+      GoRuntimeType: 1712224
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -31159,13 +31159,13 @@ Types:
       ID: 884
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.897472e+06
+      GoRuntimeType: 1897472
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
           Type: 13 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -31198,7 +31198,7 @@ Types:
       ID: 946
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.762528e+06
+      GoRuntimeType: 1762528
       GoKind: 25
       RawFields:
         - Name: msg
@@ -31230,7 +31230,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 2.416288e+06
+      GoRuntimeType: 2416288
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31420,7 +31420,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.20288e+06
+      GoRuntimeType: 1202880
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -31430,7 +31430,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.923392e+06
+      GoRuntimeType: 1923392
       GoKind: 25
       RawFields:
         - Name: sp
@@ -31455,7 +31455,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.479296e+06
+      GoRuntimeType: 1479296
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31468,7 +31468,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.761376e+06
+      GoRuntimeType: 1761376
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31493,7 +31493,7 @@ Types:
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.479136e+06
+      GoRuntimeType: 1479136
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -31506,13 +31506,13 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1.92416e+06
+      GoRuntimeType: 1924160
       GoKind: 25
       RawFields:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -31537,7 +31537,7 @@ Types:
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 2.419584e+06
+      GoRuntimeType: 2419584
       GoKind: 25
       RawFields:
         - Name: g0
@@ -31757,7 +31757,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.923904e+06
+      GoRuntimeType: 1923904
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31782,7 +31782,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.849536e+06
+      GoRuntimeType: 1849536
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31804,7 +31804,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1.849312e+06
+      GoRuntimeType: 1849312
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -31826,7 +31826,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.478816e+06
+      GoRuntimeType: 1478816
       GoKind: 25
       RawFields:
         - Name: next
@@ -31845,7 +31845,7 @@ Types:
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.202624e+06
+      GoRuntimeType: 1202624
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -31856,7 +31856,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.478976e+06
+      GoRuntimeType: 1478976
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31869,13 +31869,13 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.762336e+06
+      GoRuntimeType: 1762336
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -31922,7 +31922,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.477056e+06
+      GoRuntimeType: 1477056
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31943,7 +31943,7 @@ Types:
       ID: 668
       Name: runtime.synctestDeadlockError
       ByteSize: 24
-      GoRuntimeType: 1.603648e+06
+      GoRuntimeType: 1603648
       GoKind: 25
       RawFields:
         - Name: reason
@@ -31976,7 +31976,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.478016e+06
+      GoRuntimeType: 1478016
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -31989,7 +31989,7 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.288832e+06
+      GoRuntimeType: 1288832
       GoKind: 8
     - __kind: StructureType
       ID: 82
@@ -32032,7 +32032,7 @@ Types:
       ID: 1082
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.462912e+06
+      GoRuntimeType: 1462912
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -32048,7 +32048,7 @@ Types:
       ID: 1266
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.472256e+06
+      GoRuntimeType: 1472256
       GoKind: 25
       RawFields:
         - Name: _
@@ -32061,7 +32061,7 @@ Types:
       ID: 1269
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.623424e+06
+      GoRuntimeType: 1623424
       GoKind: 25
       RawFields:
         - Name: _
@@ -32077,7 +32077,7 @@ Types:
       ID: 1272
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.623232e+06
+      GoRuntimeType: 1623232
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -32099,7 +32099,7 @@ Types:
       ID: 1270
       Name: sync/atomic.Bool
       ByteSize: 4
-      GoRuntimeType: 1.473376e+06
+      GoRuntimeType: 1473376
       GoKind: 25
       RawFields:
         - Name: _
@@ -32112,7 +32112,7 @@ Types:
       ID: 1275
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.473536e+06
+      GoRuntimeType: 1473536
       GoKind: 25
       RawFields:
         - Name: _
@@ -32125,7 +32125,7 @@ Types:
       ID: 1273
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.623808e+06
+      GoRuntimeType: 1623808
       GoKind: 25
       RawFields:
         - Name: _
@@ -32153,7 +32153,7 @@ Types:
       ID: 996
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.289216e+06
+      GoRuntimeType: 1289216
       GoKind: 12
     - __kind: StructureType
       ID: 476
@@ -32811,7 +32811,7 @@ Types:
       ID: 939
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.71664e+06
+      GoRuntimeType: 1716640
       GoKind: 25
       RawFields:
         - Name: Name
@@ -32824,7 +32824,7 @@ Types:
       ID: 1162
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.924928e+06
+      GoRuntimeType: 1924928
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1014
@@ -32838,7 +32838,7 @@ Types:
       ID: 1012
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.382784e+06
+      GoRuntimeType: 2382784
       GoKind: 25
       RawFields:
         - Name: wall
@@ -32915,7 +32915,7 @@ Types:
       ID: 1032
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 2.072576e+06
+      GoRuntimeType: 2072576
       GoKind: 25
       RawFields:
         - Name: msg
@@ -32927,7 +32927,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 1034 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 7 BaseType int
         - Name: index
@@ -32955,7 +32955,7 @@ Types:
       ID: 1033
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.935936e+06
+      GoRuntimeType: 1935936
       GoKind: 25
       RawFields:
         - Name: id
@@ -32994,7 +32994,7 @@ Types:
       ID: 750
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.433312e+06
+      GoRuntimeType: 1433312
       GoKind: 25
       RawFields:
         - Name: Err
@@ -33010,7 +33010,7 @@ Types:
       ID: 916
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.712416e+06
+      GoRuntimeType: 1712416
       GoKind: 25
       RawFields:
         - Name: label

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -568,8 +568,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 86}
@@ -592,7 +592,7 @@ Probes:
                   EventExpressionIndex: 1
                 - ', '
                 - Error: failed to resolve reference "y"
-                  DSL: y
+                  DSL: "y"
     - id: testConflictingReturn
       version: 0
       type: LOG_PROBE
@@ -1705,8 +1705,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
       captureSnapshot: true
       instances:
         - subprogram: {subprogram: 53}
@@ -1727,8 +1727,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
     - id: testInlinedBBA
@@ -5459,8 +5459,8 @@ Probes:
         - json: {ref: x}
           dsl: x
         - ', '
-        - json: {ref: y}
-          dsl: y
+        - json: {ref: "y"}
+          dsl: "y"
         - ', '
         - json: {ref: z}
           dsl: z
@@ -5480,8 +5480,8 @@ Probes:
                   EventKind: Entry
                   EventExpressionIndex: 0
                 - ', '
-                - JSON: {Ref: y}
-                  DSL: y
+                - JSON: {Ref: "y"}
+                  DSL: "y"
                   EventKind: Entry
                   EventExpressionIndex: 1
                 - ', '
@@ -6794,7 +6794,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 7 BaseType int
           Locations:
             - Range: 0x807750..0x80777c
@@ -7331,7 +7331,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 17 BaseType float32
           Locations:
             - Range: 0x809750..0x809760
@@ -7362,7 +7362,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 17 BaseType float32
           Locations:
             - Range: 0x809770..0x809780
@@ -9814,7 +9814,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x80c750..0x80c760
@@ -11677,7 +11677,7 @@ Types:
       ID: 1195
       Name: '*archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.016768e+06
+      GoRuntimeType: 2016768
       GoKind: 22
       Pointee: 1196 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
@@ -11696,7 +11696,7 @@ Types:
       ID: 1129
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.453504e+06
+      GoRuntimeType: 1453504
       GoKind: 22
       Pointee: 1130 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
@@ -11717,21 +11717,21 @@ Types:
       ID: 1172
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.9328e+06
+      GoRuntimeType: 1932800
       GoKind: 22
       Pointee: 1173 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
       ID: 1105
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1.070752e+06
+      GoRuntimeType: 1070752
       GoKind: 22
       Pointee: 1106 StructureType archive/zip.nopCloser
     - __kind: PointerType
       ID: 1107
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
-      GoRuntimeType: 1.071008e+06
+      GoRuntimeType: 1071008
       GoKind: 22
       Pointee: 1108 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
@@ -11745,21 +11745,21 @@ Types:
       ID: 1153
       Name: '*bufio.Reader'
       ByteSize: 8
-      GoRuntimeType: 2.206848e+06
+      GoRuntimeType: 2206848
       GoKind: 22
       Pointee: 1154 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
       ID: 1184
       Name: '*bufio.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.979328e+06
+      GoRuntimeType: 1979328
       GoKind: 22
       Pointee: 1185 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 1231
       Name: '*bytes.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.308832e+06
+      GoRuntimeType: 2308832
       GoKind: 22
       Pointee: 1232 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
@@ -11792,7 +11792,7 @@ Types:
       ID: 1127
       Name: '*compress/flate.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.442304e+06
+      GoRuntimeType: 1442304
       GoKind: 22
       Pointee: 1128 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
@@ -11806,14 +11806,14 @@ Types:
       ID: 1149
       Name: '*compress/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.75216e+06
+      GoRuntimeType: 1752160
       GoKind: 22
       Pointee: 1150 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
       ID: 977
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.217568e+06
+      GoRuntimeType: 1217568
       GoKind: 22
       Pointee: 978 StructureType context.deadlineExceededError
     - __kind: PointerType
@@ -11841,49 +11841,49 @@ Types:
       ID: 1144
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
-      GoRuntimeType: 1.692704e+06
+      GoRuntimeType: 1692704
       GoKind: 22
       Pointee: 1145 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
       ID: 926
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
-      GoRuntimeType: 1.07856e+06
+      GoRuntimeType: 1078560
       GoKind: 22
       Pointee: 927 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
       ID: 1174
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.933312e+06
+      GoRuntimeType: 1933312
       GoKind: 22
       Pointee: 1175 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
       ID: 1206
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
-      GoRuntimeType: 2.150848e+06
+      GoRuntimeType: 2150848
       GoKind: 22
       Pointee: 1207 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
       ID: 1180
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.93408e+06
+      GoRuntimeType: 1934080
       GoKind: 22
       Pointee: 1181 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
       ID: 1176
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
-      GoRuntimeType: 1.933568e+06
+      GoRuntimeType: 1933568
       GoKind: 22
       Pointee: 1177 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
       ID: 1170
       Name: '*crypto/md5.digest'
       ByteSize: 8
-      GoRuntimeType: 1.930752e+06
+      GoRuntimeType: 1930752
       GoKind: 22
       Pointee: 1171 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
@@ -11897,21 +11897,21 @@ Types:
       ID: 1193
       Name: '*crypto/sha1.digest'
       ByteSize: 8
-      GoRuntimeType: 2.014464e+06
+      GoRuntimeType: 2014464
       GoKind: 22
       Pointee: 1194 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
       ID: 1178
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
-      GoRuntimeType: 1.933824e+06
+      GoRuntimeType: 1933824
       GoKind: 22
       Pointee: 1179 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
       ID: 1162
       Name: '*crypto/sha3.SHAKE'
       ByteSize: 8
-      GoRuntimeType: 1.835712e+06
+      GoRuntimeType: 1835712
       GoKind: 22
       Pointee: 1163 UnresolvedPointeeType crypto/sha3.SHAKE
     - __kind: PointerType
@@ -11925,14 +11925,14 @@ Types:
       ID: 915
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
-      GoRuntimeType: 1.06e+06
+      GoRuntimeType: 1060000
       GoKind: 22
       Pointee: 916 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 1257
       Name: '*crypto/tls.Conn'
       ByteSize: 8
-      GoRuntimeType: 2.41136e+06
+      GoRuntimeType: 2411360
       GoKind: 22
       Pointee: 1258 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
@@ -11953,14 +11953,14 @@ Types:
       ID: 914
       Name: '*crypto/tls.alert'
       ByteSize: 8
-      GoRuntimeType: 1.058336e+06
+      GoRuntimeType: 1058336
       GoKind: 22
       Pointee: 869 BaseType crypto/tls.alert
     - __kind: PointerType
       ID: 1137
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.581536e+06
+      GoRuntimeType: 1581536
       GoKind: 22
       Pointee: 1138 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
@@ -11974,21 +11974,21 @@ Types:
       ID: 1142
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
-      GoRuntimeType: 1.666784e+06
+      GoRuntimeType: 1666784
       GoKind: 22
       Pointee: 1143 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
       ID: 1012
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
-      GoRuntimeType: 1.442784e+06
+      GoRuntimeType: 1442784
       GoKind: 22
       Pointee: 1013 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
       ID: 1029
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.043104e+06
+      GoRuntimeType: 2043104
       GoKind: 22
       Pointee: 1030 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
@@ -12023,7 +12023,7 @@ Types:
       ID: 920
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
-      GoRuntimeType: 1.065248e+06
+      GoRuntimeType: 1065248
       GoKind: 22
       Pointee: 921 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
@@ -12072,7 +12072,7 @@ Types:
       ID: 1095
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1.055776e+06
+      GoRuntimeType: 1055776
       GoKind: 22
       Pointee: 1096 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -12093,7 +12093,7 @@ Types:
       ID: 904
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1.051936e+06
+      GoRuntimeType: 1051936
       GoKind: 22
       Pointee: 905 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
@@ -12128,7 +12128,7 @@ Types:
       ID: 1237
       Name: '*encoding/json.encodeState'
       ByteSize: 8
-      GoRuntimeType: 2.329952e+06
+      GoRuntimeType: 2329952
       GoKind: 22
       Pointee: 1238 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
@@ -12142,7 +12142,7 @@ Types:
       ID: 1103
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
-      GoRuntimeType: 1.067552e+06
+      GoRuntimeType: 1067552
       GoKind: 22
       Pointee: 1104 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
@@ -12170,7 +12170,7 @@ Types:
       ID: 871
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1.036192e+06
+      GoRuntimeType: 1036192
       GoKind: 22
       Pointee: 872 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -12191,21 +12191,21 @@ Types:
       ID: 1225
       Name: '*fmt.pp'
       ByteSize: 8
-      GoRuntimeType: 2.291392e+06
+      GoRuntimeType: 2291392
       GoKind: 22
       Pointee: 1226 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
       ID: 873
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.03632e+06
+      GoRuntimeType: 1036320
       GoKind: 22
       Pointee: 874 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 875
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.036448e+06
+      GoRuntimeType: 1036448
       GoKind: 22
       Pointee: 876 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -12290,14 +12290,14 @@ Types:
       ID: 1115
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.223072e+06
+      GoRuntimeType: 1223072
       GoKind: 22
       Pointee: 1116 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
       ID: 1203
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
-      GoRuntimeType: 2.088576e+06
+      GoRuntimeType: 2088576
       GoKind: 22
       Pointee: 1204 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
@@ -12311,14 +12311,14 @@ Types:
       ID: 986
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
-      GoRuntimeType: 1.226528e+06
+      GoRuntimeType: 1226528
       GoKind: 22
       Pointee: 987 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 1233
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
-      GoRuntimeType: 2.30992e+06
+      GoRuntimeType: 2309920
       GoKind: 22
       Pointee: 1234 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
@@ -12470,7 +12470,7 @@ Types:
       ID: 1156
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.830336e+06
+      GoRuntimeType: 1830336
       GoKind: 22
       Pointee: 1157 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
@@ -12484,21 +12484,21 @@ Types:
       ID: 1135
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
-      GoRuntimeType: 1.580256e+06
+      GoRuntimeType: 1580256
       GoKind: 22
       Pointee: 1136 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
       ID: 1091
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1.054624e+06
+      GoRuntimeType: 1054624
       GoKind: 22
       Pointee: 1092 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1125
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1.440384e+06
+      GoRuntimeType: 1440384
       GoKind: 22
       Pointee: 1126 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
@@ -12512,28 +12512,28 @@ Types:
       ID: 1191
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
-      GoRuntimeType: 2.006688e+06
+      GoRuntimeType: 2006688
       GoKind: 22
       Pointee: 1192 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
       ID: 1210
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
-      GoRuntimeType: 2.165024e+06
+      GoRuntimeType: 2165024
       GoKind: 22
       Pointee: 1205 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
       ID: 1209
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
-      GoRuntimeType: 2.16464e+06
+      GoRuntimeType: 2164640
       GoKind: 22
       Pointee: 1208 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
       ID: 1093
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1.054752e+06
+      GoRuntimeType: 1054752
       GoKind: 22
       Pointee: 1094 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
@@ -12554,70 +12554,70 @@ Types:
       ID: 1158
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
-      GoRuntimeType: 1.832128e+06
+      GoRuntimeType: 1832128
       GoKind: 22
       Pointee: 1159 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
       ID: 1199
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.042816e+06
+      GoRuntimeType: 2042816
       GoKind: 22
       Pointee: 1200 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
       ID: 1201
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.073888e+06
+      GoRuntimeType: 2073888
       GoKind: 22
       Pointee: 1202 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
       ID: 1017
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
-      GoRuntimeType: 1.455904e+06
+      GoRuntimeType: 1455904
       GoKind: 22
       Pointee: 1018 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
       ID: 930
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.079328e+06
+      GoRuntimeType: 1079328
       GoKind: 22
       Pointee: 931 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
       ID: 928
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.0792e+06
+      GoRuntimeType: 1079200
       GoKind: 22
       Pointee: 929 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
       ID: 932
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.083296e+06
+      GoRuntimeType: 1083296
       GoKind: 22
       Pointee: 933 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
       ID: 934
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
-      GoRuntimeType: 1.083424e+06
+      GoRuntimeType: 1083424
       GoKind: 22
       Pointee: 935 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
       ID: 1146
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
-      GoRuntimeType: 1.695584e+06
+      GoRuntimeType: 1695584
       GoKind: 22
       Pointee: 1147 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
       ID: 922
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
-      GoRuntimeType: 1.06576e+06
+      GoRuntimeType: 1065760
       GoKind: 22
       Pointee: 923 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
@@ -12631,112 +12631,112 @@ Types:
       ID: 1249
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
-      GoRuntimeType: 2.38528e+06
+      GoRuntimeType: 2385280
       GoKind: 22
       Pointee: 1250 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
       ID: 988
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
-      GoRuntimeType: 1.235616e+06
+      GoRuntimeType: 1235616
       GoKind: 22
       Pointee: 989 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
       ID: 961
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1.214112e+06
+      GoRuntimeType: 1214112
       GoKind: 22
       Pointee: 962 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 955
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1.213728e+06
+      GoRuntimeType: 1213728
       GoKind: 22
       Pointee: 956 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 890
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.045792e+06
+      GoRuntimeType: 1045792
       GoKind: 22
       Pointee: 891 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 967
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.214496e+06
+      GoRuntimeType: 1214496
       GoKind: 22
       Pointee: 968 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 889
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1.045664e+06
+      GoRuntimeType: 1045664
       GoKind: 22
       Pointee: 868 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 959
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1.213984e+06
+      GoRuntimeType: 1213984
       GoKind: 22
       Pointee: 960 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
       ID: 957
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1.213856e+06
+      GoRuntimeType: 1213856
       GoKind: 22
       Pointee: 958 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 965
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1.214368e+06
+      GoRuntimeType: 1214368
       GoKind: 22
       Pointee: 966 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 963
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1.21424e+06
+      GoRuntimeType: 1214240
       GoKind: 22
       Pointee: 964 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
       ID: 1253
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.400384e+06
+      GoRuntimeType: 2400384
       GoKind: 22
       Pointee: 1254 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
       ID: 971
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1.21488e+06
+      GoRuntimeType: 1214880
       GoKind: 22
       Pointee: 972 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 894
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1.046048e+06
+      GoRuntimeType: 1046048
       GoKind: 22
       Pointee: 895 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 892
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1.04592e+06
+      GoRuntimeType: 1045920
       GoKind: 22
       Pointee: 893 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 969
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1.214752e+06
+      GoRuntimeType: 1214752
       GoKind: 22
       Pointee: 970 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -12799,35 +12799,35 @@ Types:
       ID: 1032
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
-      GoRuntimeType: 1.694048e+06
+      GoRuntimeType: 1694048
       GoKind: 22
       Pointee: 1033 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
       ID: 938
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
-      GoRuntimeType: 1.098144e+06
+      GoRuntimeType: 1098144
       GoKind: 22
       Pointee: 939 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
       ID: 1121
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
-      GoRuntimeType: 1.276448e+06
+      GoRuntimeType: 1276448
       GoKind: 22
       Pointee: 1122 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
       ID: 1215
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 2.179616e+06
+      GoRuntimeType: 2179616
       GoKind: 22
       Pointee: 1216 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
       ID: 1109
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
-      GoRuntimeType: 1.100448e+06
+      GoRuntimeType: 1100448
       GoKind: 22
       Pointee: 1110 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
@@ -12841,7 +12841,7 @@ Types:
       ID: 996
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.278112e+06
+      GoRuntimeType: 1278112
       GoKind: 22
       Pointee: 997 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
@@ -12903,7 +12903,7 @@ Types:
       ID: 1213
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.177696e+06
+      GoRuntimeType: 2177696
       GoKind: 22
       Pointee: 1214 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -12931,14 +12931,14 @@ Types:
       ID: 994
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
-      GoRuntimeType: 1.275168e+06
+      GoRuntimeType: 1275168
       GoKind: 22
       Pointee: 995 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
       ID: 1019
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 1.463264e+06
+      GoRuntimeType: 1463264
       GoKind: 22
       Pointee: 1020 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
@@ -12952,21 +12952,21 @@ Types:
       ID: 1164
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
-      GoRuntimeType: 1.837952e+06
+      GoRuntimeType: 1837952
       GoKind: 22
       Pointee: 1165 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
       ID: 1119
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
-      GoRuntimeType: 1.271712e+06
+      GoRuntimeType: 1271712
       GoKind: 22
       Pointee: 1120 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
       ID: 936
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
-      GoRuntimeType: 1.092384e+06
+      GoRuntimeType: 1092384
       GoKind: 22
       Pointee: 937 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
@@ -12987,21 +12987,21 @@ Types:
       ID: 924
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
-      GoRuntimeType: 1.069088e+06
+      GoRuntimeType: 1069088
       GoKind: 22
       Pointee: 925 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
       ID: 992
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.2424e+06
+      GoRuntimeType: 1242400
       GoKind: 22
       Pointee: 993 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
       ID: 990
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
-      GoRuntimeType: 1.242144e+06
+      GoRuntimeType: 1242144
       GoKind: 22
       Pointee: 991 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
@@ -13029,7 +13029,7 @@ Types:
       ID: 1168
       Name: '*hash/crc32.digest'
       ByteSize: 8
-      GoRuntimeType: 1.928704e+06
+      GoRuntimeType: 1928704
       GoKind: 22
       Pointee: 1169 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
@@ -13085,7 +13085,7 @@ Types:
       ID: 1021
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 2.226784e+06
+      GoRuntimeType: 2226784
       GoKind: 22
       Pointee: 1022 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
@@ -13113,21 +13113,21 @@ Types:
       ID: 953
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1.21296e+06
+      GoRuntimeType: 1212960
       GoKind: 22
       Pointee: 954 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 1255
       Name: '*internal/poll.FD'
       ByteSize: 8
-      GoRuntimeType: 2.406048e+06
+      GoRuntimeType: 2406048
       GoKind: 22
       Pointee: 1256 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
       ID: 951
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 1.212832e+06
+      GoRuntimeType: 1212832
       GoKind: 22
       Pointee: 952 StructureType internal/poll.errNetClosing
     - __kind: PointerType
@@ -13141,7 +13141,7 @@ Types:
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
       ByteSize: 8
-      GoRuntimeType: 1.595936e+06
+      GoRuntimeType: 1595936
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
@@ -13160,7 +13160,7 @@ Types:
       ID: 908
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
-      GoRuntimeType: 1.056672e+06
+      GoRuntimeType: 1056672
       GoKind: 22
       Pointee: 909 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
@@ -13174,35 +13174,35 @@ Types:
       ID: 1113
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.204128e+06
+      GoRuntimeType: 1204128
       GoKind: 22
       Pointee: 1114 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1111
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.203744e+06
+      GoRuntimeType: 1203744
       GoKind: 22
       Pointee: 1112 StructureType io.discard
     - __kind: PointerType
       ID: 1085
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.037216e+06
+      GoRuntimeType: 1037216
       GoKind: 22
       Pointee: 1086 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 949
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 1.21232e+06
+      GoRuntimeType: 1212320
       GoKind: 22
       Pointee: 950 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 1160
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
-      GoRuntimeType: 1.832352e+06
+      GoRuntimeType: 1832352
       GoKind: 22
       Pointee: 1161 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
@@ -13609,63 +13609,63 @@ Types:
       ID: 980
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1.220896e+06
+      GoRuntimeType: 1220896
       GoKind: 22
       Pointee: 981 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1006
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1.438624e+06
+      GoRuntimeType: 1438624
       GoKind: 22
       Pointee: 1007 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 1219
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2.265024e+06
+      GoRuntimeType: 2265024
       GoKind: 22
       Pointee: 1220 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 1004
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1.438304e+06
+      GoRuntimeType: 1438304
       GoKind: 22
       Pointee: 1005 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 982
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1.221024e+06
+      GoRuntimeType: 1221024
       GoKind: 22
       Pointee: 983 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1229
       Name: '*net.TCPConn'
       ByteSize: 8
-      GoRuntimeType: 2.292416e+06
+      GoRuntimeType: 2292416
       GoKind: 22
       Pointee: 1230 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
       ID: 1239
       Name: '*net.UDPConn'
       ByteSize: 8
-      GoRuntimeType: 2.337536e+06
+      GoRuntimeType: 2337536
       GoKind: 22
       Pointee: 1240 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
       ID: 1227
       Name: '*net.UnixConn'
       ByteSize: 8
-      GoRuntimeType: 2.291904e+06
+      GoRuntimeType: 2291904
       GoKind: 22
       Pointee: 1228 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
       ID: 979
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1.220128e+06
+      GoRuntimeType: 1220128
       GoKind: 22
       Pointee: 942 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -13677,28 +13677,28 @@ Types:
       ID: 906
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1.052832e+06
+      GoRuntimeType: 1052832
       GoKind: 22
       Pointee: 907 StructureType net.canceledError
     - __kind: PointerType
       ID: 1197
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2.039936e+06
+      GoRuntimeType: 2039936
       GoKind: 22
       Pointee: 1198 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1050
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1.876032e+06
+      GoRuntimeType: 1876032
       GoKind: 22
       Pointee: 1051 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 1241
       Name: '*net.netFD'
       ByteSize: 8
-      GoRuntimeType: 2.341792e+06
+      GoRuntimeType: 2341792
       GoKind: 22
       Pointee: 1242 UnresolvedPointeeType net.netFD
     - __kind: PointerType
@@ -13719,35 +13719,35 @@ Types:
       ID: 1223
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.277952e+06
+      GoRuntimeType: 2277952
       GoKind: 22
       Pointee: 1224 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1221
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.277472e+06
+      GoRuntimeType: 2277472
       GoKind: 22
       Pointee: 1222 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 984
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1.221664e+06
+      GoRuntimeType: 1221664
       GoKind: 22
       Pointee: 985 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1008
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.438784e+06
+      GoRuntimeType: 1438784
       GoKind: 22
       Pointee: 1009 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 896
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1.048608e+06
+      GoRuntimeType: 1048608
       GoKind: 22
       Pointee: 897 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
@@ -13775,7 +13775,7 @@ Types:
       ID: 1000
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1.434304e+06
+      GoRuntimeType: 1434304
       GoKind: 22
       Pointee: 1001 StructureType net/http.http2StreamError
     - __kind: PointerType
@@ -13789,7 +13789,7 @@ Types:
       ID: 1131
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
-      GoRuntimeType: 1.576416e+06
+      GoRuntimeType: 1576416
       GoKind: 22
       Pointee: 1132 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
@@ -13832,21 +13832,21 @@ Types:
       ID: 975
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1.2168e+06
+      GoRuntimeType: 1216800
       GoKind: 22
       Pointee: 976 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 902
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1.04912e+06
+      GoRuntimeType: 1049120
       GoKind: 22
       Pointee: 903 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
       ID: 1186
       Name: '*net/http.http2pipe'
       ByteSize: 8
-      GoRuntimeType: 1.98112e+06
+      GoRuntimeType: 1981120
       GoKind: 22
       Pointee: 1187 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
@@ -13872,28 +13872,28 @@ Types:
       ID: 898
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1.048864e+06
+      GoRuntimeType: 1048864
       GoKind: 22
       Pointee: 899 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1133
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2.227616e+06
+      GoRuntimeType: 2227616
       GoKind: 22
       Pointee: 1134 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1089
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1.048736e+06
+      GoRuntimeType: 1048736
       GoKind: 22
       Pointee: 1090 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 1123
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1.434464e+06
+      GoRuntimeType: 1434464
       GoKind: 22
       Pointee: 1124 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
@@ -13907,28 +13907,28 @@ Types:
       ID: 1002
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.435584e+06
+      GoRuntimeType: 1435584
       GoKind: 22
       Pointee: 1003 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 973
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1.216672e+06
+      GoRuntimeType: 1216672
       GoKind: 22
       Pointee: 974 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
       ID: 900
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1.048992e+06
+      GoRuntimeType: 1048992
       GoKind: 22
       Pointee: 901 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1166
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1.872224e+06
+      GoRuntimeType: 1872224
       GoKind: 22
       Pointee: 1167 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
@@ -13942,14 +13942,14 @@ Types:
       ID: 1188
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
-      GoRuntimeType: 1.982912e+06
+      GoRuntimeType: 1982912
       GoKind: 22
       Pointee: 1189 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
       ID: 1099
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
-      GoRuntimeType: 1.061024e+06
+      GoRuntimeType: 1061024
       GoKind: 22
       Pointee: 1100 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
@@ -13970,14 +13970,14 @@ Types:
       ID: 1139
       Name: '*net/smtp.Client'
       ByteSize: 8
-      GoRuntimeType: 2.14944e+06
+      GoRuntimeType: 2149440
       GoKind: 22
       Pointee: 1140 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
       ID: 1101
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
-      GoRuntimeType: 1.065376e+06
+      GoRuntimeType: 1065376
       GoKind: 22
       Pointee: 1102 StructureType net/smtp.dataCloser
     - __kind: PointerType
@@ -14003,14 +14003,14 @@ Types:
       ID: 1097
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
-      GoRuntimeType: 1.060512e+06
+      GoRuntimeType: 1060512
       GoKind: 22
       Pointee: 1098 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
       ID: 1010
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1.439104e+06
+      GoRuntimeType: 1439104
       GoKind: 22
       Pointee: 1011 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
@@ -14176,63 +14176,63 @@ Types:
       ID: 1247
       Name: '*os.File'
       ByteSize: 8
-      GoRuntimeType: 2.379904e+06
+      GoRuntimeType: 2379904
       GoKind: 22
       Pointee: 1248 UnresolvedPointeeType os.File
     - __kind: PointerType
       ID: 879
       Name: '*os.LinkError'
       ByteSize: 8
-      GoRuntimeType: 1.039904e+06
+      GoRuntimeType: 1039904
       GoKind: 22
       Pointee: 880 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 945
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 1.205408e+06
+      GoRuntimeType: 1205408
       GoKind: 22
       Pointee: 946 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 1245
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2.379168e+06
+      GoRuntimeType: 2379168
       GoKind: 22
       Pointee: 1246 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
       ID: 1243
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2.378432e+06
+      GoRuntimeType: 2378432
       GoKind: 22
       Pointee: 1244 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
       ID: 910
       Name: '*os/exec.Error'
       ByteSize: 8
-      GoRuntimeType: 1.057056e+06
+      GoRuntimeType: 1057056
       GoKind: 22
       Pointee: 911 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
       ID: 1053
       Name: '*os/exec.ExitError'
       ByteSize: 8
-      GoRuntimeType: 2.120352e+06
+      GoRuntimeType: 2120352
       GoKind: 22
       Pointee: 1054 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
       ID: 1117
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
-      GoRuntimeType: 1.227936e+06
+      GoRuntimeType: 1227936
       GoKind: 22
       Pointee: 1118 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
       ID: 912
       Name: '*os/exec.wrappedError'
       ByteSize: 8
-      GoRuntimeType: 1.057184e+06
+      GoRuntimeType: 1057184
       GoKind: 22
       Pointee: 913 StructureType os/exec.wrappedError
     - __kind: PointerType
@@ -14272,14 +14272,14 @@ Types:
       ID: 883
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1.04272e+06
+      GoRuntimeType: 1042720
       GoKind: 22
       Pointee: 884 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 887
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1.04336e+06
+      GoRuntimeType: 1043360
       GoKind: 22
       Pointee: 888 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
@@ -14293,14 +14293,14 @@ Types:
       ID: 25
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 1.432224e+06
+      GoRuntimeType: 1432224
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 885
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1.042848e+06
+      GoRuntimeType: 1042848
       GoKind: 22
       Pointee: 886 StructureType runtime.boundsError
     - __kind: PointerType
@@ -14321,14 +14321,14 @@ Types:
       ID: 947
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 1.211296e+06
+      GoRuntimeType: 1211296
       GoKind: 22
       Pointee: 948 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 881
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1.041056e+06
+      GoRuntimeType: 1041056
       GoKind: 22
       Pointee: 862 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14340,28 +14340,28 @@ Types:
       ID: 59
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 1.210016e+06
+      GoRuntimeType: 1210016
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1.432864e+06
+      GoRuntimeType: 1432864
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 68
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1.042464e+06
+      GoRuntimeType: 1042464
       GoKind: 22
       Pointee: 370 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 882
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1.041184e+06
+      GoRuntimeType: 1041184
       GoKind: 22
       Pointee: 865 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14380,7 +14380,7 @@ Types:
       ID: 50
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 1.573696e+06
+      GoRuntimeType: 1573696
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
@@ -14394,14 +14394,14 @@ Types:
       ID: 45
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 2.085376e+06
+      GoRuntimeType: 2085376
       GoKind: 22
       Pointee: 46 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 83
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1.644896e+06
+      GoRuntimeType: 1644896
       GoKind: 22
       Pointee: 84 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -14415,7 +14415,7 @@ Types:
       ID: 877
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 1.038752e+06
+      GoRuntimeType: 1038752
       GoKind: 22
       Pointee: 878 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
@@ -14434,14 +14434,14 @@ Types:
       ID: 1182
       Name: '*strings.Builder'
       ByteSize: 8
-      GoRuntimeType: 1.978816e+06
+      GoRuntimeType: 1978816
       GoKind: 22
       Pointee: 1183 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
       ID: 1087
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
-      GoRuntimeType: 1.03888e+06
+      GoRuntimeType: 1038880
       GoKind: 22
       Pointee: 1088 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
@@ -14462,7 +14462,7 @@ Types:
       ID: 999
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 1.433824e+06
+      GoRuntimeType: 1433824
       GoKind: 22
       Pointee: 998 BaseType syscall.Errno
     - __kind: PointerType
@@ -14604,21 +14604,21 @@ Types:
       ID: 1217
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
-      GoRuntimeType: 2.19184e+06
+      GoRuntimeType: 2191840
       GoKind: 22
       Pointee: 1218 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
       ID: 940
       Name: '*text/template.ExecError'
       ByteSize: 8
-      GoRuntimeType: 1.101984e+06
+      GoRuntimeType: 1101984
       GoKind: 22
       Pointee: 941 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 1015
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1.649504e+06
+      GoRuntimeType: 1649504
       GoKind: 22
       Pointee: 1016 UnresolvedPointeeType time.Location
     - __kind: PointerType
@@ -14700,7 +14700,7 @@ Types:
       ID: 1211
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
-      GoRuntimeType: 2.167328e+06
+      GoRuntimeType: 2167328
       GoKind: 22
       Pointee: 1212 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
@@ -14721,14 +14721,14 @@ Types:
       ID: 917
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
-      GoRuntimeType: 1.060768e+06
+      GoRuntimeType: 1060768
       GoKind: 22
       Pointee: 918 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
       ID: 919
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
-      GoRuntimeType: 1.060896e+06
+      GoRuntimeType: 1060896
       GoKind: 22
       Pointee: 870 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
@@ -17293,14 +17293,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17315,14 +17315,14 @@ Types:
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 25
           Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: y}
+                  Variable: {subprogram: 53, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -23063,14 +23063,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -23096,14 +23096,14 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: y
+        - Name: "y"
           Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: y}
+                  Variable: {subprogram: 149, index: 1, name: "y"}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -25069,7 +25069,7 @@ Types:
     - __kind: StructureType
       ID: 1080
       Name: archive/zip.dirWriter
-      GoRuntimeType: 1.134112e+06
+      GoRuntimeType: 1134112
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25080,7 +25080,7 @@ Types:
       ID: 1106
       Name: archive/zip.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1.587616e+06
+      GoRuntimeType: 1587616
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -25170,7 +25170,7 @@ Types:
     - __kind: StructureType
       ID: 978
       Name: context.deadlineExceededError
-      GoRuntimeType: 1.499936e+06
+      GoRuntimeType: 1499936
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25198,7 +25198,7 @@ Types:
     - __kind: StructureType
       ID: 927
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
-      GoRuntimeType: 1.30608e+06
+      GoRuntimeType: 1306080
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25261,7 +25261,7 @@ Types:
       ID: 747
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
-      GoRuntimeType: 1.757536e+06
+      GoRuntimeType: 1757536
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25277,7 +25277,7 @@ Types:
       ID: 869
       Name: crypto/tls.alert
       ByteSize: 1
-      GoRuntimeType: 1.007008e+06
+      GoRuntimeType: 1007008
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1138
@@ -25303,7 +25303,7 @@ Types:
       ID: 818
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
-      GoRuntimeType: 1.760416e+06
+      GoRuntimeType: 1760416
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25318,14 +25318,14 @@ Types:
     - __kind: StructureType
       ID: 812
       Name: crypto/x509.ConstraintViolationError
-      GoRuntimeType: 1.131552e+06
+      GoRuntimeType: 1131552
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 814
       Name: crypto/x509.HostnameError
       ByteSize: 24
-      GoRuntimeType: 1.622848e+06
+      GoRuntimeType: 1622848
       GoKind: 25
       RawFields:
         - Name: Certificate
@@ -25350,7 +25350,7 @@ Types:
       ID: 921
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
-      GoRuntimeType: 1.583456e+06
+      GoRuntimeType: 1583456
       GoKind: 25
       RawFields:
         - Name: Err
@@ -25359,14 +25359,14 @@ Types:
     - __kind: StructureType
       ID: 820
       Name: crypto/x509.UnhandledCriticalExtension
-      GoRuntimeType: 1.131808e+06
+      GoRuntimeType: 1131808
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 816
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
-      GoRuntimeType: 1.760224e+06
+      GoRuntimeType: 1760224
       GoKind: 25
       RawFields:
         - Name: Cert
@@ -25382,7 +25382,7 @@ Types:
       ID: 834
       Name: encoding/asn1.StructuralError
       ByteSize: 16
-      GoRuntimeType: 1.454144e+06
+      GoRuntimeType: 1454144
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25392,7 +25392,7 @@ Types:
       ID: 838
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
-      GoRuntimeType: 1.454304e+06
+      GoRuntimeType: 1454304
       GoKind: 25
       RawFields:
         - Name: Msg
@@ -25450,7 +25450,7 @@ Types:
       ID: 707
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1.437344e+06
+      GoRuntimeType: 1437344
       GoKind: 25
       RawFields:
         - Name: error
@@ -25468,7 +25468,7 @@ Types:
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.040928e+06
+      GoRuntimeType: 1040928
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25562,7 +25562,7 @@ Types:
       ID: 716
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
-      GoRuntimeType: 1.756384e+06
+      GoRuntimeType: 1756384
       GoKind: 25
       RawFields:
         - Name: Metric
@@ -25585,7 +25585,7 @@ Types:
     - __kind: StructureType
       ID: 722
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
-      GoRuntimeType: 1.12784e+06
+      GoRuntimeType: 1127840
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -25615,7 +25615,7 @@ Types:
       ID: 1038
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
-      GoRuntimeType: 2.251872e+06
+      GoRuntimeType: 2251872
       GoKind: 25
       RawFields:
         - Name: metricType
@@ -25731,7 +25731,7 @@ Types:
     - __kind: StructureType
       ID: 767
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
-      GoRuntimeType: 1.130784e+06
+      GoRuntimeType: 1130784
       GoKind: 25
       RawFields: []
     - __kind: BaseType
@@ -25743,14 +25743,14 @@ Types:
     - __kind: StructureType
       ID: 765
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
-      GoRuntimeType: 1.130656e+06
+      GoRuntimeType: 1130656
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 763
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
-      GoRuntimeType: 1.620768e+06
+      GoRuntimeType: 1620768
       GoKind: 25
       RawFields:
         - Name: OS
@@ -25763,7 +25763,7 @@ Types:
       ID: 783
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
-      GoRuntimeType: 1.621568e+06
+      GoRuntimeType: 1621568
       GoKind: 25
       RawFields:
         - Name: File
@@ -25776,7 +25776,7 @@ Types:
       ID: 787
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
-      GoRuntimeType: 1.759648e+06
+      GoRuntimeType: 1759648
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25792,7 +25792,7 @@ Types:
       ID: 785
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
-      GoRuntimeType: 1.447104e+06
+      GoRuntimeType: 1447104
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25802,7 +25802,7 @@ Types:
       ID: 781
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
-      GoRuntimeType: 1.446784e+06
+      GoRuntimeType: 1446784
       GoKind: 25
       RawFields:
         - Name: File
@@ -25812,14 +25812,14 @@ Types:
       ID: 1024
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
-      GoRuntimeType: 1.520896e+06
+      GoRuntimeType: 1520896
       GoKind: 21
       HeaderType: 1026 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
       ID: 1047
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
-      GoRuntimeType: 1.064352e+06
+      GoRuntimeType: 1064352
       GoKind: 23
       RawFields:
         - Name: array
@@ -25842,7 +25842,7 @@ Types:
       ID: 795
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
-      GoRuntimeType: 1.621888e+06
+      GoRuntimeType: 1621888
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25855,7 +25855,7 @@ Types:
       ID: 789
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
-      GoRuntimeType: 1.447264e+06
+      GoRuntimeType: 1447264
       GoKind: 25
       RawFields:
         - Name: Name
@@ -25865,7 +25865,7 @@ Types:
       ID: 793
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
-      GoRuntimeType: 1.75984e+06
+      GoRuntimeType: 1759840
       GoKind: 25
       RawFields:
         - Name: Type
@@ -25881,7 +25881,7 @@ Types:
       ID: 791
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
-      GoRuntimeType: 1.621728e+06
+      GoRuntimeType: 1621728
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25894,7 +25894,7 @@ Types:
       ID: 797
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
-      GoRuntimeType: 1.447424e+06
+      GoRuntimeType: 1447424
       GoKind: 25
       RawFields:
         - Name: Expired
@@ -25904,7 +25904,7 @@ Types:
       ID: 803
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
-      GoRuntimeType: 1.622208e+06
+      GoRuntimeType: 1622208
       GoKind: 25
       RawFields:
         - Name: Actual
@@ -25917,7 +25917,7 @@ Types:
       ID: 805
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
-      GoRuntimeType: 1.447744e+06
+      GoRuntimeType: 1447744
       GoKind: 25
       RawFields:
         - Name: KeyID
@@ -25927,7 +25927,7 @@ Types:
       ID: 801
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
-      GoRuntimeType: 1.622048e+06
+      GoRuntimeType: 1622048
       GoKind: 25
       RawFields:
         - Name: Expected
@@ -25940,7 +25940,7 @@ Types:
       ID: 799
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
-      GoRuntimeType: 1.447584e+06
+      GoRuntimeType: 1447584
       GoKind: 25
       RawFields:
         - Name: Role
@@ -25950,7 +25950,7 @@ Types:
       ID: 807
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
-      GoRuntimeType: 1.622368e+06
+      GoRuntimeType: 1622368
       GoKind: 25
       RawFields:
         - Name: Given
@@ -25963,7 +25963,7 @@ Types:
       ID: 724
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1.439584e+06
+      GoRuntimeType: 1439584
       GoKind: 25
       RawFields:
         - Name: message
@@ -25977,7 +25977,7 @@ Types:
       ID: 726
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1.439744e+06
+      GoRuntimeType: 1439744
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -25999,7 +25999,7 @@ Types:
       ID: 730
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1.440064e+06
+      GoRuntimeType: 1440064
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -26013,7 +26013,7 @@ Types:
       ID: 1205
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
-      GoRuntimeType: 2.138208e+06
+      GoRuntimeType: 2138208
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -26026,7 +26026,7 @@ Types:
       ID: 1208
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
-      GoRuntimeType: 2.164256e+06
+      GoRuntimeType: 2164256
       GoKind: 25
       RawFields:
         - Name: rollingFileWriter
@@ -26046,7 +26046,7 @@ Types:
       ID: 728
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1.439904e+06
+      GoRuntimeType: 1439904
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -26056,7 +26056,7 @@ Types:
       ID: 732
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1.440224e+06
+      GoRuntimeType: 1440224
       GoKind: 25
       RawFields:
         - Name: baseError
@@ -26106,7 +26106,7 @@ Types:
       ID: 738
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
-      GoRuntimeType: 1.441184e+06
+      GoRuntimeType: 1441184
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
@@ -26121,7 +26121,7 @@ Types:
       ID: 962
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1.870432e+06
+      GoRuntimeType: 1870432
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -26141,7 +26141,7 @@ Types:
       ID: 891
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
-      GoRuntimeType: 1.729088e+06
+      GoRuntimeType: 1729088
       GoKind: 25
       RawFields:
         - Name: Got
@@ -26154,7 +26154,7 @@ Types:
       ID: 968
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1.87088e+06
+      GoRuntimeType: 1870880
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26170,13 +26170,13 @@ Types:
       ID: 868
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 1.00432e+06
+      GoRuntimeType: 1004320
       GoKind: 8
     - __kind: StructureType
       ID: 960
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1.870208e+06
+      GoRuntimeType: 1870208
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -26198,7 +26198,7 @@ Types:
       ID: 958
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1.869984e+06
+      GoRuntimeType: 1869984
       GoKind: 25
       RawFields:
         - Name: Method
@@ -26214,7 +26214,7 @@ Types:
       ID: 966
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1.784544e+06
+      GoRuntimeType: 1784544
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26227,7 +26227,7 @@ Types:
       ID: 964
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1.870656e+06
+      GoRuntimeType: 1870656
       GoKind: 25
       RawFields:
         - Name: Value
@@ -26247,7 +26247,7 @@ Types:
       ID: 972
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1.650464e+06
+      GoRuntimeType: 1650464
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -26256,20 +26256,20 @@ Types:
     - __kind: StructureType
       ID: 895
       Name: github.com/tinylib/msgp/msgp.errRecursion
-      GoRuntimeType: 1.299552e+06
+      GoRuntimeType: 1299552
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 893
       Name: github.com/tinylib/msgp/msgp.errShort
-      GoRuntimeType: 1.299424e+06
+      GoRuntimeType: 1299424
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 970
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1.784736e+06
+      GoRuntimeType: 1784736
       GoKind: 25
       RawFields:
         - Name: cause
@@ -26352,7 +26352,7 @@ Types:
         - Name: X
           Offset: 0
           Type: 7 BaseType int
-        - Name: Y
+        - Name: "Y"
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
@@ -26393,7 +26393,7 @@ Types:
       ID: 939
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
-      GoRuntimeType: 1.465984e+06
+      GoRuntimeType: 1465984
       GoKind: 25
       RawFields:
         - Name: error
@@ -26403,7 +26403,7 @@ Types:
       ID: 1122
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
-      GoRuntimeType: 1.704416e+06
+      GoRuntimeType: 1704416
       GoKind: 25
       RawFields:
         - Name: WriteSyncer
@@ -26417,7 +26417,7 @@ Types:
       ID: 1148
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
-      GoRuntimeType: 1.141664e+06
+      GoRuntimeType: 1141664
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26430,7 +26430,7 @@ Types:
       ID: 1110
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
-      GoRuntimeType: 1.592736e+06
+      GoRuntimeType: 1592736
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -26446,13 +26446,13 @@ Types:
       ID: 1031
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.017568e+06
+      GoRuntimeType: 1017568
       GoKind: 10
     - __kind: StructureType
       ID: 997
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
-      GoRuntimeType: 1.908288e+06
+      GoRuntimeType: 1908288
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -26468,7 +26468,7 @@ Types:
       ID: 854
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
-      GoRuntimeType: 1.629888e+06
+      GoRuntimeType: 1629888
       GoKind: 25
       RawFields:
         - Name: Code
@@ -26561,7 +26561,7 @@ Types:
       ID: 858
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.466624e+06
+      GoRuntimeType: 1466624
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26577,7 +26577,7 @@ Types:
       ID: 846
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
-      GoRuntimeType: 1.461664e+06
+      GoRuntimeType: 1461664
       GoKind: 25
       RawFields:
         - Name: error
@@ -26591,7 +26591,7 @@ Types:
       ID: 1020
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
-      GoRuntimeType: 1.937152e+06
+      GoRuntimeType: 1937152
       GoKind: 25
       RawFields:
         - Name: Desc
@@ -26607,7 +26607,7 @@ Types:
       ID: 848
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
-      GoRuntimeType: 1.629408e+06
+      GoRuntimeType: 1629408
       GoKind: 25
       RawFields:
         - Name: Err
@@ -26620,7 +26620,7 @@ Types:
       ID: 1165
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
-      GoRuntimeType: 1.99648e+06
+      GoRuntimeType: 1996480
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -26637,7 +26637,7 @@ Types:
       ID: 937
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
-      GoRuntimeType: 1.590336e+06
+      GoRuntimeType: 1590336
       GoKind: 25
       RawFields:
         - Name: error
@@ -26662,14 +26662,14 @@ Types:
     - __kind: StructureType
       ID: 991
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
-      GoRuntimeType: 1.532416e+06
+      GoRuntimeType: 1532416
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 840
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
-      GoRuntimeType: 1.454944e+06
+      GoRuntimeType: 1454944
       GoKind: 25
       RawFields:
         - Name: Line
@@ -26679,7 +26679,7 @@ Types:
       ID: 842
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
-      GoRuntimeType: 1.455104e+06
+      GoRuntimeType: 1455104
       GoKind: 25
       RawFields:
         - Name: Line
@@ -27136,7 +27136,7 @@ Types:
       ID: 92
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 1.878944e+06
+      GoRuntimeType: 1878944
       GoKind: 25
       RawFields:
         - Name: buf
@@ -27148,7 +27148,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -27173,7 +27173,7 @@ Types:
     - __kind: StructureType
       ID: 952
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1.496736e+06
+      GoRuntimeType: 1496736
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27184,7 +27184,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 1.227296e+06
+      GoRuntimeType: 1227296
       GoKind: 25
       RawFields:
         - Name: u
@@ -27194,7 +27194,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 1.664864e+06
+      GoRuntimeType: 1664864
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27214,7 +27214,7 @@ Types:
       ID: 33
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.510496e+06
+      GoRuntimeType: 1510496
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27227,7 +27227,7 @@ Types:
       ID: 37
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 1.510336e+06
+      GoRuntimeType: 1510336
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -27239,13 +27239,13 @@ Types:
     - __kind: StructureType
       ID: 77
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 1.00672e+06
+      GoRuntimeType: 1006720
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 34
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 1.006624e+06
+      GoRuntimeType: 1006624
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
@@ -27271,7 +27271,7 @@ Types:
       ID: 909
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
-      GoRuntimeType: 1.581216e+06
+      GoRuntimeType: 1581216
       GoKind: 25
       RawFields:
         - Name: typ
@@ -27287,7 +27287,7 @@ Types:
       ID: 1269
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.494176e+06
+      GoRuntimeType: 1494176
       GoKind: 25
       RawFields:
         - Name: state
@@ -27304,7 +27304,7 @@ Types:
       ID: 1155
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.203872e+06
+      GoRuntimeType: 1203872
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27317,7 +27317,7 @@ Types:
       ID: 1190
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.037344e+06
+      GoRuntimeType: 1037344
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27330,7 +27330,7 @@ Types:
       ID: 1141
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.124128e+06
+      GoRuntimeType: 1124128
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27343,7 +27343,7 @@ Types:
       ID: 137
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.037088e+06
+      GoRuntimeType: 1037088
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27355,7 +27355,7 @@ Types:
     - __kind: StructureType
       ID: 1112
       Name: io.discard
-      GoRuntimeType: 1.482496e+06
+      GoRuntimeType: 1482496
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -27425,7 +27425,7 @@ Types:
       ID: 172
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.035936e+06
+      GoRuntimeType: 1035936
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27438,7 +27438,7 @@ Types:
       ID: 134
       Name: main.bigStruct
       ByteSize: 48
-      GoRuntimeType: 1.637024e+06
+      GoRuntimeType: 1637024
       GoKind: 25
       RawFields:
         - Name: x
@@ -27454,7 +27454,7 @@ Types:
       ID: 149
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.20016e+06
+      GoRuntimeType: 1200160
       GoKind: 25
       RawFields:
         - Name: a
@@ -27464,7 +27464,7 @@ Types:
       ID: 385
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.200032e+06
+      GoRuntimeType: 1200032
       GoKind: 25
       RawFields:
         - Name: a
@@ -27478,7 +27478,7 @@ Types:
       ID: 156
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.199392e+06
+      GoRuntimeType: 1199392
       GoKind: 25
       RawFields:
         - Name: a
@@ -27488,7 +27488,7 @@ Types:
       ID: 1335
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.199264e+06
+      GoRuntimeType: 1199264
       GoKind: 25
       RawFields:
         - Name: a
@@ -27498,7 +27498,7 @@ Types:
       ID: 1350
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.199136e+06
+      GoRuntimeType: 1199136
       GoKind: 25
       RawFields:
         - Name: a
@@ -27508,7 +27508,7 @@ Types:
       ID: 138
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.201312e+06
+      GoRuntimeType: 1201312
       GoKind: 25
       RawFields:
         - Name: a
@@ -27518,7 +27518,7 @@ Types:
       ID: 140
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.201184e+06
+      GoRuntimeType: 1201184
       GoKind: 25
       RawFields:
         - Name: a
@@ -27532,7 +27532,7 @@ Types:
       ID: 142
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.200544e+06
+      GoRuntimeType: 1200544
       GoKind: 25
       RawFields:
         - Name: a
@@ -27542,7 +27542,7 @@ Types:
       ID: 1305
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.200416e+06
+      GoRuntimeType: 1200416
       GoKind: 25
       RawFields:
         - Name: a
@@ -27552,7 +27552,7 @@ Types:
       ID: 1307
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.200288e+06
+      GoRuntimeType: 1200288
       GoKind: 25
       RawFields:
         - Name: a
@@ -27562,7 +27562,7 @@ Types:
       ID: 143
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.202464e+06
+      GoRuntimeType: 1202464
       GoKind: 25
       RawFields:
         - Name: a
@@ -27572,7 +27572,7 @@ Types:
       ID: 375
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.202336e+06
+      GoRuntimeType: 1202336
       GoKind: 25
       RawFields:
         - Name: a
@@ -27586,7 +27586,7 @@ Types:
       ID: 148
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.201696e+06
+      GoRuntimeType: 1201696
       GoKind: 25
       RawFields:
         - Name: a
@@ -27596,7 +27596,7 @@ Types:
       ID: 1311
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.201568e+06
+      GoRuntimeType: 1201568
       GoKind: 25
       RawFields:
         - Name: a
@@ -27606,7 +27606,7 @@ Types:
       ID: 1317
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.20144e+06
+      GoRuntimeType: 1201440
       GoKind: 25
       RawFields:
         - Name: a
@@ -27621,7 +27621,7 @@ Types:
       ID: 170
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.862592e+06
+      GoRuntimeType: 1862592
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -27643,7 +27643,7 @@ Types:
       ID: 165
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.998048e+06
+      GoRuntimeType: 1998048
       GoKind: 25
       RawFields:
         - Name: _
@@ -27671,7 +27671,7 @@ Types:
       ID: 363
       Name: main.firstBehavior
       ByteSize: 16
-      GoRuntimeType: 1.430144e+06
+      GoRuntimeType: 1430144
       GoKind: 25
       RawFields:
         - Name: s
@@ -28014,7 +28014,7 @@ Types:
       ID: 129
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.481536e+06
+      GoRuntimeType: 1481536
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -28027,7 +28027,7 @@ Types:
       ID: 256
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.481216e+06
+      GoRuntimeType: 1481216
       GoKind: 25
       RawFields:
         - Name: val
@@ -28061,14 +28061,14 @@ Types:
       ID: 1279
       Name: main.secondBehavior
       ByteSize: 8
-      GoRuntimeType: 1.430304e+06
+      GoRuntimeType: 1430304
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 168
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.036064e+06
+      GoRuntimeType: 1036064
       GoKind: 20
       RawFields:
         - Name: tab
@@ -28121,7 +28121,7 @@ Types:
       ID: 174
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.19888e+06
+      GoRuntimeType: 1198880
       GoKind: 25
       RawFields:
         - Name: a
@@ -28191,7 +28191,7 @@ Types:
       ID: 175
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.199008e+06
+      GoRuntimeType: 1199008
       GoKind: 25
       RawFields:
         - Name: m
@@ -29305,119 +29305,119 @@ Types:
       ID: 233
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.143712e+06
+      GoRuntimeType: 1143712
       GoKind: 21
       HeaderType: 235 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 228
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.14384e+06
+      GoRuntimeType: 1143840
       GoKind: 21
       HeaderType: 230 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 196
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.143968e+06
+      GoRuntimeType: 1143968
       GoKind: 21
       HeaderType: 198 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 208
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.144096e+06
+      GoRuntimeType: 1144096
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 150
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.143584e+06
+      GoRuntimeType: 1143584
       GoKind: 21
       HeaderType: 152 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 1289
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.143456e+06
+      GoRuntimeType: 1143456
       GoKind: 21
       HeaderType: 1291 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1323
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.142816e+06
+      GoRuntimeType: 1142816
       GoKind: 21
       HeaderType: 1325 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 1338
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.142688e+06
+      GoRuntimeType: 1142688
       GoKind: 21
       HeaderType: 1340 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 176
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.142048e+06
+      GoRuntimeType: 1142048
       GoKind: 21
       HeaderType: 178 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 1353
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.14256e+06
+      GoRuntimeType: 1142560
       GoKind: 21
       HeaderType: 1355 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 243
       Name: map[int]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.144224e+06
+      GoRuntimeType: 1144224
       GoKind: 21
       HeaderType: 245 GoSwissMapHeaderType map<int,struct {}>
     - __kind: GoMapType
       ID: 213
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.144352e+06
+      GoRuntimeType: 1144352
       GoKind: 21
       HeaderType: 215 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 203
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.14448e+06
+      GoRuntimeType: 1144480
       GoKind: 21
       HeaderType: 205 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 191
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.144608e+06
+      GoRuntimeType: 1144608
       GoKind: 21
       HeaderType: 193 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 186
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.144736e+06
+      GoRuntimeType: 1144736
       GoKind: 21
       HeaderType: 188 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 181
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.144864e+06
+      GoRuntimeType: 1144864
       GoKind: 21
       HeaderType: 183 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 238
       Name: map[struct {}]int
       ByteSize: 8
-      GoRuntimeType: 1.144992e+06
+      GoRuntimeType: 1144992
       GoKind: 21
       HeaderType: 240 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
@@ -29460,28 +29460,28 @@ Types:
       ID: 248
       Name: map[struct {}]struct {}
       ByteSize: 8
-      GoRuntimeType: 1.14512e+06
+      GoRuntimeType: 1145120
       GoKind: 21
       HeaderType: 250 GoSwissMapHeaderType map<struct {},struct {}>
     - __kind: GoMapType
       ID: 223
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.145248e+06
+      GoRuntimeType: 1145248
       GoKind: 21
       HeaderType: 225 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 218
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.145376e+06
+      GoRuntimeType: 1145376
       GoKind: 21
       HeaderType: 220 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
       ID: 779
       Name: math/big.ErrNaN
       ByteSize: 16
-      GoRuntimeType: 1.446304e+06
+      GoRuntimeType: 1446304
       GoKind: 25
       RawFields:
         - Name: msg
@@ -29491,7 +29491,7 @@ Types:
       ID: 1076
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
-      GoRuntimeType: 1.443264e+06
+      GoRuntimeType: 1443264
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29505,7 +29505,7 @@ Types:
       ID: 1046
       Name: net.Conn
       ByteSize: 16
-      GoRuntimeType: 1.619488e+06
+      GoRuntimeType: 1619488
       GoKind: 20
       RawFields:
         - Name: tab
@@ -29546,7 +29546,7 @@ Types:
       ID: 942
       Name: net.UnknownNetworkError
       ByteSize: 16
-      GoRuntimeType: 1.127456e+06
+      GoRuntimeType: 1127456
       GoKind: 24
       RawFields:
         - Name: str
@@ -29564,7 +29564,7 @@ Types:
     - __kind: StructureType
       ID: 907
       Name: net.canceledError
-      GoRuntimeType: 1.300832e+06
+      GoRuntimeType: 1300832
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29575,7 +29575,7 @@ Types:
       ID: 1051
       Name: net.dialResult·1
       ByteSize: 40
-      GoRuntimeType: 2.137504e+06
+      GoRuntimeType: 2137504
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29597,13 +29597,13 @@ Types:
     - __kind: StructureType
       ID: 1236
       Name: net.noReadFrom
-      GoRuntimeType: 1.127712e+06
+      GoRuntimeType: 1127712
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1235
       Name: net.noWriteTo
-      GoRuntimeType: 1.127584e+06
+      GoRuntimeType: 1127584
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29614,7 +29614,7 @@ Types:
       ID: 711
       Name: net.result·2
       ByteSize: 112
-      GoRuntimeType: 1.756192e+06
+      GoRuntimeType: 1756192
       GoKind: 25
       RawFields:
         - Name: p
@@ -29630,7 +29630,7 @@ Types:
       ID: 1224
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.31968e+06
+      GoRuntimeType: 2319680
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -29643,7 +29643,7 @@ Types:
       ID: 1222
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.319136e+06
+      GoRuntimeType: 2319136
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -29668,7 +29668,7 @@ Types:
       ID: 1070
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1.434784e+06
+      GoRuntimeType: 1434784
       GoKind: 25
       RawFields:
         - Name: w
@@ -29684,13 +29684,13 @@ Types:
       ID: 1023
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 1.004416e+06
+      GoRuntimeType: 1004416
       GoKind: 10
     - __kind: StructureType
       ID: 687
       Name: net/http.http2GoAwayError
       ByteSize: 24
-      GoRuntimeType: 1.753696e+06
+      GoRuntimeType: 1753696
       GoKind: 25
       RawFields:
         - Name: LastStreamID
@@ -29706,7 +29706,7 @@ Types:
       ID: 1001
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1.9264e+06
+      GoRuntimeType: 1926400
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -29722,7 +29722,7 @@ Types:
       ID: 691
       Name: net/http.http2connError
       ByteSize: 24
-      GoRuntimeType: 1.619008e+06
+      GoRuntimeType: 1619008
       GoKind: 25
       RawFields:
         - Name: Code
@@ -29799,7 +29799,7 @@ Types:
     - __kind: StructureType
       ID: 903
       Name: net/http.http2noCachedConnError
-      GoRuntimeType: 1.300064e+06
+      GoRuntimeType: 1300064
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -29829,7 +29829,7 @@ Types:
       ID: 1072
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
-      GoRuntimeType: 1.754464e+06
+      GoRuntimeType: 1754464
       GoKind: 25
       RawFields:
         - Name: conn
@@ -29852,7 +29852,7 @@ Types:
       ID: 899
       Name: net/http.nothingWrittenError
       ByteSize: 16
-      GoRuntimeType: 1.577216e+06
+      GoRuntimeType: 1577216
       GoKind: 25
       RawFields:
         - Name: error
@@ -29866,7 +29866,7 @@ Types:
       ID: 1090
       Name: net/http.persistConnWriter
       ByteSize: 8
-      GoRuntimeType: 1.577056e+06
+      GoRuntimeType: 1577056
       GoKind: 25
       RawFields:
         - Name: pc
@@ -29876,7 +29876,7 @@ Types:
       ID: 1124
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1.827872e+06
+      GoRuntimeType: 1827872
       GoKind: 25
       RawFields:
         - Name: _
@@ -29892,7 +29892,7 @@ Types:
       ID: 695
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1.435744e+06
+      GoRuntimeType: 1435744
       GoKind: 25
       RawFields:
         - Name: error
@@ -29905,14 +29905,14 @@ Types:
     - __kind: StructureType
       ID: 974
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1.499616e+06
+      GoRuntimeType: 1499616
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 901
       Name: net/http.transportReadFromServerError
       ByteSize: 16
-      GoRuntimeType: 1.577376e+06
+      GoRuntimeType: 1577376
       GoKind: 25
       RawFields:
         - Name: err
@@ -29922,7 +29922,7 @@ Types:
       ID: 1167
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2.057184e+06
+      GoRuntimeType: 2057184
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -29939,7 +29939,7 @@ Types:
       ID: 1189
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
-      GoRuntimeType: 2.072928e+06
+      GoRuntimeType: 2072928
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -29953,7 +29953,7 @@ Types:
       ID: 771
       Name: net/netip.parseAddrError
       ByteSize: 48
-      GoRuntimeType: 1.759264e+06
+      GoRuntimeType: 1759264
       GoKind: 25
       RawFields:
         - Name: in
@@ -29969,7 +29969,7 @@ Types:
       ID: 769
       Name: net/netip.parsePrefixError
       ByteSize: 32
-      GoRuntimeType: 1.620928e+06
+      GoRuntimeType: 1620928
       GoKind: 25
       RawFields:
         - Name: in
@@ -29986,7 +29986,7 @@ Types:
       ID: 1102
       Name: net/smtp.dataCloser
       ByteSize: 24
-      GoRuntimeType: 1.623168e+06
+      GoRuntimeType: 1623168
       GoKind: 25
       RawFields:
         - Name: c
@@ -30304,7 +30304,7 @@ Types:
       ID: 485
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.312352e+06
+      GoRuntimeType: 1312352
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30317,7 +30317,7 @@ Types:
       ID: 477
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.312608e+06
+      GoRuntimeType: 1312608
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30330,7 +30330,7 @@ Types:
       ID: 425
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.312864e+06
+      GoRuntimeType: 1312864
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30343,7 +30343,7 @@ Types:
       ID: 444
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.31312e+06
+      GoRuntimeType: 1313120
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30356,7 +30356,7 @@ Types:
       ID: 381
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.312096e+06
+      GoRuntimeType: 1312096
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30369,7 +30369,7 @@ Types:
       ID: 1297
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.31184e+06
+      GoRuntimeType: 1311840
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30382,7 +30382,7 @@ Types:
       ID: 1331
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.31056e+06
+      GoRuntimeType: 1310560
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30395,7 +30395,7 @@ Types:
       ID: 1346
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.310304e+06
+      GoRuntimeType: 1310304
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30408,7 +30408,7 @@ Types:
       ID: 393
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.309024e+06
+      GoRuntimeType: 1309024
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30421,7 +30421,7 @@ Types:
       ID: 1361
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.310048e+06
+      GoRuntimeType: 1310048
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30434,7 +30434,7 @@ Types:
       ID: 501
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
-      GoRuntimeType: 1.313376e+06
+      GoRuntimeType: 1313376
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30447,7 +30447,7 @@ Types:
       ID: 452
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.313632e+06
+      GoRuntimeType: 1313632
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30460,7 +30460,7 @@ Types:
       ID: 434
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.313888e+06
+      GoRuntimeType: 1313888
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30473,7 +30473,7 @@ Types:
       ID: 417
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.314144e+06
+      GoRuntimeType: 1314144
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30486,7 +30486,7 @@ Types:
       ID: 1058
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
-      GoRuntimeType: 1.375584e+06
+      GoRuntimeType: 1375584
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30499,7 +30499,7 @@ Types:
       ID: 409
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.3144e+06
+      GoRuntimeType: 1314400
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30512,7 +30512,7 @@ Types:
       ID: 401
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.314656e+06
+      GoRuntimeType: 1314656
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30525,7 +30525,7 @@ Types:
       ID: 493
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
-      GoRuntimeType: 1.314912e+06
+      GoRuntimeType: 1314912
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30610,7 +30610,7 @@ Types:
       ID: 509
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
-      GoRuntimeType: 1.315168e+06
+      GoRuntimeType: 1315168
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30623,7 +30623,7 @@ Types:
       ID: 468
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.315424e+06
+      GoRuntimeType: 1315424
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30636,7 +30636,7 @@ Types:
       ID: 460
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.31568e+06
+      GoRuntimeType: 1315680
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -30649,7 +30649,7 @@ Types:
       ID: 487
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.312224e+06
+      GoRuntimeType: 1312224
       GoKind: 25
       RawFields:
         - Name: key
@@ -30662,7 +30662,7 @@ Types:
       ID: 479
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.31248e+06
+      GoRuntimeType: 1312480
       GoKind: 25
       RawFields:
         - Name: key
@@ -30675,7 +30675,7 @@ Types:
       ID: 427
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.312736e+06
+      GoRuntimeType: 1312736
       GoKind: 25
       RawFields:
         - Name: key
@@ -30688,7 +30688,7 @@ Types:
       ID: 446
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.312992e+06
+      GoRuntimeType: 1312992
       GoKind: 25
       RawFields:
         - Name: key
@@ -30701,7 +30701,7 @@ Types:
       ID: 383
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.311968e+06
+      GoRuntimeType: 1311968
       GoKind: 25
       RawFields:
         - Name: key
@@ -30714,7 +30714,7 @@ Types:
       ID: 1299
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.311712e+06
+      GoRuntimeType: 1311712
       GoKind: 25
       RawFields:
         - Name: key
@@ -30727,7 +30727,7 @@ Types:
       ID: 1333
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.310432e+06
+      GoRuntimeType: 1310432
       GoKind: 25
       RawFields:
         - Name: key
@@ -30740,7 +30740,7 @@ Types:
       ID: 1348
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.310176e+06
+      GoRuntimeType: 1310176
       GoKind: 25
       RawFields:
         - Name: key
@@ -30753,7 +30753,7 @@ Types:
       ID: 395
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.308896e+06
+      GoRuntimeType: 1308896
       GoKind: 25
       RawFields:
         - Name: key
@@ -30766,7 +30766,7 @@ Types:
       ID: 1363
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.30992e+06
+      GoRuntimeType: 1309920
       GoKind: 25
       RawFields:
         - Name: key
@@ -30779,7 +30779,7 @@ Types:
       ID: 503
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
-      GoRuntimeType: 1.313248e+06
+      GoRuntimeType: 1313248
       GoKind: 25
       RawFields:
         - Name: key
@@ -30792,7 +30792,7 @@ Types:
       ID: 454
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.313504e+06
+      GoRuntimeType: 1313504
       GoKind: 25
       RawFields:
         - Name: key
@@ -30805,7 +30805,7 @@ Types:
       ID: 436
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.31376e+06
+      GoRuntimeType: 1313760
       GoKind: 25
       RawFields:
         - Name: key
@@ -30818,7 +30818,7 @@ Types:
       ID: 419
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.314016e+06
+      GoRuntimeType: 1314016
       GoKind: 25
       RawFields:
         - Name: key
@@ -30831,7 +30831,7 @@ Types:
       ID: 1060
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
-      GoRuntimeType: 1.375456e+06
+      GoRuntimeType: 1375456
       GoKind: 25
       RawFields:
         - Name: key
@@ -30844,7 +30844,7 @@ Types:
       ID: 411
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.314272e+06
+      GoRuntimeType: 1314272
       GoKind: 25
       RawFields:
         - Name: key
@@ -30857,7 +30857,7 @@ Types:
       ID: 403
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.314528e+06
+      GoRuntimeType: 1314528
       GoKind: 25
       RawFields:
         - Name: key
@@ -30870,7 +30870,7 @@ Types:
       ID: 495
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
-      GoRuntimeType: 1.314784e+06
+      GoRuntimeType: 1314784
       GoKind: 25
       RawFields:
         - Name: key
@@ -30954,7 +30954,7 @@ Types:
     - __kind: StructureType
       ID: 511
       Name: noalg.struct { key struct {}; elem struct {} }
-      GoRuntimeType: 1.31504e+06
+      GoRuntimeType: 1315040
       GoKind: 25
       RawFields:
         - Name: key
@@ -30967,7 +30967,7 @@ Types:
       ID: 470
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.315296e+06
+      GoRuntimeType: 1315296
       GoKind: 25
       RawFields:
         - Name: key
@@ -30980,7 +30980,7 @@ Types:
       ID: 462
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.315552e+06
+      GoRuntimeType: 1315552
       GoKind: 25
       RawFields:
         - Name: key
@@ -31005,7 +31005,7 @@ Types:
       ID: 1246
       Name: os.fileWithoutReadFrom
       ByteSize: 8
-      GoRuntimeType: 2.39008e+06
+      GoRuntimeType: 2390080
       GoKind: 25
       RawFields:
         - Name: noReadFrom
@@ -31018,7 +31018,7 @@ Types:
       ID: 1244
       Name: os.fileWithoutWriteTo
       ByteSize: 8
-      GoRuntimeType: 2.38928e+06
+      GoRuntimeType: 2389280
       GoKind: 25
       RawFields:
         - Name: noWriteTo
@@ -31030,13 +31030,13 @@ Types:
     - __kind: StructureType
       ID: 1252
       Name: os.noReadFrom
-      GoRuntimeType: 1.125152e+06
+      GoRuntimeType: 1125152
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1251
       Name: os.noWriteTo
-      GoRuntimeType: 1.125024e+06
+      GoRuntimeType: 1125024
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -31055,7 +31055,7 @@ Types:
       ID: 913
       Name: os/exec.wrappedError
       ByteSize: 32
-      GoRuntimeType: 1.729664e+06
+      GoRuntimeType: 1729664
       GoKind: 25
       RawFields:
         - Name: prefix
@@ -31117,13 +31117,13 @@ Types:
       ID: 886
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 1.915456e+06
+      GoRuntimeType: 1915456
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
           Type: 13 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -31143,14 +31143,14 @@ Types:
     - __kind: StructureType
       ID: 90
       Name: runtime.dlogPerM
-      GoRuntimeType: 1.003552e+06
+      GoRuntimeType: 1003552
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 948
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1.780512e+06
+      GoRuntimeType: 1780512
       GoKind: 25
       RawFields:
         - Name: msg
@@ -31163,7 +31163,7 @@ Types:
       ID: 862
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 1.002976e+06
+      GoRuntimeType: 1002976
       GoKind: 24
       RawFields:
         - Name: str
@@ -31182,7 +31182,7 @@ Types:
       ID: 23
       Name: runtime.g
       ByteSize: 456
-      GoRuntimeType: 2.438816e+06
+      GoRuntimeType: 2438816
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31384,7 +31384,7 @@ Types:
       ID: 55
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 1.209888e+06
+      GoRuntimeType: 1209888
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -31394,7 +31394,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1.942208e+06
+      GoRuntimeType: 1942208
       GoKind: 25
       RawFields:
         - Name: sp
@@ -31419,7 +31419,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1.488736e+06
+      GoRuntimeType: 1488736
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31432,7 +31432,7 @@ Types:
       ID: 60
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1.77936e+06
+      GoRuntimeType: 1779360
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31457,7 +31457,7 @@ Types:
       ID: 96
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1.491136e+06
+      GoRuntimeType: 1491136
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -31470,7 +31470,7 @@ Types:
       ID: 72
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 1.490336e+06
+      GoRuntimeType: 1490336
       GoKind: 25
       RawFields:
         - Name: prev
@@ -31489,7 +31489,7 @@ Types:
       ID: 30
       Name: runtime.m
       ByteSize: 1824
-      GoRuntimeType: 2.444096e+06
+      GoRuntimeType: 2444096
       GoKind: 25
       RawFields:
         - Name: g0
@@ -31718,7 +31718,7 @@ Types:
       ID: 75
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1.94272e+06
+      GoRuntimeType: 1942720
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31743,7 +31743,7 @@ Types:
       ID: 91
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1.867968e+06
+      GoRuntimeType: 1867968
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31765,7 +31765,7 @@ Types:
       ID: 80
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 1.942976e+06
+      GoRuntimeType: 1942976
       GoKind: 25
       RawFields:
         - Name: writing
@@ -31790,7 +31790,7 @@ Types:
       ID: 74
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1.490816e+06
+      GoRuntimeType: 1490816
       GoKind: 25
       RawFields:
         - Name: next
@@ -31803,7 +31803,7 @@ Types:
       ID: 98
       Name: runtime.mWeakPointer
       ByteSize: 8
-      GoRuntimeType: 1.574176e+06
+      GoRuntimeType: 1574176
       GoKind: 25
       RawFields:
         - Name: m
@@ -31819,7 +31819,7 @@ Types:
       ID: 71
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 1.210912e+06
+      GoRuntimeType: 1210912
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -31830,7 +31830,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1.490976e+06
+      GoRuntimeType: 1490976
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31843,13 +31843,13 @@ Types:
       ID: 89
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1.78032e+06
+      GoRuntimeType: 1780320
       GoKind: 25
       RawFields:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val
@@ -31862,7 +31862,7 @@ Types:
       ID: 865
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 1.003072e+06
+      GoRuntimeType: 1003072
       GoKind: 24
       RawFields:
         - Name: str
@@ -31896,7 +31896,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1.487456e+06
+      GoRuntimeType: 1487456
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31917,7 +31917,7 @@ Types:
       ID: 672
       Name: runtime.synctestDeadlockError
       ByteSize: 24
-      GoRuntimeType: 1.618688e+06
+      GoRuntimeType: 1618688
       GoKind: 25
       RawFields:
         - Name: reason
@@ -31950,7 +31950,7 @@ Types:
       ID: 56
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1.489056e+06
+      GoRuntimeType: 1489056
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -31963,19 +31963,19 @@ Types:
       ID: 35
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 1.618368e+06
+      GoRuntimeType: 1618368
       GoKind: 8
     - __kind: StructureType
       ID: 85
       Name: runtime.winlibcall
-      GoRuntimeType: 1.003456e+06
+      GoRuntimeType: 1003456
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 52
       Name: runtime.xRegPerG
       ByteSize: 8
-      GoRuntimeType: 1.20976e+06
+      GoRuntimeType: 1209760
       GoKind: 25
       RawFields:
         - Name: state
@@ -32020,7 +32020,7 @@ Types:
       ID: 1084
       Name: struct { io.Writer }
       ByteSize: 16
-      GoRuntimeType: 1.473984e+06
+      GoRuntimeType: 1473984
       GoKind: 25
       RawFields:
         - Name: Writer
@@ -32036,7 +32036,7 @@ Types:
       ID: 1267
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.483456e+06
+      GoRuntimeType: 1483456
       GoKind: 25
       RawFields:
         - Name: _
@@ -32049,7 +32049,7 @@ Types:
       ID: 1270
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.638944e+06
+      GoRuntimeType: 1638944
       GoKind: 25
       RawFields:
         - Name: _
@@ -32065,7 +32065,7 @@ Types:
       ID: 1273
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.638752e+06
+      GoRuntimeType: 1638752
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -32080,14 +32080,14 @@ Types:
     - __kind: StructureType
       ID: 1268
       Name: sync.noCopy
-      GoRuntimeType: 1.00192e+06
+      GoRuntimeType: 1001920
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1271
       Name: sync/atomic.Bool
       ByteSize: 4
-      GoRuntimeType: 1.484576e+06
+      GoRuntimeType: 1484576
       GoKind: 25
       RawFields:
         - Name: _
@@ -32100,7 +32100,7 @@ Types:
       ID: 1276
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.484736e+06
+      GoRuntimeType: 1484736
       GoKind: 25
       RawFields:
         - Name: _
@@ -32113,7 +32113,7 @@ Types:
       ID: 1274
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.639328e+06
+      GoRuntimeType: 1639328
       GoKind: 25
       RawFields:
         - Name: _
@@ -32128,20 +32128,20 @@ Types:
     - __kind: StructureType
       ID: 1275
       Name: sync/atomic.align64
-      GoRuntimeType: 1.002112e+06
+      GoRuntimeType: 1002112
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 1272
       Name: sync/atomic.noCopy
-      GoRuntimeType: 1.002016e+06
+      GoRuntimeType: 1002016
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 998
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 1.299168e+06
+      GoRuntimeType: 1299168
       GoKind: 12
     - __kind: StructureType
       ID: 482
@@ -32799,7 +32799,7 @@ Types:
       ID: 941
       Name: text/template.ExecError
       ByteSize: 32
-      GoRuntimeType: 1.73408e+06
+      GoRuntimeType: 1734080
       GoKind: 25
       RawFields:
         - Name: Name
@@ -32812,7 +32812,7 @@ Types:
       ID: 1151
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1.943744e+06
+      GoRuntimeType: 1943744
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1016
@@ -32826,7 +32826,7 @@ Types:
       ID: 1014
       Name: time.Time
       ByteSize: 24
-      GoRuntimeType: 2.405088e+06
+      GoRuntimeType: 2405088
       GoKind: 25
       RawFields:
         - Name: wall
@@ -32907,7 +32907,7 @@ Types:
       ID: 1034
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
-      GoRuntimeType: 2.093696e+06
+      GoRuntimeType: 2093696
       GoKind: 25
       RawFields:
         - Name: msg
@@ -32919,7 +32919,7 @@ Types:
         - Name: section
           Offset: 36
           Type: 1036 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
-        - Name: off
+        - Name: "off"
           Offset: 40
           Type: 7 BaseType int
         - Name: index
@@ -32941,13 +32941,13 @@ Types:
       ID: 1037
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
-      GoRuntimeType: 1.00864e+06
+      GoRuntimeType: 1008640
       GoKind: 9
     - __kind: StructureType
       ID: 1035
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
-      GoRuntimeType: 1.955008e+06
+      GoRuntimeType: 1955008
       GoKind: 25
       RawFields:
         - Name: id
@@ -32986,7 +32986,7 @@ Types:
       ID: 757
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
-      GoRuntimeType: 1.443424e+06
+      GoRuntimeType: 1443424
       GoKind: 25
       RawFields:
         - Name: Err
@@ -33002,7 +33002,7 @@ Types:
       ID: 918
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
-      GoRuntimeType: 1.729856e+06
+      GoRuntimeType: 1729856
       GoKind: 25
       RawFields:
         - Name: label
@@ -33015,7 +33015,7 @@ Types:
       ID: 870
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
-      GoRuntimeType: 1.007488e+06
+      GoRuntimeType: 1007488
       GoKind: 5
 MaxTypeID: 1690
 Issues:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -321,13 +321,13 @@ Probes:
       when:
         dsl: n == 7 && tag == "match"
         json:
-            and: [{eq: [{ref: n}, 7]}, {eq: [{ref: tag}, match]}]
+            and: [{eq: [{ref: "n"}, 7]}, {eq: [{ref: tag}, match]}]
       sampling: {snapshotsPerSecond: 10}
       template: n == 7 && tag == "match" [n={n}, tag={tag}]
       segments:
         - n == 7 && tag == "match" [n=
-        - json: {ref: n}
-          dsl: n
+        - json: {ref: "n"}
+          dsl: "n"
         - ', tag='
         - json: {ref: tag}
           dsl: tag
@@ -343,7 +343,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -371,8 +371,8 @@ Probes:
             TemplateString: n == 7 && tag == "match" [n={n}, tag={tag}]
             Segments:
                 - n == 7 && tag == "match" [n=
-                - JSON: {Ref: n}
-                  DSL: n
+                - JSON: {Ref: "n"}
+                  DSL: "n"
                   EventKind: Line
                   EventExpressionIndex: 0
                 - ', tag='
@@ -1214,7 +1214,7 @@ Probes:
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
-      when: {dsl: n == 7, json: {eq: [{ref: n}, 7]}}
+      when: {dsl: n == 7, json: {eq: [{ref: "n"}, 7]}}
       sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
@@ -1232,7 +1232,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -6154,7 +6154,7 @@ Subprograms:
       OutOfLinePCRanges: [0x4a9fe0..0x4aa0c5]
       InlinePCRanges: []
       Variables:
-        - Name: n
+        - Name: "n"
           Type: 9 BaseType int
           Locations:
             - Range: 0x4a9fe0..0x4aa01c
@@ -6898,7 +6898,7 @@ Subprograms:
           Type: 132 ArrayType [131072]int64
           Locations:
             - Range: 0x4ab760..0x4ab7ea
-              Pieces: [{Size: 1.048576e+06, Op: {CfaOffset: 0}}]
+              Pieces: [{Size: 1048576, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
@@ -8224,7 +8224,7 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
-                  Offset: 1.048568e+06
+                  Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8250,7 +8250,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
-                  Bias: 1.048576e+06
+                  Bias: 1048576
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8690,14 +8690,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8735,14 +8735,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: local
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -11895,7 +11895,7 @@ Types:
     - __kind: ArrayType
       ID: 132
       Name: '[131072]int64'
-      ByteSize: 1.048576e+06
+      ByteSize: 1048576
       GoRuntimeType: 45088
       GoKind: 17
       Count: 131072
@@ -12991,7 +12991,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -13098,7 +13098,7 @@ Types:
     - __kind: StructureType
       ID: 134
       Name: main.bigArrayStruct
-      ByteSize: 1.048584e+06
+      ByteSize: 1048584
       GoRuntimeType: 76704
       GoKind: 25
       RawFields:
@@ -13364,7 +13364,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 13 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 9 BaseType int
         - Name: signed
@@ -13699,7 +13699,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -14037,7 +14037,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -321,13 +321,13 @@ Probes:
       when:
         dsl: n == 7 && tag == "match"
         json:
-            and: [{eq: [{ref: n}, 7]}, {eq: [{ref: tag}, match]}]
+            and: [{eq: [{ref: "n"}, 7]}, {eq: [{ref: tag}, match]}]
       sampling: {snapshotsPerSecond: 10}
       template: n == 7 && tag == "match" [n={n}, tag={tag}]
       segments:
         - n == 7 && tag == "match" [n=
-        - json: {ref: n}
-          dsl: n
+        - json: {ref: "n"}
+          dsl: "n"
         - ', tag='
         - json: {ref: tag}
           dsl: tag
@@ -343,7 +343,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -371,8 +371,8 @@ Probes:
             TemplateString: n == 7 && tag == "match" [n={n}, tag={tag}]
             Segments:
                 - n == 7 && tag == "match" [n=
-                - JSON: {Ref: n}
-                  DSL: n
+                - JSON: {Ref: "n"}
+                  DSL: "n"
                   EventKind: Line
                   EventExpressionIndex: 0
                 - ', tag='
@@ -1214,7 +1214,7 @@ Probes:
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
-      when: {dsl: n == 7, json: {eq: [{ref: n}, 7]}}
+      when: {dsl: n == 7, json: {eq: [{ref: "n"}, 7]}}
       sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
@@ -1232,7 +1232,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -6217,7 +6217,7 @@ Subprograms:
       OutOfLinePCRanges: [0x4ac0c0..0x4ac1a5]
       InlinePCRanges: []
       Variables:
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x4ac0c0..0x4ac0fc
@@ -6969,7 +6969,7 @@ Subprograms:
           Type: 130 ArrayType [131072]int64
           Locations:
             - Range: 0x4ad840..0x4ad8ca
-              Pieces: [{Size: 1.048576e+06, Op: {CfaOffset: 0}}]
+              Pieces: [{Size: 1048576, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
@@ -8381,7 +8381,7 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
-                  Offset: 1.048568e+06
+                  Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8407,7 +8407,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
-                  Bias: 1.048576e+06
+                  Bias: 1048576
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8847,14 +8847,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8892,14 +8892,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -12869,7 +12869,7 @@ Types:
     - __kind: ArrayType
       ID: 130
       Name: '[131072]int64'
-      ByteSize: 1.048576e+06
+      ByteSize: 1048576
       GoRuntimeType: 50656
       GoKind: 17
       Count: 131072
@@ -13523,7 +13523,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -13630,7 +13630,7 @@ Types:
     - __kind: StructureType
       ID: 132
       Name: main.bigArrayStruct
-      ByteSize: 1.048584e+06
+      ByteSize: 1048584
       GoRuntimeType: 90016
       GoKind: 25
       RawFields:
@@ -14492,7 +14492,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 12 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -14833,7 +14833,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -15195,7 +15195,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -321,13 +321,13 @@ Probes:
       when:
         dsl: n == 7 && tag == "match"
         json:
-            and: [{eq: [{ref: n}, 7]}, {eq: [{ref: tag}, match]}]
+            and: [{eq: [{ref: "n"}, 7]}, {eq: [{ref: tag}, match]}]
       sampling: {snapshotsPerSecond: 10}
       template: n == 7 && tag == "match" [n={n}, tag={tag}]
       segments:
         - n == 7 && tag == "match" [n=
-        - json: {ref: n}
-          dsl: n
+        - json: {ref: "n"}
+          dsl: "n"
         - ', tag='
         - json: {ref: tag}
           dsl: tag
@@ -343,7 +343,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -371,8 +371,8 @@ Probes:
             TemplateString: n == 7 && tag == "match" [n={n}, tag={tag}]
             Segments:
                 - n == 7 && tag == "match" [n=
-                - JSON: {Ref: n}
-                  DSL: n
+                - JSON: {Ref: "n"}
+                  DSL: "n"
                   EventKind: Line
                   EventExpressionIndex: 0
                 - ', tag='
@@ -1214,7 +1214,7 @@ Probes:
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
-      when: {dsl: n == 7, json: {eq: [{ref: n}, 7]}}
+      when: {dsl: n == 7, json: {eq: [{ref: "n"}, 7]}}
       sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
@@ -1232,7 +1232,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -6217,7 +6217,7 @@ Subprograms:
       OutOfLinePCRanges: [0x4b2780..0x4b2859]
       InlinePCRanges: []
       Variables:
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x4b2780..0x4b27a4
@@ -6963,7 +6963,7 @@ Subprograms:
           Type: 132 ArrayType [131072]int64
           Locations:
             - Range: 0x4b3e60..0x4b3eea
-              Pieces: [{Size: 1.048576e+06, Op: {CfaOffset: 0}}]
+              Pieces: [{Size: 1048576, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
@@ -8426,7 +8426,7 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
-                  Offset: 1.048568e+06
+                  Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8452,7 +8452,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
-                  Bias: 1.048576e+06
+                  Bias: 1048576
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8892,14 +8892,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8937,14 +8937,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -12907,7 +12907,7 @@ Types:
     - __kind: ArrayType
       ID: 132
       Name: '[131072]int64'
-      ByteSize: 1.048576e+06
+      ByteSize: 1048576
       GoRuntimeType: 52096
       GoKind: 17
       Count: 131072
@@ -13588,7 +13588,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -13724,7 +13724,7 @@ Types:
     - __kind: StructureType
       ID: 134
       Name: main.bigArrayStruct
-      ByteSize: 1.048584e+06
+      ByteSize: 1048584
       GoRuntimeType: 92640
       GoKind: 25
       RawFields:
@@ -14613,7 +14613,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 12 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -14960,7 +14960,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -15323,7 +15323,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
@@ -321,13 +321,13 @@ Probes:
       when:
         dsl: n == 7 && tag == "match"
         json:
-            and: [{eq: [{ref: n}, 7]}, {eq: [{ref: tag}, match]}]
+            and: [{eq: [{ref: "n"}, 7]}, {eq: [{ref: tag}, match]}]
       sampling: {snapshotsPerSecond: 10}
       template: n == 7 && tag == "match" [n={n}, tag={tag}]
       segments:
         - n == 7 && tag == "match" [n=
-        - json: {ref: n}
-          dsl: n
+        - json: {ref: "n"}
+          dsl: "n"
         - ', tag='
         - json: {ref: tag}
           dsl: tag
@@ -343,7 +343,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -371,8 +371,8 @@ Probes:
             TemplateString: n == 7 && tag == "match" [n={n}, tag={tag}]
             Segments:
                 - n == 7 && tag == "match" [n=
-                - JSON: {Ref: n}
-                  DSL: n
+                - JSON: {Ref: "n"}
+                  DSL: "n"
                   EventKind: Line
                   EventExpressionIndex: 0
                 - ', tag='
@@ -1214,7 +1214,7 @@ Probes:
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
-      when: {dsl: n == 7, json: {eq: [{ref: n}, 7]}}
+      when: {dsl: n == 7, json: {eq: [{ref: "n"}, 7]}}
       sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
@@ -1232,7 +1232,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -6271,7 +6271,7 @@ Subprograms:
       OutOfLinePCRanges: [0x4c5e20..0x4c5ef9]
       InlinePCRanges: []
       Variables:
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0x4c5e20..0x4c5e44
@@ -7023,7 +7023,7 @@ Subprograms:
           Type: 137 ArrayType [131072]int64
           Locations:
             - Range: 0x4c7540..0x4c75ca
-              Pieces: [{Size: 1.048576e+06, Op: {CfaOffset: 0}}]
+              Pieces: [{Size: 1048576, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
@@ -8483,7 +8483,7 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
-                  Offset: 1.048568e+06
+                  Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8509,7 +8509,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
-                  Bias: 1.048576e+06
+                  Bias: 1048576
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8949,14 +8949,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8994,14 +8994,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -12964,7 +12964,7 @@ Types:
     - __kind: ArrayType
       ID: 137
       Name: '[131072]int64'
-      ByteSize: 1.048576e+06
+      ByteSize: 1048576
       GoRuntimeType: 54848
       GoKind: 17
       Count: 131072
@@ -13651,7 +13651,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -13784,7 +13784,7 @@ Types:
     - __kind: StructureType
       ID: 139
       Name: main.bigArrayStruct
-      ByteSize: 1.048584e+06
+      ByteSize: 1048584
       GoRuntimeType: 97120
       GoKind: 25
       RawFields:
@@ -14673,7 +14673,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 12 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -15399,7 +15399,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -321,13 +321,13 @@ Probes:
       when:
         dsl: n == 7 && tag == "match"
         json:
-            and: [{eq: [{ref: n}, 7]}, {eq: [{ref: tag}, match]}]
+            and: [{eq: [{ref: "n"}, 7]}, {eq: [{ref: tag}, match]}]
       sampling: {snapshotsPerSecond: 10}
       template: n == 7 && tag == "match" [n={n}, tag={tag}]
       segments:
         - n == 7 && tag == "match" [n=
-        - json: {ref: n}
-          dsl: n
+        - json: {ref: "n"}
+          dsl: "n"
         - ', tag='
         - json: {ref: tag}
           dsl: tag
@@ -343,7 +343,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -371,8 +371,8 @@ Probes:
             TemplateString: n == 7 && tag == "match" [n={n}, tag={tag}]
             Segments:
                 - n == 7 && tag == "match" [n=
-                - JSON: {Ref: n}
-                  DSL: n
+                - JSON: {Ref: "n"}
+                  DSL: "n"
                   EventKind: Line
                   EventExpressionIndex: 0
                 - ', tag='
@@ -1214,7 +1214,7 @@ Probes:
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
-      when: {dsl: n == 7, json: {eq: [{ref: n}, 7]}}
+      when: {dsl: n == 7, json: {eq: [{ref: "n"}, 7]}}
       sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
@@ -1232,7 +1232,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -6154,7 +6154,7 @@ Subprograms:
       OutOfLinePCRanges: [0xb9390..0xb9460]
       InlinePCRanges: []
       Variables:
-        - Name: n
+        - Name: "n"
           Type: 9 BaseType int
           Locations:
             - Range: 0xb9390..0xb93c8
@@ -6898,7 +6898,7 @@ Subprograms:
           Type: 132 ArrayType [131072]int64
           Locations:
             - Range: 0xba750..0xba7e0
-              Pieces: [{Size: 1.048576e+06, Op: {CfaOffset: 8}}]
+              Pieces: [{Size: 1048576, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
@@ -8224,7 +8224,7 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
-                  Offset: 1.048568e+06
+                  Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8250,7 +8250,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
-                  Bias: 1.048576e+06
+                  Bias: 1048576
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8690,14 +8690,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8735,14 +8735,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: local
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -11895,7 +11895,7 @@ Types:
     - __kind: ArrayType
       ID: 132
       Name: '[131072]int64'
-      ByteSize: 1.048576e+06
+      ByteSize: 1048576
       GoRuntimeType: 45088
       GoKind: 17
       Count: 131072
@@ -12991,7 +12991,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -13098,7 +13098,7 @@ Types:
     - __kind: StructureType
       ID: 134
       Name: main.bigArrayStruct
-      ByteSize: 1.048584e+06
+      ByteSize: 1048584
       GoRuntimeType: 76608
       GoKind: 25
       RawFields:
@@ -13364,7 +13364,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 14 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 9 BaseType int
         - Name: signed
@@ -13699,7 +13699,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -14037,7 +14037,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -321,13 +321,13 @@ Probes:
       when:
         dsl: n == 7 && tag == "match"
         json:
-            and: [{eq: [{ref: n}, 7]}, {eq: [{ref: tag}, match]}]
+            and: [{eq: [{ref: "n"}, 7]}, {eq: [{ref: tag}, match]}]
       sampling: {snapshotsPerSecond: 10}
       template: n == 7 && tag == "match" [n={n}, tag={tag}]
       segments:
         - n == 7 && tag == "match" [n=
-        - json: {ref: n}
-          dsl: n
+        - json: {ref: "n"}
+          dsl: "n"
         - ', tag='
         - json: {ref: tag}
           dsl: tag
@@ -343,7 +343,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -371,8 +371,8 @@ Probes:
             TemplateString: n == 7 && tag == "match" [n={n}, tag={tag}]
             Segments:
                 - n == 7 && tag == "match" [n=
-                - JSON: {Ref: n}
-                  DSL: n
+                - JSON: {Ref: "n"}
+                  DSL: "n"
                   EventKind: Line
                   EventExpressionIndex: 0
                 - ', tag='
@@ -1214,7 +1214,7 @@ Probes:
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
-      when: {dsl: n == 7, json: {eq: [{ref: n}, 7]}}
+      when: {dsl: n == 7, json: {eq: [{ref: "n"}, 7]}}
       sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
@@ -1232,7 +1232,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -6217,7 +6217,7 @@ Subprograms:
       OutOfLinePCRanges: [0xb9200..0xb92d0]
       InlinePCRanges: []
       Variables:
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0xb9200..0xb9228
@@ -6975,7 +6975,7 @@ Subprograms:
           Type: 130 ArrayType [131072]int64
           Locations:
             - Range: 0xba510..0xba5a0
-              Pieces: [{Size: 1.048576e+06, Op: {CfaOffset: 8}}]
+              Pieces: [{Size: 1048576, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
@@ -8387,7 +8387,7 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
-                  Offset: 1.048568e+06
+                  Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8413,7 +8413,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
-                  Bias: 1.048576e+06
+                  Bias: 1048576
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8853,14 +8853,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8898,14 +8898,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -12875,7 +12875,7 @@ Types:
     - __kind: ArrayType
       ID: 130
       Name: '[131072]int64'
-      ByteSize: 1.048576e+06
+      ByteSize: 1048576
       GoRuntimeType: 50624
       GoKind: 17
       Count: 131072
@@ -13529,7 +13529,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -13636,7 +13636,7 @@ Types:
     - __kind: StructureType
       ID: 132
       Name: main.bigArrayStruct
-      ByteSize: 1.048584e+06
+      ByteSize: 1048584
       GoRuntimeType: 89888
       GoKind: 25
       RawFields:
@@ -14498,7 +14498,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 13 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -14839,7 +14839,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -15201,7 +15201,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -321,13 +321,13 @@ Probes:
       when:
         dsl: n == 7 && tag == "match"
         json:
-            and: [{eq: [{ref: n}, 7]}, {eq: [{ref: tag}, match]}]
+            and: [{eq: [{ref: "n"}, 7]}, {eq: [{ref: tag}, match]}]
       sampling: {snapshotsPerSecond: 10}
       template: n == 7 && tag == "match" [n={n}, tag={tag}]
       segments:
         - n == 7 && tag == "match" [n=
-        - json: {ref: n}
-          dsl: n
+        - json: {ref: "n"}
+          dsl: "n"
         - ', tag='
         - json: {ref: tag}
           dsl: tag
@@ -343,7 +343,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -371,8 +371,8 @@ Probes:
             TemplateString: n == 7 && tag == "match" [n={n}, tag={tag}]
             Segments:
                 - n == 7 && tag == "match" [n=
-                - JSON: {Ref: n}
-                  DSL: n
+                - JSON: {Ref: "n"}
+                  DSL: "n"
                   EventKind: Line
                   EventExpressionIndex: 0
                 - ', tag='
@@ -1214,7 +1214,7 @@ Probes:
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
-      when: {dsl: n == 7, json: {eq: [{ref: n}, 7]}}
+      when: {dsl: n == 7, json: {eq: [{ref: "n"}, 7]}}
       sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
@@ -1232,7 +1232,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -6217,7 +6217,7 @@ Subprograms:
       OutOfLinePCRanges: [0xbbc70..0xbbd30]
       InlinePCRanges: []
       Variables:
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0xbbc70..0xbbc98
@@ -6975,7 +6975,7 @@ Subprograms:
           Type: 132 ArrayType [131072]int64
           Locations:
             - Range: 0xbcd90..0xbce20
-              Pieces: [{Size: 1.048576e+06, Op: {CfaOffset: 8}}]
+              Pieces: [{Size: 1048576, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
@@ -8438,7 +8438,7 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
-                  Offset: 1.048568e+06
+                  Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8464,7 +8464,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
-                  Bias: 1.048576e+06
+                  Bias: 1048576
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8904,14 +8904,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8949,14 +8949,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -12919,7 +12919,7 @@ Types:
     - __kind: ArrayType
       ID: 132
       Name: '[131072]int64'
-      ByteSize: 1.048576e+06
+      ByteSize: 1048576
       GoRuntimeType: 52096
       GoKind: 17
       Count: 131072
@@ -13600,7 +13600,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -13736,7 +13736,7 @@ Types:
     - __kind: StructureType
       ID: 134
       Name: main.bigArrayStruct
-      ByteSize: 1.048584e+06
+      ByteSize: 1048584
       GoRuntimeType: 92544
       GoKind: 25
       RawFields:
@@ -14625,7 +14625,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 13 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -14972,7 +14972,7 @@ Types:
         - Name: fn
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: n
+        - Name: "n"
           Offset: 8
           Type: 1 BaseType uintptr
         - Name: args
@@ -15335,7 +15335,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
@@ -321,13 +321,13 @@ Probes:
       when:
         dsl: n == 7 && tag == "match"
         json:
-            and: [{eq: [{ref: n}, 7]}, {eq: [{ref: tag}, match]}]
+            and: [{eq: [{ref: "n"}, 7]}, {eq: [{ref: tag}, match]}]
       sampling: {snapshotsPerSecond: 10}
       template: n == 7 && tag == "match" [n={n}, tag={tag}]
       segments:
         - n == 7 && tag == "match" [n=
-        - json: {ref: n}
-          dsl: n
+        - json: {ref: "n"}
+          dsl: "n"
         - ', tag='
         - json: {ref: tag}
           dsl: tag
@@ -343,7 +343,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -371,8 +371,8 @@ Probes:
             TemplateString: n == 7 && tag == "match" [n={n}, tag={tag}]
             Segments:
                 - n == 7 && tag == "match" [n=
-                - JSON: {Ref: n}
-                  DSL: n
+                - JSON: {Ref: "n"}
+                  DSL: "n"
                   EventKind: Line
                   EventExpressionIndex: 0
                 - ', tag='
@@ -1214,7 +1214,7 @@ Probes:
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
-      when: {dsl: n == 7, json: {eq: [{ref: n}, 7]}}
+      when: {dsl: n == 7, json: {eq: [{ref: "n"}, 7]}}
       sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
@@ -1232,7 +1232,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 28, index: 0, name: n}
+                      Variable: {subprogram: 28, index: 0, name: "n"}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -6271,7 +6271,7 @@ Subprograms:
       OutOfLinePCRanges: [0xcbca0..0xcbd60]
       InlinePCRanges: []
       Variables:
-        - Name: n
+        - Name: "n"
           Type: 7 BaseType int
           Locations:
             - Range: 0xcbca0..0xcbcc8
@@ -7041,7 +7041,7 @@ Subprograms:
           Type: 137 ArrayType [131072]int64
           Locations:
             - Range: 0xcce40..0xcced0
-              Pieces: [{Size: 1.048576e+06, Op: {CfaOffset: 8}}]
+              Pieces: [{Size: 1048576, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
@@ -8501,7 +8501,7 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
-                  Offset: 1.048568e+06
+                  Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8527,7 +8527,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
-                  Bias: 1.048576e+06
+                  Bias: 1048576
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
@@ -8967,14 +8967,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -9012,14 +9012,14 @@ Types:
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
-        - Name: n
+        - Name: "n"
           Offset: 1
           Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: n}
+                  Variable: {subprogram: 28, index: 0, name: "n"}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -12982,7 +12982,7 @@ Types:
     - __kind: ArrayType
       ID: 137
       Name: '[131072]int64'
-      ByteSize: 1.048576e+06
+      ByteSize: 1048576
       GoRuntimeType: 54752
       GoKind: 17
       Count: 131072
@@ -13669,7 +13669,7 @@ Types:
         - Name: i
           Offset: 288
           Type: 2 BaseType uint32
-        - Name: n
+        - Name: "n"
           Offset: 292
           Type: 2 BaseType uint32
         - Name: c
@@ -13802,7 +13802,7 @@ Types:
     - __kind: StructureType
       ID: 139
       Name: main.bigArrayStruct
-      ByteSize: 1.048584e+06
+      ByteSize: 1048584
       GoRuntimeType: 96928
       GoKind: 25
       RawFields:
@@ -14691,7 +14691,7 @@ Types:
         - Name: x
           Offset: 0
           Type: 13 BaseType int64
-        - Name: y
+        - Name: "y"
           Offset: 8
           Type: 7 BaseType int
         - Name: signed
@@ -15417,7 +15417,7 @@ Types:
         - Name: targetpc
           Offset: 0
           Type: 1 BaseType uintptr
-        - Name: off
+        - Name: "off"
           Offset: 8
           Type: 2 BaseType uint32
         - Name: val

--- a/pkg/dyninst/irprinter/yaml.go
+++ b/pkg/dyninst/irprinter/yaml.go
@@ -8,9 +8,9 @@
 package irprinter
 
 import (
+	"bytes"
 	"fmt"
 
-	"github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
 	"go.yaml.in/yaml/v3"
 
@@ -23,90 +23,142 @@ func PrintYAML(p *ir.Program) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var vv any
-	if err := json.Unmarshal(marshaledJSON, &vv,
-		json.WithUnmarshalers(json.UnmarshalFromFunc(anyToYaml)),
-	); err != nil {
-		return nil, err
-	}
-	marshaledYAML, err := yaml.Marshal(vv)
+	dec := jsontext.NewDecoder(bytes.NewReader(marshaledJSON))
+	root, err := jsonStreamToYAMLNode(dec)
 	if err != nil {
 		return nil, err
 	}
-	return marshaledYAML, nil
+	return yaml.Marshal(root)
 }
 
-func anyToYaml(dec *jsontext.Decoder, v *any) error {
+// flowStyleByteLimit is the JSON byte length below which a value is rendered
+// with YAML flow style. Matches the prior behaviour of anyToYaml: short
+// composite values inline, long ones use block style.
+const flowStyleByteLimit = 60
+
+// isYAML11Bool reports whether s is a string that YAML 1.1 parsers would
+// interpret as a boolean. The yaml-v3 emitter quotes such strings when
+// encoding from a Go string so the output stays YAML-1.1-safe; we replicate
+// that for parity since the Node-path encode does not.
+func isYAML11Bool(s string) bool {
+	switch s {
+	case "y", "Y", "yes", "Yes", "YES", "on", "On", "ON",
+		"n", "N", "no", "No", "NO", "off", "Off", "OFF":
+		return true
+	}
+	return false
+}
+
+// jsonStreamToYAMLNode reads a single JSON value from dec and returns the
+// corresponding yaml.Node tree. It does not allocate an intermediate `any`
+// representation: scalars become ScalarNode, arrays become SequenceNode,
+// objects become MappingNode whose Content preserves JSON key order.
+func jsonStreamToYAMLNode(dec *jsontext.Decoder) (*yaml.Node, error) {
 	kind := dec.PeekKind()
-	if kind != '{' {
-		return json.SkipFunc
+	switch kind {
+	case '{':
+		return readObjectNode(dec)
+	case '[':
+		return readArrayNode(dec)
+	case '"', '0', 't', 'f', 'n':
+		return readScalarNode(dec)
+	default:
+		return nil, fmt.Errorf("unexpected JSON kind: %s", kind)
 	}
-	_, err := dec.ReadToken()
-	if err != nil {
-		return err
+}
+
+func readObjectNode(dec *jsontext.Decoder) (*yaml.Node, error) {
+	if _, err := dec.ReadToken(); err != nil { // consume '{'
+		return nil, err
 	}
-	out := yaml.Node{
-		Kind: yaml.MappingNode,
-		Tag:  "!!map",
+	out := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	for dec.PeekKind() != '}' {
+		keyTok, err := dec.ReadToken()
+		if err != nil {
+			return nil, err
+		}
+		if keyTok.Kind() != '"' {
+			return nil, fmt.Errorf("expected JSON object key, got %s", keyTok.Kind())
+		}
+		keyNode := &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!str",
+			Value: keyTok.String(),
+		}
+		// Map values get flow style applied if their JSON form is short
+		// enough. This matches the prior behaviour where short objects
+		// and arrays were inlined as map values.
+		valBegin := dec.InputOffset()
+		valNode, err := jsonStreamToYAMLNode(dec)
+		if err != nil {
+			return nil, err
+		}
+		if (valNode.Kind == yaml.MappingNode || valNode.Kind == yaml.SequenceNode) &&
+			dec.InputOffset()-valBegin < flowStyleByteLimit {
+			valNode.Style = yaml.FlowStyle
+		}
+		out.Content = append(out.Content, keyNode, valNode)
 	}
-	for {
-		kind := dec.PeekKind()
-		if kind == '}' {
-			break
-		}
-		if kind != '"' {
-			return fmt.Errorf("expected string, got %s", kind)
-		}
-		var key string
-		{
-			if err := json.UnmarshalDecode(dec, &key); err != nil {
-				return err
-			}
-			n := yaml.Node{}
-			if err := n.Encode(key); err != nil {
-				return err
-			}
-			out.Content = append(out.Content, &n)
-		}
-		{
-			var vv any
-			before := dec.InputOffset()
-			if err := json.UnmarshalDecode(dec, &vv); err != nil {
-				return err
-			}
-			after := dec.InputOffset()
-			if slice, ok := vv.([]any); ok {
-				var yamlSlice []*yaml.Node
-				for _, v := range slice {
-					n := yaml.Node{}
-					if err := n.Encode(v); err != nil {
-						return fmt.Errorf("failed to encode %v %T: %w", v, v, err)
-					}
-					yamlSlice = append(yamlSlice, &n)
-				}
-				var listNode yaml.Node
-				if err := listNode.Encode(yamlSlice); err != nil {
-					return fmt.Errorf("failed to encode %v %T: %w", vv, vv, err)
-				}
-				vv = &listNode
-			}
-			n := yaml.Node{}
-			if err := n.Encode(vv); err != nil {
-				return fmt.Errorf("failed to encode %v %T: %w", vv, vv, err)
-			}
-			if after-before < 60 {
-				n.Style = yaml.FlowStyle
-			}
-			out.Content = append(out.Content, &n)
-		}
+	if _, err := dec.ReadToken(); err != nil { // consume '}'
+		return nil, err
 	}
+	return out, nil
+}
+
+func readArrayNode(dec *jsontext.Decoder) (*yaml.Node, error) {
+	if _, err := dec.ReadToken(); err != nil { // consume '['
+		return nil, err
+	}
+	out := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+	for dec.PeekKind() != ']' {
+		elemNode, err := jsonStreamToYAMLNode(dec)
+		if err != nil {
+			return nil, err
+		}
+		out.Content = append(out.Content, elemNode)
+	}
+	if _, err := dec.ReadToken(); err != nil { // consume ']'
+		return nil, err
+	}
+	return out, nil
+}
+
+func readScalarNode(dec *jsontext.Decoder) (*yaml.Node, error) {
 	tok, err := dec.ReadToken()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if tok.Kind() != '}' {
-		return fmt.Errorf("expected }, got %s", tok.Kind())
+	n := &yaml.Node{Kind: yaml.ScalarNode}
+	switch tok.Kind() {
+	case '"':
+		// Set !!str so the encoder runs its resolve-based quoting
+		// logic: if the string looks like another YAML type (e.g.
+		// "0x4af3c6" reads as an int, "" as null), it emits it
+		// double-quoted; otherwise plain. The encoder's Node-path
+		// resolve does not detect YAML 1.1 booleans like "y" or "no",
+		// so handle those by forcing DoubleQuotedStyle directly.
+		n.Tag = "!!str"
+		n.Value = tok.String()
+		if isYAML11Bool(n.Value) {
+			n.Style = yaml.DoubleQuotedStyle
+		}
+	case '0':
+		// Numbers are unambiguous as plain scalars; keep the original
+		// JSON spelling (preserves integer form rather than reformatting
+		// through float64).
+		n.Value = tok.String()
+	case 't', 'f':
+		n.Tag = "!!bool"
+		if tok.Bool() {
+			n.Value = "true"
+		} else {
+			n.Value = "false"
+		}
+	case 'n':
+		n.Tag = "!!null"
+		n.Value = "null"
+	default:
+		return nil, fmt.Errorf("unexpected scalar JSON kind: %s", tok.Kind())
 	}
-	*v = out
-	return nil
+	return n, nil
 }


### PR DESCRIPTION
### What does this PR do?

PrintYAML previously round-tripped each leaf and slice through yaml.Node.Encode, which marshals the value to YAML bytes and re-parses them just to populate the Node. For irgen TestSnapshotTesting that path dominated the test: 83% of allocations and 34% of CPU lived inside PrintYAML, with every yaml.Node.Encode call paying for fresh emitter and parser buffers (1.5 GiB and 0.6 GiB of allocations respectively across one variant).

Stream the JSON output of PrintJSON with jsontext.Decoder and build the yaml.Node tree directly. Track InputOffset across each value so we can apply FlowStyle to short composite map values (the prior <60-byte heuristic) without buffering anything. Set explicit tags so the encoder's resolve-based quoting still kicks in for ambiguous strings, and force DoubleQuotedStyle on YAML 1.1 boolean-like strings ("y", "no", "off", ...) which the Node-path emitter no longer detects on its own.

Snapshot output is unchanged in structure. Two stylistic improvements fall out of removing the round-trip:

1. JSON integers stay as ints rather than being reformatted through float64 (e.g. GoRuntimeType: 1433984 instead of 1.433984e+06).
2. YAML 1.1 ambiguous strings are now consistently quoted everywhere they appear (e.g. Name: "n", name: "y") rather than only inside flow contexts. The previous inconsistency was an accident of FlowStyle being assigned to map-value scalars and clobbering DoubleQuotedStyle.

### Motivation

TestSnapshotTesting end-to-end: ~51s -> ~12s (~4.2x).

### Describe how you validated your changes

Testing only

### Additional Notes
