### PR TITLE
[AGENTRUN-1272] packaging/aix: bundle libiconv and suppress libintl dependency in Python

### DIFF
--- a/packaging/aix/stages/01-native-libs.sh
+++ b/packaging/aix/stages/01-native-libs.sh
@@ -75,6 +75,9 @@ NCURSES_VERSION="6.5"      # yum install ncurses-devel
 READLINE_VERSION="8.2"     # yum install readline-devel
 SQLITE_VERSION="3.50.4"    # yum install sqlite-devel
 GDBM_VERSION="1.23"        # yum install gdbm-devel
+# Runtime dependencies bundled to make the package self-contained (not build deps):
+LIBICONV_VERSION="1.17"    # yum install libiconv  (runtime dep of libxml2.so and libintl)
+LIBINTL_VERSION="0.21"     # yum install gettext   (runtime dep of libpython3.13.so)
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -466,6 +469,27 @@ for lib in libxslt libexslt; do
         cp "/opt/freeware/lib/pkgconfig/${lib}.pc" "$EMBEDDED_DESTDIR/lib/pkgconfig/"
     fi
 done
+
+# ── libiconv (AIX Toolbox: yum install libiconv) ─────────────────────────────
+#
+# libxml2.so links against libiconv.a(libiconv.so.2). The AIX system
+# /usr/lib/libiconv.a uses member shr4_64.o (different name), so it cannot
+# satisfy this runtime dependency. Bundle the GNU toolbox version instead to
+# make the package self-contained.
+# libintl.a(libintl.so.8) also has a transitive dependency on libiconv.
+stage_toolbox_lib libiconv "$LIBICONV_VERSION" \
+    /opt/freeware/lib/libiconv.a
+
+# ── libintl (AIX Toolbox: yum install gettext) ────────────────────────────────
+#
+# libpython3.13.so links against libintl.a(libintl.so.8). Patching Python source
+# to remove #include <libintl.h> prevents compile errors but Python's configure
+# still detects ngettext() and links against libintl at build time. Bundle the
+# toolbox version to make the package self-contained.
+# Note: /usr/lib/libintl.a exists on some AIX systems (symlink to the RPM
+# runtime) but is absent on hosts without RPM installed.
+stage_toolbox_lib libintl "$LIBINTL_VERSION" \
+    /opt/freeware/lib/libintl.a
 
 # ─── Ensure standard directories exist ────────────────────────────────────────
 

--- a/packaging/aix/stages/01-native-libs.sh
+++ b/packaging/aix/stages/01-native-libs.sh
@@ -75,9 +75,8 @@ NCURSES_VERSION="6.5"      # yum install ncurses-devel
 READLINE_VERSION="8.2"     # yum install readline-devel
 SQLITE_VERSION="3.50.4"    # yum install sqlite-devel
 GDBM_VERSION="1.23"        # yum install gdbm-devel
-# Runtime dependencies bundled to make the package self-contained (not build deps):
-LIBICONV_VERSION="1.17"    # yum install libiconv  (runtime dep of libxml2.so and libintl)
-LIBINTL_VERSION="0.21"     # yum install gettext   (runtime dep of libpython3.13.so)
+# Runtime dependency bundled to make the package self-contained (not a build dep):
+LIBICONV_VERSION="1.17"    # yum install libiconv  (runtime dep of libxml2.so)
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -474,22 +473,15 @@ done
 #
 # libxml2.so links against libiconv.a(libiconv.so.2). The AIX system
 # /usr/lib/libiconv.a uses member shr4_64.o (different name), so it cannot
-# satisfy this runtime dependency. Bundle the GNU toolbox version instead to
-# make the package self-contained.
-# libintl.a(libintl.so.8) also has a transitive dependency on libiconv.
+# satisfy this runtime dependency. Bundle the GNU toolbox version instead.
+#
+# Note: libintl.a (GNU gettext) is NOT bundled here. The toolbox libintl.so.8
+# has a hardcoded path to /opt/freeware/lib/libiconv.a baked in at build time,
+# so bundling it would still require /opt/freeware/lib/libiconv.a on the target.
+# Instead, Python is configured with ac_cv_search_ngettext=no (in 02-python.sh)
+# to suppress the libintl link entirely, since the agent does not use Python i18n.
 stage_toolbox_lib libiconv "$LIBICONV_VERSION" \
     /opt/freeware/lib/libiconv.a
-
-# ── libintl (AIX Toolbox: yum install gettext) ────────────────────────────────
-#
-# libpython3.13.so links against libintl.a(libintl.so.8). Patching Python source
-# to remove #include <libintl.h> prevents compile errors but Python's configure
-# still detects ngettext() and links against libintl at build time. Bundle the
-# toolbox version to make the package self-contained.
-# Note: /usr/lib/libintl.a exists on some AIX systems (symlink to the RPM
-# runtime) but is absent on hosts without RPM installed.
-stage_toolbox_lib libintl "$LIBINTL_VERSION" \
-    /opt/freeware/lib/libintl.a
 
 # ─── Ensure standard directories exist ────────────────────────────────────────
 

--- a/packaging/aix/stages/01-native-libs.sh
+++ b/packaging/aix/stages/01-native-libs.sh
@@ -75,8 +75,7 @@ NCURSES_VERSION="6.5"      # yum install ncurses-devel
 READLINE_VERSION="8.2"     # yum install readline-devel
 SQLITE_VERSION="3.50.4"    # yum install sqlite-devel
 GDBM_VERSION="1.23"        # yum install gdbm-devel
-# Runtime dependency bundled to make the package self-contained (not a build dep):
-LIBICONV_VERSION="1.17"    # yum install libiconv  (runtime dep of libxml2.so)
+LIBICONV_VERSION="1.17"    # yum install libiconv
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/packaging/aix/stages/02-python.sh
+++ b/packaging/aix/stages/02-python.sh
@@ -107,8 +107,11 @@ log "Applying AIX-specific patches to Python ${PYTHON_VERSION} source"
 
 cd "$PYTHON_SRC"
 
-# Patch: remove libintl dependency from Modules/getpath.c
-# libintl (GNU message catalog library) is not present on stock AIX.
+# Patch: remove libintl header from Modules/getpath.c
+# libintl.h is absent on stock AIX. Comment it out so the compile doesn't fail.
+# Note: Python's configure still detects ngettext() in /opt/freeware/lib/libintl.a
+# and links libpython3.13.so against it at build time. libintl.a is therefore
+# bundled in the embedded tree by stage 01 so the package is self-contained.
 # The unix-agent carries this patch for Python 3.8; the include may or may
 # not still be present in 3.13 — apply defensively.
 if grep -q 'libintl\.h' Modules/getpath.c 2>/dev/null; then

--- a/packaging/aix/stages/02-python.sh
+++ b/packaging/aix/stages/02-python.sh
@@ -334,6 +334,14 @@ log "AIX patching complete."
 #   headers and libs ARE during the build, not $EMBEDDED which is the final path)
 # --with-dbmliborder=gdbm : use gdbm built in Stage 1
 # --without-ensurepip : we bootstrap pip manually below (step 7)
+# ac_cv_header_libintl_h=no / ac_cv_lib_intl_textdomain=no : suppress libintl link.
+#   Python's configure tests for libintl.h (ac_cv_header_libintl_h) and then
+#   textdomain() in -lintl (ac_cv_lib_intl_textdomain). If both pass, it adds
+#   -lintl to LIBS, linking libpython3.13.so against the toolbox libintl.
+#   The toolbox libintl.so.8 has a hardcoded path to /opt/freeware/lib/libiconv.a
+#   baked in at build time, making it impossible to fully bundle without rebuilding
+#   libintl from source. Since the agent does not use Python's i18n/gettext support,
+#   suppress the detection entirely.
 
 log "Configuring Python ${PYTHON_VERSION} (--prefix=$EMBEDDED)"
 log "  (Note: configure can take several minutes on POWER8)"
@@ -352,7 +360,9 @@ cd "$PYTHON_SRC"
     CPPFLAGS="$CPPFLAGS" \
     LDFLAGS="$LDFLAGS" \
     ARFLAGS="$ARFLAGS" \
-    NM="$NM"
+    NM="$NM" \
+    ac_cv_header_libintl_h=no \
+    ac_cv_lib_intl_textdomain=no
 
 log "Configure complete."
 

--- a/packaging/aix/stages/05-python-extensions.sh
+++ b/packaging/aix/stages/05-python-extensions.sh
@@ -41,8 +41,8 @@ PYTHON_BIN=$EMBEDDED_DESTDIR/bin/python${PYTHON_MAJ_MIN}
 # automatically picks up the correct version without a separate edit to this file.
 #
 # Sources:
-#   pymqi, pyodbc — integrations-core/agent_requirements.in (format: "pkg==x.y.z")
-#   ibm_db        — integrations-core/ibm_db2/hatch.toml (Python 3 line)
+#   pymqi, pyodbc  — integrations-core/agent_requirements.in (format: "pkg==x.y.z")
+#   ibm_db         — integrations-core/ibm_db2/hatch.toml (Python 3 line)
 
 AGENT_REQ="$INTEGRATIONS_CORE/agent_requirements.in"
 PYMQI_VERSION=$(grep '^pymqi==' "$AGENT_REQ" | cut -d= -f3)

--- a/packaging/aix/stages/05-python-extensions.sh
+++ b/packaging/aix/stages/05-python-extensions.sh
@@ -99,15 +99,27 @@ extract_version() {
         | sed "s/.*${_pkg}-\([0-9][0-9.]*\)-.*/\1/"
 }
 
+# Fall back to the installed version if a package is not in the lockfile.
+# cffi and lxml are C extensions built from source on AIX; newer integrations-core
+# lockfiles only list pre-built binary wheels and omit source-only packages.
+installed_version() {
+    _pkg=$1
+    "$PIP" show "$_pkg" 2>/dev/null | grep "^Version:" | awk '{print $2}'
+}
+
 CFFI_VERSION=$(extract_version cffi)
 PSUTIL_VERSION=$(extract_version psutil)
 LXML_VERSION=$(extract_version lxml)
 CRYPTOGRAPHY_VERSION=$(extract_version cryptography)
 
+[ -z "$CFFI_VERSION" ] && CFFI_VERSION=$(installed_version cffi)
+[ -z "$LXML_VERSION" ] && LXML_VERSION=$(installed_version lxml)
+
 if [ -z "$CFFI_VERSION" ] || [ -z "$PSUTIL_VERSION" ] || [ -z "$LXML_VERSION" ] || [ -z "$CRYPTOGRAPHY_VERSION" ]; then
     log "ERROR: could not read one or more package versions from $LOCKFILE"
     log "  cffi=$CFFI_VERSION psutil=$PSUTIL_VERSION lxml=$LXML_VERSION cryptography=$CRYPTOGRAPHY_VERSION"
-    log "  Check that $LOCKFILE contains cffi, psutil, lxml, cryptography entries."
+    log "  Check that $LOCKFILE contains psutil, cryptography entries."
+    log "  cffi and lxml fall back to the currently installed version if absent from lockfile."
     exit 1
 fi
 

--- a/packaging/aix/stages/05-python-extensions.sh
+++ b/packaging/aix/stages/05-python-extensions.sh
@@ -99,27 +99,22 @@ extract_version() {
         | sed "s/.*${_pkg}-\([0-9][0-9.]*\)-.*/\1/"
 }
 
-# Fall back to the installed version if a package is not in the lockfile.
-# cffi and lxml are C extensions built from source on AIX; newer integrations-core
-# lockfiles only list pre-built binary wheels and omit source-only packages.
-installed_version() {
-    _pkg=$1
-    "$PIP" show "$_pkg" 2>/dev/null | grep "^Version:" | awk '{print $2}'
-}
-
 CFFI_VERSION=$(extract_version cffi)
 PSUTIL_VERSION=$(extract_version psutil)
 LXML_VERSION=$(extract_version lxml)
 CRYPTOGRAPHY_VERSION=$(extract_version cryptography)
 
-[ -z "$CFFI_VERSION" ] && CFFI_VERSION=$(installed_version cffi)
-[ -z "$LXML_VERSION" ] && LXML_VERSION=$(installed_version lxml)
+# cffi and lxml are compiled from source on AIX and have no pre-built AIX wheels,
+# so they never appear in the integrations-core lockfile (which only lists packages
+# that have binary wheels in Datadog's registry). Pin them explicitly here.
+# Update these when the cryptography or ibm_was check bumps its requirements.
+: "${CFFI_VERSION:=2.0.0}"
+: "${LXML_VERSION:=6.0.1}"
 
-if [ -z "$CFFI_VERSION" ] || [ -z "$PSUTIL_VERSION" ] || [ -z "$LXML_VERSION" ] || [ -z "$CRYPTOGRAPHY_VERSION" ]; then
+if [ -z "$PSUTIL_VERSION" ] || [ -z "$CRYPTOGRAPHY_VERSION" ]; then
     log "ERROR: could not read one or more package versions from $LOCKFILE"
-    log "  cffi=$CFFI_VERSION psutil=$PSUTIL_VERSION lxml=$LXML_VERSION cryptography=$CRYPTOGRAPHY_VERSION"
-    log "  Check that $LOCKFILE contains psutil, cryptography entries."
-    log "  cffi and lxml fall back to the currently installed version if absent from lockfile."
+    log "  psutil=$PSUTIL_VERSION cryptography=$CRYPTOGRAPHY_VERSION"
+    log "  Check that $LOCKFILE contains psutil and cryptography entries."
     exit 1
 fi
 

--- a/packaging/aix/stages/05-python-extensions.sh
+++ b/packaging/aix/stages/05-python-extensions.sh
@@ -41,25 +41,23 @@ PYTHON_BIN=$EMBEDDED_DESTDIR/bin/python${PYTHON_MAJ_MIN}
 # automatically picks up the correct version without a separate edit to this file.
 #
 # Sources:
-#   pymqi, pyodbc, lxml — integrations-core/agent_requirements.in (format: "pkg==x.y.z")
-#   ibm_db              — integrations-core/ibm_db2/hatch.toml (Python 3 line)
+#   pymqi, pyodbc — integrations-core/agent_requirements.in (format: "pkg==x.y.z")
+#   ibm_db        — integrations-core/ibm_db2/hatch.toml (Python 3 line)
 
 AGENT_REQ="$INTEGRATIONS_CORE/agent_requirements.in"
 PYMQI_VERSION=$(grep '^pymqi==' "$AGENT_REQ" | cut -d= -f3)
 PYODBC_VERSION=$(grep '^pyodbc==' "$AGENT_REQ" | cut -d= -f3)
-LXML_VERSION=$(grep '^lxml==' "$AGENT_REQ" | cut -d= -f3)
 IBM_DB_VERSION=$(grep "ibm_db==[0-9]" "$INTEGRATIONS_CORE/ibm_db2/hatch.toml" \
     | grep "python_version > '3" | sed "s/.*ibm_db==\([0-9][^;'\"]*\).*/\1/")
 
-if [ -z "$PYMQI_VERSION" ] || [ -z "$PYODBC_VERSION" ] || [ -z "$LXML_VERSION" ] || [ -z "$IBM_DB_VERSION" ]; then
+if [ -z "$PYMQI_VERSION" ] || [ -z "$PYODBC_VERSION" ] || [ -z "$IBM_DB_VERSION" ]; then
     log "ERROR: could not read one or more C-extension versions from integrations-core"
     log "  PYMQI_VERSION='$PYMQI_VERSION'  (source: $AGENT_REQ)"
     log "  PYODBC_VERSION='$PYODBC_VERSION'  (source: $AGENT_REQ)"
-    log "  LXML_VERSION='$LXML_VERSION'  (source: $AGENT_REQ)"
     log "  IBM_DB_VERSION='$IBM_DB_VERSION'  (source: $INTEGRATIONS_CORE/ibm_db2/hatch.toml)"
     exit 1
 fi
-log "C-extension versions from integrations-core: pymqi=$PYMQI_VERSION pyodbc=$PYODBC_VERSION lxml=$LXML_VERSION ibm_db=$IBM_DB_VERSION"
+log "C-extension versions from integrations-core: pymqi=$PYMQI_VERSION pyodbc=$PYODBC_VERSION ibm_db=$IBM_DB_VERSION"
 
 # --- Pre-flight: confirm pip${PYTHON_MAJ_MIN} exists ---
 if [ ! -x "$PIP" ]; then
@@ -103,18 +101,13 @@ extract_version() {
 
 CFFI_VERSION=$(extract_version cffi)
 PSUTIL_VERSION=$(extract_version psutil)
+LXML_VERSION=$(extract_version lxml)
 CRYPTOGRAPHY_VERSION=$(extract_version cryptography)
 
-# cffi is compiled from source on AIX and has no pre-built AIX wheels, so it
-# never appears in the integrations-core lockfile (which only lists packages
-# that have binary wheels in Datadog's registry). Pin it explicitly here.
-# Update when cryptography bumps its cffi requirement.
-: "${CFFI_VERSION:=2.0.0}"
-
-if [ -z "$PSUTIL_VERSION" ] || [ -z "$CRYPTOGRAPHY_VERSION" ]; then
+if [ -z "$CFFI_VERSION" ] || [ -z "$PSUTIL_VERSION" ] || [ -z "$LXML_VERSION" ] || [ -z "$CRYPTOGRAPHY_VERSION" ]; then
     log "ERROR: could not read one or more package versions from $LOCKFILE"
-    log "  psutil=$PSUTIL_VERSION cryptography=$CRYPTOGRAPHY_VERSION"
-    log "  Check that $LOCKFILE contains psutil and cryptography entries."
+    log "  cffi=$CFFI_VERSION psutil=$PSUTIL_VERSION lxml=$LXML_VERSION cryptography=$CRYPTOGRAPHY_VERSION"
+    log "  Check that $LOCKFILE contains cffi, psutil, lxml, cryptography entries."
     exit 1
 fi
 

--- a/packaging/aix/stages/05-python-extensions.sh
+++ b/packaging/aix/stages/05-python-extensions.sh
@@ -41,23 +41,25 @@ PYTHON_BIN=$EMBEDDED_DESTDIR/bin/python${PYTHON_MAJ_MIN}
 # automatically picks up the correct version without a separate edit to this file.
 #
 # Sources:
-#   pymqi, pyodbc  — integrations-core/agent_requirements.in (format: "pkg==x.y.z")
-#   ibm_db         — integrations-core/ibm_db2/hatch.toml (Python 3 line)
+#   pymqi, pyodbc, lxml — integrations-core/agent_requirements.in (format: "pkg==x.y.z")
+#   ibm_db              — integrations-core/ibm_db2/hatch.toml (Python 3 line)
 
 AGENT_REQ="$INTEGRATIONS_CORE/agent_requirements.in"
 PYMQI_VERSION=$(grep '^pymqi==' "$AGENT_REQ" | cut -d= -f3)
 PYODBC_VERSION=$(grep '^pyodbc==' "$AGENT_REQ" | cut -d= -f3)
+LXML_VERSION=$(grep '^lxml==' "$AGENT_REQ" | cut -d= -f3)
 IBM_DB_VERSION=$(grep "ibm_db==[0-9]" "$INTEGRATIONS_CORE/ibm_db2/hatch.toml" \
     | grep "python_version > '3" | sed "s/.*ibm_db==\([0-9][^;'\"]*\).*/\1/")
 
-if [ -z "$PYMQI_VERSION" ] || [ -z "$PYODBC_VERSION" ] || [ -z "$IBM_DB_VERSION" ]; then
+if [ -z "$PYMQI_VERSION" ] || [ -z "$PYODBC_VERSION" ] || [ -z "$LXML_VERSION" ] || [ -z "$IBM_DB_VERSION" ]; then
     log "ERROR: could not read one or more C-extension versions from integrations-core"
     log "  PYMQI_VERSION='$PYMQI_VERSION'  (source: $AGENT_REQ)"
     log "  PYODBC_VERSION='$PYODBC_VERSION'  (source: $AGENT_REQ)"
+    log "  LXML_VERSION='$LXML_VERSION'  (source: $AGENT_REQ)"
     log "  IBM_DB_VERSION='$IBM_DB_VERSION'  (source: $INTEGRATIONS_CORE/ibm_db2/hatch.toml)"
     exit 1
 fi
-log "C-extension versions from integrations-core: pymqi=$PYMQI_VERSION pyodbc=$PYODBC_VERSION ibm_db=$IBM_DB_VERSION"
+log "C-extension versions from integrations-core: pymqi=$PYMQI_VERSION pyodbc=$PYODBC_VERSION lxml=$LXML_VERSION ibm_db=$IBM_DB_VERSION"
 
 # --- Pre-flight: confirm pip${PYTHON_MAJ_MIN} exists ---
 if [ ! -x "$PIP" ]; then
@@ -101,15 +103,13 @@ extract_version() {
 
 CFFI_VERSION=$(extract_version cffi)
 PSUTIL_VERSION=$(extract_version psutil)
-LXML_VERSION=$(extract_version lxml)
 CRYPTOGRAPHY_VERSION=$(extract_version cryptography)
 
-# cffi and lxml are compiled from source on AIX and have no pre-built AIX wheels,
-# so they never appear in the integrations-core lockfile (which only lists packages
-# that have binary wheels in Datadog's registry). Pin them explicitly here.
-# Update these when the cryptography or ibm_was check bumps its requirements.
+# cffi is compiled from source on AIX and has no pre-built AIX wheels, so it
+# never appears in the integrations-core lockfile (which only lists packages
+# that have binary wheels in Datadog's registry). Pin it explicitly here.
+# Update when cryptography bumps its cffi requirement.
 : "${CFFI_VERSION:=2.0.0}"
-: "${LXML_VERSION:=6.0.1}"
 
 if [ -z "$PSUTIL_VERSION" ] || [ -z "$CRYPTOGRAPHY_VERSION" ]; then
     log "ERROR: could not read one or more package versions from $LOCKFILE"


### PR DESCRIPTION
### What does this PR do?

- Bundles `libiconv.a` from AIX Toolbox into the embedded tree (`01-native-libs.sh`)
- Suppresses the `libintl` link in `libpython3.13.so` at Python configure time (`02-python.sh`)

### Motivation

`libxml2.so` links against `libiconv.a(libiconv.so.2)`. The AIX system `/usr/lib/libiconv.a` uses a different archive member name (`shr4_64.o`) and cannot satisfy this dependency. Without bundling, the agent fails to load on hosts without AIX Toolbox installed.

`libpython3.13.so` also links against `libintl.a(libintl.so.8)` because Python's `configure` detects `textdomain()` in the toolbox's `libintl.a`. Bundling `libintl.a` doesn't help: the toolbox binary has `/opt/freeware/lib/libiconv.a` hardcoded as an absolute path in its XCOFF loader section, bypassing the process LIBPATH. Suppressing the detection at configure time (`ac_cv_lib_intl_textdomain=no`) removes the dependency entirely — the agent doesn't use Python i18n.

### Describe how you validated your changes

Built the package and installed on AIX 7.2 with both `/opt/freeware/lib/libiconv.a` and `/opt/freeware/lib/libintl.a` temporarily renamed:

- `agent version` — binary loads without shared library errors
- `agent check cpu/memory/disk` — metrics produced normally
- `agent check lparstats` — Python check produces 24 metrics, status OK

### Additional Notes

N/A