### PR TITLE
Urgent: add missing cache extension to `build_iot_agent-binary_arm64`

### DIFF
--- a/.gitlab/build/binary_build/linux.yml
+++ b/.gitlab/build/binary_build/linux.yml
@@ -86,6 +86,7 @@ build_iot_agent-binary_x64:
     - $S3_CP_CMD $CI_PROJECT_DIR/$AGENT_BINARIES_DIR/agent $S3_ARTIFACTS_URI/iot/agent
 
 build_iot_agent-binary_arm64:
+  extends: .bazel:defs:cache:progressive
   rules: !reference [.on_all_builds]
   stage: binary_build
   timeout: 20m


### PR DESCRIPTION
### What does this PR do?
Add missing cache extension.

### Motivation
Job `build_iot_agent-binary_arm64` fail consistently due to the missing cache extension ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1644783831)).
Simpler than reverting:
- #50149.

### Describe how you validated your changes
I didn't because the failing job was not plugged in CI.

### Additional Notes
Fix for the above:
- #50160.