### PR TITLE
Add ci-kpi.compute: time-to-trustworthy-green per PR

### DIFF
--- a/.github/workflows/ci-kpi.yml
+++ b/.github/workflows/ci-kpi.yml
@@ -1,0 +1,49 @@
+name: "CI KPI: time-to-trustworthy-green"
+
+on:
+  workflow_dispatch:
+    inputs:
+      window:
+        description: "Lookback window in days"
+        required: false
+        default: "14"
+        type: string
+      dry_run:
+        description: "Print metrics instead of submitting"
+        required: false
+        default: "false"
+        type: string
+  schedule:
+    - cron: "17 * * * *"  # hourly, offset to avoid the top-of-hour rush
+
+permissions: {}
+
+jobs:
+  compute:
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+    env:
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout datadog-agent repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Install dda
+        uses: ./.github/actions/install-dda
+        with:
+          features: legacy-tasks
+
+      - name: Compute and emit time-to-trustworthy-green
+        run: |
+          window="${{ inputs.window || '14' }}"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            dda inv -- ci-kpi.compute --window="$window" --dry-run
+          else
+            dda inv -- ci-kpi.compute --window="$window"
+          fi

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -14,6 +14,7 @@ from tasks import (
     auth,
     bench,
     buildimages,
+    ci_kpi,
     claude,
     cluster_agent,
     cluster_agent_cloudfoundry,
@@ -199,6 +200,7 @@ ns.add_collection(agent)
 ns.add_collection(ami)
 ns.add_collection(agent_ci_api)
 ns.add_collection(buildimages)
+ns.add_collection(ci_kpi, "ci-kpi")
 ns.add_collection(claude)
 ns.add_collection(cluster_agent)
 ns.add_collection(cluster_agent_cloudfoundry)

--- a/tasks/ci_kpi.py
+++ b/tasks/ci_kpi.py
@@ -1,0 +1,219 @@
+"""
+Compute the "Time-to-Trustworthy-Green per PR" CI KPI and emit it to Datadog.
+
+See `tasks/libs/pipeline/ci_kpi.py` for the KPI definition and the
+`compute_pr_metric` algorithm. This module is the I/O layer: it walks PRs
+on GitHub, joins them to pipelines on GitLab by commit SHA, builds
+`PRSnapshot`s, and submits per-PR metrics to Datadog.
+
+Usage:
+    dda inv ci-kpi.compute --window=14 --dry-run
+    dda inv ci-kpi.compute --window=14
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+
+from invoke import task
+from invoke.context import Context
+
+from tasks.libs.ciproviders.github_api import GithubAPI
+from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
+from tasks.libs.common.constants import GITHUB_REPO_NAME
+from tasks.libs.common.datadog_api import create_count, create_gauge, send_metrics
+from tasks.libs.pipeline.ci_kpi import (
+    PipelineEvent,
+    PRMetric,
+    PRSnapshot,
+    compute_metrics,
+)
+
+SKIP_CI_LABELS = {"qa/skip-qa", "skip-ci", "no-ci"}
+GITLAB_PROJECT = "DataDog/datadog-agent"
+
+
+def _to_utc(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _require_utc(dt: datetime) -> datetime:
+    """Like `_to_utc` but the input is guaranteed non-None — keeps type checkers happy."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _classify_branch(branch: str) -> str:
+    if branch.startswith("gh-readonly-queue/") or "/merge-queue/" in branch:
+        return "merge_queue"
+    return "dev"
+
+
+def _build_snapshot(pr, gitlab_repo) -> PRSnapshot | None:
+    """Pull GitHub PR + GitLab pipelines and build a PRSnapshot.
+
+    Returns None if the PR has no commits we can inspect (e.g. transient
+    GH state); the caller should skip such PRs without failing the run.
+    """
+    commits = list(pr.get_commits())
+    if not commits:
+        return None
+
+    shas = [c.sha for c in commits]
+
+    # Earliest commit timestamp gives us "first push" — the clock can't
+    # start before code existed on the PR.
+    first_commit_ts = min(_require_utc(c.commit.author.date) for c in commits)
+    pr_opened = _require_utc(pr.created_at)
+    clock_start = max(first_commit_ts, pr_opened)
+
+    # Collect pipelines for every SHA the PR carried (force-pushes included).
+    pipelines: list[PipelineEvent] = []
+    for sha in shas:
+        try:
+            for p in gitlab_repo.pipelines.list(sha=sha, get_all=True):
+                pipelines.append(
+                    PipelineEvent(
+                        pipeline_id=int(p.id),
+                        sha=sha,
+                        source=str(p.source),
+                        status=str(p.status),
+                        created_at=_to_utc(_parse_gitlab_ts(p.created_at)),
+                        finished_at=_to_utc(_parse_gitlab_ts(p.finished_at)),
+                    )
+                )
+        except Exception as e:
+            # One bad SHA shouldn't fail the whole window. Surface and skip.
+            print(f"[ci-kpi] skipping sha {sha[:8]} on PR #{pr.number}: {e}", file=sys.stderr)
+
+    labels = {label.name for label in pr.get_labels()}
+    skip_ci = bool(labels & SKIP_CI_LABELS)
+    is_draft_only = pr.draft and pr.state == "closed" and not pr.merged
+
+    return PRSnapshot(
+        pr_id=pr.number,
+        branch=pr.head.ref,
+        branch_kind=_classify_branch(pr.head.ref),
+        clock_start=clock_start,
+        pipelines=tuple(pipelines),
+        n_pushes=len(shas),
+        skip_ci=skip_ci,
+        is_draft_only=is_draft_only,
+    )
+
+
+def _parse_gitlab_ts(value) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+
+def _list_recent_prs(gh: GithubAPI, since: datetime):
+    """Yield PRs touched (created/updated/closed) since the cutoff.
+
+    GitHub's API returns PRs sorted by `updated` desc, so we can stop
+    iterating once we go past the cutoff.
+    """
+    for pr in gh.repo.get_pulls(state="all", sort="updated", direction="desc"):
+        if _to_utc(pr.updated_at) < since:
+            break
+        yield pr
+
+
+def _series_for(metric: PRMetric, ts: int):
+    common_tags = [
+        f"pr_id:{metric.pr_id}",
+        f"branch_kind:{metric.branch_kind}",
+        f"had_manual_retry:{str(metric.had_manual_retry).lower()}",
+        "repository:datadog-agent",
+    ]
+    if metric.team:
+        common_tags.append(f"team:{metric.team}")
+
+    series = []
+    if metric.duration_s is not None:
+        series.append(
+            create_gauge(
+                metric_name="datadog.ci.time_to_trustworthy_green",
+                timestamp=ts,
+                value=metric.duration_s,
+                tags=common_tags,
+                unit="second",
+            )
+        )
+    series.append(
+        create_gauge(
+            metric_name="datadog.ci.pr_pushes",
+            timestamp=ts,
+            value=metric.n_pushes,
+            tags=common_tags,
+        )
+    )
+    if not metric.reached_trustworthy_green:
+        series.append(
+            create_count(
+                metric_name="datadog.ci.pr_never_green_count",
+                timestamp=ts,
+                value=1,
+                tags=common_tags,
+            )
+        )
+    return series
+
+
+@task
+def compute(ctx: Context, window: int = 14, dry_run: bool = False):
+    """Compute time-to-trustworthy-green for PRs touched in the last `window` days.
+
+    With `--dry-run`, prints the per-PR records without submitting metrics.
+    """
+    if window <= 0:
+        print("--window must be positive", file=sys.stderr)
+        sys.exit(2)
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=window)
+    gh = GithubAPI(repository=GITHUB_REPO_NAME)
+    gitlab_repo = get_gitlab_repo(GITLAB_PROJECT)
+
+    snapshots: list[PRSnapshot] = []
+    for pr in _list_recent_prs(gh, cutoff):
+        try:
+            snap = _build_snapshot(pr, gitlab_repo)
+        except Exception as e:
+            print(f"[ci-kpi] skipping PR #{pr.number}: {e}", file=sys.stderr)
+            continue
+        if snap is not None:
+            snapshots.append(snap)
+
+    metrics = compute_metrics(snapshots)
+    ts = int(datetime.now(timezone.utc).timestamp())
+
+    if dry_run:
+        for m in metrics:
+            duration = f"{m.duration_s:.0f}s" if m.duration_s is not None else "never-green"
+            print(
+                f"PR #{m.pr_id}\tduration={duration}\tpushes={m.n_pushes}\t"
+                f"pipelines={m.n_pipelines}\tmanual_retry={m.had_manual_retry}\t"
+                f"branch_kind={m.branch_kind}"
+            )
+        print(f"\n{len(metrics)} PRs evaluated, dry-run (no metrics submitted).")
+        return
+
+    series = []
+    for m in metrics:
+        series.extend(_series_for(m, ts))
+
+    if not series:
+        print("[ci-kpi] no metrics to submit")
+        return
+
+    send_metrics(series)
+    print(f"[ci-kpi] submitted {len(series)} series for {len(metrics)} PRs")

--- a/tasks/libs/pipeline/ci_kpi.py
+++ b/tasks/libs/pipeline/ci_kpi.py
@@ -1,0 +1,166 @@
+"""
+Pure-logic helpers for the "Time-to-Trustworthy-Green per PR" KPI.
+
+This module deliberately has no I/O so the computation can be unit-tested
+with synthetic fixtures. The invoke task in `tasks/ci_kpi.py` is the
+thin wrapper that talks to GitHub and GitLab and feeds these helpers.
+
+KPI definition:
+    Wall-clock from PR open (or first push, whichever is later) to the
+    first pipeline that reached green without any manual rerun for that
+    same commit. Aggregated at p90 across PRs in a window.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+# Pipeline sources GitLab uses when a pipeline was triggered by a human-driven
+# action rather than a normal git push. Any pipeline with one of these sources
+# attached to a SHA invalidates "trustworthy green" for that SHA.
+MANUAL_PIPELINE_SOURCES = frozenset({"web", "api", "trigger"})
+
+# Pipeline sources we accept as the "natural" trigger for a push. A pipeline
+# from one of these is the only kind that can constitute a trustworthy green.
+NATURAL_PIPELINE_SOURCES = frozenset({"push", "merge_request_event"})
+
+
+@dataclass(frozen=True)
+class PipelineEvent:
+    """A single GitLab pipeline run for a SHA on a PR.
+
+    `has_manually_retried_job` is the v1 heuristic: True iff any job inside
+    this pipeline reports `retried=True` from a manual replay. The current
+    implementation does not distinguish auto-retries (configured in
+    `.gitlab-ci.yml retry:`) from manual ones, so this may overcount; the
+    plan is to refine after two weeks of data.
+    """
+
+    pipeline_id: int
+    sha: str
+    source: str
+    status: str
+    created_at: datetime
+    finished_at: datetime | None
+    has_manually_retried_job: bool = False
+
+
+@dataclass(frozen=True)
+class PRSnapshot:
+    """Everything we need about a PR to compute the KPI."""
+
+    pr_id: int
+    branch: str
+    branch_kind: str  # "dev" | "merge_queue"
+    clock_start: datetime  # PR ready-for-review timestamp, or first push if later
+    pipelines: tuple[PipelineEvent, ...] = field(default_factory=tuple)
+    n_pushes: int = 0
+    skip_ci: bool = False
+    is_draft_only: bool = False
+    team: str | None = None
+
+
+@dataclass(frozen=True)
+class PRMetric:
+    """The output of the computation for a single PR."""
+
+    pr_id: int
+    duration_s: float | None
+    reached_trustworthy_green: bool
+    had_manual_retry: bool
+    n_pushes: int
+    n_pipelines: int
+    branch_kind: str
+    team: str | None
+
+
+def is_eligible(snapshot: PRSnapshot) -> bool:
+    """A PR is part of the KPI population unless it's a no-CI PR or never left draft."""
+    if snapshot.skip_ci:
+        return False
+    if snapshot.is_draft_only:
+        return False
+    return True
+
+
+def find_trustworthy_green(snapshot: PRSnapshot) -> PipelineEvent | None:
+    """Return the earliest pipeline that constitutes a trustworthy green for the PR.
+
+    A pipeline `P` qualifies iff all of:
+      * `P.status == "success"`,
+      * `P.source` is a natural source (push / merge_request_event),
+      * no earlier pipeline for the *same SHA* has a manual source,
+      * no earlier pipeline for the same SHA had a manually retried job,
+      * `P` itself has no manually retried jobs.
+
+    Earliness is measured by `finished_at` (the moment the dev would see green).
+    """
+    finished = [p for p in snapshot.pipelines if p.finished_at is not None]
+    finished.sort(key=lambda p: p.finished_at)
+
+    for candidate in finished:
+        if candidate.status != "success":
+            continue
+        if candidate.source not in NATURAL_PIPELINE_SOURCES:
+            continue
+        if candidate.has_manually_retried_job:
+            continue
+
+        # Anything for the same SHA that finished before this candidate
+        # can taint it. We look at finished_at on the prior pipeline because
+        # that's when the dev would have observed the manual rerun.
+        tainted = False
+        for prior in finished:
+            if prior is candidate:
+                continue
+            if prior.sha != candidate.sha:
+                continue
+            if prior.finished_at >= candidate.finished_at:
+                continue
+            if prior.source in MANUAL_PIPELINE_SOURCES or prior.has_manually_retried_job:
+                tainted = True
+                break
+
+        if not tainted:
+            return candidate
+
+    return None
+
+
+def had_any_manual_retry(snapshot: PRSnapshot) -> bool:
+    """Informational: did anyone rerun anything on this PR, ever?"""
+    for p in snapshot.pipelines:
+        if p.source in MANUAL_PIPELINE_SOURCES:
+            return True
+        if p.has_manually_retried_job:
+            return True
+    return False
+
+
+def compute_pr_metric(snapshot: PRSnapshot) -> PRMetric:
+    """Reduce a snapshot to the KPI record."""
+    green = find_trustworthy_green(snapshot)
+    if green is None or green.finished_at is None:
+        duration_s: float | None = None
+        reached = False
+    else:
+        delta = green.finished_at - snapshot.clock_start
+        duration_s = max(delta.total_seconds(), 0.0)
+        reached = True
+
+    return PRMetric(
+        pr_id=snapshot.pr_id,
+        duration_s=duration_s,
+        reached_trustworthy_green=reached,
+        had_manual_retry=had_any_manual_retry(snapshot),
+        n_pushes=snapshot.n_pushes,
+        n_pipelines=len(snapshot.pipelines),
+        branch_kind=snapshot.branch_kind,
+        team=snapshot.team,
+    )
+
+
+def compute_metrics(snapshots: list[PRSnapshot]) -> list[PRMetric]:
+    """Compute KPI records for the eligible subset of snapshots."""
+    return [compute_pr_metric(s) for s in snapshots if is_eligible(s)]

--- a/tasks/unit_tests/ci_kpi_tests.py
+++ b/tasks/unit_tests/ci_kpi_tests.py
@@ -1,0 +1,194 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from tasks.libs.pipeline.ci_kpi import (
+    PipelineEvent,
+    PRSnapshot,
+    compute_metrics,
+    compute_pr_metric,
+    find_trustworthy_green,
+    is_eligible,
+)
+
+UTC = timezone.utc
+
+
+def _ts(minutes_from_epoch: int) -> datetime:
+    return datetime(2026, 4, 1, 0, 0, tzinfo=UTC) + timedelta(minutes=minutes_from_epoch)
+
+
+def _pipeline(
+    pid: int,
+    sha: str,
+    *,
+    source: str = "push",
+    status: str = "success",
+    started: int = 0,
+    finished: int | None = 30,
+    manual_retry: bool = False,
+) -> PipelineEvent:
+    return PipelineEvent(
+        pipeline_id=pid,
+        sha=sha,
+        source=source,
+        status=status,
+        created_at=_ts(started),
+        finished_at=_ts(finished) if finished is not None else None,
+        has_manually_retried_job=manual_retry,
+    )
+
+
+def _snapshot(
+    *,
+    pipelines: list[PipelineEvent],
+    n_pushes: int = 1,
+    branch_kind: str = "dev",
+    skip_ci: bool = False,
+    is_draft_only: bool = False,
+    clock_offset: int = 0,
+) -> PRSnapshot:
+    return PRSnapshot(
+        pr_id=42,
+        branch="feature-branch",
+        branch_kind=branch_kind,
+        clock_start=_ts(clock_offset),
+        pipelines=tuple(pipelines),
+        n_pushes=n_pushes,
+        skip_ci=skip_ci,
+        is_draft_only=is_draft_only,
+    )
+
+
+class TestTrustworthyGreen(unittest.TestCase):
+    def test_happy_path_first_push_goes_green_no_retries(self):
+        snap = _snapshot(pipelines=[_pipeline(1, "sha1", started=2, finished=22)])
+
+        green = find_trustworthy_green(snap)
+        metric = compute_pr_metric(snap)
+
+        self.assertIsNotNone(green)
+        self.assertEqual(green.pipeline_id, 1)
+        self.assertTrue(metric.reached_trustworthy_green)
+        # Clock starts at 0, candidate finishes at minute 22 → 22 * 60s.
+        self.assertEqual(metric.duration_s, 22 * 60)
+        self.assertFalse(metric.had_manual_retry)
+
+    def test_manual_rerun_taints_first_success_so_clock_extends_to_next_clean_push(self):
+        # Push 1 needed a manual rerun; push 2 went green naturally.
+        first_push_failed = _pipeline(1, "sha1", status="failed", started=0, finished=10)
+        first_push_rerun_green = _pipeline(2, "sha1", source="web", status="success", started=11, finished=21)
+        second_push_green = _pipeline(3, "sha2", started=30, finished=50)
+
+        snap = _snapshot(
+            pipelines=[first_push_failed, first_push_rerun_green, second_push_green],
+            n_pushes=2,
+        )
+        metric = compute_pr_metric(snap)
+
+        self.assertTrue(metric.reached_trustworthy_green)
+        # The second push's natural-source success is the trustworthy green.
+        self.assertEqual(metric.duration_s, 50 * 60)
+        self.assertTrue(metric.had_manual_retry)
+
+    def test_manually_retried_job_within_green_pipeline_disqualifies_it(self):
+        bad_green = _pipeline(1, "sha1", started=0, finished=20, manual_retry=True)
+        clean_green_later = _pipeline(2, "sha2", started=30, finished=40)
+
+        snap = _snapshot(pipelines=[bad_green, clean_green_later], n_pushes=2)
+        metric = compute_pr_metric(snap)
+
+        self.assertTrue(metric.reached_trustworthy_green)
+        self.assertEqual(metric.duration_s, 40 * 60)
+        self.assertTrue(metric.had_manual_retry)
+
+    def test_force_push_invalidates_old_pipelines_but_new_sha_can_still_go_green(self):
+        # Old SHA had a manual rerun then was force-pushed away; new SHA is clean.
+        old_sha_failed = _pipeline(1, "sha-old", status="failed", started=0, finished=8)
+        old_sha_manual = _pipeline(2, "sha-old", source="web", status="success", started=9, finished=15)
+        new_sha_green = _pipeline(3, "sha-new", started=20, finished=35)
+
+        snap = _snapshot(pipelines=[old_sha_failed, old_sha_manual, new_sha_green], n_pushes=2)
+        metric = compute_pr_metric(snap)
+
+        # The trustworthy green is the natural-source success on the new SHA;
+        # the manual on the old SHA only taints the old SHA's lineage.
+        self.assertTrue(metric.reached_trustworthy_green)
+        self.assertEqual(metric.duration_s, 35 * 60)
+        self.assertTrue(metric.had_manual_retry)
+
+    def test_pr_with_only_failures_never_reaches_trustworthy_green(self):
+        snap = _snapshot(
+            pipelines=[
+                _pipeline(1, "sha1", status="failed", started=0, finished=10),
+                _pipeline(2, "sha2", status="failed", started=20, finished=30),
+            ],
+            n_pushes=2,
+        )
+        metric = compute_pr_metric(snap)
+
+        self.assertFalse(metric.reached_trustworthy_green)
+        self.assertIsNone(metric.duration_s)
+
+    def test_pipeline_still_running_is_ignored(self):
+        running = _pipeline(1, "sha1", status="running", started=0, finished=None)
+        green = _pipeline(2, "sha1", started=5, finished=25)
+
+        snap = _snapshot(pipelines=[running, green])
+        metric = compute_pr_metric(snap)
+
+        self.assertTrue(metric.reached_trustworthy_green)
+        self.assertEqual(metric.duration_s, 25 * 60)
+
+    def test_clock_start_after_pipeline_yields_clamped_zero(self):
+        # Defensive: if PR was opened after the green pipeline finished
+        # (rare race in data: PR converted from a long-lived branch), the
+        # duration should clamp to zero rather than go negative.
+        green = _pipeline(1, "sha1", started=0, finished=10)
+        snap = _snapshot(pipelines=[green], clock_offset=20)
+
+        metric = compute_pr_metric(snap)
+
+        self.assertTrue(metric.reached_trustworthy_green)
+        self.assertEqual(metric.duration_s, 0.0)
+
+
+class TestEligibility(unittest.TestCase):
+    def test_skip_ci_label_excludes_pr(self):
+        snap = _snapshot(pipelines=[_pipeline(1, "sha1")], skip_ci=True)
+        self.assertFalse(is_eligible(snap))
+
+    def test_draft_only_pr_excluded(self):
+        snap = _snapshot(pipelines=[_pipeline(1, "sha1")], is_draft_only=True)
+        self.assertFalse(is_eligible(snap))
+
+    def test_compute_metrics_filters_ineligible(self):
+        ok = _snapshot(pipelines=[_pipeline(1, "sha1", finished=10)])
+        skipped = PRSnapshot(
+            pr_id=99,
+            branch="b",
+            branch_kind="dev",
+            clock_start=_ts(0),
+            pipelines=(_pipeline(2, "sha2"),),
+            skip_ci=True,
+        )
+
+        results = compute_metrics([ok, skipped])
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].pr_id, 42)
+
+
+class TestMergeQueueTagging(unittest.TestCase):
+    def test_branch_kind_propagates_to_metric(self):
+        snap = _snapshot(
+            pipelines=[_pipeline(1, "sha1", source="merge_request_event", finished=10)],
+            branch_kind="merge_queue",
+        )
+        metric = compute_pr_metric(snap)
+
+        self.assertEqual(metric.branch_kind, "merge_queue")
+        self.assertTrue(metric.reached_trustworthy_green)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Introduces a new CI developer-experience KPI: **Time-to-Trustworthy-Green per PR (p90)** — wall-clock from PR open (or first push) to the first green CI without manual reruns.

Designed to replace the existing **p50 of dev-branch pipeline duration** as the developer-experience headline metric. p50 hides the things that actually shape CI experience:

- tail-latency days (p90 captures, p50 doesn't)
- push fan-out and fix iterations (one PR ≠ one pipeline)
- flake-and-rerun cost (extends the clock; doesn't move pipeline duration)
- queue/runner saturation (visible in wall-clock, invisible in job-duration)

See `Optimise the datadog-agent CI pipeline` Confluence page for the broader CI-strategy context this lands in.

## What changed

- `tasks/libs/pipeline/ci_kpi.py` — pure-logic module: `PipelineEvent`, `PRSnapshot`, `PRMetric`, plus `find_trustworthy_green` / `compute_pr_metric` / `compute_metrics`.
- `tasks/ci_kpi.py` — invoke task that joins GitHub PRs to GitLab pipelines by SHA, builds snapshots, and emits Datadog metrics. Supports `--dry-run`.
- `tasks/unit_tests/ci_kpi_tests.py` — 11 tests covering happy path, manual-rerun taint, manually-retried-job disqualification, force-push, never-green, draft/skip-ci eligibility, and merge-queue tagging.
- `.github/workflows/ci-kpi.yml` — hourly schedule + manual `workflow_dispatch` with `--window` and `--dry-run` inputs.

## Metrics emitted

- `datadog.ci.time_to_trustworthy_green` (gauge, seconds) — per-PR
- `datadog.ci.pr_pushes` (gauge) — distribution of pushes per PR
- `datadog.ci.pr_never_green_count` (count) — PRs that didn't reach trustworthy-green in the window

Tagged with `pr_id`, `branch_kind` (`dev` | `merge_queue`), `had_manual_retry`, `repository`.

## v1 limitations (intentional)

- Manual-vs-auto retry detection currently relies on pipeline `source ∈ {web, api, trigger}`. Job-level `retried` is plumbed through the data model but not populated yet — pipelines.jobs.list() would multiply API calls. Will tighten if the v1 heuristic proves noisy after 2 weeks of data.
- Lands **alongside** existing p50, not replacing it. Promotion to headline KPI happens after a 4-week comparison window.

## Test plan

- [x] `dda inv invoke-unit-tests.run -t ci_kpi` — 11 tests pass
- [x] `dda inv linter.python` — clean
- [ ] Workflow `workflow_dispatch` smoke run with `dry_run=true` after merge
- [ ] Validate emitted metrics appear in Datadog with expected tags
- [ ] Spot-check 5 PRs at the p90 tail manually against computed clocks (week 1)
- [ ] Build companion dashboard with side-by-side p50-pipeline-duration vs p90-time-to-trustworthy-green

🤖 Generated with [Claude Code](https://claude.com/claude-code)