### PR TITLE
Use smaller VM for openshift tests

### DIFF
--- a/test/e2e-framework/components/kubernetes/openshift.go
+++ b/test/e2e-framework/components/kubernetes/openshift.go
@@ -100,7 +100,7 @@ func NewOpenShiftCluster(env config.Env, vm *remote.Host, name string, pullSecre
 		}
 
 		setupCRC, err := runner.Command(commonEnvironment.CommonNamer().ResourceName("crc-setup"), &command.Args{
-			Create: pulumi.String("crc config set disk-size 100 && crc config set cpus 12 && crc config set memory 32768 && crc setup"),
+			Create: pulumi.String("crc config set disk-size 100 && crc config set cpus 6 && crc config set memory 16384 && crc setup"),
 		}, utils.MergeOptions(opts, utils.PulumiDependsOn(pullSecretFile, enableLinger))...)
 		if err != nil {
 			return err

--- a/test/e2e-framework/components/kubernetes/openshift.go
+++ b/test/e2e-framework/components/kubernetes/openshift.go
@@ -100,7 +100,7 @@ func NewOpenShiftCluster(env config.Env, vm *remote.Host, name string, pullSecre
 		}
 
 		setupCRC, err := runner.Command(commonEnvironment.CommonNamer().ResourceName("crc-setup"), &command.Args{
-			Create: pulumi.String("crc config set disk-size 100 && crc config set cpus 9 && crc config set memory 24576 && crc setup"),
+			Create: pulumi.String("crc config set disk-size 100 && crc config set cpus 12 && crc config set memory 32768 && crc setup"),
 		}, utils.MergeOptions(opts, utils.PulumiDependsOn(pullSecretFile, enableLinger))...)
 		if err != nil {
 			return err

--- a/test/e2e-framework/components/kubernetes/openshift.go
+++ b/test/e2e-framework/components/kubernetes/openshift.go
@@ -100,7 +100,7 @@ func NewOpenShiftCluster(env config.Env, vm *remote.Host, name string, pullSecre
 		}
 
 		setupCRC, err := runner.Command(commonEnvironment.CommonNamer().ResourceName("crc-setup"), &command.Args{
-			Create: pulumi.String("crc config set disk-size 100 && crc config set cpus 6 && crc config set memory 16384 && crc setup"),
+			Create: pulumi.String("crc config set disk-size 100 && crc config set cpus 9 && crc config set memory 24576 && crc setup"),
 		}, utils.MergeOptions(opts, utils.PulumiDependsOn(pullSecretFile, enableLinger))...)
 		if err != nil {
 			return err

--- a/test/e2e-framework/testing/provisioners/gcp/kubernetes/openshiftvm/openshiftvm.go
+++ b/test/e2e-framework/testing/provisioners/gcp/kubernetes/openshiftvm/openshiftvm.go
@@ -89,7 +89,7 @@ func OpenShiftVMRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, param
 	osDesc := os.DescriptorFromString("redhat:9", os.RedHat9)
 	vm, err := compute.NewVM(gcpEnv, "openshift",
 		compute.WithOS(osDesc),
-		compute.WithInstancetype("n2-standard-8"),
+		compute.WithInstancetype("n4-standard-16"),
 		compute.WithNestedVirt(true),
 		// this is used by the dumpCluster debug function
 		compute.WithLabels(map[string]string{"kube-provider": "openshift"}),

--- a/test/e2e-framework/testing/provisioners/gcp/kubernetes/openshiftvm/openshiftvm.go
+++ b/test/e2e-framework/testing/provisioners/gcp/kubernetes/openshiftvm/openshiftvm.go
@@ -89,7 +89,7 @@ func OpenShiftVMRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, param
 	osDesc := os.DescriptorFromString("redhat:9", os.RedHat9)
 	vm, err := compute.NewVM(gcpEnv, "openshift",
 		compute.WithOS(osDesc),
-		compute.WithInstancetype("n2-standard-32"),
+		compute.WithInstancetype("n2-standard-8"),
 		compute.WithNestedVirt(true),
 		// this is used by the dumpCluster debug function
 		compute.WithLabels(map[string]string{"kube-provider": "openshift"}),


### PR DESCRIPTION
### What does this PR do?

Change instance type used by openshift tests.
n2-standard-32 was a 32 CPU 128 Gb of memory which seems a lot for a "simple" test. Also we faced availability issues with those instances. Using smaller instances (8 CPU 32Gb of memory) should be cheaper and we expect GCP to have more availability for those smaller instances

### Motivation

### Describe how you validated your changes

### Additional Notes
