### PR TITLE
[observer] Synchronous metric ingest, sharded storage, ticker-driven advance

### DIFF
--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -38,10 +38,13 @@ type seriesContextRef struct {
 // The engine does not own reporters or scheduling policy. It accepts explicit
 // Advance calls and returns results that callers route to their own outputs.
 type engine struct {
-	// mu protects detectors, correlators, extractors, logObservers,
-	// lastAnalyzedDataTime, and latestDataTime from concurrent access.
-	// Writers (Advance, Reset, SetDetectors, SetCorrelators, SetExtractors)
-	// take a write lock; readers (stateView methods) take a read lock.
+	// mu protects detectors, correlators, extractors, logObservers, and
+	// contextRefs from concurrent access. Writers (Advance, Reset,
+	// SetDetectors, SetCorrelators, SetExtractors) take a write lock; readers
+	// (stateView methods) take a read lock. lastAnalyzedDataTime and
+	// latestDataTime are stored as atomics so producers calling
+	// IngestMetricSync from arbitrary goroutines do not need to synchronize on
+	// engine state.
 	mu sync.RWMutex
 
 	storage          *timeSeriesStorage
@@ -59,10 +62,14 @@ type engine struct {
 	logObservers []observerdef.LogObserver
 
 	// lastAnalyzedDataTime is the data timestamp up to which detection has run.
-	lastAnalyzedDataTime int64
+	// Updated by advanceWithReason; read by IngestMetricSync, IngestLog, and
+	// the scheduler ticker. Stored as atomic so the metric ingest hot path
+	// stays lock-free.
+	lastAnalyzedDataTime atomic.Int64
 
-	// latestDataTime is the latest data timestamp seen across all ingested observations.
-	latestDataTime int64
+	// latestDataTime is the latest data timestamp seen across all ingested
+	// observations. Monotonic; updated via CompareAndSwap loop.
+	latestDataTime atomic.Int64
 
 	// Raw anomaly tracking (for telemetry and testbench display).
 	rawAnomalies         []observerdef.Anomaly
@@ -103,10 +110,13 @@ type engine struct {
 	onAdvance      func(advanceEntry) // scheduler trace
 
 	// Counters for data ingestion anomalies, reset after each advance.
-	latePoints         atomic.Int64     // points ingested after their timestamp was already analyzed
-	latePointsBySource map[string]int64 // per-source breakdown (single-goroutine access from run loop)
-	handles            []*handle        // registered handles for per-source drop collection
-	handlesMu          sync.Mutex       // protects handles slice
+	latePoints           atomic.Int64 // points ingested after their timestamp was already analyzed
+	latePointsBySource   sync.Map     // string source → *atomic.Int64; concurrent-safe
+	latePointsSourceKeys []string     // tracked keys so advance can drain & reset
+	latePointsKeysMu     sync.Mutex   // protects latePointsSourceKeys append-only growth
+
+	handles   []*handle  // registered handles for per-source drop collection
+	handlesMu sync.Mutex // protects handles slice
 }
 
 // engineConfig holds the parameters for constructing an engine.
@@ -210,19 +220,86 @@ func (e *engine) registerHandle(h *handle) {
 // IngestMetric stores a metric observation and consults the scheduler policy
 // to determine whether detectors should advance. Returns advance requests
 // that the caller should execute via Advance.
+//
+// Used by tests, the testbench, and the engine's own log-derived metric path.
+// The live ingest path uses IngestMetricSync which avoids the metricObs heap
+// box and does not invoke the scheduler synchronously.
 func (e *engine) IngestMetric(source string, m *metricObs) []advanceRequest {
 	e.storage.Add(source, m.name, m.value, m.timestamp, m.tags)
-	// Track points that arrive after their timestamp was already analyzed.
-	// These points are in storage but were invisible to detectors at analysis time.
-	if m.timestamp <= e.lastAnalyzedDataTime {
-		e.latePoints.Add(1)
-		if e.latePointsBySource == nil {
-			e.latePointsBySource = make(map[string]int64)
-		}
-		e.latePointsBySource[source]++
-	}
-	e.trackLatestDataTime(m.timestamp)
+	e.recordIngestion(source, m.timestamp)
 	return e.scheduler.onObservation(m.timestamp, e.schedulerState())
+}
+
+// IngestMetricSync is the live-ingest entry point for metric handles. It is
+// called synchronously from producer goroutines (DogStatsD, HF runners, the
+// aggregator). It writes through to storage and bumps the engine's data-time
+// trackers but does NOT call into the scheduler — advance scheduling is
+// driven by the scheduler ticker on a separate goroutine.
+//
+// Lifetime contract: the storage write completes before this function
+// returns, so the caller may reuse name/tags/sample memory immediately. No
+// references are retained beyond the synchronous storage.Add call (storage
+// canonicalizes tags and aliases name internally only on first occurrence).
+func (e *engine) IngestMetricSync(source, name string, value float64, timestamp int64, tags []string) {
+	e.storage.Add(source, name, value, timestamp, tags)
+	e.recordIngestion(source, timestamp)
+}
+
+// recordIngestion updates late-point counters and latestDataTime for an
+// observation at the given source/timestamp. Safe to call from any goroutine.
+func (e *engine) recordIngestion(source string, timestamp int64) {
+	if timestamp <= e.lastAnalyzedDataTime.Load() {
+		e.latePoints.Add(1)
+		e.bumpLatePointsBySource(source)
+	}
+	e.trackLatestDataTime(timestamp)
+}
+
+// bumpLatePointsBySource increments the per-source late-point counter
+// concurrently. The first observation for a source allocates the atomic and
+// records the key for drain at advance time.
+func (e *engine) bumpLatePointsBySource(source string) {
+	if v, ok := e.latePointsBySource.Load(source); ok {
+		v.(*atomic.Int64).Add(1)
+		return
+	}
+	cnt := new(atomic.Int64)
+	cnt.Add(1)
+	if existing, loaded := e.latePointsBySource.LoadOrStore(source, cnt); loaded {
+		existing.(*atomic.Int64).Add(1)
+		return
+	}
+	e.latePointsKeysMu.Lock()
+	e.latePointsSourceKeys = append(e.latePointsSourceKeys, source)
+	e.latePointsKeysMu.Unlock()
+}
+
+// drainLatePointsBySource atomically swaps each per-source counter to zero
+// and returns a snapshot of non-zero counts. Used by advanceWithReason.
+func (e *engine) drainLatePointsBySource() map[string]int64 {
+	e.latePointsKeysMu.Lock()
+	keys := e.latePointsSourceKeys
+	e.latePointsKeysMu.Unlock()
+
+	if len(keys) == 0 {
+		return nil
+	}
+	var out map[string]int64
+	for _, k := range keys {
+		v, ok := e.latePointsBySource.Load(k)
+		if !ok {
+			continue
+		}
+		n := v.(*atomic.Int64).Swap(0)
+		if n == 0 {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]int64)
+		}
+		out[k] = n
+	}
+	return out
 }
 
 // IngestLog processes a log observation: runs extractors to produce virtual metrics,
@@ -309,17 +386,24 @@ func (e *engine) removeContextRefsForEvictedKeys(namespace string, evictedKeys [
 }
 
 // trackLatestDataTime updates latestDataTime if the given timestamp is newer.
+// Concurrent-safe via CompareAndSwap; monotonic.
 func (e *engine) trackLatestDataTime(dataTimeSec int64) {
-	if dataTimeSec > e.latestDataTime {
-		e.latestDataTime = dataTimeSec
+	for {
+		cur := e.latestDataTime.Load()
+		if dataTimeSec <= cur {
+			return
+		}
+		if e.latestDataTime.CompareAndSwap(cur, dataTimeSec) {
+			return
+		}
 	}
 }
 
 // schedulerState returns the current scheduler-relevant state.
 func (e *engine) schedulerState() schedulerState {
 	return schedulerState{
-		lastAnalyzedDataTime: e.lastAnalyzedDataTime,
-		latestDataTime:       e.latestDataTime,
+		lastAnalyzedDataTime: e.lastAnalyzedDataTime.Load(),
+		latestDataTime:       e.latestDataTime.Load(),
 	}
 }
 
@@ -343,21 +427,17 @@ func (e *engine) advanceWithReason(upToSec int64, reason advanceReason) advanceR
 	// runDetectorsAndCorrelators because emit() callbacks may re-enter
 	// stateView methods that take mu.RLock, causing a deadlock.
 	e.mu.Lock()
-	if upToSec <= e.lastAnalyzedDataTime {
+	if upToSec <= e.lastAnalyzedDataTime.Load() {
 		e.mu.Unlock()
 		return advanceResult{}
 	}
 	detectors := e.detectors
 	correlators := e.correlators
-	e.lastAnalyzedDataTime = upToSec
+	e.lastAnalyzedDataTime.Store(upToSec)
 	e.mu.Unlock()
 
 	if e.onAdvance != nil {
-		var lateBySource map[string]int64
-		if len(e.latePointsBySource) > 0 {
-			lateBySource = e.latePointsBySource
-			e.latePointsBySource = nil
-		}
+		lateBySource := e.drainLatePointsBySource()
 		var totalDrops int64
 		var dropsBySource map[string]int64
 		e.handlesMu.Lock()
@@ -730,8 +810,8 @@ func (e *engine) Reset() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	e.lastAnalyzedDataTime = 0
-	e.latestDataTime = 0
+	e.lastAnalyzedDataTime.Store(0)
+	e.latestDataTime.Store(0)
 
 	for _, detector := range e.detectors {
 		if resetter, ok := detector.(interface{ Reset() }); ok {

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -46,6 +46,17 @@ type engine struct {
 	// goroutines do not need to synchronize on engine state.
 	mu sync.RWMutex
 
+	// advanceMu serializes log ingestion and analysis advance against each
+	// other. Pre-redesign these ran on a single run-loop goroutine; the
+	// scheduler-ticker now runs advanceWithReason on its own goroutine, so
+	// it can race with IngestLog (called from the run loop) for shared
+	// mutable state — extractor pattern maps, detector adapter caches,
+	// correlator state — that is not internally thread-safe. Take this
+	// mutex around the full IngestLog body and the full advanceWithReason
+	// body. The producer-side metric ingest path (IngestMetricSync) does
+	// NOT take this lock; it goes straight into sharded storage.
+	advanceMu sync.Mutex
+
 	storage          *timeSeriesStorage
 	extractors       []observerdef.LogMetricsExtractor
 	detectors        []observerdef.Detector
@@ -311,7 +322,14 @@ func (e *engine) drainLatePointsBySource() map[string]int64 {
 // IngestLog processes a log observation: runs extractors to produce virtual metrics,
 // notifies log observers, and consults the scheduler policy to determine whether
 // detectors should advance. Returns advance requests that the caller should execute.
+//
+// Holds advanceMu for its full body so concurrent ticker-driven advances cannot
+// race with extractor.ProcessLog or logObserver.ProcessLog — both mutate
+// state that is also read by enrichAnomaly via context providers and by
+// detector Detect() calls.
 func (e *engine) IngestLog(source string, l *logObs) ([]advanceRequest, []observerdef.ObserverTelemetry) {
+	e.advanceMu.Lock()
+	defer e.advanceMu.Unlock()
 	sourceTag := "observer_source:" + source
 	view := &logView{obs: l}
 	var logTelemetry = []observerdef.ObserverTelemetry{}
@@ -432,7 +450,15 @@ func (e *engine) Advance(upToSec int64) advanceResult {
 
 // advanceWithReason runs detectors and correlators up to the given event time,
 // recording the reason for the advance in the emitted event.
+//
+// Holds advanceMu for the full body so concurrent log ingestion cannot race
+// with detector/correlator state. emit() callbacks run inside this lock; they
+// must not take advanceMu reentrantly. They may take e.mu.RLock via
+// stateView methods — that's fine because we release e.mu before emit/detect.
 func (e *engine) advanceWithReason(upToSec int64, reason advanceReason) advanceResult {
+	e.advanceMu.Lock()
+	defer e.advanceMu.Unlock()
+
 	// Snapshot mutable fields under the lock. We cannot hold mu during
 	// runDetectorsAndCorrelators because emit() callbacks may re-enter
 	// stateView methods that take mu.RLock, causing a deadlock.

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -448,6 +448,8 @@ func (e *engine) advanceWithReason(upToSec int64, reason advanceReason) advanceR
 
 	if e.onAdvance != nil {
 		lateBySource := e.drainLatePointsBySource()
+		// h.dropCount counts only log/profile observations dropped on
+		// channel-full; metric ingest is synchronous and does not drop.
 		var totalDrops int64
 		var dropsBySource map[string]int64
 		e.handlesMu.Lock()
@@ -604,7 +606,12 @@ func (e *engine) enrichAnomaly(a *observerdef.Anomaly) {
 	if !ok {
 		return
 	}
+	// contextProviders is replaced wholesale by SetExtractors (testbench
+	// component toggling) under e.mu — RLock here so the read does not
+	// race with that swap.
+	e.mu.RLock()
 	provider, ok := e.contextProviders[ref.namespace]
+	e.mu.RUnlock()
 	if !ok {
 		return
 	}

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -38,13 +38,12 @@ type seriesContextRef struct {
 // The engine does not own reporters or scheduling policy. It accepts explicit
 // Advance calls and returns results that callers route to their own outputs.
 type engine struct {
-	// mu protects detectors, correlators, extractors, logObservers, and
-	// contextRefs from concurrent access. Writers (Advance, Reset,
-	// SetDetectors, SetCorrelators, SetExtractors) take a write lock; readers
-	// (stateView methods) take a read lock. lastAnalyzedDataTime and
-	// latestDataTime are stored as atomics so producers calling
-	// IngestMetricSync from arbitrary goroutines do not need to synchronize on
-	// engine state.
+	// mu protects detectors, correlators, extractors, and logObservers from
+	// concurrent access. Writers (Advance, Reset, SetDetectors,
+	// SetCorrelators, SetExtractors) take a write lock; readers (stateView
+	// methods) take a read lock. lastAnalyzedDataTime and latestDataTime are
+	// stored as atomics so producers calling IngestMetricSync from arbitrary
+	// goroutines do not need to synchronize on engine state.
 	mu sync.RWMutex
 
 	storage          *timeSeriesStorage
@@ -52,7 +51,14 @@ type engine struct {
 	detectors        []observerdef.Detector
 	correlators      []observerdef.Correlator
 	contextProviders map[string]observerdef.ContextProvider // namespace → provider
-	contextRefs      map[string]seriesContextRef
+
+	// contextRefs maps a stored series key to its originating extractor's
+	// context. Written by IngestLog (run-loop goroutine) and read by
+	// enrichAnomaly (scheduler-ticker goroutine via advance). Protected by
+	// its own mutex so reads don't contend with detector/correlator config
+	// changes on engine.mu.
+	contextRefs   map[string]seriesContextRef
+	contextRefsMu sync.RWMutex
 
 	// scheduler decides when the engine should advance analysis.
 	scheduler schedulerPolicy
@@ -323,10 +329,12 @@ func (e *engine) IngestLog(source string, l *logObs) ([]advanceRequest, []observ
 			e.storage.Add(extractor.Name(), m.Name, m.Value, l.timestampMs/1000, tags)
 			if m.ContextKey != "" {
 				sk := seriesKey(extractor.Name(), m.Name, tags)
+				e.contextRefsMu.Lock()
 				e.contextRefs[sk] = seriesContextRef{
 					namespace:  extractor.Name(),
 					contextKey: m.ContextKey,
 				}
+				e.contextRefsMu.Unlock()
 			}
 		}
 		if len(out.Telemetry) > 0 {
@@ -375,6 +383,8 @@ func (e *engine) removeContextRefsForEvictedKeys(namespace string, evictedKeys [
 	if len(want) == 0 {
 		return
 	}
+	e.contextRefsMu.Lock()
+	defer e.contextRefsMu.Unlock()
 	for seriesID, ref := range e.contextRefs {
 		if ref.namespace != namespace {
 			continue
@@ -588,7 +598,9 @@ func (e *engine) enrichAnomaly(a *observerdef.Anomaly) {
 	}
 	fullKey := seriesKey(a.Source.Namespace, a.Source.Name, a.Source.Tags)
 
+	e.contextRefsMu.RLock()
 	ref, ok := e.contextRefs[fullKey]
+	e.contextRefsMu.RUnlock()
 	if !ok {
 		return
 	}
@@ -801,7 +813,9 @@ func (e *engine) SetExtractors(extractors []observerdef.LogMetricsExtractor) {
 	validateUniqueExtractorNames(extractors)
 	e.extractors = extractors
 	e.contextProviders = collectContextProviders(extractors)
+	e.contextRefsMu.Lock()
 	e.contextRefs = make(map[string]seriesContextRef)
+	e.contextRefsMu.Unlock()
 }
 
 // Reset clears analysis state so detectors will re-analyze from scratch.
@@ -829,7 +843,9 @@ func (e *engine) Reset() {
 		}
 	}
 
+	e.contextRefsMu.Lock()
 	e.contextRefs = make(map[string]seriesContextRef)
+	e.contextRefsMu.Unlock()
 }
 
 // resetRawAnomalies clears the raw anomaly tracking state.

--- a/comp/observer/impl/engine_concurrent_test.go
+++ b/comp/observer/impl/engine_concurrent_test.go
@@ -19,7 +19,8 @@ import (
 
 // stubContextExtractor is a minimal LogMetricsExtractor that emits one
 // metric per ProcessLog with a stable ContextKey so the engine populates
-// contextRefs.
+// contextRefs. It also implements ContextProvider so the engine has a
+// non-nil entry in contextProviders for enrichAnomaly to look up.
 type stubContextExtractor struct {
 	name string
 }
@@ -37,6 +38,30 @@ func (e *stubContextExtractor) ProcessLog(_ observerdef.LogView) observerdef.Log
 		},
 	}
 }
+func (e *stubContextExtractor) GetContextByKey(_ string) (observerdef.MetricContext, bool) {
+	return observerdef.MetricContext{Pattern: "stub-pattern"}, true
+}
+
+// stubAnomalyDetector emits one anomaly per Detect() with a Source that
+// matches the contextRef key the stub extractor writes. This drives
+// enrichAnomaly, which reads contextRefs and contextProviders.
+type stubAnomalyDetector struct{ extractorName string }
+
+func (d *stubAnomalyDetector) Name() string { return "stub_detector" }
+func (d *stubAnomalyDetector) Detect(_ observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
+	return observerdef.DetectionResult{
+		Anomalies: []observerdef.Anomaly{{
+			Type:         observerdef.AnomalyTypeMetric,
+			DetectorName: d.Name(),
+			Source: observerdef.SeriesDescriptor{
+				Namespace: d.extractorName,
+				Name:      "stub.count",
+				Tags:      []string{"k:v", "observer_source:source-a"},
+			},
+			Timestamp: dataTime,
+		}},
+	}
+}
 
 // TestEngine_ConcurrentLogIngestAndAdvance interleaves IngestLog (which
 // writes contextRefs) with advanceWithReason (which reads contextRefs
@@ -46,9 +71,14 @@ func (e *stubContextExtractor) ProcessLog(_ observerdef.LogView) observerdef.Log
 func TestEngine_ConcurrentLogIngestAndAdvance(t *testing.T) {
 	storage := newTimeSeriesStorage()
 	extractor := &stubContextExtractor{name: "stub_ext"}
+	detector := &stubAnomalyDetector{extractorName: extractor.Name()}
 	eng := newEngine(engineConfig{
 		storage:    storage,
 		extractors: []observerdef.LogMetricsExtractor{extractor},
+		detectors:  []observerdef.Detector{detector},
+		contextProviders: map[string]observerdef.ContextProvider{
+			extractor.Name(): extractor,
+		},
 	})
 
 	const ingestIters = 500

--- a/comp/observer/impl/engine_concurrent_test.go
+++ b/comp/observer/impl/engine_concurrent_test.go
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// stubContextExtractor is a minimal LogMetricsExtractor that emits one
+// metric per ProcessLog with a stable ContextKey so the engine populates
+// contextRefs.
+type stubContextExtractor struct {
+	name string
+}
+
+func (e *stubContextExtractor) Name() string { return e.name }
+func (e *stubContextExtractor) ProcessLog(_ observerdef.LogView) observerdef.LogMetricsExtractorOutput {
+	return observerdef.LogMetricsExtractorOutput{
+		Metrics: []observerdef.MetricOutput{
+			{
+				Name:       "stub.count",
+				Value:      1,
+				Tags:       []string{"k:v"},
+				ContextKey: "ctx:" + e.name,
+			},
+		},
+	}
+}
+
+// TestEngine_ConcurrentLogIngestAndAdvance interleaves IngestLog (which
+// writes contextRefs) with advanceWithReason (which reads contextRefs
+// and contextProviders via enrichAnomaly). The two paths now run on
+// different goroutines (run-loop vs scheduler ticker) in production, so
+// race-detector coverage of the interleaving is the safety bar.
+func TestEngine_ConcurrentLogIngestAndAdvance(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	extractor := &stubContextExtractor{name: "stub_ext"}
+	eng := newEngine(engineConfig{
+		storage:    storage,
+		extractors: []observerdef.LogMetricsExtractor{extractor},
+	})
+
+	const ingestIters = 500
+	const advanceIters = 500
+
+	var stop atomic.Bool
+	var workers, reader sync.WaitGroup
+
+	workers.Add(2)
+	go func() {
+		defer workers.Done()
+		for i := 0; i < ingestIters; i++ {
+			_, _ = eng.IngestLog("source-a", &logObs{
+				content:     []byte("test"),
+				timestampMs: int64((i + 1) * 1000),
+			})
+		}
+	}()
+
+	go func() {
+		defer workers.Done()
+		for i := 0; i < advanceIters; i++ {
+			_ = eng.advanceWithReason(int64(i+1), advanceReasonManual)
+		}
+	}()
+
+	// Reader simulating testbench/state-view callers reading
+	// LatestDataTime and LastAnalyzedTime concurrently.
+	reader.Add(1)
+	go func() {
+		defer reader.Done()
+		for !stop.Load() {
+			_ = eng.latestDataTime.Load()
+			_ = eng.lastAnalyzedDataTime.Load()
+		}
+	}()
+
+	workers.Wait()
+	stop.Store(true)
+	reader.Wait()
+
+	// Sanity: storage saw the extractor's virtual metrics.
+	got := storage.TotalSeriesCount("")
+	require.GreaterOrEqual(t, got, 1, "extractor should have written at least one series")
+}
+
+// TestStorage_SeriesGenerationUnderConcurrency verifies that the
+// SeriesGeneration counter increments exactly once per new series even
+// when N writers race to create distinct series.
+func TestStorage_SeriesGenerationUnderConcurrency(t *testing.T) {
+	const writers = 16
+	const seriesPerWriter = 200
+
+	storage := newTimeSeriesStorage()
+	startGen := storage.SeriesGeneration()
+
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		go func(writerID int) {
+			defer wg.Done()
+			for s := 0; s < seriesPerWriter; s++ {
+				name := fmt.Sprintf("metric.w%d.s%d", writerID, s)
+				storage.Add("ns", name, 1.0, 1, nil)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	expected := uint64(writers * seriesPerWriter)
+	delta := storage.SeriesGeneration() - startGen
+	assert.Equal(t, expected, delta, "expected one SeriesGeneration tick per new series")
+	assert.Equal(t, int(expected), storage.TotalSeriesCount(""))
+}

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -75,10 +75,12 @@ type Provides struct {
 	Comp observerdef.Component
 }
 
-// observation is a message sent from handles to the observer.
+// observation is a message sent from log/profile handles to the observer's
+// run loop. Metric handles bypass this channel entirely and call the engine
+// synchronously; only logs and profiles still need the buffered hand-off so
+// extractor work runs off the producer's goroutine.
 type observation struct {
 	source  string
-	metric  *metricObs
 	log     *logObs
 	profile *profileObs
 }
@@ -242,6 +244,7 @@ func NewComponent(deps Requires) Provides {
 		hfContainerEnabled:   hfContainerEnabled,
 		hfFilterSources:      hfFilterSources,
 		ingestMetricsEnabled: cfg.GetBool("observer.ingest_metrics.enabled"),
+		schedulerStop:        make(chan struct{}),
 	}
 
 	if !obs.ingestMetricsEnabled {
@@ -303,6 +306,15 @@ func NewComponent(deps Requires) Provides {
 	}
 
 	go obs.run()
+	go obs.runScheduler(obs.schedulerStop)
+	if deps.Lifecycle != nil {
+		deps.Lifecycle.Append(compdef.Hook{
+			OnStop: func(_ context.Context) error {
+				close(obs.schedulerStop)
+				return nil
+			},
+		})
+	}
 
 	// Start high-frequency system check runner if enabled.
 	// Checks run at 1s and route metrics into the observer via a dedicated
@@ -522,15 +534,23 @@ type observerImpl struct {
 	// and log-derived virtual metrics produced inside the engine by
 	// LogMetricsExtractors are unaffected because they bypass the handle.
 	ingestMetricsEnabled bool
+
+	// schedulerStop signals the scheduler ticker goroutine to exit. Closed
+	// from the lifecycle OnStop hook.
+	schedulerStop chan struct{}
 }
 
-// run is the main dispatch loop, processing all observations sequentially.
+// run is the dispatch loop for log and profile observations. Metric
+// observations bypass this channel and write directly into storage from the
+// producer goroutine; advance scheduling for the metric path is driven by
+// runScheduler on a separate goroutine.
+//
+// Logs still trigger advance synchronously here because log ingestion is
+// rare relative to metrics and the per-call scheduler check costs nothing
+// compared to extractor work.
 func (o *observerImpl) run() {
 	for obs := range o.obsCh {
 		var requests []advanceRequest
-		if obs.metric != nil {
-			requests = o.engine.IngestMetric(obs.source, obs.metric)
-		}
 		if obs.log != nil {
 			logRequests, logTelemetry := o.engine.IngestLog(obs.source, obs.log)
 			requests = append(requests, logRequests...)
@@ -544,6 +564,38 @@ func (o *observerImpl) run() {
 		for _, req := range requests {
 			result := o.engine.advanceWithReason(req.upToSec, req.reason)
 			o.telemetryHandler.handleTelemetry(result.telemetry)
+		}
+	}
+}
+
+// schedulerTickInterval is how often the scheduler ticker checks whether an
+// advance is due. Short enough to keep advance latency comparable to
+// per-sample scheduling under typical 1s-bucket ingest, long enough not to
+// burn CPU spinning on the scheduler when no data is arriving.
+const schedulerTickInterval = 100 * time.Millisecond
+
+// runScheduler drives the analysis scheduler off the metric ingest path. It
+// ticks at a small interval, asks the scheduler whether the latest data time
+// warrants an advance, and runs the detectors if so. This replaces the
+// per-sample scheduler.onObservation call that used to happen inside the
+// run loop.
+func (o *observerImpl) runScheduler(stop <-chan struct{}) {
+	t := time.NewTicker(schedulerTickInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-t.C:
+			latest := o.engine.latestDataTime.Load()
+			if latest == 0 {
+				continue
+			}
+			requests := o.engine.scheduler.onObservation(latest, o.engine.schedulerState())
+			for _, req := range requests {
+				result := o.engine.advanceWithReason(req.upToSec, req.reason)
+				o.telemetryHandler.handleTelemetry(result.telemetry)
+			}
 		}
 	}
 }
@@ -693,7 +745,7 @@ func (o *observerImpl) GetHandle(name string) observerdef.Handle {
 // wrapped with metricDropHandle so external metrics are dropped at the edge,
 // while ObserveLog/ObserveProfile pass through.
 func (o *observerImpl) innerHandle(name string) observerdef.Handle {
-	h := &handle{ch: o.obsCh, source: name, dropCounter: o.dropCounter}
+	h := &handle{engine: o.engine, ch: o.obsCh, source: name, dropCounter: o.dropCounter}
 	o.engine.registerHandle(h)
 	var out observerdef.Handle = h
 	if len(o.hfFilterSources) > 0 && name == "all-metrics" {
@@ -817,11 +869,14 @@ func (o *observerImpl) DumpMetrics(path string) error {
 }
 
 // handle is the lightweight observation interface passed to other components.
-// It only holds a channel and source name - all processing happens in the observer.
+// Metric writes call into the engine synchronously (no channel, no copy).
+// Logs and profiles still go through the buffered observation channel because
+// extractor work on logs is too slow to run on producer threads.
 type handle struct {
+	engine      *engine
 	ch          chan<- observation
 	source      string
-	dropCount   atomic.Int64      // per-handle drop counter, collected by engine at advance time
+	dropCount   atomic.Int64      // log/profile drops on channel-full; metric path is sync and never drops
 	dropCounter telemetry.Counter // tagged by source for Prometheus visibility; may be nil
 }
 
@@ -830,8 +885,10 @@ func (h *handle) ObserveMetric(sample observerdef.MetricView) {
 	_ = h.ObserveMetricAndReportDrop(sample)
 }
 
-// ObserveMetricAndReportDrop observes a metric and reports whether this
-// specific call was dropped by the observer channel.
+// ObserveMetricAndReportDrop observes a metric synchronously. The metric
+// path is lock-stepped with storage so it never drops on backpressure; the
+// boolean return is retained for compatibility with the recordingHandle
+// (parquet recorder) interface and always reports false.
 func (h *handle) ObserveMetricAndReportDrop(sample observerdef.MetricView) bool {
 	timestamp := sample.GetTimestampUnix()
 	if timestamp == 0 {
@@ -845,27 +902,12 @@ func (h *handle) ObserveMetricAndReportDrop(sample observerdef.MetricView) bool 
 		return false
 	}
 
-	obs := observation{
-		source: h.source,
-		metric: &metricObs{
-			name:      name,
-			value:     sample.GetValue(),
-			tags:      copyTags(sample.GetRawTags()),
-			timestamp: timestamp,
-		},
-	}
-
-	// Non-blocking send - drop if channel is full.
-	select {
-	case h.ch <- obs:
-		return false
-	default:
-		h.dropCount.Add(1)
-		if h.dropCounter != nil {
-			h.dropCounter.Add(1, h.source)
-		}
-		return true
-	}
+	// Borrowed reference: storage.Add hashes name+tags and updates the bucket
+	// synchronously. On cold path (first occurrence of a series) storage
+	// canonicalizes its own copy of tags and aliases the name string. The
+	// caller may reuse name/tags slice memory immediately after this returns.
+	h.engine.IngestMetricSync(h.source, name, sample.GetValue(), timestamp, sample.GetRawTags())
+	return false
 }
 
 // ObserveLog observes a log message.

--- a/comp/observer/impl/stateview.go
+++ b/comp/observer/impl/stateview.go
@@ -195,14 +195,10 @@ func (sv *stateView) Telemetry() []observerdef.ObserverTelemetry {
 
 // LastAnalyzedTime returns the data timestamp up to which detection has run.
 func (sv *stateView) LastAnalyzedTime() int64 {
-	sv.engine.mu.RLock()
-	defer sv.engine.mu.RUnlock()
-	return sv.engine.lastAnalyzedDataTime
+	return sv.engine.lastAnalyzedDataTime.Load()
 }
 
 // LatestDataTime returns the latest data timestamp seen across all ingested observations.
 func (sv *stateView) LatestDataTime() int64 {
-	sv.engine.mu.RLock()
-	defer sv.engine.mu.RUnlock()
-	return sv.engine.latestDataTime
+	return sv.engine.latestDataTime.Load()
 }

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -15,49 +15,79 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
-// timeSeriesStorage is an internal storage for time series data.
-type timeSeriesStorage struct {
+// numStorageShards is the number of independently-locked shards the storage
+// is partitioned into. A series identity hashes to exactly one shard, so two
+// writes to different series can proceed in parallel as long as they map to
+// different shards. 16 keeps the per-shard mutex cache footprint small while
+// giving DogStatsD's worker goroutines enough room to write concurrently.
+const numStorageShards = 16
+
+// storageShard owns one slice of the (namespace, name, tags) keyspace. The
+// shard mutex protects both the series map and the column data of every
+// seriesStats it owns. Cross-shard reads are coordinated by RLock-ing each
+// shard independently — the result is per-shard consistent but not
+// strictly cross-shard atomic, which is acceptable for analyzer scans.
+type storageShard struct {
 	mu     sync.RWMutex
 	series map[string]*seriesStats
+}
 
-	// observationTimestamps tracks all timestamps where observations occurred,
-	// even if no metric series was written for that timestamp.
+// timeSeriesStorage is the engine's metric store. Writes shard by series
+// identity; reads either dispatch to the owning shard (by ref or by key) or
+// scan all shards (for cross-shard listings).
+type timeSeriesStorage struct {
+	shards [numStorageShards]storageShard
+
+	// stateMu protects rarely-contended global state: observation
+	// timestamps that are not tied to a specific series, and per-metric
+	// drop accounting.
+	stateMu               sync.Mutex
 	observationTimestamps map[int64]struct{}
+	droppedNonFinite      int64
+	droppedExtreme        int64
+	droppedByMetric       map[string]int64
+	sampledDrops          map[string]int
 
-	// Compact numeric IDs for O(1) lookups and API responses.
-	seriesIDs     map[string]observer.SeriesRef // internal key → numeric ref
-	seriesIDKeys  []string                      // numeric ID → internal key (index = ID)
-	seriesIDStats []*seriesStats                // numeric ID → *seriesStats (index = ID)
+	// idMu protects the global compact-ID tables. Held only on the cold
+	// path (first occurrence of a series) and on lookup-by-string-key
+	// (CompactSeriesID).
+	idMu          sync.Mutex
+	seriesIDs     map[string]observer.SeriesRef // string key → numeric ref
+	seriesIDKeys  []string                      // numeric ID → string key
+	seriesIDStats []*seriesStats                // numeric ID → *seriesStats
 
-	// Global generation for the series catalog; increments only when a new
-	// series key is created, not on every write to an existing series.
-	seriesGen uint64
-
-	// Drop accounting for invalid/unsafe input values.
-	droppedNonFinite int64
-	droppedExtreme   int64
-	droppedByMetric  map[string]int64
-	sampledDrops     map[string]int
+	// seriesGen increments once per new series. Atomic so SeriesGeneration
+	// can read without taking a lock.
+	seriesGen atomic.Uint64
 }
 
 // seriesStats contains accumulated statistics for a time series (internal).
 // Data is stored in columnar layout: parallel arrays indexed by point position.
-// Timestamps are stored in sorted order, enabling binary search for range queries.
+// Timestamps are stored in sorted order, enabling binary search for range
+// queries.
+//
+// Lifetime: a seriesStats lives in exactly one shard for its entire
+// existence. Namespace, Name, Tags, internalKey, and shardIdx are
+// effectively immutable after the constructor returns. Column arrays and
+// writeGeneration are mutated under the owning shard's write lock.
 type seriesStats struct {
 	Namespace   string
 	Name        string
 	Tags        []string
 	internalKey string // cached map key to avoid recomputation
+	shardIdx    uint8  // index into timeSeriesStorage.shards
 
 	// writeGeneration is per-series and increments on every Add, including
 	// same-bucket merges into an existing point.
 	writeGeneration int64
 
-	// Columnar storage — all slices have the same length, indexed by point position.
+	// Columnar storage — all slices have the same length, indexed by point
+	// position.
 	timestamps []int64
 	sums       []float64
 	counts     []int64
@@ -65,13 +95,10 @@ type seriesStats struct {
 	maxes      []float64
 }
 
-// pointCount returns the number of stored points.
 func (s *seriesStats) pointCount() int {
 	return len(s.timestamps)
 }
 
-// sampleCount returns the total number of samples for a series.
-// A point can contain multiple samples if it is aggregated.
 func (s *seriesStats) sampleCount() int64 {
 	count := int64(0)
 	for _, c := range s.counts {
@@ -83,7 +110,6 @@ func (s *seriesStats) sampleCount() int64 {
 // Aggregate is an alias to the definition in the observer component for internal use.
 type Aggregate = observer.Aggregate
 
-// Re-export aggregate constants for internal use.
 const (
 	AggregateAverage = observer.AggregateAverage
 	AggregateSum     = observer.AggregateSum
@@ -92,8 +118,6 @@ const (
 	AggregateMax     = observer.AggregateMax
 )
 
-// aggregateColumn returns the pre-materialized column values for a given aggregate.
-// For Average, it computes sum/count on the fly. For others, it returns the column directly.
 func (s *seriesStats) aggregateColumn(agg Aggregate) []float64 {
 	switch agg {
 	case AggregateSum:
@@ -123,7 +147,6 @@ func (s *seriesStats) aggregateColumn(agg Aggregate) []float64 {
 	}
 }
 
-// aggregateAt extracts the specified statistic at index i.
 func (s *seriesStats) aggregateAt(i int, agg Aggregate) float64 {
 	switch agg {
 	case AggregateAverage:
@@ -144,7 +167,6 @@ func (s *seriesStats) aggregateAt(i int, agg Aggregate) float64 {
 	}
 }
 
-// toSeries converts internal stats to the simplified Series for analyses.
 func (s *seriesStats) toSeries(agg Aggregate) observer.Series {
 	n := s.pointCount()
 	points := make([]observer.Point, n)
@@ -172,13 +194,22 @@ func searchAfter(timestamps []int64, value int64) int {
 
 // newTimeSeriesStorage creates a new time series storage.
 func newTimeSeriesStorage() *timeSeriesStorage {
-	return &timeSeriesStorage{
-		series:                make(map[string]*seriesStats),
+	s := &timeSeriesStorage{
 		observationTimestamps: make(map[int64]struct{}),
 		seriesIDs:             make(map[string]observer.SeriesRef),
 		droppedByMetric:       make(map[string]int64),
 		sampledDrops:          make(map[string]int),
 	}
+	for i := range s.shards {
+		s.shards[i].series = make(map[string]*seriesStats)
+	}
+	return s
+}
+
+// shardFor returns the shard that owns the given series identity.
+func (s *timeSeriesStorage) shardFor(namespace, name string, tags []string) *storageShard {
+	h := hashSeriesIdentity(namespace, name, tags)
+	return &s.shards[h%numStorageShards]
 }
 
 // Add records a data point for a named metric in a namespace.
@@ -187,9 +218,6 @@ func newTimeSeriesStorage() *timeSeriesStorage {
 // correct even when data arrives out of order.
 // Returns true if this point created a new series (cardinality +1), false otherwise.
 func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp int64, tags []string) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if math.IsInf(value, 0) || math.IsNaN(value) {
 		s.recordDroppedValue("non_finite", namespace, name, value, timestamp, tags)
 		return false
@@ -200,23 +228,27 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		s.recordDroppedValue("extreme", namespace, name, value, timestamp, tags)
 		return false
 	}
+
+	h := hashSeriesIdentity(namespace, name, tags)
+	shardIdx := uint8(h % numStorageShards)
+	shard := &s.shards[shardIdx]
 	key := seriesKey(namespace, name, tags)
 
-	stats, exists := s.series[key]
+	shard.mu.Lock()
+	defer shard.mu.Unlock()
+
+	stats, exists := shard.series[key]
 	if !exists {
 		stats = &seriesStats{
 			Namespace:   namespace,
 			Name:        name,
 			Tags:        canonicalizeTags(tags),
 			internalKey: key,
+			shardIdx:    shardIdx,
 		}
-		s.series[key] = stats
-		// Assign a compact numeric ID.
-		id := observer.SeriesRef(len(s.seriesIDKeys))
-		s.seriesIDs[key] = id
-		s.seriesIDKeys = append(s.seriesIDKeys, key)
-		s.seriesIDStats = append(s.seriesIDStats, stats)
-		s.seriesGen++
+		shard.series[key] = stats
+		s.assignID(key, stats)
+		s.seriesGen.Add(1)
 	}
 	isNew := !exists
 	stats.writeGeneration++
@@ -224,13 +256,11 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 	// Bucket by second.
 	bucket := timestamp
 
-	// Binary search for the bucket in the sorted timestamps array.
 	idx := sort.Search(len(stats.timestamps), func(i int) bool {
 		return stats.timestamps[i] >= bucket
 	})
 
 	if idx < len(stats.timestamps) && stats.timestamps[idx] == bucket {
-		// Update existing bucket in-place.
 		stats.sums[idx] += value
 		stats.counts[idx]++
 		if value < stats.mins[idx] {
@@ -250,7 +280,19 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 	return isNew
 }
 
-// insertInt64 inserts v at position idx in s, maintaining order.
+// assignID registers a new series with the global compact-ID tables. Caller
+// must already hold the owning shard's write lock; idMu is taken briefly
+// here. Series creation is rare enough that this serialization is invisible
+// in practice.
+func (s *timeSeriesStorage) assignID(key string, stats *seriesStats) {
+	s.idMu.Lock()
+	defer s.idMu.Unlock()
+	id := observer.SeriesRef(len(s.seriesIDKeys))
+	s.seriesIDs[key] = id
+	s.seriesIDKeys = append(s.seriesIDKeys, key)
+	s.seriesIDStats = append(s.seriesIDStats, stats)
+}
+
 func insertInt64(s []int64, idx int, v int64) []int64 {
 	s = append(s, 0)
 	copy(s[idx+1:], s[idx:])
@@ -258,7 +300,6 @@ func insertInt64(s []int64, idx int, v int64) []int64 {
 	return s
 }
 
-// insertFloat64 inserts v at position idx in s, maintaining order.
 func insertFloat64(s []float64, idx int, v float64) []float64 {
 	s = append(s, 0)
 	copy(s[idx+1:], s[idx:])
@@ -267,6 +308,8 @@ func insertFloat64(s []float64, idx int, v float64) []float64 {
 }
 
 func (s *timeSeriesStorage) recordDroppedValue(reason, namespace, name string, value float64, timestamp int64, tags []string) {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
 	switch reason {
 	case "non_finite":
 		s.droppedNonFinite++
@@ -285,8 +328,8 @@ func (s *timeSeriesStorage) recordDroppedValue(reason, namespace, name string, v
 }
 
 func (s *timeSeriesStorage) DroppedValueStats() (nonFinite int64, extreme int64, byMetric map[string]int64) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
 
 	byMetric = make(map[string]int64, len(s.droppedByMetric))
 	for k, v := range s.droppedByMetric {
@@ -298,27 +341,35 @@ func (s *timeSeriesStorage) DroppedValueStats() (nonFinite int64, extreme int64,
 // GetSeries returns the series using the specified aggregation.
 // If tags is nil, finds the first series matching namespace and name (ignoring tags).
 func (s *timeSeriesStorage) GetSeries(namespace, name string, tags []string, agg Aggregate) *observer.Series {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	if tags != nil {
-		// Exact match with tags
+		shard := s.shardFor(namespace, name, tags)
 		key := seriesKey(namespace, name, tags)
-		stats := s.series[key]
+		shard.mu.RLock()
+		stats := shard.series[key]
 		if stats == nil {
+			shard.mu.RUnlock()
 			return nil
 		}
 		series := stats.toSeries(agg)
+		shard.mu.RUnlock()
 		return &series
 	}
 
-	// tags is nil: find first matching series by namespace and name
+	// tags is nil: find first matching series by namespace and name across
+	// all shards. The set of (namespace, name, *) hashes to many shards
+	// because tags participate in the hash, so we have to scan.
 	prefix := namespace + "|" + name + "|"
-	for key, stats := range s.series {
-		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
-			series := stats.toSeries(agg)
-			return &series
+	for i := range s.shards {
+		shard := &s.shards[i]
+		shard.mu.RLock()
+		for key, stats := range shard.series {
+			if strings.HasPrefix(key, prefix) {
+				series := stats.toSeries(agg)
+				shard.mu.RUnlock()
+				return &series
+			}
 		}
+		shard.mu.RUnlock()
 	}
 	return nil
 }
@@ -326,24 +377,23 @@ func (s *timeSeriesStorage) GetSeries(namespace, name string, tags []string, agg
 // GetSeriesSince returns points with timestamp > since (for delta updates).
 // If since is 0, returns all points.
 func (s *timeSeriesStorage) GetSeriesSince(namespace, name string, tags []string, agg Aggregate, since int64) *observer.Series {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
+	shard := s.shardFor(namespace, name, tags)
 	key := seriesKey(namespace, name, tags)
-	stats := s.series[key]
+
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
+
+	stats := shard.series[key]
 	if stats == nil {
 		return nil
 	}
 
-	// If since is 0, return all points
 	if since == 0 {
 		series := stats.toSeries(agg)
 		return &series
 	}
 
-	// Binary search for the first timestamp > since.
 	startIdx := searchAfter(stats.timestamps, since)
-
 	n := stats.pointCount()
 	points := make([]observer.Point, 0, n-startIdx)
 	for i := startIdx; i < n; i++ {
@@ -363,12 +413,14 @@ func (s *timeSeriesStorage) GetSeriesSince(namespace, name string, tags []string
 
 // Namespaces returns the set of namespaces that have data.
 func (s *timeSeriesStorage) Namespaces() []string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	seen := make(map[string]struct{})
-	for _, stats := range s.series {
-		seen[stats.Namespace] = struct{}{}
+	for i := range s.shards {
+		shard := &s.shards[i]
+		shard.mu.RLock()
+		for _, stats := range shard.series {
+			seen[stats.Namespace] = struct{}{}
+		}
+		shard.mu.RUnlock()
 	}
 	result := make([]string, 0, len(seen))
 	for ns := range seen {
@@ -380,52 +432,54 @@ func (s *timeSeriesStorage) Namespaces() []string {
 
 // AllSeries returns all series in a namespace using the specified aggregation.
 func (s *timeSeriesStorage) AllSeries(namespace string, agg Aggregate) []observer.Series {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	var result []observer.Series
-	for _, stats := range s.series {
-		if stats.Namespace == namespace {
-			result = append(result, stats.toSeries(agg))
+	for i := range s.shards {
+		shard := &s.shards[i]
+		shard.mu.RLock()
+		for _, stats := range shard.series {
+			if stats.Namespace == namespace {
+				result = append(result, stats.toSeries(agg))
+			}
 		}
+		shard.mu.RUnlock()
 	}
 	return result
 }
 
 // TimeBounds returns the minimum and maximum timestamps across all stored points.
 func (s *timeSeriesStorage) TimeBounds() (minTs int64, maxTs int64, ok bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	var min int64
 	var max int64
 	found := false
 
-	for _, stats := range s.series {
-		n := stats.pointCount()
-		if n == 0 {
-			continue
-		}
-		// Timestamps are sorted, but some series may start with default/non-data
-		// zero timestamps. Ignore only the non-positive prefix, not the series.
-		firstIdx := searchAfter(stats.timestamps, 0)
-		if firstIdx >= n {
-			continue
-		}
-		first := stats.timestamps[firstIdx]
-		last := stats.timestamps[n-1]
-		if !found {
-			min = first
-			max = last
-			found = true
-		} else {
-			if first < min {
+	for i := range s.shards {
+		shard := &s.shards[i]
+		shard.mu.RLock()
+		for _, stats := range shard.series {
+			n := stats.pointCount()
+			if n == 0 {
+				continue
+			}
+			firstIdx := searchAfter(stats.timestamps, 0)
+			if firstIdx >= n {
+				continue
+			}
+			first := stats.timestamps[firstIdx]
+			last := stats.timestamps[n-1]
+			if !found {
 				min = first
-			}
-			if last > max {
 				max = last
+				found = true
+			} else {
+				if first < min {
+					min = first
+				}
+				if last > max {
+					max = last
+				}
 			}
 		}
+		shard.mu.RUnlock()
 	}
 
 	return min, max, found
@@ -433,16 +487,18 @@ func (s *timeSeriesStorage) TimeBounds() (minTs int64, maxTs int64, ok bool) {
 
 // MaxTimestamp returns the latest timestamp across all series in storage.
 func (s *timeSeriesStorage) MaxTimestamp() int64 {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	var max int64
-	for _, stats := range s.series {
-		if n := stats.pointCount(); n > 0 {
-			if t := stats.timestamps[n-1]; t > max {
-				max = t
+	for i := range s.shards {
+		shard := &s.shards[i]
+		shard.mu.RLock()
+		for _, stats := range shard.series {
+			if n := stats.pointCount(); n > 0 {
+				if t := stats.timestamps[n-1]; t > max {
+					max = t
+				}
 			}
 		}
+		shard.mu.RUnlock()
 	}
 	return max
 }
@@ -509,29 +565,109 @@ func joinTags(tags []string) string {
 	}
 }
 
-// resolveByID returns the seriesStats for a numeric series ID.
-// Returns nil for out-of-range IDs. Caller must hold s.mu (read or write).
+// FNV-1a 64-bit constants, inlined to avoid sync.Pool / hash.Hash allocation.
+const (
+	fnvOffset64 = 14695981039346656037
+	fnvPrime64  = 1099511628211
+)
+
+func fnvUpdateByte(h uint64, b byte) uint64 {
+	return (h ^ uint64(b)) * fnvPrime64
+}
+
+func fnvUpdateString(h uint64, s string) uint64 {
+	for i := 0; i < len(s); i++ {
+		h = (h ^ uint64(s[i])) * fnvPrime64
+	}
+	return h
+}
+
+// hashSeriesIdentity hashes (namespace, name, canonicalized tags) into a
+// 64-bit identity that matches across equivalent tag orderings. Allocates
+// nothing for the common case (≤16 tags), so it is cheap to call on every
+// storage write to dispatch to a shard.
+func hashSeriesIdentity(namespace, name string, tags []string) uint64 {
+	h := uint64(fnvOffset64)
+	h = fnvUpdateString(h, namespace)
+	h = fnvUpdateByte(h, '|')
+	h = fnvUpdateString(h, name)
+	h = fnvUpdateByte(h, '|')
+
+	n := len(tags)
+	switch n {
+	case 0:
+		return h
+	case 1:
+		return fnvUpdateString(h, tags[0])
+	}
+
+	if tagsSorted(tags) {
+		for i, t := range tags {
+			if i > 0 {
+				h = fnvUpdateByte(h, ',')
+			}
+			h = fnvUpdateString(h, t)
+		}
+		return h
+	}
+
+	// Sort an index buffer rather than the caller's slice; for typical tag
+	// counts the buffer is stack-allocated.
+	var idxBuf [16]int
+	var idx []int
+	if n <= len(idxBuf) {
+		idx = idxBuf[:n]
+	} else {
+		idx = make([]int, n)
+	}
+	for i := range idx {
+		idx[i] = i
+	}
+	for i := 1; i < n; i++ {
+		for j := i; j > 0 && tags[idx[j-1]] > tags[idx[j]]; j-- {
+			idx[j], idx[j-1] = idx[j-1], idx[j]
+		}
+	}
+	for i, k := range idx {
+		if i > 0 {
+			h = fnvUpdateByte(h, ',')
+		}
+		h = fnvUpdateString(h, tags[k])
+	}
+	return h
+}
+
+// resolveByID returns the seriesStats for a numeric series ID without
+// taking any lock. The seriesIDStats slice is append-only after a series is
+// created; the *seriesStats pointer is stable for the storage's lifetime.
+// Callers that read the stats' column data must RLock the owning shard.
 func (s *timeSeriesStorage) resolveByID(ref observer.SeriesRef) *seriesStats {
+	s.idMu.Lock()
+	defer s.idMu.Unlock()
 	if ref < 0 || int(ref) >= len(s.seriesIDStats) {
 		return nil
 	}
 	return s.seriesIDStats[ref]
 }
 
+// shardOf returns the shard that owns the given seriesStats.
+func (s *timeSeriesStorage) shardOf(stats *seriesStats) *storageShard {
+	return &s.shards[stats.shardIdx]
+}
+
 // GetSeriesMeta returns the metadata for a series by its numeric ref.
 // Returns nil if the ref is out of range.
 func (s *timeSeriesStorage) GetSeriesMeta(ref observer.SeriesRef) *observer.SeriesMeta {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	ss := s.resolveByID(ref)
-	if ss == nil {
+	stats := s.resolveByID(ref)
+	if stats == nil {
 		return nil
 	}
+	// Namespace, Name, Tags are immutable post-construction; no lock needed.
 	return &observer.SeriesMeta{
 		Ref:       ref,
-		Namespace: ss.Namespace,
-		Name:      ss.Name,
-		Tags:      ss.Tags,
+		Namespace: stats.Namespace,
+		Name:      stats.Name,
+		Tags:      stats.Tags,
 	}
 }
 
@@ -548,21 +684,41 @@ type seriesMeta struct {
 // ListSeriesMetadata returns lightweight metadata for all series in a namespace.
 // Unlike AllSeries, this does not materialize point data — it only reads point counts.
 func (s *timeSeriesStorage) ListSeriesMetadata(namespace string) []seriesMeta {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	type entry struct {
+		key   string
+		stats *seriesStats
+		count int
+	}
+	var entries []entry
+	for i := range s.shards {
+		shard := &s.shards[i]
+		shard.mu.RLock()
+		for key, stats := range shard.series {
+			if stats.Namespace == namespace {
+				entries = append(entries, entry{key: key, stats: stats, count: stats.pointCount()})
+			}
+		}
+		shard.mu.RUnlock()
+	}
 
-	var result []seriesMeta
-	for key, stats := range s.series {
-		if stats.Namespace == namespace {
-			result = append(result, seriesMeta{
-				Ref:        s.seriesIDs[key],
-				Namespace:  stats.Namespace,
-				Name:       stats.Name,
-				Tags:       copyTags(stats.Tags),
-				PointCount: stats.pointCount(),
-			})
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// Resolve refs from the global ID table.
+	s.idMu.Lock()
+	result := make([]seriesMeta, len(entries))
+	for i, e := range entries {
+		result[i] = seriesMeta{
+			Ref:        s.seriesIDs[e.key],
+			Namespace:  e.stats.Namespace,
+			Name:       e.stats.Name,
+			Tags:       copyTags(e.stats.Tags),
+			PointCount: e.count,
 		}
 	}
+	s.idMu.Unlock()
+
 	sort.Slice(result, func(i, j int) bool {
 		if result[i].Ref != result[j].Ref {
 			return result[i].Ref < result[j].Ref
@@ -578,42 +734,37 @@ func (s *timeSeriesStorage) ListSeriesMetadata(namespace string) []seriesMeta {
 // GetSeriesByNumericID looks up a series by its compact numeric ID and returns
 // the data using the specified aggregation.
 func (s *timeSeriesStorage) GetSeriesByNumericID(ref observer.SeriesRef, agg Aggregate) *observer.Series {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	if ref < 0 || int(ref) >= len(s.seriesIDKeys) {
-		return nil
-	}
-	key := s.seriesIDKeys[ref]
-	stats := s.series[key]
+	stats := s.resolveByID(ref)
 	if stats == nil {
 		return nil
 	}
+	shard := s.shardOf(stats)
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
 	series := stats.toSeries(agg)
 	return &series
 }
 
 // ListAllSeriesCompact returns lightweight metadata for every stored series.
 func (s *timeSeriesStorage) ListAllSeriesCompact() []seriesCompact {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	result := make([]seriesCompact, 0, len(s.series))
-	for _, st := range s.series {
-		result = append(result, seriesCompact{
-			Namespace: st.Namespace,
-			Name:      st.Name,
-			Tags:      st.Tags,
-		})
+	var result []seriesCompact
+	for i := range s.shards {
+		shard := &s.shards[i]
+		shard.mu.RLock()
+		for _, st := range shard.series {
+			result = append(result, seriesCompact{
+				Namespace: st.Namespace,
+				Name:      st.Name,
+				Tags:      st.Tags,
+			})
+		}
+		shard.mu.RUnlock()
 	}
 	return result
 }
 
 // DumpToFile writes all series to a JSON file for debugging.
 func (s *timeSeriesStorage) DumpToFile(path string) error {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	type dumpPoint struct {
 		Timestamp int64   `json:"ts"`
 		Sum       float64 `json:"sum"`
@@ -629,23 +780,28 @@ func (s *timeSeriesStorage) DumpToFile(path string) error {
 	}
 
 	var out []dumpSeries
-	for _, st := range s.series {
-		ds := dumpSeries{
-			Namespace: st.Namespace,
-			Name:      st.Name,
-			Tags:      st.Tags,
+	for i := range s.shards {
+		shard := &s.shards[i]
+		shard.mu.RLock()
+		for _, st := range shard.series {
+			ds := dumpSeries{
+				Namespace: st.Namespace,
+				Name:      st.Name,
+				Tags:      st.Tags,
+			}
+			n := st.pointCount()
+			for i := 0; i < n; i++ {
+				ds.Points = append(ds.Points, dumpPoint{
+					Timestamp: st.timestamps[i],
+					Sum:       st.sums[i],
+					Count:     st.counts[i],
+					Min:       st.mins[i],
+					Max:       st.maxes[i],
+				})
+			}
+			out = append(out, ds)
 		}
-		n := st.pointCount()
-		for i := 0; i < n; i++ {
-			ds.Points = append(ds.Points, dumpPoint{
-				Timestamp: st.timestamps[i],
-				Sum:       st.sums[i],
-				Count:     st.counts[i],
-				Min:       st.mins[i],
-				Max:       st.maxes[i],
-			})
-		}
-		out = append(out, ds)
+		shard.mu.RUnlock()
 	}
 
 	data, err := json.MarshalIndent(out, "", "  ")
@@ -657,19 +813,23 @@ func (s *timeSeriesStorage) DumpToFile(path string) error {
 
 // DataTimestamps returns all unique timestamps that have data, sorted ascending.
 func (s *timeSeriesStorage) DataTimestamps() []int64 {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	seen := make(map[int64]struct{})
-	for _, stats := range s.series {
-		for _, ts := range stats.timestamps {
-			seen[ts] = struct{}{}
+	for i := range s.shards {
+		shard := &s.shards[i]
+		shard.mu.RLock()
+		for _, stats := range shard.series {
+			for _, ts := range stats.timestamps {
+				seen[ts] = struct{}{}
+			}
 		}
+		shard.mu.RUnlock()
 	}
 	// Include observation timestamps (e.g., from logs that produced no virtual metrics).
+	s.stateMu.Lock()
 	for ts := range s.observationTimestamps {
 		seen[ts] = struct{}{}
 	}
+	s.stateMu.Unlock()
 
 	timestamps := make([]int64, 0, len(seen))
 	for ts := range seen {
@@ -682,26 +842,18 @@ func (s *timeSeriesStorage) DataTimestamps() []int64 {
 // SeriesGeneration returns a counter that increments whenever a new series key
 // is created. Callers can use this to safely cache ListSeries results.
 func (s *timeSeriesStorage) SeriesGeneration() uint64 {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.seriesGen
+	return s.seriesGen.Load()
 }
 
 // CompactSeriesID translates a full series key to its compact numeric ID string.
 // The full key format is "namespace|name:agg|tags" where the storage key is
-// "namespace|name|tags" (without the agg suffix). This method strips the agg
-// suffix, looks up the numeric ID, and returns "numericID:agg".
-// Returns the original key unchanged if no mapping exists.
+// "namespace|name|tags" (without the agg suffix).
 func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	namespace, nameWithAgg, tags, ok := parseSeriesKey(fullKey)
 	if !ok {
 		return fullKey
 	}
 
-	// Split off the aggregation suffix from the name.
 	baseName := nameWithAgg
 	aggStr := ""
 	if idx := strings.LastIndex(nameWithAgg, ":"); idx > 0 {
@@ -709,9 +861,11 @@ func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
 		aggStr = nameWithAgg[idx+1:]
 	}
 
-	// Look up the storage key (without agg suffix).
 	storageKey := seriesKey(namespace, baseName, tags)
+
+	s.idMu.Lock()
 	numID, found := s.seriesIDs[storageKey]
+	s.idMu.Unlock()
 	if !found {
 		return fullKey
 	}
@@ -726,62 +880,82 @@ func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
 
 // ListSeries returns metadata for all series matching the filter.
 func (s *timeSeriesStorage) ListSeries(filter observer.SeriesFilter) []observer.SeriesMeta {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	var result []observer.SeriesMeta
-listSeriesLoop:
-	for key, stats := range s.series {
-		if filter.Namespace != "" {
-			if stats.Namespace != filter.Namespace {
-				continue
-			}
-		} else {
-			for _, ex := range filter.ExcludeNamespaces {
-				if stats.Namespace == ex {
-					continue listSeriesLoop
+	type entry struct {
+		key   string
+		stats *seriesStats
+	}
+	var entries []entry
+	for i := range s.shards {
+		shard := &s.shards[i]
+		shard.mu.RLock()
+	listSeriesLoop:
+		for key, stats := range shard.series {
+			if filter.Namespace != "" {
+				if stats.Namespace != filter.Namespace {
+					continue
+				}
+			} else {
+				for _, ex := range filter.ExcludeNamespaces {
+					if stats.Namespace == ex {
+						continue listSeriesLoop
+					}
 				}
 			}
+			if filter.NamePattern != "" && !strings.HasPrefix(stats.Name, filter.NamePattern) {
+				continue
+			}
+			if !matchTags(stats.Tags, filter.TagMatchers) {
+				continue
+			}
+			entries = append(entries, entry{key: key, stats: stats})
 		}
-		if filter.NamePattern != "" && !strings.HasPrefix(stats.Name, filter.NamePattern) {
-			continue
-		}
-		if !matchTags(stats.Tags, filter.TagMatchers) {
-			continue
-		}
-		result = append(result, observer.SeriesMeta{
-			Ref:       s.seriesIDs[key],
-			Namespace: stats.Namespace,
-			Name:      stats.Name,
-			Tags:      stats.Tags,
-		})
+		shard.mu.RUnlock()
 	}
+
+	if len(entries) == 0 {
+		return nil
+	}
+
+	result := make([]observer.SeriesMeta, len(entries))
+	s.idMu.Lock()
+	for i, e := range entries {
+		result[i] = observer.SeriesMeta{
+			Ref:       s.seriesIDs[e.key],
+			Namespace: e.stats.Namespace,
+			Name:      e.stats.Name,
+			Tags:      e.stats.Tags,
+		}
+	}
+	s.idMu.Unlock()
 	return result
 }
 
 // PointCount returns the number of raw data points for a series.
 func (s *timeSeriesStorage) PointCount(ref observer.SeriesRef) int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	if stats := s.resolveByID(ref); stats != nil {
-		return stats.pointCount()
+	stats := s.resolveByID(ref)
+	if stats == nil {
+		return 0
 	}
-	return 0
+	shard := s.shardOf(stats)
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
+	return stats.pointCount()
 }
 
 // TotalSampleCount returns the total number of stored samples across all series,
 // excluding series in excludeNamespace (pass "" to include all namespaces).
-// A point can contain multiple samples if it is aggregated.
 func (s *timeSeriesStorage) TotalSampleCount(excludeNamespace string) int64 {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 	total := int64(0)
-	for _, stats := range s.series {
-		if excludeNamespace != "" && stats.Namespace == excludeNamespace {
-			continue
+	for i := range s.shards {
+		shard := &s.shards[i]
+		shard.mu.RLock()
+		for _, stats := range shard.series {
+			if excludeNamespace != "" && stats.Namespace == excludeNamespace {
+				continue
+			}
+			total += stats.sampleCount()
 		}
-		total += stats.sampleCount()
+		shard.mu.RUnlock()
 	}
 	return total
 }
@@ -789,14 +963,17 @@ func (s *timeSeriesStorage) TotalSampleCount(excludeNamespace string) int64 {
 // TotalSeriesCount returns the number of unique series (name + tag combinations),
 // excluding series in excludeNamespace (pass "" to include all namespaces).
 func (s *timeSeriesStorage) TotalSeriesCount(excludeNamespace string) int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 	total := 0
-	for _, stats := range s.series {
-		if excludeNamespace != "" && stats.Namespace == excludeNamespace {
-			continue
+	for i := range s.shards {
+		shard := &s.shards[i]
+		shard.mu.RLock()
+		for _, stats := range shard.series {
+			if excludeNamespace != "" && stats.Namespace == excludeNamespace {
+				continue
+			}
+			total++
 		}
-		total++
+		shard.mu.RUnlock()
 	}
 	return total
 }
@@ -804,11 +981,14 @@ func (s *timeSeriesStorage) TotalSeriesCount(excludeNamespace string) int {
 // PointCountUpTo returns the number of raw data points with timestamp <= endTime.
 // Uses binary search since timestamps are sorted.
 func (s *timeSeriesStorage) PointCountUpTo(ref observer.SeriesRef, endTime int64) int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	stats := s.resolveByID(ref)
-	if stats == nil || stats.pointCount() == 0 {
+	if stats == nil {
+		return 0
+	}
+	shard := s.shardOf(stats)
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
+	if stats.pointCount() == 0 {
 		return 0
 	}
 	return searchAfter(stats.timestamps, endTime)
@@ -818,43 +998,63 @@ func (s *timeSeriesStorage) PointCountUpTo(ref observer.SeriesRef, endTime int64
 // This is used for log observations that may not produce virtual metrics but still
 // need to appear in DataTimestamps for replay fidelity.
 func (s *timeSeriesStorage) RecordObservationTime(timestamp int64) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.stateMu.Lock()
 	s.observationTimestamps[timestamp] = struct{}{}
+	s.stateMu.Unlock()
 }
 
 // WriteGeneration returns a counter that increments on every Add call
 // (including same-bucket merges). Detectors use this to detect value
 // changes that don't create new buckets.
 func (s *timeSeriesStorage) WriteGeneration(ref observer.SeriesRef) int64 {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	if stats := s.resolveByID(ref); stats != nil {
-		return stats.writeGeneration
+	stats := s.resolveByID(ref)
+	if stats == nil {
+		return 0
 	}
-	return 0
+	shard := s.shardOf(stats)
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
+	return stats.writeGeneration
 }
 
 // BulkSeriesStatus returns the point count (up to endTime) and write generation
-// for each ref in a single lock acquisition. This avoids the overhead of
-// 2×len(refs) individual RLock/RUnlock calls in hot detector loops.
-// Implements bulkStatusReader (metrics_detector_util.go).
+// for each ref in a single pass. Each ref's owning shard is RLocked
+// individually; cross-ref consistency is per-shard.
 func (s *timeSeriesStorage) BulkSeriesStatus(refs []observer.SeriesRef, endTime int64) []seriesStatus {
 	result := make([]seriesStatus, len(refs))
 
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
+	// Group refs by shard to take each shard's RLock once.
+	var byShard [numStorageShards][]int
+	statsByRef := make([]*seriesStats, len(refs))
+	s.idMu.Lock()
 	for i, ref := range refs {
-		stats := s.resolveByID(ref)
-		if stats == nil || stats.pointCount() == 0 {
+		if ref < 0 || int(ref) >= len(s.seriesIDStats) {
 			continue
 		}
-		result[i] = seriesStatus{
-			pointCount:      searchAfter(stats.timestamps, endTime),
-			writeGeneration: stats.writeGeneration,
+		stats := s.seriesIDStats[ref]
+		statsByRef[i] = stats
+		byShard[stats.shardIdx] = append(byShard[stats.shardIdx], i)
+	}
+	s.idMu.Unlock()
+
+	for shardIdx := range byShard {
+		idxs := byShard[shardIdx]
+		if len(idxs) == 0 {
+			continue
 		}
+		shard := &s.shards[shardIdx]
+		shard.mu.RLock()
+		for _, i := range idxs {
+			stats := statsByRef[i]
+			if stats == nil || stats.pointCount() == 0 {
+				continue
+			}
+			result[i] = seriesStatus{
+				pointCount:      searchAfter(stats.timestamps, endTime),
+				writeGeneration: stats.writeGeneration,
+			}
+		}
+		shard.mu.RUnlock()
 	}
 	return result
 }
@@ -880,26 +1080,21 @@ func matchTags(tags []string, matchers map[string]string) bool {
 
 // GetSeriesRange returns points within a time range (start, end].
 // Start is exclusive, end is inclusive. Use start=0 to read from the beginning.
-// Uses binary search on the timestamps column for O(log N) range lookup.
 func (s *timeSeriesStorage) GetSeriesRange(ref observer.SeriesRef, start, end int64, agg Aggregate) *observer.Series {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	stats := s.resolveByID(ref)
 	if stats == nil {
 		return nil
 	}
+	shard := s.shardOf(stats)
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
 
-	// Binary search: find first index where timestamp > start
 	lo := searchAfter(stats.timestamps, start)
-	// Binary search: find first index where timestamp > end
 	hi := searchAfter(stats.timestamps, end)
 
-	// Range is [lo, hi) in the arrays, corresponding to (start, end] in time.
 	resultLen := hi - lo
 	points := make([]observer.Point, resultLen)
 
-	// For aggregates that map directly to a column, avoid per-point switch.
 	switch agg {
 	case AggregateSum:
 		for i := 0; i < resultLen; i++ {
@@ -929,7 +1124,7 @@ func (s *timeSeriesStorage) GetSeriesRange(ref observer.SeriesRef, start, end in
 				Value:     float64(stats.counts[lo+i]),
 			}
 		}
-	default: // AggregateAverage and any unknown
+	default:
 		for i := 0; i < resultLen; i++ {
 			points[i] = observer.Point{
 				Timestamp: stats.timestamps[lo+i],
@@ -947,7 +1142,7 @@ func (s *timeSeriesStorage) GetSeriesRange(ref observer.SeriesRef, start, end in
 }
 
 // pointBufPool reuses point buffers across ForEachPoint calls to avoid
-// per-call allocation. Each buffer grows to its high-water mark and stays.
+// per-call allocation.
 var pointBufPool = sync.Pool{
 	New: func() any { return &[]observer.Point{} },
 }
@@ -955,9 +1150,6 @@ var pointBufPool = sync.Pool{
 // ForEachPoint calls fn for every point in the time range (start, end].
 // The Series pointer is valid only for the duration of the callback.
 // Returns false if the series was not found.
-//
-// Points are copied under the read lock into a pooled buffer; the callback
-// runs outside the lock so callers cannot block writers.
 func (s *timeSeriesStorage) ForEachPoint(
 	ref observer.SeriesRef, start, end int64, agg Aggregate,
 	fn func(*observer.Series, observer.Point),
@@ -981,18 +1173,15 @@ func (s *timeSeriesStorage) ForEachPoint(
 	return true
 }
 
-// SumRange returns the aggregate total over the time range (start, end] without
-// allocating any intermediate slices. It operates directly on the columnar
-// data arrays, using binary search to locate the range boundaries.
-// Returns 0 if the series is not found or the range is empty.
+// SumRange returns the aggregate total over the time range (start, end].
 func (s *timeSeriesStorage) SumRange(ref observer.SeriesRef, start, end int64, agg Aggregate) float64 {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	stats := s.resolveByID(ref)
 	if stats == nil {
 		return 0
 	}
+	shard := s.shardOf(stats)
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
 
 	lo := searchAfter(stats.timestamps, start)
 	hi := searchAfter(stats.timestamps, end)
@@ -1027,19 +1216,17 @@ func (s *timeSeriesStorage) SumRange(ref observer.SeriesRef, start, end int64, a
 }
 
 // snapshotRange copies points for a time range into buf under the read lock.
-// Returns the series metadata, the (potentially grown) buffer, and whether the
-// series was found.
 func (s *timeSeriesStorage) snapshotRange(
 	ref observer.SeriesRef, start, end int64, agg Aggregate,
 	buf []observer.Point,
 ) (observer.Series, []observer.Point, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	stats := s.resolveByID(ref)
 	if stats == nil {
 		return observer.Series{}, buf, false
 	}
+	shard := s.shardOf(stats)
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
 
 	lo := searchAfter(stats.timestamps, start)
 	hi := searchAfter(stats.timestamps, end)

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -53,10 +53,11 @@ type timeSeriesStorage struct {
 	droppedByMetric       map[string]int64
 	sampledDrops          map[string]int
 
-	// idMu protects the global compact-ID tables. Held only on the cold
-	// path (first occurrence of a series) and on lookup-by-string-key
-	// (CompactSeriesID).
-	idMu          sync.Mutex
+	// idMu protects the global compact-ID tables. Append-only writes (new
+	// series creation, the cold path) take Lock(); ref-resolution reads
+	// (resolveByID, CompactSeriesID, BulkSeriesStatus's ref-grouping) take
+	// RLock so detector read paths don't serialize through one mutex.
+	idMu          sync.RWMutex
 	seriesIDs     map[string]observer.SeriesRef // string key → numeric ref
 	seriesIDKeys  []string                      // numeric ID → string key
 	seriesIDStats []*seriesStats                // numeric ID → *seriesStats
@@ -637,13 +638,14 @@ func hashSeriesIdentity(namespace, name string, tags []string) uint64 {
 	return h
 }
 
-// resolveByID returns the seriesStats for a numeric series ID without
-// taking any lock. The seriesIDStats slice is append-only after a series is
-// created; the *seriesStats pointer is stable for the storage's lifetime.
-// Callers that read the stats' column data must RLock the owning shard.
+// resolveByID returns the seriesStats for a numeric series ID. Held under
+// idMu.RLock so detector reads don't serialize against each other; the
+// append-only slice can be safely read concurrently while writers
+// (assignID) take Lock(). Callers that read the stats' column data must
+// then RLock the owning shard.
 func (s *timeSeriesStorage) resolveByID(ref observer.SeriesRef) *seriesStats {
-	s.idMu.Lock()
-	defer s.idMu.Unlock()
+	s.idMu.RLock()
+	defer s.idMu.RUnlock()
 	if ref < 0 || int(ref) >= len(s.seriesIDStats) {
 		return nil
 	}
@@ -706,7 +708,7 @@ func (s *timeSeriesStorage) ListSeriesMetadata(namespace string) []seriesMeta {
 	}
 
 	// Resolve refs from the global ID table.
-	s.idMu.Lock()
+	s.idMu.RLock()
 	result := make([]seriesMeta, len(entries))
 	for i, e := range entries {
 		result[i] = seriesMeta{
@@ -717,7 +719,7 @@ func (s *timeSeriesStorage) ListSeriesMetadata(namespace string) []seriesMeta {
 			PointCount: e.count,
 		}
 	}
-	s.idMu.Unlock()
+	s.idMu.RUnlock()
 
 	sort.Slice(result, func(i, j int) bool {
 		if result[i].Ref != result[j].Ref {
@@ -863,9 +865,9 @@ func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
 
 	storageKey := seriesKey(namespace, baseName, tags)
 
-	s.idMu.Lock()
+	s.idMu.RLock()
 	numID, found := s.seriesIDs[storageKey]
-	s.idMu.Unlock()
+	s.idMu.RUnlock()
 	if !found {
 		return fullKey
 	}
@@ -917,7 +919,7 @@ func (s *timeSeriesStorage) ListSeries(filter observer.SeriesFilter) []observer.
 	}
 
 	result := make([]observer.SeriesMeta, len(entries))
-	s.idMu.Lock()
+	s.idMu.RLock()
 	for i, e := range entries {
 		result[i] = observer.SeriesMeta{
 			Ref:       s.seriesIDs[e.key],
@@ -926,7 +928,7 @@ func (s *timeSeriesStorage) ListSeries(filter observer.SeriesFilter) []observer.
 			Tags:      e.stats.Tags,
 		}
 	}
-	s.idMu.Unlock()
+	s.idMu.RUnlock()
 	return result
 }
 
@@ -1026,7 +1028,7 @@ func (s *timeSeriesStorage) BulkSeriesStatus(refs []observer.SeriesRef, endTime 
 	// Group refs by shard to take each shard's RLock once.
 	var byShard [numStorageShards][]int
 	statsByRef := make([]*seriesStats, len(refs))
-	s.idMu.Lock()
+	s.idMu.RLock()
 	for i, ref := range refs {
 		if ref < 0 || int(ref) >= len(s.seriesIDStats) {
 			continue
@@ -1035,7 +1037,7 @@ func (s *timeSeriesStorage) BulkSeriesStatus(refs []observer.SeriesRef, endTime 
 		statsByRef[i] = stats
 		byShard[stats.shardIdx] = append(byShard[stats.shardIdx], i)
 	}
-	s.idMu.Unlock()
+	s.idMu.RUnlock()
 
 	for shardIdx := range byShard {
 		idxs := byShard[shardIdx]

--- a/comp/observer/impl/storage_concurrent_test.go
+++ b/comp/observer/impl/storage_concurrent_test.go
@@ -1,0 +1,163 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// TestStorageConcurrentAdd_DistinctSeries verifies that many goroutines
+// writing to disjoint series in parallel produce the expected per-series
+// totals. Disjoint series stress shard fan-out and the cold-path ID
+// allocation under contention.
+func TestStorageConcurrentAdd_DistinctSeries(t *testing.T) {
+	const numWriters = 32
+	const seriesPerWriter = 100
+	const samplesPerSeries = 50
+
+	storage := newTimeSeriesStorage()
+
+	var wg sync.WaitGroup
+	wg.Add(numWriters)
+	for w := 0; w < numWriters; w++ {
+		go func(writerID int) {
+			defer wg.Done()
+			for s := 0; s < seriesPerWriter; s++ {
+				name := fmt.Sprintf("metric.w%d.s%d", writerID, s)
+				tags := []string{fmt.Sprintf("writer:%d", writerID), fmt.Sprintf("series:%d", s)}
+				for i := 0; i < samplesPerSeries; i++ {
+					storage.Add("ns", name, float64(i+1), int64(i+1), tags)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	got := storage.TotalSeriesCount("")
+	require.Equal(t, numWriters*seriesPerWriter, got, "expected one series per (writer, series) pair")
+
+	// Spot-check a few series values: last writer, last series, sample sum
+	// should be 1+2+...+samplesPerSeries.
+	expectedSum := float64(samplesPerSeries * (samplesPerSeries + 1) / 2)
+	for w := 0; w < numWriters; w += 7 {
+		for s := 0; s < seriesPerWriter; s += 11 {
+			name := fmt.Sprintf("metric.w%d.s%d", w, s)
+			tags := []string{fmt.Sprintf("writer:%d", w), fmt.Sprintf("series:%d", s)}
+			series := storage.GetSeries("ns", name, tags, AggregateSum)
+			require.NotNilf(t, series, "missing series w=%d s=%d", w, s)
+			var sum float64
+			for _, p := range series.Points {
+				sum += p.Value
+			}
+			assert.Equalf(t, expectedSum, sum, "wrong sum for w=%d s=%d", w, s)
+		}
+	}
+}
+
+// TestStorageConcurrentAdd_SharedSeries verifies that many goroutines
+// writing to the SAME series produce the correct merged total. This
+// stresses the shard write lock — every write hashes to one shard and
+// must serialize, but the result must still be consistent.
+func TestStorageConcurrentAdd_SharedSeries(t *testing.T) {
+	const numWriters = 16
+	const samplesPerWriter = 1000
+
+	storage := newTimeSeriesStorage()
+	tags := []string{"shared:true"}
+
+	var wg sync.WaitGroup
+	wg.Add(numWriters)
+	for w := 0; w < numWriters; w++ {
+		go func(writerID int) {
+			defer wg.Done()
+			for i := 0; i < samplesPerWriter; i++ {
+				// All writers target the same (namespace, name, tags)
+				// at the same timestamp so the bucket update path
+				// is exercised under contention.
+				storage.Add("ns", "metric.shared", 1.0, 100, tags)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	require.Equal(t, 1, storage.TotalSeriesCount(""), "shared series must coalesce into a single seriesStats")
+
+	series := storage.GetSeries("ns", "metric.shared", tags, AggregateSum)
+	require.NotNil(t, series)
+	require.Len(t, series.Points, 1)
+
+	// Sum aggregate should be (1.0 * total samples).
+	totalSamples := numWriters * samplesPerWriter
+	assert.Equal(t, float64(totalSamples), series.Points[0].Value)
+
+	// And the count aggregate should reflect every individual sample.
+	cseries := storage.GetSeries("ns", "metric.shared", tags, AggregateCount)
+	require.NotNil(t, cseries)
+	require.Len(t, cseries.Points, 1)
+	assert.Equal(t, float64(totalSamples), cseries.Points[0].Value)
+}
+
+// TestStorageConcurrentReadDuringWrite exercises the read path while writes
+// are in flight. Readers must never observe torn state: point counts must
+// be non-negative and writeGeneration must be monotonic.
+func TestStorageConcurrentReadDuringWrite(t *testing.T) {
+	const numWriters = 8
+	const samplesPerWriter = 5000
+
+	storage := newTimeSeriesStorage()
+	tags := []string{"k:v"}
+
+	// Pre-create the series so the reader always has a ref to look up.
+	storage.Add("ns", "metric.warm", 1.0, 1, tags)
+	metas := storage.ListSeries(observer.SeriesFilter{Namespace: "ns"})
+	require.Len(t, metas, 1)
+	ref := metas[0].Ref
+
+	var stop atomic.Bool
+	var readerErrors atomic.Int64
+
+	var writers, reader sync.WaitGroup
+	reader.Add(1)
+	go func() {
+		defer reader.Done()
+		var lastGen int64
+		for !stop.Load() {
+			gen := storage.WriteGeneration(ref)
+			pc := storage.PointCount(ref)
+			if pc < 0 || gen < lastGen {
+				readerErrors.Add(1)
+			}
+			lastGen = gen
+		}
+	}()
+
+	writers.Add(numWriters)
+	for w := 0; w < numWriters; w++ {
+		go func() {
+			defer writers.Done()
+			for i := 0; i < samplesPerWriter; i++ {
+				ts := int64(1 + (i % 100)) // small range so bucket merges dominate
+				storage.Add("ns", "metric.warm", float64(i), ts, tags)
+			}
+		}()
+	}
+
+	writers.Wait()
+	stop.Store(true)
+	reader.Wait()
+
+	expected := int64(1 + numWriters*samplesPerWriter)
+	assert.Equal(t, int64(0), readerErrors.Load(), "reader observed inconsistent state")
+	assert.Equal(t, expected, storage.WriteGeneration(ref), "expected one writeGeneration tick per Add")
+}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -1096,7 +1096,7 @@ func (tb *TestBench) seriesCount() int {
 	if storage == nil {
 		return 0
 	}
-	return len(storage.series)
+	return storage.TotalSeriesCount("")
 }
 
 // GetCorrelatorStats returns stats from all correlators (enabled or not).


### PR DESCRIPTION
## Summary

Redesigns the observer's metric ingest pipeline to eliminate three operational and efficiency problems the current architecture forces on us:

1. **Drops under load.** The 1000-deep observation channel between `handle.ObserveMetric` and the engine run-loop drains only as fast as the run-loop's *slowest* job — and that loop interleaves ingestion with detection. When detectors run long, the channel fills and we silently drop metrics. We've observed this in live mode: the parquet recorder captures points the live engine drops, even though one writes to disk and the other writes to memory.
2. **Per-sample allocation on the DogStatsD hot path.** Every `ObserveMetric` builds a `metricObs{}` on the heap, copies the tags slice, wraps it in an `observation{}`, and channel-sends. At DogStatsD ingestion rates this is the dominant allocation in the pipeline.
3. **No producer parallelism.** A single global mutex inside storage means many concurrent producer goroutines (DogStatsD workers, HF runners, the aggregator) serialize through one critical section even when they're touching distinct series.

## Changes

### 1. Synchronous metric ingest (`engine.IngestMetricSync`)
`handle.ObserveMetric` now calls into the engine directly with scalar arguments. No channel, no `metricObs` heap box, no `copyTags` on the hot path. The producer's lifetime contract collapses to "name and tags valid for the duration of the call" — every existing caller satisfies this trivially because storage canonicalizes its own copy of tags on cold path and only aliases the name string when creating a new series.

Logs and profiles still flow through the buffered channel + run-loop, since extractor work is too heavy for producer threads.

### 2. Ticker-driven scheduler
A 100ms ticker on its own goroutine drives advance scheduling based on `latestDataTime`. Per-sample `scheduler.onObservation` calls are gone from the metric path. A slow detector now causes ""analysis is behind data-time"" (recoverable, observable) instead of ""we lost data"" (irrecoverable). Logs still trigger advance synchronously per ingest because their rate is low enough.

### 3. Sharded storage
`timeSeriesStorage` now holds `[16]storageShard`. Writes hash `(namespace, name, canonicalized tags)` via an allocation-free FNV-1a and dispatch to a single shard, so two writes to different series can proceed in parallel as long as they land on different shards. Compact `SeriesRef`s remain globally unique via an append-only `seriesIDStats` slice under `idMu` (now `sync.RWMutex` so detector ref-resolution doesn't serialize through one mutex).

Cross-shard reads (`AllSeries`, `ListSeries`, `TimeBounds`, etc.) RLock each shard independently and aggregate — per-shard consistent, not cross-shard atomic, which is fine for analyzer scans.

## Expected impact

**No drops on the metric path.** A sharded mutex's worst case is queueing on a single shard (microseconds). The 1000-deep channel's worst case under a multi-second detector run was millions of dropped points. Drop-on-channel-full disappears for metrics; the symptom of detector slowdown becomes observable lag, not lost data.

**Reduced allocations.** The per-sample `metricObs{}` heap allocation, the `copyTags` slice copy, and the `observation{}` carrier are all eliminated on the metric path. Storage canonicalizes once on cold path (first occurrence of a series).

**Producer-internal parallelism.** Multi-worker producers like DogStatsD now write to N shards instead of serializing through one mutex. With 16 shards on series-identity hashing, a single producer with M worker goroutines runs `min(M, 16)`-way parallel.

**Single-thread ingest is not regressed.** Local benchmark shows `BenchmarkIngestion_SeriesCount` is roughly equivalent to the old implementation across `series=50/200/500/2000`, with measurable improvement at low cardinality due to smaller per-shard maps.

## Safety verification

This is a concurrency-heavy change. Verification done locally:

- **`go test -race ./comp/observer/impl/` passes** — full suite, repeated up to 5x. Includes 30+ existing tests covering ingestion, detection, scheduling, log extraction, replay, and recorder integration.
- **New concurrent tests** (`storage_concurrent_test.go`, `engine_concurrent_test.go`):
  - `TestStorageConcurrentAdd_DistinctSeries` — N writers × M distinct series, verifies cardinality and per-series sums.
  - `TestStorageConcurrentAdd_SharedSeries` — N writers hammering one series, verifies merged total under shard contention.
  - `TestStorageConcurrentReadDuringWrite` — readers checking `WriteGeneration`/`PointCount` while writers update buckets, verifies monotonicity and non-negativity.
  - `TestStorage_SeriesGenerationUnderConcurrency` — N writers each creating M unique series, verifies `SeriesGeneration` increments exactly once per new series.
  - `TestEngine_ConcurrentLogIngestAndAdvance` — drives `IngestLog` (writes `contextRefs`) concurrently with `advanceWithReason` (which now reads `contextRefs`/`contextProviders` from a separate goroutine via `enrichAnomaly`), with a state-view-style atomic reader on the side. Wired with a real detector so `enrichAnomaly` actually runs concurrently with the writes.
- **Three rounds of subagent review.** Each round triaged what the prior round missed and was followed by fixes:
  - Round 1: caught the `contextRefs` race between `IngestLog` and ticker-driven advance, and that `idMu` was a non-RW mutex serializing all detector reads.
  - Round 2: caught a residual race on `contextProviders` (also written by `SetExtractors`), confirmed lock ordering across the three goroutines is consistent, verified the producer lifetime contract across every caller in `pkg/aggregator`, `pkg/aggregator/sender`, `comp/dogstatsd/server`, `comp/observer/impl/hfrunner`, and `comp/anomalydetection/recorder`.
  - Round 3: caught that the new concurrent test wasn't actually exercising `enrichAnomaly` because the engine had no detectors configured. Added a stub detector and stub `ContextProvider`.
- **Downstream packages still build:** `comp/anomalydetection/recorder` tests pass under `-race`.
- **`go vet` clean.**

## Risks / caveats

- **Advance latency under quiet-then-burst.** Up to 100ms between data arrival and detection on the metric path (was per-sample). Logs are unaffected. Configurable via the `schedulerTickInterval` constant; can be lowered if needed.
- **`dropsBySource` telemetry** in the advance log now reflects only log/profile channel-full drops. Metric drops are zero by construction. Internal-only telemetry; no external dashboards depend on this. Comment added in `engine.go` for future readers.
- **Cross-shard reads are not atomic.** `AllSeries`/`ListSeries` etc. RLock each shard independently. A series created mid-scan in an unscanned shard won't appear in this scan's result but will in the next. Acceptable for analyzer scans.

## Test plan

- [x] `go test -race ./comp/observer/impl/` passes locally (5x).
- [x] `go vet ./comp/observer/impl/` clean.
- [x] Downstream packages (`comp/anomalydetection/recorder`) tests pass under `-race`.
- [x] Ingestion benchmarks show no single-thread regression.
- [ ] Live-cluster validation: deploy to a test cluster and confirm no drops under realistic DogStatsD load and that detectors continue to fire as expected within a couple of advance cycles of data arrival.