### PR TITLE
[AGENTRUN-1277] [flare] Move go-routine-dump.log to profiler component flare provider

### DIFF
--- a/comp/core/profiler/impl/profiler.go
+++ b/comp/core/profiler/impl/profiler.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
-	"runtime/pprof"
 	"strconv"
 	"time"
 
@@ -220,9 +219,13 @@ func (p profiler) setProfilerSetting(settingName string, newValue int, fb flaret
 // example, the flare api call must be expanded to take in an optional profile duration
 // before the cli command can be fully ported over.
 func (p profiler) fillFlare(_ context.Context, fb flaretypes.FlareBuilder) error {
-	var goroutineBuf bytes.Buffer
-	if err := pprof.Lookup("goroutine").WriteTo(&goroutineBuf, 2); err == nil {
-		fb.AddFile("go-routine-dump.log", goroutineBuf.Bytes()) //nolint:errcheck
+	// Fetch the goroutine dump from the running agent's pprof endpoint rather
+	// than calling runtime/pprof directly. This ensures we capture the agent's
+	// goroutines, and gracefully produces no file when the agent is unreachable
+	// (e.g. local flare mode) instead of capturing the CLI's own goroutines.
+	pprofURL := "http://127.0.0.1:" + strconv.Itoa(p.cfg.GetInt("expvar_port")) + "/debug/pprof/goroutine?debug=2"
+	if data, err := p.ipcClient.Get(pprofURL, ipchttp.WithLeaveConnectionOpen); err == nil {
+		fb.AddFile("go-routine-dump.log", data) //nolint:errcheck
 	}
 
 	duration := fb.GetFlareArgs().ProfileDuration

--- a/comp/core/profiler/impl/profiler.go
+++ b/comp/core/profiler/impl/profiler.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"runtime/pprof"
 	"strconv"
 	"time"
 
@@ -219,6 +220,11 @@ func (p profiler) setProfilerSetting(settingName string, newValue int, fb flaret
 // example, the flare api call must be expanded to take in an optional profile duration
 // before the cli command can be fully ported over.
 func (p profiler) fillFlare(_ context.Context, fb flaretypes.FlareBuilder) error {
+	var goroutineBuf bytes.Buffer
+	if err := pprof.Lookup("goroutine").WriteTo(&goroutineBuf, 2); err == nil {
+		fb.AddFile("go-routine-dump.log", goroutineBuf.Bytes()) //nolint:errcheck
+	}
+
 	duration := fb.GetFlareArgs().ProfileDuration
 
 	if duration <= 0 {

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -89,7 +89,6 @@ func ExtraFlareProviders(workloadmeta option.Option[workloadmeta.Component], ipc
 	for filename, fromFunc := range map[string]func() ([]byte, error){
 		"envvars.log":                         common.GetEnvVars,
 		"health.yaml":                         getHealth,
-		"go-routine-dump.log":                 func() ([]byte, error) { return remote.GetGoRoutineDump() },
 		"telemetry.log":                       func() ([]byte, error) { return remote.getHTTPCallContent(telemetryURL) },
 		"connectivity/resolved_endpoints.txt": getEndpointDNS,
 	} {


### PR DESCRIPTION
## What does this PR do?

`ExtraFlareProviders` was making an HTTP GET to the in-process pprof endpoint to collect the goroutine dump. This PR moves that fetch into the profiler component's `fillFlare`, keeping the same HTTP approach.

The goroutine dump is collected before the `ProfileDuration` guard so it is always included regardless of whether profiling is enabled. Using the HTTP endpoint (rather than `runtime/pprof` directly) means the call fails gracefully when the agent is unreachable, so local flares do not accidentally capture the CLI's own goroutines.

`GetGoRoutineDump` is kept on `RemoteFlareProvider` since the cluster agent still uses it.

## Motivation

`pkg/flare.ExtraFlareProviders()` is explicitly marked as legacy code that should be removed. This is one step in that direction.

## Testing

CI

## Related

Part of a series migrating legacy flare providers off `pkg/flare.ExtraFlareProviders()` to proper FX component providers.