### PR TITLE
[AGENTRUN-1277] [flare] Move workload-list.log to workloadmeta component flare provider

### DIFF
--- a/comp/core/workloadmeta/impl/flare_provider.go
+++ b/comp/core/workloadmeta/impl/flare_provider.go
@@ -74,8 +74,11 @@ func (w *workloadmeta) workloadListFlareProvider(_ context.Context, fb flaretype
 
 // fillFlare collects workloadmeta data for the flare archive.
 func (w *workloadmeta) fillFlare(ctx context.Context, fb flaretypes.FlareBuilder) error {
+	// workloadListFlareProvider runs first: it is fast (in-memory dump) and
+	// must not be starved by sbomFlareProvider, which can be slow when many
+	// or large image SBOMs are present and may exhaust the provider timeout.
 	return errors.Join(
-		w.sbomFlareProvider(ctx, fb),
 		w.workloadListFlareProvider(ctx, fb),
+		w.sbomFlareProvider(ctx, fb),
 	)
 }

--- a/comp/core/workloadmeta/impl/flare_provider.go
+++ b/comp/core/workloadmeta/impl/flare_provider.go
@@ -6,6 +6,7 @@
 package workloadmetaimpl
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -61,4 +62,21 @@ var invalidChars = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
 func idToFileSafe(id string) string {
 	// replace invalid characters with underscores
 	return invalidChars.ReplaceAllString(id, "_")
+}
+
+func (w *workloadmeta) workloadListFlareProvider(_ context.Context, fb flaretypes.FlareBuilder) error {
+	dump := w.Dump(true)
+	var buf bytes.Buffer
+	dump.Write(&buf)
+	return fb.AddFile("workload-list.log", buf.Bytes())
+}
+
+// fillFlare collects workloadmeta data for the flare archive.
+func (w *workloadmeta) fillFlare(ctx context.Context, fb flaretypes.FlareBuilder) error {
+	sbomErr := w.sbomFlareProvider(ctx, fb)
+	listErr := w.workloadListFlareProvider(ctx, fb)
+	if sbomErr != nil {
+		return sbomErr
+	}
+	return listErr
 }

--- a/comp/core/workloadmeta/impl/flare_provider.go
+++ b/comp/core/workloadmeta/impl/flare_provider.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -73,10 +74,8 @@ func (w *workloadmeta) workloadListFlareProvider(_ context.Context, fb flaretype
 
 // fillFlare collects workloadmeta data for the flare archive.
 func (w *workloadmeta) fillFlare(ctx context.Context, fb flaretypes.FlareBuilder) error {
-	sbomErr := w.sbomFlareProvider(ctx, fb)
-	listErr := w.workloadListFlareProvider(ctx, fb)
-	if sbomErr != nil {
-		return sbomErr
-	}
-	return listErr
+	return errors.Join(
+		w.sbomFlareProvider(ctx, fb),
+		w.workloadListFlareProvider(ctx, fb),
+	)
 }

--- a/comp/core/workloadmeta/impl/workloadmeta.go
+++ b/comp/core/workloadmeta/impl/workloadmeta.go
@@ -125,7 +125,7 @@ func NewWorkloadMeta(deps Dependencies) Provider {
 
 	return Provider{
 		Comp:          wm,
-		FlareProvider: flaretypes.NewProvider(wm.sbomFlareProvider),
+		FlareProvider: flaretypes.NewProvider(wm.fillFlare),
 		Endpoint:      api.NewAgentEndpointProvider(wm.writeResponse, "/workload-list", "GET"),
 	}
 }

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -248,8 +248,7 @@ func (r *RemoteFlareProvider) provideExtraFiles(_ context.Context, fb flaretypes
 		fb.AddFile("status.log", []byte("unable to get the status of the agent, is it running?"))           //nolint:errcheck
 		fb.AddFile("config-check.log", []byte("unable to get loaded checks config, is the agent running?")) //nolint:errcheck
 	} else {
-		fb.AddFileFromFunc("tagger-list.json", r.getAgentTaggerList)    //nolint:errcheck
-		fb.AddFileFromFunc("workload-list.log", r.getAgentWorkloadList) //nolint:errcheck
+		fb.AddFileFromFunc("tagger-list.json", r.getAgentTaggerList) //nolint:errcheck
 		if !coreagent.ProcessChecksRunInCoreAgent() {
 			fb.AddFileFromFunc("process-agent_tagger-list.json", r.getProcessAgentTaggerList) //nolint:errcheck
 			r.getChecksFromProcessAgent(fb, getProcessAPIAddressPort)
@@ -414,15 +413,6 @@ func (r *RemoteFlareProvider) GetTaggerList(remoteURL string) ([]byte, error) {
 	writer.Flush()
 
 	return b.Bytes(), nil
-}
-
-func (r *RemoteFlareProvider) getAgentWorkloadList() ([]byte, error) {
-	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
-	if err != nil {
-		return nil, err
-	}
-
-	return r.GetWorkloadList(fmt.Sprintf("https://%v:%v/agent/workload-list?verbose=true", ipcAddress, pkgconfigsetup.Datadog().GetInt("cmd_port")))
 }
 
 // GetWorkloadList fetches the workload list from the given URL.

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -143,40 +143,6 @@ func TestGetAgentTaggerList(t *testing.T) {
 	assert.Contains(t, string(content), "image_name:custom-agent")
 }
 
-func TestGetWorkloadList(t *testing.T) {
-	workloadMap := make(map[string]workloadmeta.WorkloadEntity)
-	workloadMap["kind_id"] = workloadmeta.WorkloadEntity{
-		Infos: map[string]string{
-			"container_id_1": "Name: init-volume ID: e19e1ba787",
-			"container_id_2": "Name: init-config ID: 4e0ffee5d6",
-		},
-	}
-	resp := workloadmeta.WorkloadDumpResponse{
-		Entities: workloadMap,
-	}
-	ipcComp := ipcmock.New(t)
-
-	ts := ipcComp.NewMockServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		out, _ := json.Marshal(resp)
-		w.Write(out)
-	}))
-
-	setupIPCAddress(t, configmock.New(t), ts.URL)
-
-	remoteProvider := RemoteFlareProvider{
-		IPC: ipcComp,
-	}
-
-	content, err := remoteProvider.getAgentWorkloadList()
-	require.NoError(t, err)
-
-	assert.Contains(t, string(content), "kind_id")
-	assert.Contains(t, string(content), "container_id_1")
-	assert.Contains(t, string(content), "Name: init-volume ID: e19e1ba787")
-	assert.Contains(t, string(content), "container_id_2")
-	assert.Contains(t, string(content), "Name: init-config ID: 4e0ffee5d6")
-}
-
 func TestVersionHistory(t *testing.T) {
 	srcDir := createTestFile(t, "version-history.json")
 


### PR DESCRIPTION
## What does this PR do?

`provideExtraFiles` was making a round-trip HTTPS IPC call to `/agent/workload-list?verbose=true` — an endpoint the workloadmeta component itself serves — then unmarshaling the JSON response and re-rendering it as plain text.

This PR eliminates the round-trip by calling `Dump(true)` directly on the workloadmeta component inside its own flare provider:

- `workloadListFlareProvider` calls `w.Dump(true)` directly, writes via `WorkloadDumpResponse.Write`, and adds the result as `workload-list.log`
- Both the existing `sbomFlareProvider` and the new `workloadListFlareProvider` are combined under a single `fillFlare` entry point so both always run regardless of individual errors
- `getAgentWorkloadList` and `TestGetWorkloadList` are removed from `pkg/flare/`

`GetWorkloadList` (the generic IPC helper used by the cluster agent path) is kept unchanged.

## Motivation

`pkg/flare.ExtraFlareProviders()` is explicitly marked as legacy code that should be removed. This is one step in that direction, removing an unnecessary HTTP self-call in favour of direct component access. Also removes a JSON marshal/unmarshal cycle: the old path serialized the workload dump to JSON over HTTP, then deserialized it back just to call `Write()`.

## Testing

CI

## Related

Part of a series migrating legacy flare providers off `pkg/flare.ExtraFlareProviders()` to proper FX component providers.