### PR TITLE
stop a warning

### DIFF
--- a/omnibus/config/software/preparation.rb
+++ b/omnibus/config/software/preparation.rb
@@ -19,6 +19,8 @@ name "preparation"
 description "the steps required to preprare the build"
 default_version "1.0.0"
 
+skip_transitive_dependency_licensing true
+
 build do
   block do
     %w{embedded/lib embedded/bin bin}.each do |dir|


### PR DESCRIPTION
### What does this PR do?

Stops trying to collect licenses on a piece of build prep where it does not apply. Stops an annoying message in build logs.
```
              [Licensing] W | 2026-04-30T03:37:31+00:00 | Software 'preparation' is not supported project type for transitive dependency license collection. See https://github.com/chef/license_scout for the list of supported languages and dependency managers. If this project does not have any transitive dependencies, consider setting 'skip_transitive_dependency_licensing' to 'true' in order to correct this error.
```

### Motivation

I'm reading a log of build logs lately and this is clutter that distracts.
