### PR TITLE
[SBOM] Do not override metadata with empty ones from system-probe

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
@@ -151,10 +151,19 @@ func workloadmetaEventFromSBOMEventSet(store workloadmeta.Component, event *sbom
 		}
 	}
 
-	// Compress the final merged SBOM for storage
-	finalCompressedSBOM, err = sbomutil.CompressSBOM(&workloadmeta.SBOM{
+	// Compress the final merged SBOM, preserving scan metadata from the existing
+	// SBOM so Status/GenerationTime/etc. survive the runtime-enrichment update.
+	sbomToCompress := &workloadmeta.SBOM{
 		CycloneDXBOM: finalBom,
-	})
+	}
+	if existingImage != nil && existingImage.SBOM != nil {
+		sbomToCompress.Status = existingImage.SBOM.Status
+		sbomToCompress.GenerationTime = existingImage.SBOM.GenerationTime
+		sbomToCompress.GenerationDuration = existingImage.SBOM.GenerationDuration
+		sbomToCompress.GenerationMethod = existingImage.SBOM.GenerationMethod
+		sbomToCompress.Error = existingImage.SBOM.Error
+	}
+	finalCompressedSBOM, err = sbomutil.CompressSBOM(sbomToCompress)
 	if err != nil {
 		return workloadmeta.Event{}, fmt.Errorf("failed to compress SBOM for image %s: %w", imageID, err)
 	}


### PR DESCRIPTION
### What does this PR do?

Use the SBOM metadata from the core agent instead of the empty ones
sent by system-probe.

### Motivation

Override would cause the workload meta to store empty metadata for container images as
shown by the following SBOM JSON files in a flare:

{
    "CycloneDXBOM": {},
    "GenerationTime": "0001-01-01T00:00:00Z",
    "GenerationDuration": 0,
    "GenerationMethod": "",
    "Status": "",
    "Error": ""
}


### Describe how you validated your changes

### Additional Notes
