### PR TITLE
dyninst/irgen: skip convergence checking with --short

### DIFF
--- a/pkg/dyninst/irgen/snapshot_test.go
+++ b/pkg/dyninst/irgen/snapshot_test.go
@@ -149,7 +149,8 @@ func runTest(t *testing.T, cfg testprogs.Config, prog string) {
 	}
 
 	// Make sure that the IR eventually gets to the same set of types as
-	// when we don't have a limit.
+	// when we don't have a limit. Skipped under -short since each
+	// iteration runs a full GenerateIR pass.
 	var irWithLimit1 *ir.Program
 	for i := 1; ; i++ {
 		probesCfgs := testprogs.MustGetProbeDefinitions(t, prog)
@@ -160,6 +161,9 @@ func runTest(t *testing.T, cfg testprogs.Config, prog string) {
 
 		if i == 1 {
 			irWithLimit1 = irWithLimit
+			if testing.Short() {
+				break
+			}
 		}
 		typeNames := func(p *ir.Program) []string {
 			var names []string


### PR DESCRIPTION
It takes time. This further reduces the runtime from ~12s to ~7s.
