### PR TITLE
Push bazel build .deb file for installer to output cache

### DIFF
--- a/.gitlab/build/package_build/installer.yml
+++ b/.gitlab/build/package_build/installer.yml
@@ -24,7 +24,6 @@
     # NOTE: for now, we consider "ociru" to be a "redhat_target" in omnibus/lib/ostools.rb
     # if we ever start building on a different platform, that might need to change
     - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --host-distribution=ociru --install-directory="$INSTALL_DIR"
-    - echo $OMNIBUS_PACKAGE_DIR
     - ls -la $OMNIBUS_PACKAGE_DIR
     - !reference [.upload_sbom_artifacts]
   variables:
@@ -126,6 +125,8 @@ installer-install-scripts:
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --target-project="installer" ${INSTALL_DIR_PARAM}
+    - bazelisk run --config=release --//:install_dir=${INSTALL_DIR}  -- //packages/installer/linux:copy_out --destdir=${OMNIBUS_PACKAGE_DIR}
+    - echo $OMNIBUS_PACKAGE_DIR
     - ls -la $OMNIBUS_PACKAGE_DIR
     - !reference [.upload_sbom_artifacts]
   variables:

--- a/.gitlab/build/package_build/installer.yml
+++ b/.gitlab/build/package_build/installer.yml
@@ -125,7 +125,7 @@ installer-install-scripts:
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --target-project="installer" ${INSTALL_DIR_PARAM}
-    - bazelisk run --config=release --//:install_dir=${INSTALL_DIR}  -- //packages/installer/linux:copy_out --destdir=${OMNIBUS_PACKAGE_DIR}
+    - PACKAGE_VERSION=$CI_PIPELINE_ID bazelisk run --config=release --//:install_dir=${INSTALL_DIR}  -- //packages/installer/linux:copy_out --destdir=${OMNIBUS_PACKAGE_DIR}
     - echo $OMNIBUS_PACKAGE_DIR
     - ls -la $OMNIBUS_PACKAGE_DIR
     - !reference [.upload_sbom_artifacts]

--- a/.gitlab/build/package_build/installer.yml
+++ b/.gitlab/build/package_build/installer.yml
@@ -24,6 +24,7 @@
     # NOTE: for now, we consider "ociru" to be a "redhat_target" in omnibus/lib/ostools.rb
     # if we ever start building on a different platform, that might need to change
     - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --host-distribution=ociru --install-directory="$INSTALL_DIR"
+    - echo $OMNIBUS_PACKAGE_DIR
     - ls -la $OMNIBUS_PACKAGE_DIR
     - !reference [.upload_sbom_artifacts]
   variables:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -439,7 +439,7 @@ prebuilt_file(
 
 prebuilt_file(
     name = "installer_binary",
-    target_label = "@@//:bin/installer/installer",
+    target_label = "@@//:bin/installer",
     target_name = "installer",
 )
 

--- a/bazel/repo/prebuilt_file.bzl
+++ b/bazel/repo/prebuilt_file.bzl
@@ -73,6 +73,7 @@ def _prebuilt_file(rctx):
             target_path = str(actual_label),
         ))
     else:
+        rctx.report_progress("=== NO built file: %s" % str(actual_label))
         rctx.file("BUILD", _BUILD_FILE_NOT_FOUND.format(
             target_name = rctx.attr.target_name,
             target_path = target_path,

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -62,10 +62,8 @@ build do
       ci_project_dir = ENV["CI_PROJECT_DIR"]
       omnibus_package_dir = "#{ci_project_dir}/omnibus/pkg"
     end
-    command "echo TRYING TO install to #{omnibus_package_dir}", :live_stream => Omnibus.logger.live_stream(:info)
-    if omnibus_package_dir
-      command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=#{omnibus_package_dir}", :live_stream => Omnibus.logger.live_stream(:info)
-    end
+    command "echo OMNIBUS_PACKAGE_DIR is '#{omnibus_package_dir}'", :live_stream => Omnibus.logger.live_stream(:info)
+    command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=#{install_dir}/..", :live_stream => Omnibus.logger.live_stream(:info)
   elsif windows_target?
     command "dda inv -- -e installer.build --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     copy 'bin/installer/installer.exe', "#{install_dir}/datadog-installer.exe"

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -55,9 +55,8 @@ build do
     # Copy both the .deb and .rpm out to the artifact outputs
     # In the package job, we'll compare these to the omnibus built packages and report the diffs
     # When the diffs go away, we delete the package job and just use this one.
-    omnibus_package_dir = Omnibus::Config.package_dir()
     mkdir "omnibus/pkg"
-    command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=omnibus/pkg", :live_stream => Omnibus.logger.live_stream(:info)
+    command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=omnibus/pkg/x", :live_stream => Omnibus.logger.live_stream(:info)
   elsif windows_target?
     command "dda inv -- -e installer.build --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     copy 'bin/installer/installer.exe', "#{install_dir}/datadog-installer.exe"

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -56,7 +56,8 @@ build do
     # In the package job, we'll compare these to the omnibus built packages and report the diffs
     # When the diffs go away, we delete the package job and just use this one.
     omnibus_package_dir = Omnibus::Config.package_dir()
-    command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=#{omnibus_package_dir}", :live_stream => Omnibus.logger.live_stream(:info)
+    mkdir "omnibus/pkg"
+    command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=omnibus/pkg", :live_stream => Omnibus.logger.live_stream(:info)
   elsif windows_target?
     command "dda inv -- -e installer.build --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     copy 'bin/installer/installer.exe', "#{install_dir}/datadog-installer.exe"

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -55,14 +55,16 @@ build do
     # Copy both the .deb and .rpm out to artifact outputs
     # In the package job, we'll compare these to the omnibus built packages and report the diffs
     # When the diffs go away, we delete the package job and just use this one.
+    omnibus_package_dir = ""
     if ENV["OMNIBUS_PACKAGE_DIR"]
       omnibus_package_dir = ENV["OMNIBUS_PACKAGE_DIR"]
     elsif ENV["CI_PROJECT_DIR"]
       ci_project_dir = ENV["CI_PROJECT_DIR"]
       omnibus_package_dir = "#{ci_project_dir}/omnibus/pkg"
     end
+    command "echo TRYING TO install to #{omnibus_package_dir}", :live_stream => Omnibus.logger.live_stream(:info)
     if omnibus_package_dir
-      command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=#{omnibus_package_dir}"
+      command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=#{omnibus_package_dir}", :live_stream => Omnibus.logger.live_stream(:info)
     end
   elsif windows_target?
     command "dda inv -- -e installer.build --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -47,6 +47,7 @@ build do
     copy 'bin/installer', "#{install_dir}/bin/"
 
     # Build both packages and dump them where gitlab will upload them.
+    command_on_repo_root "bazelisk clean --expunge", :live_stream => Omnibus.logger.live_stream(:info)
     command_on_repo_root "bazelisk build #{bazel_flags} //packages/installer/linux:whole_distro_tar_deb", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     # There are no convenience symlinks, so we need to do some path manipulations to get the absolute path.
     command_on_repo_root "bazelisk cquery #{bazel_flags} --output=files //packages/installer/linux:whole_distro_tar_deb | sed -e 's@bazel-out/@@' >/tmp/installer_linux_tar_deb_file.txt"
@@ -56,7 +57,6 @@ build do
     # In the package job, we'll compare these to the omnibus built packages and report the diffs
     # When the diffs go away, we delete the package job and just use this one.
     mkdir "omnibus/pkg"
-    command_on_repo_root "bazelisk clean --expunge", :live_stream => Omnibus.logger.live_stream(:info)
     command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=omnibus/pkg", :live_stream => Omnibus.logger.live_stream(:info)
   elsif windows_target?
     command "dda inv -- -e installer.build --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -56,7 +56,8 @@ build do
     # In the package job, we'll compare these to the omnibus built packages and report the diffs
     # When the diffs go away, we delete the package job and just use this one.
     mkdir "omnibus/pkg"
-    command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=omnibus/pkg/x", :live_stream => Omnibus.logger.live_stream(:info)
+    command_on_repo_root "bazelisk clean --expunge", :live_stream => Omnibus.logger.live_stream(:info)
+    command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=omnibus/pkg", :live_stream => Omnibus.logger.live_stream(:info)
   elsif windows_target?
     command "dda inv -- -e installer.build --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     copy 'bin/installer/installer.exe', "#{install_dir}/datadog-installer.exe"

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -52,18 +52,11 @@ build do
     command_on_repo_root "bazelisk cquery #{bazel_flags} --output=files //packages/installer/linux:whole_distro_tar_deb | sed -e 's@bazel-out/@@' >/tmp/installer_linux_tar_deb_file.txt"
     command_on_repo_root "tar tvf $(bazelisk info output_path)/$(cat /tmp/installer_linux_tar_deb_file.txt)", :live_stream => Omnibus.logger.live_stream(:info)
 
-    # Copy both the .deb and .rpm out to artifact outputs
+    # Copy both the .deb and .rpm out to the artifact outputs
     # In the package job, we'll compare these to the omnibus built packages and report the diffs
     # When the diffs go away, we delete the package job and just use this one.
-    omnibus_package_dir = ""
-    if ENV["OMNIBUS_PACKAGE_DIR"]
-      omnibus_package_dir = ENV["OMNIBUS_PACKAGE_DIR"]
-    elsif ENV["CI_PROJECT_DIR"]
-      ci_project_dir = ENV["CI_PROJECT_DIR"]
-      omnibus_package_dir = "#{ci_project_dir}/omnibus/pkg"
-    end
-    command "echo OMNIBUS_PACKAGE_DIR is '#{omnibus_package_dir}'", :live_stream => Omnibus.logger.live_stream(:info)
-    command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=#{install_dir}/..", :live_stream => Omnibus.logger.live_stream(:info)
+    omnibus_package_dir = Omnibus::Config.package_dir()
+    command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=#{omnibus_package_dir}", :live_stream => Omnibus.logger.live_stream(:info)
   elsif windows_target?
     command "dda inv -- -e installer.build --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     copy 'bin/installer/installer.exe', "#{install_dir}/datadog-installer.exe"


### PR DESCRIPTION
### What does this PR do?

Builds the full .deb for the installer in the build step. Push it to the cache.

### Motivation

I need to get this .deb and the omnibus built .deb in the same job at the same time so we can diff them to see we are done.

### Describe how you validated your changes

### Additional Notes
