### PR TITLE
AGTMETRICS-503 Allow Go checks to use HistogramBucket

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -23,6 +23,10 @@ import (
 
 const checksSourceTypeName = "System"
 
+type bucketBounds struct {
+	lower, upper float64
+}
+
 // CheckSampler aggregates metrics from one Check instance
 type CheckSampler struct {
 	id                     checkid.ID
@@ -32,6 +36,7 @@ type CheckSampler struct {
 	metrics                metrics.CheckMetrics
 	sketchMap              sketchMap
 	lastBucketValue        map[ckey.ContextKey]int64
+	lastBucketValueByBound map[ckey.ContextKey]map[bucketBounds]int64
 	deregistered           bool
 	contextResolverMetrics bool
 	logThrottling          util.SimpleThrottler
@@ -120,10 +125,30 @@ func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket, tagFilterList
 
 	// if the bucket is monotonic and we have already seen the bucket we only send the delta
 	if bucket.Monotonic {
-		lastBucketValue, bucketFound := cs.lastBucketValue[contextKey]
+		lastBucketValue := int64(0)
+		bucketFound := false
 		rawValue := bucket.Value
 
-		cs.lastBucketValue[contextKey] = rawValue
+		// Openmetrics checks can send lots of metrics with lots of
+		// buckets, but include bucket bounds in the tags and only have
+		// one bucket per context key. It pays to use a simpler map to
+		// track bucket values for such metrics.
+		if !bucket.MultipleBuckets {
+			lastBucketValue, bucketFound = cs.lastBucketValue[contextKey]
+			cs.lastBucketValue[contextKey] = rawValue
+		} else {
+			if cs.lastBucketValueByBound == nil {
+				cs.lastBucketValueByBound = make(map[ckey.ContextKey]map[bucketBounds]int64)
+			}
+			lastBucketValues := cs.lastBucketValueByBound[contextKey]
+			if lastBucketValues == nil {
+				lastBucketValues = make(map[bucketBounds]int64)
+				cs.lastBucketValueByBound[contextKey] = lastBucketValues
+			}
+			bucketBounds := bucketBoundsFor(bucket)
+			lastBucketValue, bucketFound = lastBucketValues[bucketBounds]
+			lastBucketValues[bucketBounds] = rawValue
+		}
 
 		// Return early so we don't report the first raw value instead of the delta which will cause spikes
 		if !bucketFound && !bucket.FlushFirstValue {
@@ -235,6 +260,7 @@ func (cs *CheckSampler) commit(timestamp float64, filterList *utilstrings.Matche
 	// garbage collect unused buckets
 	for _, ctxKey := range expiredContextKeys {
 		delete(cs.lastBucketValue, ctxKey)
+		delete(cs.lastBucketValueByBound, ctxKey)
 	}
 
 	cs.metrics.Expire(expiredContextKeys, timestamp)
@@ -286,4 +312,11 @@ func (cs *CheckSampler) updateMetrics() {
 
 	tlmChecksContexts.Set(float64(totalContexts), idString)
 	cs.contextResolver.updateMetrics(tlmChecksContextsByMtype, tlmChecksContextsBytesByMtype)
+}
+
+func bucketBoundsFor(bucket *metrics.HistogramBucket) bucketBounds {
+	return bucketBounds{
+		lower: bucket.LowerBound,
+		upper: bucket.UpperBound,
+	}
 }

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -444,6 +444,119 @@ func TestCheckHistogramBucketReset(t *testing.T) {
 	testWithTagsStore(t, testCheckHistogramBucketReset)
 }
 
+func testCheckHistogramBucketMultipleBucketsSampling(t *testing.T, store *tags.Store) {
+	taggerComponent := nooptagger.NewComponent()
+	checkSampler := newCheckSampler(1, true, true, 1*time.Second, true, store, checkid.ID("hello:world:1234"), taggerComponent)
+
+	tagmatcher := filterlistimpl.NewNoopTagMatcher()
+	matcher := strings.NewMatcher([]string{}, false)
+
+	// Two buckets with the same name and tags (so they share a context key)
+	// but different bounds. MultipleBuckets: true forces addBucket to track
+	// last-seen monotonic values per (contextKey, bounds) pair.
+	bucket1 := &metrics.HistogramBucket{
+		Name:            "my.histogram",
+		Value:           4,
+		LowerBound:      10.0,
+		UpperBound:      20.0,
+		Tags:            []string{"foo", "bar"},
+		Timestamp:       12345.0,
+		Monotonic:       true,
+		FlushFirstValue: true,
+		MultipleBuckets: true,
+	}
+	bucket2 := &metrics.HistogramBucket{
+		Name:            "my.histogram",
+		Value:           6,
+		LowerBound:      30.0,
+		UpperBound:      40.0,
+		Tags:            []string{"foo", "bar"},
+		Timestamp:       12345.0,
+		Monotonic:       true,
+		FlushFirstValue: true,
+		MultipleBuckets: true,
+	}
+
+	checkSampler.addBucket(bucket1, tagmatcher)
+	checkSampler.addBucket(bucket2, tagmatcher)
+
+	ctx := generateContextKey(bucket1)
+	require.Equal(t, ctx, generateContextKey(bucket2))
+
+	// MultipleBuckets path must populate lastBucketValueByBound and leave
+	// the simple lastBucketValue map untouched.
+	assert.Len(t, checkSampler.lastBucketValue, 0)
+	require.Len(t, checkSampler.lastBucketValueByBound, 1)
+	assert.Len(t, checkSampler.lastBucketValueByBound[ctx], 2)
+
+	checkSampler.commit(12349.0, &matcher)
+	_, flushed := checkSampler.flush()
+	require.Len(t, flushed, 1)
+
+	expSketch := &quantile.Agent{}
+	expSketch.InsertInterpolate(10.0, 20.0, 4)
+	expSketch.InsertInterpolate(30.0, 40.0, 6)
+	metrics.AssertSketchSeriesApproxEqual(t, &metrics.SketchSeries{
+		Name: "my.histogram",
+		Tags: tagset.CompositeTagsFromSlice([]string{"foo", "bar"}),
+		Points: []metrics.SketchPoint{
+			{Ts: 12345.0, Sketch: expSketch.Finish()},
+		},
+		ContextKey: ctx,
+	}, flushed[0], .03)
+
+	// Second round: same bounds, larger raw values. Per-bound de-cumulation
+	// should produce delta sketches (3 and 5), not the raw new values.
+	bucket3 := &metrics.HistogramBucket{
+		Name:            "my.histogram",
+		Value:           7,
+		LowerBound:      10.0,
+		UpperBound:      20.0,
+		Tags:            []string{"foo", "bar"},
+		Timestamp:       12400.0,
+		Monotonic:       true,
+		MultipleBuckets: true,
+	}
+	bucket4 := &metrics.HistogramBucket{
+		Name:            "my.histogram",
+		Value:           11,
+		LowerBound:      30.0,
+		UpperBound:      40.0,
+		Tags:            []string{"foo", "bar"},
+		Timestamp:       12400.0,
+		Monotonic:       true,
+		MultipleBuckets: true,
+	}
+
+	checkSampler.addBucket(bucket3, tagmatcher)
+	checkSampler.addBucket(bucket4, tagmatcher)
+
+	checkSampler.commit(12401.0, &matcher)
+	_, flushed = checkSampler.flush()
+	require.Len(t, flushed, 1)
+
+	expSketch = &quantile.Agent{}
+	expSketch.InsertInterpolate(10.0, 20.0, 3)
+	expSketch.InsertInterpolate(30.0, 40.0, 5)
+	metrics.AssertSketchSeriesApproxEqual(t, &metrics.SketchSeries{
+		Name: "my.histogram",
+		Tags: tagset.CompositeTagsFromSlice([]string{"foo", "bar"}),
+		Points: []metrics.SketchPoint{
+			{Ts: 12400.0, Sketch: expSketch.Finish()},
+		},
+		ContextKey: ctx,
+	}, flushed[0], .03)
+
+	// One more commit without further adds expires the context (sampler was
+	// constructed with expirationCount=1) and triggers GC of the new map.
+	checkSampler.commit(12402.0, &matcher)
+	assert.Len(t, checkSampler.lastBucketValueByBound, 0)
+}
+
+func TestCheckHistogramBucketMultipleBucketsSampling(t *testing.T) {
+	testWithTagsStore(t, testCheckHistogramBucketMultipleBucketsSampling)
+}
+
 func sketchOf(lower, upper float64, count uint) *quantile.Sketch {
 	s := quantile.Agent{}
 	s.InsertInterpolate(lower, upper, count)

--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -49,9 +49,9 @@ func (m *MockSender) AssertMonotonicCount(t *testing.T, method string, metric st
 	return m.Mock.AssertCalled(t, method, metric, value, hostname, MatchTagsContains(tags), flushFirstValue)
 }
 
-// AssertHistogramBucket allows to assert a histogram bucket was emitted with given parameters.
+// AssertOpenmetricsBucket allows to assert an openmetrics bucket was emitted with given parameters.
 // Additional tags over the ones specified don't make it fail
-func (m *MockSender) AssertHistogramBucket(t *testing.T, method string, metric string, value int64, lowerBound float64, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) bool {
+func (m *MockSender) AssertOpenmetricsBucket(t *testing.T, method string, metric string, value int64, lowerBound float64, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) bool {
 	return m.Mock.AssertCalled(t, method, metric, value, lowerBound, upperBound, monotonic, hostname, tags, flushFirstValue)
 }
 

--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -55,6 +55,12 @@ func (m *MockSender) AssertOpenmetricsBucket(t *testing.T, method string, metric
 	return m.Mock.AssertCalled(t, method, metric, value, lowerBound, upperBound, monotonic, hostname, tags, flushFirstValue)
 }
 
+// AssertHistogramBucket allows to assert a histogram bucket was emitted with given parameters.
+// Additional tags over the ones specified don't make it fail
+func (m *MockSender) AssertHistogramBucket(t *testing.T, method string, metric string, value int64, lowerBound float64, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) bool {
+	return m.Mock.AssertCalled(t, method, metric, value, lowerBound, upperBound, monotonic, hostname, tags, flushFirstValue)
+}
+
 // AssertMetricInRange allows to assert a metric was emitted with given parameters, with a value in a given range.
 // Additional tags over the ones specified don't make it fail
 func (m *MockSender) AssertMetricInRange(t *testing.T, method string, metric string, min float64, max float64, hostname string, tags []string) bool {

--- a/pkg/aggregator/mocksender/mocked_methods.go
+++ b/pkg/aggregator/mocksender/mocked_methods.go
@@ -98,6 +98,11 @@ func (m *MockSender) OpenmetricsBucket(metric string, value int64, lowerBound, u
 	m.Called(metric, value, lowerBound, upperBound, monotonic, hostname, tags, flushFirstValue)
 }
 
+// HistogramBucket enables the histogram bucket mock call.
+func (m *MockSender) HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
+	m.Called(metric, value, lowerBound, upperBound, monotonic, hostname, tags, flushFirstValue)
+}
+
 // Commit enables the commit mock call.
 func (m *MockSender) Commit() {
 	m.Called()

--- a/pkg/aggregator/mocksender/mocked_methods.go
+++ b/pkg/aggregator/mocksender/mocked_methods.go
@@ -93,8 +93,8 @@ func (m *MockSender) EventPlatformEvent(rawEvent []byte, eventType string) {
 	m.Called(rawEvent, eventType)
 }
 
-// HistogramBucket enables the histogram bucket mock call.
-func (m *MockSender) HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
+// OpenmetricsBucket enables the openmetrics bucket mock call.
+func (m *MockSender) OpenmetricsBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
 	m.Called(metric, value, lowerBound, upperBound, monotonic, hostname, tags, flushFirstValue)
 }
 

--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -115,7 +115,7 @@ func (m *MockSender) SetupAcceptAll() {
 	// The second argument should have been `mock.AnythingOfType("[]byte")` instead of `mock.AnythingOfType("[]uint8")`
 	// See https://github.com/stretchr/testify/issues/387
 	m.On("EventPlatformEvent", mock.AnythingOfType("[]uint8"), mock.AnythingOfType("string")).Return()
-	m.On("HistogramBucket",
+	m.On("OpenmetricsBucket",
 		mock.AnythingOfType("string"),   // metric name
 		mock.AnythingOfType("int64"),    // value
 		mock.AnythingOfType("float64"),  // lower bound

--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -115,16 +115,19 @@ func (m *MockSender) SetupAcceptAll() {
 	// The second argument should have been `mock.AnythingOfType("[]byte")` instead of `mock.AnythingOfType("[]uint8")`
 	// See https://github.com/stretchr/testify/issues/387
 	m.On("EventPlatformEvent", mock.AnythingOfType("[]uint8"), mock.AnythingOfType("string")).Return()
-	m.On("OpenmetricsBucket",
-		mock.AnythingOfType("string"),   // metric name
-		mock.AnythingOfType("int64"),    // value
-		mock.AnythingOfType("float64"),  // lower bound
-		mock.AnythingOfType("float64"),  // upper bound
-		mock.AnythingOfType("bool"),     // monotonic
-		mock.AnythingOfType("string"),   // hostname
-		mock.AnythingOfType("[]string"), // tags
-		mock.AnythingOfType("bool"),     // FlushFirstValue
-	).Return()
+	bucketCalls := []string{"OpenmetricsBucket", "HistogramBucket"}
+	for _, call := range bucketCalls {
+		m.On(call,
+			mock.AnythingOfType("string"),   // metric name
+			mock.AnythingOfType("int64"),    // value
+			mock.AnythingOfType("float64"),  // lower bound
+			mock.AnythingOfType("float64"),  // upper bound
+			mock.AnythingOfType("bool"),     // monotonic
+			mock.AnythingOfType("string"),   // hostname
+			mock.AnythingOfType("[]string"), // tags
+			mock.AnythingOfType("bool"),     // FlushFirstValue
+		).Return()
+	}
 	m.On("GetSenderStats", mock.AnythingOfType("stats.SenderStats")).Return()
 	m.On("DisableDefaultHostname", mock.AnythingOfType("bool")).Return()
 	m.On("SetCheckCustomTags", mock.AnythingOfType("[]string")).Return()

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -262,8 +262,31 @@ func (s *checkSender) Histogram(metric string, value float64, hostname string, t
 	s.sendMetricSample(metric, value, hostname, tags, metrics.HistogramType, false, false, 0)
 }
 
-// OpenmetricsBucket should be called to directly send raw buckets to be submitted as distribution metrics
+// HistogramBucket should be called to send pre-aggregated histogram observations as a sketch.
+//
+// value is the number of observations that fall between lowerBound and upperBound. Observations
+// will be spread proportionally over a range of sketch buckets.
+//
+// lowerBound and upperBound specify the range of observations counted by the bucket. To record
+// number of observations for a discrete number (e.g. a count itself), use the same value for both
+// bounds.
+//
+// monotonic flag indicates that value increases monotonically between calls, and a separate delta
+// for each bucket will be computed. First value for each bucket will not be reported because no
+// previous value to compute from, unless flushFirstValue is supplied (e.g. if caller knows that the
+// histogram started from zero recently).
+func (s *checkSender) HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
+	s.sendHistogramBucket(metric, value, lowerBound, upperBound, monotonic, hostname, tags, flushFirstValue, true)
+}
+
+// OpenmetricsBucket should be called to directly send raw buckets to be submitted as distribution metrics.
+// It assumes a single bucket per (metric name, tags) context, as produced by Openmetrics/Prometheus
+// integrations that encode bucket bounds in the `lower_bound` tag.
 func (s *checkSender) OpenmetricsBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
+	s.sendHistogramBucket(metric, value, lowerBound, upperBound, monotonic, hostname, tags, flushFirstValue, false)
+}
+
+func (s *checkSender) sendHistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue, multipleBuckets bool) {
 	tags = append(tags, s.checkTags...)
 
 	log.Tracef(
@@ -287,6 +310,7 @@ func (s *checkSender) OpenmetricsBucket(metric string, value int64, lowerBound, 
 		Tags:            tags,
 		Timestamp:       timeNowNano(),
 		FlushFirstValue: flushFirstValue,
+		MultipleBuckets: multipleBuckets,
 	}
 
 	if hostname == "" && !s.defaultHostnameDisabled {

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -262,8 +262,8 @@ func (s *checkSender) Histogram(metric string, value float64, hostname string, t
 	s.sendMetricSample(metric, value, hostname, tags, metrics.HistogramType, false, false, 0)
 }
 
-// HistogramBucket should be called to directly send raw buckets to be submitted as distribution metrics
-func (s *checkSender) HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
+// OpenmetricsBucket should be called to directly send raw buckets to be submitted as distribution metrics
+func (s *checkSender) OpenmetricsBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
 	tags = append(tags, s.checkTags...)
 
 	log.Tracef(

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -262,7 +262,8 @@ func (s *checkSender) Histogram(metric string, value float64, hostname string, t
 	s.sendMetricSample(metric, value, hostname, tags, metrics.HistogramType, false, false, 0)
 }
 
-// HistogramBucket should be called to send pre-aggregated histogram observations as a sketch.
+// HistogramBucket should be called to send pre-aggregated histogram observations as a sketch,
+// providing compact, aggregatable representation for histograms with bounded error.
 //
 // value is the number of observations that fall between lowerBound and upperBound. Observations
 // will be spread proportionally over a range of sketch buckets.

--- a/pkg/aggregator/sender/sender.go
+++ b/pkg/aggregator/sender/sender.go
@@ -28,7 +28,7 @@ type Sender interface {
 	Historate(metric string, value float64, hostname string, tags []string)
 	Distribution(metric string, value float64, hostname string, tags []string)
 	ServiceCheck(checkName string, status servicecheck.ServiceCheckStatus, hostname string, tags []string, message string)
-	HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool)
+	OpenmetricsBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool)
 	// GaugeWithTimestamp reports a new gauge value to the intake with the given timestamp.
 	// Gauge time series measure a simple value over time.
 	// Unlike Gauge(), each submitted value will be passed to the intake as is, without aggregation. Each time series can have only one value per timestamp.

--- a/pkg/aggregator/sender/sender.go
+++ b/pkg/aggregator/sender/sender.go
@@ -29,6 +29,7 @@ type Sender interface {
 	Distribution(metric string, value float64, hostname string, tags []string)
 	ServiceCheck(checkName string, status servicecheck.ServiceCheckStatus, hostname string, tags []string, message string)
 	OpenmetricsBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool)
+	HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool)
 	// GaugeWithTimestamp reports a new gauge value to the intake with the given timestamp.
 	// Gauge time series measure a simple value over time.
 	// Unlike Gauge(), each submitted value will be passed to the intake as is, without aggregation. Each time series can have only one value per timestamp.

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -48,7 +48,7 @@ type senderWithChans struct {
 }
 
 func initSender(id checkid.ID, defaultHostname string) (s senderWithChans) {
-	s.itemChan = make(chan senderItem, 10)
+	s.itemChan = make(chan senderItem, 16)
 	s.serviceCheckChan = make(chan servicecheck.ServiceCheck, 10)
 	s.eventChan = make(chan event.Event, 10)
 	s.orchestratorChan = make(chan senderOrchestratorMetadata, 10)
@@ -527,6 +527,7 @@ func TestCheckSenderInterface(t *testing.T) {
 	s.sender.Counter("my.counter_metric", 1.0, "my-hostname", []string{"foo", "bar"})
 	s.sender.Histogram("my.histo_metric", 3.0, "my-hostname", []string{"foo", "bar"})
 	s.sender.OpenmetricsBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", []string{"foo", "bar"}, true)
+	s.sender.HistogramBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", []string{"foo", "bar"}, false)
 	s.sender.Distribution("my.distribution", 43.0, "my-hostname", []string{"foo", "bar"})
 	s.sender.Commit()
 	s.sender.ServiceCheck("my_service.can_connect", servicecheck.ServiceCheckOK, "my-hostname", []string{"foo", "bar"}, "message")
@@ -590,6 +591,18 @@ func TestCheckSenderInterface(t *testing.T) {
 	assert.Equal(t, "my-hostname", histogramBucket.bucket.Host)
 	assert.Equal(t, []string{"foo", "bar"}, histogramBucket.bucket.Tags)
 	assert.Equal(t, true, histogramBucket.bucket.FlushFirstValue)
+	assert.Equal(t, false, histogramBucket.bucket.MultipleBuckets)
+
+	histogramBucket = (<-s.itemChan).(*senderHistogramBucket)
+	assert.Equal(t, "my.histogram_bucket", histogramBucket.bucket.Name)
+	assert.Equal(t, int64(42), histogramBucket.bucket.Value)
+	assert.Equal(t, 1.0, histogramBucket.bucket.LowerBound)
+	assert.Equal(t, 2.0, histogramBucket.bucket.UpperBound)
+	assert.Equal(t, true, histogramBucket.bucket.Monotonic)
+	assert.Equal(t, "my-hostname", histogramBucket.bucket.Host)
+	assert.Equal(t, []string{"foo", "bar"}, histogramBucket.bucket.Tags)
+	assert.Equal(t, false, histogramBucket.bucket.FlushFirstValue)
+	assert.Equal(t, true, histogramBucket.bucket.MultipleBuckets)
 
 	distributionSample := (<-s.itemChan).(*senderMetricSample)
 	assert.EqualValues(t, checkID1, distributionSample.id)

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -488,13 +488,13 @@ func TestGetSenderAddCheckCustomTagsHistogramBucket(t *testing.T) {
 	s := initSender(checkID1, "")
 
 	// no custom tags
-	s.sender.HistogramBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", nil, false)
+	s.sender.OpenmetricsBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", nil, false)
 	bucketSample := (<-s.itemChan).(*senderHistogramBucket)
 	assert.Nil(t, bucketSample.bucket.Tags)
 
 	// only tags added by the check
 	checkTags := []string{"check:tag1", "check:tag2"}
-	s.sender.HistogramBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", checkTags, false)
+	s.sender.OpenmetricsBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", checkTags, false)
 	bucketSample = (<-s.itemChan).(*senderHistogramBucket)
 	assert.Equal(t, checkTags, bucketSample.bucket.Tags)
 
@@ -504,12 +504,12 @@ func TestGetSenderAddCheckCustomTagsHistogramBucket(t *testing.T) {
 	assert.Len(t, s.sender.checkTags, 2)
 
 	// only tags coming from the configuration file
-	s.sender.HistogramBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", nil, false)
+	s.sender.OpenmetricsBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", nil, false)
 	bucketSample = (<-s.itemChan).(*senderHistogramBucket)
 	assert.Equal(t, customTags, bucketSample.bucket.Tags)
 
 	// tags added by the check + tags coming from the configuration file
-	s.sender.HistogramBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", checkTags, false)
+	s.sender.OpenmetricsBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", checkTags, false)
 	bucketSample = (<-s.itemChan).(*senderHistogramBucket)
 	assert.Equal(t, append(checkTags, customTags...), bucketSample.bucket.Tags)
 }
@@ -526,7 +526,7 @@ func TestCheckSenderInterface(t *testing.T) {
 	s.sender.MonotonicCountWithFlushFirstValue("my.monotonic_count_metric", 12.0, "my-hostname", []string{"foo", "bar"}, true)
 	s.sender.Counter("my.counter_metric", 1.0, "my-hostname", []string{"foo", "bar"})
 	s.sender.Histogram("my.histo_metric", 3.0, "my-hostname", []string{"foo", "bar"})
-	s.sender.HistogramBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", []string{"foo", "bar"}, true)
+	s.sender.OpenmetricsBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", []string{"foo", "bar"}, true)
 	s.sender.Distribution("my.distribution", 43.0, "my-hostname", []string{"foo", "bar"})
 	s.sender.Commit()
 	s.sender.ServiceCheck("my_service.can_connect", servicecheck.ServiceCheckOK, "my-hostname", []string{"foo", "bar"}, "message")

--- a/pkg/collector/aggregator/aggregator.go
+++ b/pkg/collector/aggregator/aggregator.go
@@ -160,7 +160,7 @@ func SubmitHistogramBucket(checkID *C.char, metricName *C.char, value C.longlong
 	_tags := CStringArrayToSlice(unsafe.Pointer(tags))
 	_flushFirstValue := bool(flushFirstValue)
 
-	sender.HistogramBucket(_name, _value, _lowerBound, _upperBound, _monotonic, _hostname, _tags, _flushFirstValue)
+	sender.OpenmetricsBucket(_name, _value, _lowerBound, _upperBound, _monotonic, _hostname, _tags, _flushFirstValue)
 }
 
 // SubmitEventPlatformEvent is the method exposed to scripts to submit event platform events

--- a/pkg/collector/aggregator/test_aggregator.go
+++ b/pkg/collector/aggregator/test_aggregator.go
@@ -275,7 +275,7 @@ func testSubmitHistogramBucket(t *testing.T) {
 		true,
 	)
 
-	sender.AssertHistogramBucket(t, "HistogramBucket", "test_histogram", 42, 1.0, 2.0, true, "my_hostname", []string{"tag1", "tag2"}, true)
+	sender.AssertOpenmetricsBucket(t, "OpenmetricsBucket", "test_histogram", 42, 1.0, 2.0, true, "my_hostname", []string{"tag1", "tag2"}, true)
 }
 
 func testSubmitEventPlatformEvent(t *testing.T) {

--- a/pkg/collector/corechecks/safesender.go
+++ b/pkg/collector/corechecks/safesender.go
@@ -84,9 +84,9 @@ func (ss *safeSender) ServiceCheck(checkName string, status servicecheck.Service
 	ss.Sender.ServiceCheck(checkName, status, hostname, cloneTags(tags), message)
 }
 
-// HistogramBucket implements sender.Sender#HistogramBucket.
-func (ss *safeSender) HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
-	ss.Sender.HistogramBucket(metric, value, lowerBound, upperBound, monotonic, hostname, cloneTags(tags), flushFirstValue)
+// OpenmetricsBucket implements sender.Sender#OpenmetricsBucket.
+func (ss *safeSender) OpenmetricsBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
+	ss.Sender.OpenmetricsBucket(metric, value, lowerBound, upperBound, monotonic, hostname, cloneTags(tags), flushFirstValue)
 }
 
 // SetCheckCustomTags implements sender.Sender#SetCheckCustomTags.

--- a/pkg/collector/corechecks/safesender.go
+++ b/pkg/collector/corechecks/safesender.go
@@ -89,6 +89,11 @@ func (ss *safeSender) OpenmetricsBucket(metric string, value int64, lowerBound, 
 	ss.Sender.OpenmetricsBucket(metric, value, lowerBound, upperBound, monotonic, hostname, cloneTags(tags), flushFirstValue)
 }
 
+// HistogramBucket implements sender.Sender#HistogramBucket.
+func (ss *safeSender) HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
+	ss.Sender.HistogramBucket(metric, value, lowerBound, upperBound, monotonic, hostname, cloneTags(tags), flushFirstValue)
+}
+
 // SetCheckCustomTags implements sender.Sender#SetCheckCustomTags.
 func (ss *safeSender) SetCheckCustomTags(tags []string) {
 	ss.Sender.SetCheckCustomTags(cloneTags(tags))

--- a/pkg/metrics/histogram_bucket.go
+++ b/pkg/metrics/histogram_bucket.go
@@ -21,6 +21,8 @@ type HistogramBucket struct {
 	Host            string
 	Timestamp       float64
 	FlushFirstValue bool
+	// MultipleBuckets tells check sampler to expect more buckets for the given context.
+	MultipleBuckets bool
 	Source          MetricSource
 }
 


### PR DESCRIPTION
### What does this PR do?

Generalize HistogramBucket to make it more useful outside of Prometheus/Openmetrics. In particular:

- Extend check sampler to support monotonic counters with more than one bucket per metric. Some openmetrics checks handle a lot of metrics, so we preserve old single-bucket decumulation behavior to avoid unnecessary overhead.
- Rename old HistogramBucket to OpenmetricsBucket in Go to highlight its specificity for OpenMetrics.
- Re-add HistogramBucket with the more generic behavior for Go checks.

### Motivation

An integration needs to send distributions from a pre-aggregated histogram.

### Describe how you validated your changes

### Additional Notes
