### PR TITLE
[ADP] gate `data_plane.enabled` to Linux at config load time

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1197,9 +1197,9 @@ func sanitizeAPIKeyConfig(config pkgconfigmodel.Config, key string) {
 // exposed as a parameter so that tests can exercise both branches without
 // needing to cross-compile.
 func sanitizeDataPlaneConfig(config pkgconfigmodel.Config, goos string) {
-	if goos != "linux" && config.GetBool("data_plane.enabled") {
-		log.Warnf("data_plane.enabled is not supported on %s and will be ignored", goos)
-		config.Set("data_plane.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+	if goos != "linux" && config.GetBool(DataPlaneEnabled) {
+		log.Warnf("%s is not supported on %s and will be ignored", DataPlaneEnabled, goos)
+		config.Set(DataPlaneEnabled, false, pkgconfigmodel.SourceAgentRuntime)
 	}
 }
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1188,17 +1188,20 @@ func sanitizeAPIKeyConfig(config pkgconfigmodel.Config, key string) {
 }
 
 // sanitizeDataPlaneConfig gates data_plane.enabled to Linux only.
-// The Agent Data Plane (ADP) is a Linux-only component. If a user sets
-// data_plane.enabled: true on any other OS, this function emits a warning and
-// resets the flag to false so that downstream consumers automatically see the
-// correct value without each of them needing their own platform check.
+// The Agent Data Plane (ADP) is a Linux-only component. On non-Linux platforms
+// this function always installs a SourceAgentRuntime override of false, which
+// beats file and fleet-policy sources and prevents them from re-enabling ADP
+// after this call returns. A warning is emitted only when the value was
+// explicitly set to true at call time.
 //
 // The goos parameter is the target OS string (normally runtime.GOOS). It is
 // exposed as a parameter so that tests can exercise both branches without
 // needing to cross-compile.
 func sanitizeDataPlaneConfig(config pkgconfigmodel.Config, goos string) {
-	if goos != "linux" && config.GetBool(DataPlaneEnabled) {
-		log.Warnf("%s is not supported on %s and will be ignored", DataPlaneEnabled, goos)
+	if goos != "linux" {
+		if config.GetBool(DataPlaneEnabled) {
+			log.Warnf("%s is not supported on %s and will be ignored", DataPlaneEnabled, goos)
+		}
 		config.Set(DataPlaneEnabled, false, pkgconfigmodel.SourceAgentRuntime)
 	}
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -682,6 +683,7 @@ func LoadDatadog(config pkgconfigmodel.Config, secretResolver secrets.Component,
 
 	sanitizeAPIKeyConfig(config, "api_key")
 	sanitizeAPIKeyConfig(config, "logs_config.api_key")
+	sanitizeDataPlaneConfig(config, runtime.GOOS)
 	setNumWorkers(config)
 
 	flareStrippedKeys := config.GetStringSlice("flare_stripped_keys")
@@ -1183,6 +1185,22 @@ func sanitizeAPIKeyConfig(config pkgconfigmodel.Config, key string) {
 		return
 	}
 	config.Set(key, trimmed, pkgconfigmodel.SourceAgentRuntime)
+}
+
+// sanitizeDataPlaneConfig gates data_plane.enabled to Linux only.
+// The Agent Data Plane (ADP) is a Linux-only component. If a user sets
+// data_plane.enabled: true on any other OS, this function emits a warning and
+// resets the flag to false so that downstream consumers automatically see the
+// correct value without each of them needing their own platform check.
+//
+// The goos parameter is the target OS string (normally runtime.GOOS). It is
+// exposed as a parameter so that tests can exercise both branches without
+// needing to cross-compile.
+func sanitizeDataPlaneConfig(config pkgconfigmodel.Config, goos string) {
+	if goos != "linux" && config.GetBool("data_plane.enabled") {
+		log.Warnf("data_plane.enabled is not supported on %s and will be ignored", goos)
+		config.Set("data_plane.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+	}
 }
 
 // sanitizeExternalMetricsProviderChunkSize ensures the value of `external_metrics_provider.chunk_size` is within an acceptable range

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1535,42 +1535,60 @@ func TestLoadProxyFromEnv(t *testing.T) {
 	assert.Equal(t, pkgconfigmodel.SourceConfigPostInit, cfg.GetSource("proxy.http"))
 }
 
-func TestSanitizeDataPlaneConfigLinux(t *testing.T) {
-	// On Linux, data_plane.enabled=true must be preserved unchanged.
-	cfg := newTestConf(t)
-	cfg.Set("data_plane.enabled", true, pkgconfigmodel.SourceFile)
+func TestSanitizeDataPlaneConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		goos         string
+		initialValue bool
+		wantValue    bool
+		wantSource   pkgconfigmodel.Source
+	}{
+		{
+			name:         "linux preserves true",
+			goos:         "linux",
+			initialValue: true,
+			wantValue:    true,
+			wantSource:   pkgconfigmodel.SourceFile,
+		},
+		{
+			name:         "windows resets true to false",
+			goos:         "windows",
+			initialValue: true,
+			wantValue:    false,
+			wantSource:   pkgconfigmodel.SourceAgentRuntime,
+		},
+		{
+			name:         "darwin resets true to false",
+			goos:         "darwin",
+			initialValue: true,
+			wantValue:    false,
+			wantSource:   pkgconfigmodel.SourceAgentRuntime,
+		},
+		{
+			name:         "windows no-op when already false",
+			goos:         "windows",
+			initialValue: false,
+			wantValue:    false,
+			wantSource:   pkgconfigmodel.SourceFile,
+		},
+		{
+			name:         "darwin no-op when already false",
+			goos:         "darwin",
+			initialValue: false,
+			wantValue:    false,
+			wantSource:   pkgconfigmodel.SourceFile,
+		},
+	}
 
-	sanitizeDataPlaneConfig(cfg, "linux")
-
-	assert.True(t, cfg.GetBool("data_plane.enabled"), "data_plane.enabled should remain true on linux")
-}
-
-func TestSanitizeDataPlaneConfigNonLinux(t *testing.T) {
-	// On non-Linux platforms, data_plane.enabled=true must be reset to false
-	// and a warning is emitted. We verify the config value side-effect; log
-	// output is not captured here because no log-capture infrastructure exists
-	// in this test package.
-	for _, goos := range []string{"windows", "darwin"} {
-		t.Run(goos, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			cfg := newTestConf(t)
-			cfg.Set("data_plane.enabled", true, pkgconfigmodel.SourceFile)
+			cfg.Set("data_plane.enabled", tt.initialValue, pkgconfigmodel.SourceFile)
 
-			sanitizeDataPlaneConfig(cfg, goos)
+			sanitizeDataPlaneConfig(cfg, tt.goos)
 
-			assert.False(t, cfg.GetBool("data_plane.enabled"),
-				"data_plane.enabled should be reset to false on %s", goos)
-			assert.Equal(t, pkgconfigmodel.SourceAgentRuntime, cfg.GetSource("data_plane.enabled"))
+			assert.Equal(t, tt.wantValue, cfg.GetBool("data_plane.enabled"))
+			assert.Equal(t, tt.wantSource, cfg.GetSource("data_plane.enabled"))
 		})
 	}
-}
-
-func TestSanitizeDataPlaneConfigNonLinuxAlreadyFalse(t *testing.T) {
-	// When data_plane.enabled is already false, sanitize should be a no-op on
-	// any platform (no panic, no spurious log entry).
-	cfg := newTestConf(t)
-	// default is false; leave it that way
-
-	sanitizeDataPlaneConfig(cfg, "windows")
-
-	assert.False(t, cfg.GetBool("data_plane.enabled"))
 }

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1534,3 +1534,42 @@ func TestLoadProxyFromEnv(t *testing.T) {
 	assert.Equal(t, "http://www.example.com/", cfg.Get("proxy.http"))
 	assert.Equal(t, pkgconfigmodel.SourceConfigPostInit, cfg.GetSource("proxy.http"))
 }
+
+func TestSanitizeDataPlaneConfigLinux(t *testing.T) {
+	// On Linux, data_plane.enabled=true must be preserved unchanged.
+	cfg := newTestConf(t)
+	cfg.Set("data_plane.enabled", true, pkgconfigmodel.SourceFile)
+
+	sanitizeDataPlaneConfig(cfg, "linux")
+
+	assert.True(t, cfg.GetBool("data_plane.enabled"), "data_plane.enabled should remain true on linux")
+}
+
+func TestSanitizeDataPlaneConfigNonLinux(t *testing.T) {
+	// On non-Linux platforms, data_plane.enabled=true must be reset to false
+	// and a warning is emitted. We verify the config value side-effect; log
+	// output is not captured here because no log-capture infrastructure exists
+	// in this test package.
+	for _, goos := range []string{"windows", "darwin"} {
+		t.Run(goos, func(t *testing.T) {
+			cfg := newTestConf(t)
+			cfg.Set("data_plane.enabled", true, pkgconfigmodel.SourceFile)
+
+			sanitizeDataPlaneConfig(cfg, goos)
+
+			assert.False(t, cfg.GetBool("data_plane.enabled"),
+				"data_plane.enabled should be reset to false on %s", goos)
+		})
+	}
+}
+
+func TestSanitizeDataPlaneConfigNonLinuxAlreadyFalse(t *testing.T) {
+	// When data_plane.enabled is already false, sanitize should be a no-op on
+	// any platform (no panic, no spurious log entry).
+	cfg := newTestConf(t)
+	// default is false; leave it that way
+
+	sanitizeDataPlaneConfig(cfg, "windows")
+
+	assert.False(t, cfg.GetBool("data_plane.enabled"))
+}

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1565,18 +1565,20 @@ func TestSanitizeDataPlaneConfig(t *testing.T) {
 			wantSource:   pkgconfigmodel.SourceAgentRuntime,
 		},
 		{
-			name:         "windows no-op when already false",
+			// Even when already false, non-Linux writes SourceAgentRuntime so that
+			// lower-priority sources (e.g. fleet policies) cannot re-enable ADP later.
+			name:         "windows locks false via SourceAgentRuntime",
 			goos:         "windows",
 			initialValue: false,
 			wantValue:    false,
-			wantSource:   pkgconfigmodel.SourceFile,
+			wantSource:   pkgconfigmodel.SourceAgentRuntime,
 		},
 		{
-			name:         "darwin no-op when already false",
+			name:         "darwin locks false via SourceAgentRuntime",
 			goos:         "darwin",
 			initialValue: false,
 			wantValue:    false,
-			wantSource:   pkgconfigmodel.SourceFile,
+			wantSource:   pkgconfigmodel.SourceAgentRuntime,
 		},
 	}
 

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1559,6 +1559,7 @@ func TestSanitizeDataPlaneConfigNonLinux(t *testing.T) {
 
 			assert.False(t, cfg.GetBool("data_plane.enabled"),
 				"data_plane.enabled should be reset to false on %s", goos)
+			assert.Equal(t, pkgconfigmodel.SourceAgentRuntime, cfg.GetSource("data_plane.enabled"))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

ADP (Agent Data Plane) is Linux-only, but `data_plane.enabled: true` was silently ignored on Windows and macOS with no feedback to the user. This PR adds a platform gate in the config loading path that emits a warning and resets `data_plane.enabled` to false on non-Linux platforms, ensuring every downstream consumer (dogstatsd ADP path, OTLP proxy) automatically sees the correct value without per-site guards.

Follows up on review feedback from #49891.

No changelog entry since ADP still is a "hidden feature".

## Test plan

- [x] `dda inv test --targets=./pkg/config/setup/...` passes (291 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)