### PR TITLE
chore(renovate): add gomod grouping rules for common dependency clusters

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -118,6 +118,85 @@
         "groupName": "k8s-io"
       },
       {
+        "matchManagers": ["gomod"],
+        "matchDepNames": [
+          "github.com/DataDog/datadog-api-client-go{,/**}",
+          "github.com/DataDog/dd-trace-go{,/**}",
+          "gopkg.in/DataDog/dd-trace-go.v1",
+          "github.com/DataDog/jsonapi",
+          "github.com/DataDog/opentelemetry-mapping-go{,/**}"
+        ],
+        "groupName": "datadog-go"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepNames": [
+          "github.com/hashicorp/vault{,/**}",
+          "github.com/hashicorp/consul{,/**}"
+        ],
+        "groupName": "hashicorp"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepNames": [
+          "istio.io/api",
+          "istio.io/client-go"
+        ],
+        "groupName": "istio"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepNames": [
+          "github.com/aws/karpenter-provider-aws",
+          "sigs.k8s.io/karpenter"
+        ],
+        "groupName": "karpenter"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepNames": [
+          "github.com/swaggest/jsonschema-go",
+          "github.com/invopop/jsonschema",
+          "github.com/santhosh-tekuri/jsonschema{,/**}"
+        ],
+        "groupName": "jsonschema"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepNames": [
+          "cloud.google.com/go{,/**}",
+          "github.com/google/cel-go",
+          "github.com/google/go-containerregistry"
+        ],
+        "groupName": "google-go"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepNames": [
+          "google.golang.org/grpc{,/**}",
+          "github.com/grpc-ecosystem/go-grpc-middleware{,/**}"
+        ],
+        "groupName": "grpc-go"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepNames": [
+          "github.com/stretchr/testify",
+          "github.com/vektra/mockery{,/**}",
+          "gotest.tools/gotestsum",
+          "pgregory.net/rapid"
+        ],
+        "groupName": "testing-tools"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepNames": [
+          "go.temporal.io/api",
+          "go.temporal.io/sdk"
+        ],
+        "groupName": "temporal"
+      },
+      {
         "matchManagers": ["pyenv"],
         "enabled": false
       },


### PR DESCRIPTION
## Summary

Adds 10 new `packageRules` grouping entries to `renovate.json` to reduce the number of individual dependency PRs for well-known Go module clusters:

| Group | Dependencies |
|---|---|
| `datadog-go` | `datadog-api-client-go`, `dd-trace-go` (v1+v2), `jsonapi`, `opentelemetry-mapping-go` |
| `hashicorp` | `vault/api` (+ auth sub-packages), `consul/api` |
| `istio` | `istio.io/api`, `istio.io/client-go` |
| `karpenter` | `aws/karpenter-provider-aws`, `sigs.k8s.io/karpenter` |
| `jsonschema` | `swaggest/jsonschema-go`, `invopop/jsonschema`, `santhosh-tekuri/jsonschema` |
| `google-go` | `cloud.google.com/go`, `google/cel-go`, `google/go-containerregistry` |
| `grpc-go` | `google.golang.org/grpc`, `grpc-ecosystem/go-grpc-middleware` |
| `testing-tools` | `stretchr/testify`, `vektra/mockery`, `gotest.tools/gotestsum`, `pgregory.net/rapid` |
| `temporal` | `go.temporal.io/api`, `go.temporal.io/sdk` |

No `matchUpdateTypes` override is set — Renovate's default behavior already splits major updates into individual PRs, so each group produces one minor+patch PR and separate PRs per major bump.

Related: #50189 (github-actions grouping)

## Test plan

- [ ] Verify JSON is valid (trailing-comma-tolerant — pre-existing style in this file)
- [ ] Confirm Renovate dry-run collapses the listed deps into grouped PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)