### PR TITLE
[AGENTRUN-1277] [flare] Move runtime_config_dump.yaml to config component flare provider

### DIFF
--- a/comp/core/config/BUILD.bazel
+++ b/comp/core/config/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/config/setup",
         "//pkg/util/defaultpaths",
         "//pkg/util/fxutil",
+        "@in_yaml_go_yaml_v2//:yaml",
         "@org_uber_go_fx//:fx",
     ] + select({
         "@rules_go//go/platform:windows": [

--- a/comp/core/config/config.go
+++ b/comp/core/config/config.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"go.uber.org/fx"
+	"go.yaml.in/yaml/v2"
 
 	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	delegatedauthnooptypes "github.com/DataDog/datadog-agent/comp/core/delegatedauth/noop-impl/types"
@@ -129,5 +130,9 @@ func (c *cfg) fillFlare(_ context.Context, fb flaretypes.FlareBuilder) error {
 		fb.CopyFileTo(path, filepath.Join("etc/extra_conf/", path)) //nolint:errcheck
 	}
 
-	return nil
+	yamlData, err := yaml.Marshal(c.AllSettingsWithoutSecrets())
+	if err != nil {
+		return err
+	}
+	return fb.AddFile("runtime_config_dump.yaml", yamlData)
 }

--- a/comp/core/config/go.mod
+++ b/comp/core/config/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.61.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/fx v1.24.0
+	go.yaml.in/yaml/v2 v2.4.4
 )
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect
@@ -73,7 +74,6 @@ require (
 	go.uber.org/dig v1.19.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
-	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -200,8 +200,7 @@ func (r *RemoteFlareProvider) provideRemoteConfig(ctx context.Context, fb flaret
 }
 
 func (r *RemoteFlareProvider) provideConfigDump(_ context.Context, fb flaretypes.FlareBuilder) error {
-	fb.AddFileFromFunc("process_agent_runtime_config_dump.yaml", r.getProcessAgentFullConfig)                                      //nolint:errcheck
-	fb.AddFileFromFunc("runtime_config_dump.yaml", func() ([]byte, error) { return common.MarshalDatadogRuntimeConfigDumpYAML() }) //nolint:errcheck
+	fb.AddFileFromFunc("process_agent_runtime_config_dump.yaml", r.getProcessAgentFullConfig) //nolint:errcheck
 	return nil
 }
 


### PR DESCRIPTION
## What does this PR do?

`provideConfigDump` was calling `common.MarshalDatadogRuntimeConfigDumpYAML()` which reads the in-process config via the global `pkgconfigsetup.Datadog()` accessor. The config component already holds the config object and exposes `AllSettingsWithoutSecrets()` directly through `model.Reader`.

This PR moves the runtime config dump into the config component's existing `fillFlare`, calling `c.AllSettingsWithoutSecrets()` directly. The now-empty `runtime_config_dump.yaml` line is removed from `provideConfigDump`, which retains only its process-agent IPC call.

## Motivation

`pkg/flare.ExtraFlareProviders()` is explicitly marked as legacy code that should be removed. This is one step in that direction, removing an unnecessary global config accessor in favour of direct component access.

## Testing

CI

## Related

Part of a series migrating legacy flare providers off `pkg/flare.ExtraFlareProviders()` to proper FX component providers.