### PR TITLE
Fix container CPU limit calculation

### DIFF
--- a/pkg/util/containers/metrics/containerd/collector_linux.go
+++ b/pkg/util/containers/metrics/containerd/collector_linux.go
@@ -63,14 +63,21 @@ func fillStatsFromSpec(outContainerStats *provider.ContainerStats, spec *oci.Spe
 }
 
 func computeCPULimit(containerStats *provider.ContainerStats, spec *specs.LinuxCPU) {
-	switch {
-	case spec.Cpus != "":
-		containerStats.CPU.Limit = pointer.Ptr(100 * float64(cgroups.ParseCPUSetFormat(spec.Cpus)))
-	case spec.Quota != nil && *spec.Quota > 0:
-		period := 100000 // Default CFS Period
-		if spec.Period != nil && *spec.Period > 0 {
-			period = int(*spec.Period)
-		}
-		containerStats.CPU.Limit = pointer.Ptr(100 * float64(*spec.Quota) / float64(period))
+	var limitPct *float64
+
+	if spec.Cpus != "" {
+		v := 100 * float64(cgroups.ParseCPUSetFormat(spec.Cpus))
+		limitPct = &v
 	}
+	if spec.Quota != nil && *spec.Quota > 0 {
+		period := int64(100000)
+		if spec.Period != nil && *spec.Period > 0 {
+			period = int64(*spec.Period)
+		}
+		quotaPct := 100 * float64(*spec.Quota) / float64(period)
+		if limitPct == nil || quotaPct < *limitPct {
+			limitPct = &quotaPct
+		}
+	}
+	containerStats.CPU.Limit = limitPct
 }

--- a/releasenotes/notes/fix-container-limit-51ac13a973aa5774.yaml
+++ b/releasenotes/notes/fix-container-limit-51ac13a973aa5774.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix container CPU limit calculation to account for possible quota set.


### PR DESCRIPTION
### What does this PR do?

Fix CPU limit calculation to make fractional limits match between k8s and container.

### Motivation
See https://app.datadoghq.com/notebook/14344023/agent-bug-container-cpu-limit-wrong-on-fractional-cpu-pods

### Describe how you validated your changes

### Additional Notes

