### PR TITLE
chore(renovate): group github-actions updates and schedule weekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,6 +51,8 @@
       {
         "matchManagers": ["github-actions"],
         "labels": ["dependencies", "dependencies-github-actions", "changelog/no-changelog", "qa/no-code-change"],
+        "groupName": "github-actions",
+        "schedule": ["before 9am on monday"]
       },
       {
         "matchManagers": ["docker-compose"],


### PR DESCRIPTION
## Summary

- Groups all `github-actions` dependency updates into a single batched PR (instead of one PR per action) via `groupName: "github-actions"`
- Schedules updates to run once a week, on Monday mornings before 9am UTC

## Notes

- The `schedule` overrides the inherited `schedule:nonOfficeHours` for this manager only — intentional
- If a specific timezone is needed for the Monday schedule, a `timezone` field can be added (currently defaults to UTC)

## Test plan

- [ ] Verify Renovate config is valid (trailing-comma-tolerant JSON — pre-existing style in this file)
- [ ] Confirm next Renovate run groups all github-actions updates into one PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)