### PR TITLE
Apply `testing/synctest` to `TestHighPriorityTransactionTendency`

### DIFF
--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -117,7 +117,7 @@ type Options struct {
 	DomainResolvers                map[string]pkgresolver.DomainResolver
 	ConnectionResetInterval        time.Duration
 	Secrets                        secrets.Component
-	Transport                      http.RoundTripper
+	transport                      http.RoundTripper // for testing
 }
 
 // SetFeature sets forwarder features in a feature set
@@ -396,7 +396,7 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 				options.ConnectionResetInterval,
 				domainForwarderSort,
 				pointCountTelemetry,
-				options.Transport)
+				options.transport)
 			f.domainForwarders[domain] = fwd
 			// Register all alternate domains for each forwarder
 			for _, v := range resolver.GetAlternateDomains() {

--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -117,6 +117,7 @@ type Options struct {
 	DomainResolvers                map[string]pkgresolver.DomainResolver
 	ConnectionResetInterval        time.Duration
 	Secrets                        secrets.Component
+	Transport                      http.RoundTripper
 }
 
 // SetFeature sets forwarder features in a feature set
@@ -394,7 +395,8 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 				numberOfWorkers,
 				options.ConnectionResetInterval,
 				domainForwarderSort,
-				pointCountTelemetry)
+				pointCountTelemetry,
+				options.Transport)
 			f.domainForwarders[domain] = fwd
 			// Register all alternate domains for each forwarder
 			for _, v := range resolver.GetAlternateDomains() {

--- a/comp/forwarder/defaultforwarder/domain_forwarder.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder.go
@@ -66,7 +66,8 @@ func newDomainForwarder(
 	numberOfWorkers int,
 	connectionResetInterval time.Duration,
 	transactionPrioritySorter retry.TransactionPrioritySorter,
-	pointCountTelemetry *retry.PointCountTelemetry) *domainForwarder {
+	pointCountTelemetry *retry.PointCountTelemetry,
+	transport http.RoundTripper) *domainForwarder {
 	return &domainForwarder{
 		config:                    config,
 		log:                       log,
@@ -82,7 +83,7 @@ func newDomainForwarder(
 		blockedList:               newBlockedEndpoints(config, log),
 		transactionPrioritySorter: transactionPrioritySorter,
 		pointCountTelemetry:       pointCountTelemetry,
-		Client:                    NewSharedConnection(log, isLocal, numberOfWorkers, config),
+		Client:                    NewSharedConnection(log, isLocal, numberOfWorkers, config, transport),
 	}
 }
 

--- a/comp/forwarder/defaultforwarder/domain_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder_test.go
@@ -382,7 +382,7 @@ func TestDomainForwarderRetryQueueAllPayloadsMaxSize(t *testing.T) {
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	forwarder := newDomainForwarder(mockConfig, log, secrets, "test", false, false, transactionRetryQueue, 0, 10, transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}, retry.NewPointCountTelemetry("domain"))
+	forwarder := newDomainForwarder(mockConfig, log, secrets, "test", false, false, transactionRetryQueue, 0, 10, transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}, retry.NewPointCountTelemetry("domain"), nil)
 	forwarder.blockedList.close("blocked", time.Now())
 	forwarder.blockedList.errorPerEndpoint["blocked"].until = time.Now().Add(1 * time.Minute)
 
@@ -445,7 +445,7 @@ func newDomainForwarderForTest(t *testing.T, config config.Component, log log.Co
 		retry.NewPointCountTelemetryMock())
 
 	secrets := secretsmock.New(t)
-	return newDomainForwarder(config, log, secrets, "test", ha, false, transactionRetryQueue, 1, connectionResetInterval, sorter, retry.NewPointCountTelemetry("domain"))
+	return newDomainForwarder(config, log, secrets, "test", ha, false, transactionRetryQueue, 1, connectionResetInterval, sorter, retry.NewPointCountTelemetry("domain"), nil)
 }
 
 func requireLenForwarderRetryQueue(t *testing.T, forwarder *domainForwarder, expectedValue int) {

--- a/comp/forwarder/defaultforwarder/forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_test.go
@@ -783,7 +783,7 @@ func syncTestHighPriorityTransactionTendency(t *testing.T) {
 	options := NewOptionsWithResolvers(mockConfig, log, r)
 	options.DisableAPIKeyChecking = true // Disable API key checking so no health check goroutine is started
 	options.Secrets = secrets
-	options.Transport = transport
+	options.transport = transport
 	f := NewDefaultForwarder(mockConfig, log, options)
 
 	f.Start()

--- a/comp/forwarder/defaultforwarder/forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_test.go
@@ -747,11 +747,15 @@ func syncTestProcessLikePayloadResponseTimeout(t *testing.T) {
 // are sent in a separate go func, the actual order they get sent will depend on the go scheduler.
 // This test ensures that we still on average send high priority transactions before low priority.
 func TestHighPriorityTransactionTendency(t *testing.T) {
+	synctest.Test(t, syncTestHighPriorityTransactionTendency)
+}
+
+func syncTestHighPriorityTransactionTendency(t *testing.T) {
 	var receivedRequests = make(map[string]struct{})
 	var mutex sync.Mutex
 	var requestChan = make(chan (string), 100)
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	transport := handlerTransport(func(w http.ResponseWriter, r *http.Request) {
 		mutex.Lock()
 		defer mutex.Unlock()
 		defer r.Body.Close()
@@ -767,21 +771,19 @@ func TestHighPriorityTransactionTendency(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			requestChan <- bodyStr
 		}
-	}))
+	})
 
 	mockConfig := mock.New(t)
 	mockConfig.SetWithoutSource("forwarder_backoff_max", 0.5)
 	mockConfig.SetWithoutSource("forwarder_max_concurrent_requests", 10)
 
-	oldFlushInterval := flushInterval
-	flushInterval = 500 * time.Millisecond
-	defer func() { flushInterval = oldFlushInterval }()
-
 	log := logmock.New(t)
-	r, _ := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{ts.URL: {configUtils.NewAPIKeys("path", "api_key1")}})
+	r, _ := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{"http://test.invalid": {configUtils.NewAPIKeys("path", "api_key1")}})
 	secrets := secretsmock.New(t)
 	options := NewOptionsWithResolvers(mockConfig, log, r)
+	options.DisableAPIKeyChecking = true // Disable API key checking so no health check goroutine is started
 	options.Secrets = secrets
+	options.Transport = transport
 	f := NewDefaultForwarder(mockConfig, log, options)
 
 	f.Start()

--- a/comp/forwarder/defaultforwarder/shared_connection.go
+++ b/comp/forwarder/defaultforwarder/shared_connection.go
@@ -22,6 +22,7 @@ type SharedConnection struct {
 	isLocal         bool
 	numberOfWorkers int
 	config          config.Component
+	transport       http.RoundTripper
 }
 
 // NewSharedConnection creates a new shared connection with the given
@@ -31,6 +32,7 @@ func NewSharedConnection(
 	isLocal bool,
 	numberOfWorkers int,
 	config config.Component,
+	transport http.RoundTripper,
 ) *SharedConnection {
 	sc := &SharedConnection{
 		lock:            &sync.RWMutex{},
@@ -38,6 +40,7 @@ func NewSharedConnection(
 		isLocal:         isLocal,
 		numberOfWorkers: numberOfWorkers,
 		config:          config,
+		transport:       transport,
 	}
 
 	sc.client = sc.newClient()
@@ -63,9 +66,14 @@ func (sc *SharedConnection) ResetClient() {
 }
 
 func (sc *SharedConnection) newClient() *http.Client {
+	var c *http.Client
 	if sc.isLocal {
-		return newBearerAuthHTTPClient(sc.numberOfWorkers)
+		c = newBearerAuthHTTPClient(sc.numberOfWorkers)
+	} else {
+		c = NewHTTPClient(sc.config, sc.numberOfWorkers, sc.log)
 	}
-
-	return NewHTTPClient(sc.config, sc.numberOfWorkers, sc.log)
+	if sc.transport != nil {
+		c.Transport = sc.transport
+	}
+	return c
 }

--- a/comp/forwarder/defaultforwarder/test_common.go
+++ b/comp/forwarder/defaultforwarder/test_common.go
@@ -10,6 +10,7 @@ package defaultforwarder
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"time"
 
 	"github.com/stretchr/testify/mock"
@@ -215,6 +216,14 @@ func (tf *MockedForwarder) GetDomainResolvers() []resolver.DomainResolver {
 // SubmitTransaction adds a transaction to the queue for sending.
 func (tf *MockedForwarder) SubmitTransaction(t *transaction.HTTPTransaction) error {
 	return tf.Called(t).Error(0)
+}
+
+type handlerTransport http.HandlerFunc
+
+func (tr handlerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rec := httptest.NewRecorder()
+	tr(rec, req)
+	return rec.Result(), nil
 }
 
 // NewTestForwarder creates an instance of the component based on config, but without using fx or starting it.

--- a/comp/forwarder/defaultforwarder/worker_test.go
+++ b/comp/forwarder/defaultforwarder/worker_test.go
@@ -34,7 +34,7 @@ func TestNewWorker(t *testing.T) {
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, 1, mockConfig))
+	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, 1, mockConfig, nil))
 	assert.NotNil(t, w)
 	assert.Equal(t, w.Client.GetClient().Timeout, mockConfig.GetDuration("forwarder_timeout")*time.Second)
 }
@@ -48,7 +48,7 @@ func TestNewNoSSLWorker(t *testing.T) {
 	mockConfig.SetWithoutSource("skip_ssl_validation", true)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, 1, mockConfig))
+	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, 1, mockConfig, nil))
 	assert.True(t, w.Client.GetClient().Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
 }
 
@@ -60,7 +60,7 @@ func TestWorkerStart(t *testing.T) {
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), sender, NewSharedConnection(log, false, 1, mockConfig))
+	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), sender, NewSharedConnection(log, false, 1, mockConfig, nil))
 
 	mock := newTestTransaction()
 	mock.pointCount = 1
@@ -98,7 +98,7 @@ func TestWorkerRetry(t *testing.T) {
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, 1, mockConfig))
+	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, 1, mockConfig, nil))
 
 	mock := newTestTransaction()
 	mock.On("Process", w.Client.GetClient()).Return(errors.New("some kind of error")).Times(1)
@@ -122,7 +122,7 @@ func TestWorkerRetryBlockedTransaction(t *testing.T) {
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, 1, mockConfig))
+	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, 1, mockConfig, nil))
 
 	mock := newTestTransaction()
 	mock.On("GetTarget").Return("error_url").Times(1)
@@ -146,7 +146,7 @@ func TestWorkerResetConnections(t *testing.T) {
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	connection := NewSharedConnection(log, false, 1, mockConfig)
+	connection := NewSharedConnection(log, false, 1, mockConfig, nil)
 	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, connection)
 
 	mock := newTestTransaction()
@@ -201,7 +201,7 @@ func TestWorkerCancelsInFlight(t *testing.T) {
 
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, 1, mockConfig))
+	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, 1, mockConfig, nil))
 
 	go func() {
 		w.Start()
@@ -260,7 +260,7 @@ func TestWorkerCancelsWaitingTransactions(t *testing.T) {
 
 	mockConfig.SetWithoutSource("forwarder_max_concurrent_requests", requests)
 	secrets := secretsmock.New(t)
-	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, requests, mockConfig))
+	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, requests, mockConfig, nil))
 
 	go func() {
 		w.Start()
@@ -341,7 +341,7 @@ func TestWorkerPurgeOnStop(t *testing.T) {
 	log := logmock.New(t)
 
 	secrets := secretsmock.New(t)
-	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, 1, mockConfig))
+	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, NewSharedConnection(log, false, 1, mockConfig, nil))
 	close(w.stopped)
 
 	mockTransaction := newTestTransaction()


### PR DESCRIPTION
tl;dr: **cuts Go unit test execution time by over a minute**.

### What does this PR do?
Refactor `TestHighPriorityTransactionTendency` to use `testing/synctest`:
- add a `Transport http.RoundTripper` field to `Options` and thread it down through `newDomainForwarder` -> `NewSharedConnection` -> `newClient()`, so tests can inject a channel-backed in-process transport instead of a fulll TCP connection,
- add `handlerTransport` in `test_common.go`, an adapter that implements `http.RoundTripper` by serving requests in-process via `httptest.NewRecorder`: channel operations are indeed considered durably idle by `synctest`, whereas TCP syscalls are not,
- remove the `flushInterval` override (500ms -> production default 5s) since it only existed to limit wall-clock cost,
- set `DisableAPIKeyChecking = true` to suppress the health-check goroutine that makes real DNS lookups (not durably idle) and would deadlock the `synctest` "bubble",
- wrap the test in `synctest.Test` so the fake clock drives the retry flush ticker.

### Motivation
Each of the 100 transactions triggers a retry, so the test alone was spending ~69s per run waiting for blocked-endpoint backoff timers (which default to 64s when `forwarder_backoff_max` is 0).
The `synctest` bubble advances the fake clock instantly once all goroutines are durably blocked.

### Describe how you validated your changes
Measured with:
```
go test -tags test -v -count 10 \
    -run TestHighPriorityTransactionTendency$ \
    ./comp/forwarder/defaultforwarder/
```
```
before (10 samples): 69.57 67.02 74.02 73.52 66.52 66.02 70.52 72.52 66.52 68.02 s
                     avg 69.43 s
```
```
after  (10 samples): 0.24 0.25 0.22 0.23 0.26 0.23 0.22 0.20 0.18 0.20 s
                     avg 0.22 s
```

Existing tests pass unchanged (the `Transport` override is `nil` by default, preserving all current behavior).

### Additional Notes
https://go.dev/blog/synctest