### PR TITLE
[CI][WIP] Ephemeral: run Windows OCI packaging (agent_win_oci)

### DIFF
--- a/.gitlab/windows/build/packaging/oci.yml
+++ b/.gitlab/windows/build/packaging/oci.yml
@@ -1,5 +1,6 @@
 ---
 # Windows OCI packaging jobs extracted from .gitlab/build/packaging/oci.yml
+# Ephemeral: no-op comment to run Windows CI (SKIP_WINDOWS off); remove before merging real work.
 
 .package_oci_win:
   extends: .package_oci


### PR DESCRIPTION
## Purpose

Draft-only branch to trigger GitLab Windows packaging (including `agent_win_oci`) via a no-op change under `.gitlab/` (`windows_path_2` vs `main` → `SKIP_WINDOWS=false`).

**Do not merge.** Close this PR after downloading artifacts.

## Change

- One-line comment in `.gitlab/windows/build/packaging/oci.yml`

## Cleanup

- Close PR without merging, or delete branch after artifacts are collected.
- The SNMP metadata work remains on `ian.bucad/snmp-metadata-skip-empty-scalar` without this commit.

Note: `do-no-merge/WIP` label is not defined on this repo; add manually in GitHub if you use it.

Made with [Cursor](https://cursor.com)