### PR TITLE
omnibus: include packages/ dir to the cache key computation

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -218,6 +218,7 @@ def omnibus_compute_cache_key(ctx, env: dict[str, str]) -> str:
             'tasks/agent.py',
             'deps',
             'bazel',
+            'packages',
         ],
     )
     print(f'Current hash value: {h.hexdigest()}')


### PR DESCRIPTION
### What does this PR do?

Include the `packages/` folder to the omnibus cache key computation

### Motivation

Some recipe now rely on the //packages targets to install various files but would use a stale cache since we don't invalidate when the packages targets are updated.
This can happen for any dependency we still install explicitly from omnibus in:
* config/software/datadog-agent-dependencies.rb
* config/software/openssl3.rb
* config/software/python3.rb
* config/software/installer.rb

### Describe how you validated your changes

Tested as part of investigating a suspicious size drop in the heroku package in https://github.com/DataDog/datadog-agent/pull/49403
This commit fixed it and reintroduced the missing shared library

### Additional Notes
