### PR TITLE
[ACIX-1497] Improve otel docker images caching performance

### DIFF
--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -21,16 +21,28 @@ integration_tests_otel:
 
 docker_image_build_otel:
   stage: integration_test
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   needs: ["integration_tests_otel"]
-  tags: ["docker-in-docker:amd64"]
+  extends: [.docker_build_amd64, .docker_build_job_definition]
   variables:
     KUBERNETES_MEMORY_REQUEST: 32Gi
     KUBERNETES_MEMORY_LIMIT: 32Gi
+    BUILD_ARG: |
+      --build-arg AGENT_VERSION=$CI_COMMIT_REF_NAME \
+      --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
+      --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
+      --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
+      --build-arg BASE_IMAGE_REGISTRY=registry.ddbuild.io/images/mirror \
+      --build-arg CI \
+      --build-arg DDA_VERSION=$DDA_VERSION \
+      --build-arg GOPROXY \
+      --build-arg GONOSUMDB \
+    BUILD_CONTEXT: /tmp/otel-ci
+    TARGET_TAG: agent-byoc:latest
+    CACHE_TARGET: builder_base
   before_script:
     - mkdir -p /tmp/otel-ci
     - cp comp/otelcol/collector-contrib/impl/manifest.yaml /tmp/otel-ci/
-    - cp Dockerfiles/agent-ddot/Dockerfile.agent-otel /tmp/otel-ci/
+    - cp Dockerfiles/agent-ddot/Dockerfile.agent-otel /tmp/otel-ci/Dockerfile
     - cp test/integration/docker/otel_agent_build_tests.py /tmp/otel-ci/
     - export OTELCOL_VERSION=$(yq eval '.processors[] | select(.gomod | test("opentelemetry-collector-contrib")) | .gomod' /tmp/otel-ci/manifest.yaml | head -1 | awk '{print $NF}')
     - >-
@@ -41,28 +53,15 @@ docker_image_build_otel:
       yq eval -i
       '.processors += [{"gomod": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor " + env(OTELCOL_VERSION)}]'
       /tmp/otel-ci/manifest.yaml
-  script:
     - !reference [.login_to_docker_readonly]
     - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
     - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
+  after_script:
     - |
-      docker build \
-      --build-arg AGENT_VERSION=$CI_COMMIT_REF_NAME \
-      --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
-      --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
-      --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
-      --build-arg BASE_IMAGE_REGISTRY=registry.ddbuild.io/images/mirror \
-      --build-arg CI \
-      --build-arg DDA_VERSION=$DDA_VERSION \
-      --build-arg GOPROXY \
-      --build-arg GONOSUMDB \
-      --tag agent-byoc:latest \
-      -f /tmp/otel-ci/Dockerfile.agent-otel \
-      /tmp/otel-ci
-    - |
-      OT_AGENT_IMAGE_NAME=agent-byoc \
-      OT_AGENT_TAG=latest python3 \
-      /tmp/otel-ci/otel_agent_build_tests.py
+    OT_AGENT_IMAGE_NAME=agent-byoc \
+    OT_AGENT_TAG=latest python3 \
+    /tmp/otel-ci/otel_agent_build_tests.py
+
   rules:
     - !reference [.except_mergequeue]
     - when: on_success

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -41,7 +41,7 @@ docker_image_build_otel:
       --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx
       --build-arg BASE_IMAGE_REGISTRY=registry.ddbuild.io/images/mirror
       --build-arg CI
-      --build-arg DDA_VERSION=$DDA_VERSION
+      --build-arg DDA_VERSION
       --build-arg GOPROXY
       --build-arg GONOSUMDB
       --build-arg GO_VERSION

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -27,15 +27,15 @@ docker_image_build_otel:
     KUBERNETES_MEMORY_REQUEST: 32Gi
     KUBERNETES_MEMORY_LIMIT: 32Gi
     BUILD_ARG: |
-      --build-arg AGENT_VERSION=$CI_COMMIT_REF_NAME \
-      --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
-      --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
-      --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
-      --build-arg BASE_IMAGE_REGISTRY=registry.ddbuild.io/images/mirror \
-      --build-arg CI \
-      --build-arg DDA_VERSION=$DDA_VERSION \
-      --build-arg GOPROXY \
-      --build-arg GONOSUMDB \
+      --build-arg AGENT_VERSION=$CI_COMMIT_REF_NAME
+      --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME
+      --build-arg AGENT_DOCKER_REPO=datadog/agent-dev
+      --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx
+      --build-arg BASE_IMAGE_REGISTRY=registry.ddbuild.io/images/mirror
+      --build-arg CI
+      --build-arg DDA_VERSION=$DDA_VERSION
+      --build-arg GOPROXY
+      --build-arg GONOSUMDB
     BUILD_CONTEXT: /tmp/otel-ci
     TARGET_TAG: agent-byoc:latest
     CACHE_TARGET: builder_base

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -132,7 +132,6 @@ docker_image_build_otel:
         --build-arg AGENT_OCI=registry.ddbuild.io/ci/remote-updates/datadog-agent:7.78.0-beta-byoc-integration-test-1 \
         --build-arg OUTPUT_OCI=$OUTPUT_OCI \
         --build-arg CI \
-        --build-arg DDA_VERSION=$DDA_VERSION \
         --build-arg GOPROXY=$GOPROXY \
         --build-arg GONOSUMDB=$GONOSUMDB \
         --build-arg GO_VERSION=$(cat .go-version)"
@@ -200,7 +199,6 @@ ddot_byoc_binary_build_test_ubuntu2004:
         --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
         --build-arg UBUNTU_VERSION=20.04 \
         --build-arg CI \
-        --build-arg DDA_VERSION=$DDA_VERSION \
         --build-arg GOPROXY=$GOPROXY \
         --build-arg GONOSUMDB=$GONOSUMDB \
         --build-arg GO_VERSION=$(cat .go-version)"

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -122,7 +122,8 @@ docker_image_build_otel:
         --build-arg CI \
         --build-arg DDA_VERSION=$DDA_VERSION \
         --build-arg GOPROXY=$GOPROXY \
-        --build-arg GONOSUMDB=$GONOSUMDB"
+        --build-arg GONOSUMDB=$GONOSUMDB \
+        --build-arg GO_VERSION=$(cat .go-version)"
     - !reference [.ddot_byoc_build_cache_setup, script]
     # TODO: use staging package for AGENT_OCI until DDOT extension is released in 7.78.0
     - |
@@ -189,7 +190,8 @@ ddot_byoc_binary_build_test_ubuntu2004:
         --build-arg CI \
         --build-arg DDA_VERSION=$DDA_VERSION \
         --build-arg GOPROXY=$GOPROXY \
-        --build-arg GONOSUMDB=$GONOSUMDB"
+        --build-arg GONOSUMDB=$GONOSUMDB \
+        --build-arg GO_VERSION=$(cat .go-version)"
     - !reference [.ddot_byoc_build_cache_setup, script]
     - |
       docker buildx build \

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -41,7 +41,6 @@ docker_image_build_otel:
       --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx
       --build-arg BASE_IMAGE_REGISTRY=registry.ddbuild.io/images/mirror
       --build-arg CI
-      --build-arg DDA_VERSION
       --build-arg GOPROXY
       --build-arg GONOSUMDB
       --build-arg GO_VERSION
@@ -63,8 +62,6 @@ docker_image_build_otel:
       '.processors += [{"gomod": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor " + env(OTELCOL_VERSION)}]'
       /tmp/otel-ci/manifest.yaml
     - !reference [.login_to_docker_readonly]
-    - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
-    - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
     - export GO_VERSION=$(cat .go-version)
   after_script:
     # Compute the image name and tag the template will push to, so after_script can reference them.

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -23,9 +23,17 @@ docker_image_build_otel:
   stage: integration_test
   needs: ["integration_tests_otel"]
   extends: [.docker_build_amd64, .docker_build_job_definition]
+  # TODO: switch back to ["arch:amd64"] runners (from `.docker_build_amd64`) once
+  # the docker Python SDK in the `docker_x64` build image is upgraded to >=7.0.0.
+  # The older SDK uses an `http+docker://` URL scheme internally when connecting
+  # via Unix socket, which newer urllib3 rejects — breaking the after_script
+  # tests on non-DinD runners. DinD runners avoid the code path entirely (Docker
+  # is reached over TCP), which is why the same image worked there before.
+  tags: ["docker-in-docker:amd64"]
   variables:
     KUBERNETES_MEMORY_REQUEST: 32Gi
     KUBERNETES_MEMORY_LIMIT: 32Gi
+    AFTER_SCRIPT_IGNORE_ERRORS: false # We run tests in the after_script
     BUILD_ARG: |
       --build-arg AGENT_VERSION=$CI_COMMIT_REF_NAME
       --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -44,6 +44,7 @@ docker_image_build_otel:
       --build-arg DDA_VERSION=$DDA_VERSION
       --build-arg GOPROXY
       --build-arg GONOSUMDB
+      --build-arg GO_VERSION
     BUILD_CONTEXT: /tmp/otel-ci
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent-byoc
     CACHE_TARGET: builder_base
@@ -64,6 +65,7 @@ docker_image_build_otel:
     - !reference [.login_to_docker_readonly]
     - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
     - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
+    - export GO_VERSION=$(cat .go-version)
   after_script:
     # Compute the image name and tag the template will push to, so after_script can reference them.
     # ECR_RELEASE_SUFFIX mirrors the logic in .docker_build_job_definition.

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -57,10 +57,10 @@ docker_image_build_otel:
     - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
     - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
   after_script:
-    - |
-    OT_AGENT_IMAGE_NAME=agent-byoc \
-    OT_AGENT_TAG=latest python3 \
-    /tmp/otel-ci/otel_agent_build_tests.py
+    - >-
+      OT_AGENT_IMAGE_NAME=agent-byoc
+      OT_AGENT_TAG=latest python3
+      /tmp/otel-ci/otel_agent_build_tests.py
 
   rules:
     - !reference [.except_mergequeue]

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -66,41 +66,65 @@ docker_image_build_otel:
     - !reference [.except_mergequeue]
     - when: on_success
 
+# Shared caching logic for all DDOT BYOC build jobs.
+# Expects BUILD_ARGS and IMAGE to be set before referencing.
+# Defines CACHE_FROM and CACHE_TO for use in subsequent build steps.
+.ddot_byoc_build_cache_setup:
+  script:
+    - |
+      CACHE_REGISTRY="${IMAGE}-amd64:cache"
+      CACHE_FROM="--cache-from type=registry,ref=${CACHE_REGISTRY}"
+      CACHE_TO=""
+      if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" || "$BUCKET_BRANCH" == "nightly" ]]; then
+        CACHE_TO="--cache-to type=registry,ref=${CACHE_REGISTRY},mode=max"
+      fi
+      docker buildx build \
+        --target builder_base \
+        ${CACHE_FROM} \
+        ${CACHE_TO} \
+        ${BUILD_ARGS} \
+        -f /tmp/otel-ci/Dockerfile \
+        /tmp/otel-ci
+
 # Test that the BYOC packages can be built with the existing Dockerfile
 .ddot_byoc_oci_build_test:
   stage: integration_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   needs: ["integration_tests_otel"]
   tags: ["docker-in-docker:amd64"]
+  variables:
+    IMAGE: registry.ddbuild.io/ci/datadog-agent/$DDOT_BYOC_OCI_REPO-builder
   before_script:
     - !reference [docker_image_build_otel, before_script]
     - apt-get update && apt-get install -y --no-install-recommends zstd
-  script:
-    - !reference [.login_to_docker_readonly]
-    - AGENT_VERSION=$(dda inv -- agent.version --no-include-git --no-include-pre)
-    - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
-    - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
     # Start a local OCI registry to receive both the source agent OCI and the output image
     - docker run -d -p 5000:5000 --name local-registry registry:2
-    - OUTPUT_OCI="localhost:5000/${DDOT_BYOC_OCI_REPO}:${AGENT_VERSION}"
+    - export AGENT_VERSION=$(dda inv -- agent.version --no-include-git --no-include-pre)
+    - export OUTPUT_OCI="localhost:5000/${DDOT_BYOC_OCI_REPO}:${AGENT_VERSION}"
+  script:
+    - |
+      BUILD_ARGS="\
+        --build-arg AGENT_VERSION=$AGENT_VERSION \
+        --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
+        --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
+        --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
+        --build-arg PACKAGE_TYPE=$DDOT_BYOC_PACKAGE_TYPE \
+        --build-arg AGENT_OCI=registry.ddbuild.io/ci/remote-updates/datadog-agent:7.78.0-beta-byoc-integration-test-1 \
+        --build-arg OUTPUT_OCI=$OUTPUT_OCI \
+        --build-arg CI \
+        --build-arg DDA_VERSION=$DDA_VERSION \
+        --build-arg GOPROXY=$GOPROXY \
+        --build-arg GONOSUMDB=$GONOSUMDB"
+    - !reference [.ddot_byoc_build_cache_setup, script]
     # TODO: use staging package for AGENT_OCI until DDOT extension is released in 7.78.0
     - |
-      docker build \
-      --target builder \
-      --network=host \
-      --build-arg AGENT_VERSION=$AGENT_VERSION \
-      --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
-      --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
-      --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
-      --build-arg PACKAGE_TYPE=$DDOT_BYOC_PACKAGE_TYPE \
-      --build-arg AGENT_OCI=registry.ddbuild.io/ci/remote-updates/datadog-agent:7.78.0-beta-byoc-integration-test-1 \
-      --build-arg OUTPUT_OCI=$OUTPUT_OCI \
-      --build-arg CI \
-      --build-arg DDA_VERSION=$DDA_VERSION \
-      --build-arg GOPROXY=$GOPROXY \
-      --build-arg GONOSUMDB=$GONOSUMDB \
-      -f /tmp/otel-ci/Dockerfile.agent-otel \
-      /tmp/otel-ci
+      docker buildx build \
+        --target builder \
+        --network=host \
+        ${CACHE_FROM} \
+        ${BUILD_ARGS} \
+        -f /tmp/otel-ci/Dockerfile \
+        /tmp/otel-ci
     # Verify the OCI image index was pushed and the replaced binary is present in the ddot layer
     - |
       REGISTRY_BASE="http://localhost:5000/v2/${DDOT_BYOC_OCI_REPO}"
@@ -141,28 +165,33 @@ ddot_byoc_binary_build_test_ubuntu2004:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   needs: ["integration_tests_otel"]
   tags: ["docker-in-docker:amd64"]
+  variables:
+    IMAGE: registry.ddbuild.io/ci/datadog-agent/ddot-byoc-ubuntu2004-builder
   before_script:
     - !reference [docker_image_build_otel, before_script]
+    - export AGENT_VERSION=$(dda inv -- agent.version --no-include-git --no-include-pre)
   script:
-    - !reference [.login_to_docker_readonly]
-    - AGENT_VERSION=$(dda inv -- agent.version --no-include-git --no-include-pre)
-    - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
-    - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
     - |
-      docker build \
-      --target builder \
-      --tag otel-builder-tmp \
-      --build-arg AGENT_VERSION=$AGENT_VERSION \
-      --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
-      --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
-      --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
-      --build-arg UBUNTU_VERSION=20.04 \
-      --build-arg CI \
-      --build-arg DDA_VERSION=$DDA_VERSION \
-      --build-arg GOPROXY=$GOPROXY \
-      --build-arg GONOSUMDB=$GONOSUMDB \
-      -f /tmp/otel-ci/Dockerfile.agent-otel \
-      /tmp/otel-ci
+      BUILD_ARGS="\
+        --build-arg AGENT_VERSION=$AGENT_VERSION \
+        --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
+        --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
+        --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
+        --build-arg UBUNTU_VERSION=20.04 \
+        --build-arg CI \
+        --build-arg DDA_VERSION=$DDA_VERSION \
+        --build-arg GOPROXY=$GOPROXY \
+        --build-arg GONOSUMDB=$GONOSUMDB"
+    - !reference [.ddot_byoc_build_cache_setup, script]
+    - |
+      docker buildx build \
+        --target builder \
+        --load \
+        --tag otel-builder-tmp \
+        ${CACHE_FROM} \
+        ${BUILD_ARGS} \
+        -f /tmp/otel-ci/Dockerfile \
+        /tmp/otel-ci
     - mkdir -p ddot-byoc
     - docker run --rm -v "$(pwd)/ddot-byoc:/out" otel-builder-tmp cp /workspace/datadog-agent/bin/otel-agent/otel-agent /out/otel-agent
     - BIN_PATH=ddot-byoc/otel-agent

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -70,7 +70,7 @@ docker_image_build_otel:
     # Compute the image name and tag the template will push to, so after_script can reference them.
     # ECR_RELEASE_SUFFIX mirrors the logic in .docker_build_job_definition.
     - |
-      if [[ "$BUCKET_BRANCH" == "nightly" ]]; then
+      if [[ "$BUCKET_BRANCH" == "nightly" && "$IMAGE" =~ "ci/datadog-agent/agent" ]]; then
         ECR_RELEASE_SUFFIX="-nightly"
       else
         ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG:+-release}"
@@ -92,11 +92,17 @@ docker_image_build_otel:
       CACHE_REGISTRY="${IMAGE}-amd64:cache"
       CACHE_FROM="--cache-from type=registry,ref=${CACHE_REGISTRY}"
       CACHE_TO=""
+      NO_CACHE=""
       if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" || "$BUCKET_BRANCH" == "nightly" ]]; then
         CACHE_TO="--cache-to type=registry,ref=${CACHE_REGISTRY},mode=max"
       fi
+      if [[ "$BUCKET_BRANCH" == "nightly" ]]; then
+        CACHE_FROM=""
+        NO_CACHE="--no-cache"
+      fi
       docker buildx build \
         --target builder_base \
+        ${NO_CACHE} \
         ${CACHE_FROM} \
         ${CACHE_TO} \
         ${BUILD_ARGS} \

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -45,7 +45,7 @@ docker_image_build_otel:
       --build-arg GOPROXY
       --build-arg GONOSUMDB
     BUILD_CONTEXT: /tmp/otel-ci
-    TARGET_TAG: agent-byoc:latest
+    IMAGE: registry.ddbuild.io/ci/datadog-agent/agent-byoc
     CACHE_TARGET: builder_base
   before_script:
     - mkdir -p /tmp/otel-ci
@@ -65,10 +65,17 @@ docker_image_build_otel:
     - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
     - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
   after_script:
-    - >-
-      OT_AGENT_IMAGE_NAME=agent-byoc
-      OT_AGENT_TAG=latest python3
-      /tmp/otel-ci/otel_agent_build_tests.py
+    # Compute the image name and tag the template will push to, so after_script can reference them.
+    # ECR_RELEASE_SUFFIX mirrors the logic in .docker_build_job_definition.
+    - |
+      if [[ "$BUCKET_BRANCH" == "nightly" ]]; then
+        ECR_RELEASE_SUFFIX="-nightly"
+      else
+        ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG:+-release}"
+      fi
+      export OT_AGENT_IMAGE_NAME="${IMAGE}${ECR_RELEASE_SUFFIX}"
+      export OT_AGENT_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-${ARCH}"
+    - python3 /tmp/otel-ci/otel_agent_build_tests.py
 
   rules:
     - !reference [.except_mergequeue]

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -11,7 +11,7 @@ ARG AGENT_OCI
 ARG OUTPUT_OCI
 
 # Use the Ubuntu Slim AMD64 base image
-FROM ${BASE_IMAGE_REGISTRY}/ubuntu:$UBUNTU_VERSION AS builder
+FROM ${BASE_IMAGE_REGISTRY}/ubuntu:$UBUNTU_VERSION AS builder_base
 
 # Set environment variables
 ARG AGENT_VERSION
@@ -68,28 +68,19 @@ RUN if [ "$PACKAGE_TYPE" = "windows" ]; then \
     && update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix; \
     fi
 
-# We can't get tarballs for dev branches, so we can't just pull the tarball from github.
-# Instead we make a treeless clone at the reference provided, and build from the repo.
-# We also have to use the repo clone because some invoke tasks rely on git coommands unavailable
-# in repo tarball archives. For the same reason a shallow clone will also not work.
-RUN git clone --branch ${AGENT_GIT_REF} --filter=tree:0 https://github.com/DataDog/datadog-agent.git datadog-agent
-
-# Set the working directory to the source code
-WORKDIR /workspace/datadog-agent
-
 # Install Go based on architecture
-RUN GO_VERSION=$(cat .go-version) && \
-    ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "amd64" ]; then \
-    GO_ARCH="linux-amd64"; \
-    elif [ "$ARCH" = "arm64" ]; then \
-    GO_ARCH="linux-arm64"; \
-    else \
-    echo "Unsupported architecture: $ARCH" && exit 1; \
-    fi && \
-    curl -fsSLO --retry 4 https://golang.org/dl/go${GO_VERSION}.$GO_ARCH.tar.gz && \
-    tar -C /usr/local -xzf go${GO_VERSION}.$GO_ARCH.tar.gz && \
-    rm go${GO_VERSION}.$GO_ARCH.tar.gz
+ARG GO_VERSION
+RUN ARCH=$(dpkg --print-architecture) && \
+if [ "$ARCH" = "amd64" ]; then \
+GO_ARCH="linux-amd64"; \
+elif [ "$ARCH" = "arm64" ]; then \
+GO_ARCH="linux-arm64"; \
+else \
+echo "Unsupported architecture: $ARCH" && exit 1; \
+fi && \
+curl -fsSLO --retry 4 https://golang.org/dl/go${GO_VERSION}.$GO_ARCH.tar.gz && \
+tar -C /usr/local -xzf go${GO_VERSION}.$GO_ARCH.tar.gz && \
+rm go${GO_VERSION}.$GO_ARCH.tar.gz
 
 # Set up Go environment
 ENV PATH="/usr/local/go/bin:${PATH}"
@@ -111,6 +102,16 @@ RUN ARCH=$(dpkg --print-architecture) && \
     chmod +x /usr/local/bin/dda && \
     dda self dep sync -f legacy-tasks
 
+
+FROM builder_base AS builder
+# We can't get tarballs for dev branches, so we can't just pull the tarball from github.
+# Instead we make a treeless clone at the reference provided, and build from the repo.
+# We also have to use the repo clone because some invoke tasks rely on git coommands unavailable
+# in repo tarball archives. For the same reason a shallow clone will also not work.
+RUN git clone --branch ${AGENT_GIT_REF} --filter=tree:0 https://github.com/DataDog/datadog-agent.git datadog-agent
+
+# Set the working directory to the source code
+WORKDIR /workspace/datadog-agent
 
 # Copy the manifest file
 COPY manifest.yaml /workspace/datadog-agent/comp/otelcol/collector-contrib/impl/manifest.yaml

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -95,9 +95,10 @@ RUN ARCH=$(dpkg --print-architecture) && \
 FROM builder_base AS builder
 # We can't get tarballs for dev branches, so we can't just pull the tarball from github.
 # Instead we make a treeless clone at the reference provided, and build from the repo.
-# We also have to use the repo clone because some invoke tasks rely on git coommands unavailable
+# We also have to use the repo clone because some invoke tasks rely on git commands unavailable
 # in repo tarball archives. For the same reason a shallow clone will also not work.
 ARG AGENT_GIT_REF
+ARG PACKAGE_TYPE
 RUN git clone --branch ${AGENT_GIT_REF} --filter=tree:0 https://github.com/DataDog/datadog-agent.git datadog-agent
 
 # Set the working directory to the source code

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -57,7 +57,7 @@ RUN if [ "$PACKAGE_TYPE" = "windows" ]; then \
     fi
 
 # Install Go based on architecture
-ARG GO_VERSION
+ARG GO_VERSION=1.25.9
 RUN ARCH=$(dpkg --print-architecture) && \
 if [ "$ARCH" = "amd64" ]; then \
 GO_ARCH="linux-amd64"; \
@@ -79,7 +79,7 @@ ENV GOPATH=/go
 RUN go version && \
     curl --version
 
-ARG DDA_VERSION
+ARG DDA_VERSION=v0.33.1
 ENV DDA_INTERACTIVE=false
 # Install prebuilt dda and sync tasks
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -6,21 +6,10 @@ ARG AGENT_DOCKER_TAG=${AGENT_VERSION}-full
 ARG AGENT_GIT_REF=${AGENT_VERSION}
 ARG BASE_IMAGE_REGISTRY=docker.io
 
-# Required for PACKAGE_TYPE=linux or windows: source agent OCI URL and output OCI URL.
-ARG AGENT_OCI
-ARG OUTPUT_OCI
-
 # Use the Ubuntu Slim AMD64 base image
 FROM ${BASE_IMAGE_REGISTRY}/ubuntu:$UBUNTU_VERSION AS builder_base
 
 # Set environment variables
-ARG AGENT_VERSION
-ARG AGENT_GIT_REF
-ARG CI
-ARG DDA_VERSION=v0.29.0
-ARG PACKAGE_TYPE
-ARG GOPROXY
-ARG GONOSUMDB
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set the working directory
@@ -32,8 +21,7 @@ WORKDIR /workspace
 # cause `apt update` to fail with exit code 100 or make it hang on `0% [Working]`
 # indefinitely. Therefore we create a mirrorlist with the 2 mirrors that we know
 # should be reliable enough in combination and also well maintained.
-RUN if [ "$CI" = "true" ]; then \
-  echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
+RUN echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
   echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist.ports && \
   for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
     if [ -f "$f" ]; then \
@@ -41,8 +29,7 @@ RUN if [ "$CI" = "true" ]; then \
              -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
              -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' "$f"; \
     fi; \
-  done; \
-  fi
+  done;
 
 # Update and install necessary packages
 RUN apt-get update && \
@@ -56,6 +43,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Windows cross-compilation tools if building for Windows
+ARG PACKAGE_TYPE
 RUN if [ "$PACKAGE_TYPE" = "windows" ]; then \
     apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -91,6 +79,7 @@ ENV GOPATH=/go
 RUN go version && \
     curl --version
 
+ARG DDA_VERSION
 ENV DDA_INTERACTIVE=false
 # Install prebuilt dda and sync tasks
 RUN ARCH=$(dpkg --print-architecture) && \
@@ -108,6 +97,7 @@ FROM builder_base AS builder
 # Instead we make a treeless clone at the reference provided, and build from the repo.
 # We also have to use the repo clone because some invoke tasks rely on git coommands unavailable
 # in repo tarball archives. For the same reason a shallow clone will also not work.
+ARG AGENT_GIT_REF
 RUN git clone --branch ${AGENT_GIT_REF} --filter=tree:0 https://github.com/DataDog/datadog-agent.git datadog-agent
 
 # Set the working directory to the source code
@@ -117,6 +107,8 @@ WORKDIR /workspace/datadog-agent
 COPY manifest.yaml /workspace/datadog-agent/comp/otelcol/collector-contrib/impl/manifest.yaml
 
 # Generate the files and clean up go cache to free space
+ARG GOPROXY
+ARG GONOSUMDB
 RUN GOPROXY=$GOPROXY GONOSUMDB=$GONOSUMDB dda inv collector.generate && \
     go clean -cache -modcache
 
@@ -148,6 +140,8 @@ RUN if [ "$PACKAGE_TYPE" = "linux" ] || [ "$PACKAGE_TYPE" = "windows" ]; then \
 #       --build-arg REGISTRY_AUTH=password \
 #       --secret id=registry_username,env=REGISTRY_USERNAME \
 #       --secret id=registry_password,env=REGISTRY_PASSWORD ...
+
+# Required for PACKAGE_TYPE=linux or windows: source agent OCI URL and output OCI URL.
 ARG AGENT_OCI
 ARG OUTPUT_OCI
 ARG REGISTRY_AUTH=""

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -33,6 +33,7 @@ GO_VERSION_REFERENCES: list[tuple[str, str, str, bool]] = [
     ("./.wwhrd.yml", "raw.githubusercontent.com/golang/go/go", "/LICENSE", True),
     ("./renovate.json", '"go": "', '"', True),
     ("./go.work", "go ", "", True),
+    ("./Dockerfiles/agent-ddot/Dockerfile.agent-otel", "ARG GO_VERSION=", "", True),
 ]
 
 PATTERN_MAJOR_MINOR = r'1\.\d+'


### PR DESCRIPTION
### What does this PR do?
Three things:
1. Restructure the `Dockerfile.agent-otel` to isolate a more-easily cacheable "dependencies" stage, akin to what is done on the main Agent images
2. Rework `docker_image_build_otel` so that it inherits from the main `.docker_build_job_definition` template
3. Add caching logic to the remaining BYOC jobs - these are a bit too different from `.docker_build_job_definition` to be able to cleanly use the template, so duplication is necessary.

### Motivation
- Improved performance (caching)
- Reduced reliance on apt mirrors (we shouldn't run the `apt install` steps almost ever since they should be cached most of the time) -> improved reliability
> This was the original intent behind this work, as a follow-up to incident-52989

### Describe how you validated your changes
Building the image locally works
CI

### Additional Notes
