### PR TITLE
Fix `build_iot_agent-binary_arm64` trigger rules

### DIFF
--- a/.gitlab/build/binary_build/linux.yml
+++ b/.gitlab/build/binary_build/linux.yml
@@ -87,7 +87,9 @@ build_iot_agent-binary_x64:
 
 build_iot_agent-binary_arm64:
   extends: .bazel:defs:cache:progressive
-  rules: !reference [.on_all_builds]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   stage: binary_build
   timeout: 20m
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX


### PR DESCRIPTION
### What does this PR do?
Replace `rules: !reference [.on_all_builds]` on `build_iot_agent-binary_arm64` with the same inline rules used by its "x64" sibling:
```yaml
- `!reference [.except_mergequeue]`
- `when: on_success`
```

### Motivation
`build_iot_agent-binary_arm64` only ran on `main`, deploy pipelines, or when omnibus / config-template files changed (`.on_all_builds`), while `build_iot_agent-binary_x64` ran on every non-merge-queue pipeline.

This blind spot let #49911 break the arm64 IoT build undetected on dev branches: the failure was only caught in the `main` pipeline and required force-merging #50159 - fortunately right before work resumed.

### Describe how you validated your changes
Reviewed the YAML diff and traced the history of the anchor definition.

### Additional Notes
The asymmetry dates back to the job's introduction in #8168 ("Use !reference to refactor the Gitlab config"), where `.on_all_builds` was defined as firing only when `$CI_COMMIT_BRANCH == "main" || $DEPLOY_AGENT == "true" || ...`.

The anchor was originally `.on_all_builds_a7`; #24209 ("Merge rules for agent 6 and 7 - part 5") dropped the `_a7` suffix without changing the semantics.
The x64 job has always used a simple `when: on_success` fallback and was therefore unaffected.