### PR TITLE
dyninst: run more integration style tests in parallel

### DIFF
--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -38,7 +38,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -101,7 +100,6 @@ var expectations embed.FS
 func TestEndToEnd(t *testing.T) {
 	t.Parallel()
 	dyninsttest.SkipIfKernelNotSupported(t)
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	cfgs := testprogs.MustGetCommonConfigs(t)
 	idx := slices.IndexFunc(cfgs, func(c testprogs.Config) bool {
 		return c.GOARCH == runtime.GOARCH
@@ -622,7 +620,7 @@ func findProcessID(t *testing.T, p processPredicate) uint32 {
 }
 
 func waitForServicePort(t *testing.T, stdoutPath string) int {
-	timeout := time.After(5 * time.Second)
+	timeout := time.After(10 * time.Second)
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -685,7 +683,7 @@ func waitForProbeStatus(
 	targetStatus map[string]uploader.Status,
 ) {
 	t.Logf("Waiting for probes to be %s...", targetStatus)
-	const timeout = 10 * time.Second
+	const timeout = 60 * time.Second
 
 	probeStatus := make(map[string]uploader.Status)
 	allInStatus := func() bool {
@@ -746,7 +744,7 @@ func waitForLogMessages(
 
 	var processedLogs []json.RawMessage
 
-	logProcessingTimeout := time.After(5 * time.Second)
+	logProcessingTimeout := time.After(60 * time.Second)
 	checkTicker := time.NewTicker(100 * time.Millisecond)
 	defer checkTicker.Stop()
 

--- a/pkg/dyninst/integration_drop_test.go
+++ b/pkg/dyninst/integration_drop_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
@@ -52,8 +51,7 @@ import (
 // timing is non-deterministic under pressure.
 func TestDropNotifications(t *testing.T) {
 	dyninsttest.SkipIfKernelNotSupported(t)
-	current := goleak.IgnoreCurrent()
-	t.Cleanup(func() { goleak.VerifyNone(t, current) })
+	t.Parallel()
 
 	cfgs := testprogs.MustGetCommonConfigs(t)
 	// Pick a config matching the host architecture. The drop_tester binary
@@ -282,6 +280,7 @@ func (s snapshot) ValidJSON() bool {
 }
 
 func runScenario(t *testing.T, cfg testprogs.Config, sc scenario) {
+	t.Parallel()
 	tempDir, cleanup := dyninsttest.PrepTmpDir(t, "dyninst-drop-test")
 	defer cleanup()
 

--- a/pkg/dyninst/integration_first_flush_fail_test.go
+++ b/pkg/dyninst/integration_first_flush_fail_test.go
@@ -101,8 +101,7 @@ import (
 //     is left in a state that prevents future events.
 func TestFirstFlushFailDropNotification(t *testing.T) {
 	dyninsttest.SkipIfKernelNotSupported(t)
-	current := goleak.IgnoreCurrent()
-	t.Cleanup(func() { goleak.VerifyNone(t, current) })
+	t.Parallel()
 
 	cfgs := testprogs.MustGetCommonConfigs(t)
 	var cfg testprogs.Config
@@ -259,6 +258,7 @@ func runFirstFlushFailScenario(
 	collector *tracePipeCollector,
 	variant firstFlushFailVariant,
 ) {
+	t.Parallel()
 	tempDir, cleanup := dyninsttest.PrepTmpDir(t, "dyninst-first-flush-fail-"+variant.name)
 	defer cleanup()
 


### PR DESCRIPTION
### What does this PR do?

These tests do a lot of sleeping, so we may as well run them in parallel. In the process we increase some timeouts because now they are more exposed to periods when the system is under extreme load.

### Motivation

This cuts another 35% or so off the package runtime. Now the whole dyninst rewrite path in my VM is well under a minute.

### Describe how you validated your changes

It's testing only
