### PR TITLE
[ACTP] add RunnerStartedAt and LastTaskReceivedAt to PAR dequeue requests

### DIFF
--- a/pkg/privateactionrunner/opms/BUILD.bazel
+++ b/pkg/privateactionrunner/opms/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     deps = [
         "//pkg/privateactionrunner/adapters/config",
         "@//pkg/privateactionrunner/adapters/constants",
+        "@com_github_datadog_jsonapi//:jsonapi",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/privateactionrunner/opms/opms.go
+++ b/pkg/privateactionrunner/opms/opms.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config/env"
@@ -47,6 +48,11 @@ const (
 	// idle stretches.
 	maxRetryAfter = 2 * time.Minute
 )
+
+type DequeueJSONRequest struct {
+	RunnerStartedAt    string `json:"runner_started_at,omitempty"`
+	LastTaskReceivedAt string `json:"last_task_received_at,omitempty"`
+}
 
 type PublishTaskUpdateJSONRequestPayload struct {
 	Branch       string                            `json:"branch,omitempty"`
@@ -131,6 +137,9 @@ type Client interface {
 type client struct {
 	config     *config.Config
 	httpClient *http.Client
+
+	runnerStartedAt    time.Time
+	lastTaskReceivedAt atomic.Pointer[time.Time]
 }
 
 func NewClient(cfg *config.Config) Client {
@@ -138,7 +147,8 @@ func NewClient(cfg *config.Config) Client {
 		httpClient: &http.Client{
 			Timeout: time.Millisecond * time.Duration(cfg.OpmsRequestTimeout),
 		},
-		config: cfg,
+		config:          cfg,
+		runnerStartedAt: time.Now().UTC(),
 	}
 }
 
@@ -157,7 +167,12 @@ func (c *client) endpointURL(path string) string {
 }
 
 func (c *client) DequeueTask(ctx context.Context) (*types.Task, time.Duration, error) {
-	body, headers, err := c.makeRequest(ctx, http.MethodPost, c.endpointURL(dequeuePath), nil, nil, http.StatusOK)
+	reqBody, err := c.buildDequeueRequestBody()
+	if err != nil {
+		return nil, 0, fmt.Errorf("error marshaling dequeue request body: %w", err)
+	}
+
+	body, headers, err := c.makeRequest(ctx, http.MethodPost, c.endpointURL(dequeuePath), bytes.NewReader(reqBody), nil, http.StatusOK)
 	retryAfter := parseRetryAfterMs(headers)
 	if err != nil {
 		return nil, retryAfter, fmt.Errorf("error making request to dequeue task: %w", err)
@@ -174,7 +189,20 @@ func (c *client) DequeueTask(ctx context.Context) (*types.Task, time.Duration, e
 		return nil, retryAfter, fmt.Errorf("error unmarshaling dequeue task response: %w", err)
 	}
 
+	now := time.Now().UTC()
+	c.lastTaskReceivedAt.Store(&now)
+
 	return res, retryAfter, nil
+}
+
+func (c *client) buildDequeueRequestBody() ([]byte, error) {
+	req := DequeueJSONRequest{
+		RunnerStartedAt: c.runnerStartedAt.Format(time.RFC3339),
+	}
+	if t := c.lastTaskReceivedAt.Load(); t != nil {
+		req.LastTaskReceivedAt = t.Format(time.RFC3339)
+	}
+	return json.Marshal(req)
 }
 
 func (c *client) PublishSuccess(

--- a/pkg/privateactionrunner/opms/opms.go
+++ b/pkg/privateactionrunner/opms/opms.go
@@ -171,7 +171,7 @@ func (c *client) endpointURL(path string) string {
 func (c *client) DequeueTask(ctx context.Context) (*types.Task, time.Duration, error) {
 	reqBody, err := c.buildDequeueRequestBody()
 	if err != nil {
-		return nil, 0, fmt.Errorf("error marshaling dequeue request body: %w", err)
+		return nil, 0, fmt.Errorf("error building dequeue request body: %w", err)
 	}
 
 	body, headers, err := c.makeRequest(ctx, http.MethodPost, c.endpointURL(dequeuePath), bytes.NewReader(reqBody), nil, http.StatusOK)

--- a/pkg/privateactionrunner/opms/opms.go
+++ b/pkg/privateactionrunner/opms/opms.go
@@ -32,6 +32,7 @@ import (
 	actionsclientpb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/actionsclient"
 	aperrorpb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/errorcode"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/jsonapi"
 )
 
 const (
@@ -49,18 +50,10 @@ const (
 	maxRetryAfter = 2 * time.Minute
 )
 
-type DequeueJSONRequestAttributes struct {
-	RunnerStartedAt    string `json:"runner_started_at,omitempty"`
-	LastTaskReceivedAt string `json:"last_task_received_at,omitempty"`
-}
-
-type DequeueJSONData struct {
-	Type       string                        `json:"type,omitempty"`
-	Attributes *DequeueJSONRequestAttributes `json:"attributes,omitempty"`
-}
-
 type DequeueJSONRequest struct {
-	Data *DequeueJSONData `json:"data,omitempty"`
+	ID                 string `jsonapi:"primary,dequeue"`
+	RunnerStartedAt    string `json:"runner_started_at,omitempty" jsonapi:"attribute"`
+	LastTaskReceivedAt string `json:"last_task_received_at,omitempty" jsonapi:"attribute"`
 }
 
 type PublishTaskUpdateJSONRequestPayload struct {
@@ -205,19 +198,13 @@ func (c *client) DequeueTask(ctx context.Context) (*types.Task, time.Duration, e
 }
 
 func (c *client) buildDequeueRequestBody() ([]byte, error) {
-	attrs := &DequeueJSONRequestAttributes{
+	req := &DequeueJSONRequest{
 		RunnerStartedAt: c.runnerStartedAt.Format(time.RFC3339),
 	}
 	if t := c.lastTaskReceivedAt.Load(); t != nil {
-		attrs.LastTaskReceivedAt = t.Format(time.RFC3339)
+		req.LastTaskReceivedAt = t.Format(time.RFC3339)
 	}
-	req := DequeueJSONRequest{
-		Data: &DequeueJSONData{
-			Type:       "dequeue",
-			Attributes: attrs,
-		},
-	}
-	return json.Marshal(req)
+	return jsonapi.Marshal(req, jsonapi.MarshalClientMode())
 }
 
 func (c *client) PublishSuccess(

--- a/pkg/privateactionrunner/opms/opms.go
+++ b/pkg/privateactionrunner/opms/opms.go
@@ -49,9 +49,18 @@ const (
 	maxRetryAfter = 2 * time.Minute
 )
 
-type DequeueJSONRequest struct {
+type DequeueJSONRequestAttributes struct {
 	RunnerStartedAt    string `json:"runner_started_at,omitempty"`
 	LastTaskReceivedAt string `json:"last_task_received_at,omitempty"`
+}
+
+type DequeueJSONData struct {
+	Type       string                        `json:"type,omitempty"`
+	Attributes *DequeueJSONRequestAttributes `json:"attributes,omitempty"`
+}
+
+type DequeueJSONRequest struct {
+	Data *DequeueJSONData `json:"data,omitempty"`
 }
 
 type PublishTaskUpdateJSONRequestPayload struct {
@@ -196,11 +205,17 @@ func (c *client) DequeueTask(ctx context.Context) (*types.Task, time.Duration, e
 }
 
 func (c *client) buildDequeueRequestBody() ([]byte, error) {
-	req := DequeueJSONRequest{
+	attrs := &DequeueJSONRequestAttributes{
 		RunnerStartedAt: c.runnerStartedAt.Format(time.RFC3339),
 	}
 	if t := c.lastTaskReceivedAt.Load(); t != nil {
-		req.LastTaskReceivedAt = t.Format(time.RFC3339)
+		attrs.LastTaskReceivedAt = t.Format(time.RFC3339)
+	}
+	req := DequeueJSONRequest{
+		Data: &DequeueJSONData{
+			Type:       "dequeue",
+			Attributes: attrs,
+		},
 	}
 	return json.Marshal(req)
 }

--- a/pkg/privateactionrunner/opms/opms_test.go
+++ b/pkg/privateactionrunner/opms/opms_test.go
@@ -176,14 +176,18 @@ func TestDequeueTask_RequestBody(t *testing.T) {
 		}
 
 		body := <-bodies
-		assert.Equal(t, runnerStartedAt, body.RunnerStartedAt, "%s: runner_started_at", s.name)
+		require.NotNil(t, body.Data, "%s: data", s.name)
+		assert.Equal(t, "dequeue", body.Data.Type, "%s: data.type", s.name)
+		require.NotNil(t, body.Data.Attributes, "%s: data.attributes", s.name)
+		attrs := body.Data.Attributes
+		assert.Equal(t, runnerStartedAt, attrs.RunnerStartedAt, "%s: runner_started_at", s.name)
 
 		if s.wantLastTaskReceivedAt {
-			require.NotEmpty(t, body.LastTaskReceivedAt, "%s: last_task_received_at must be set", s.name)
-			_, err := time.Parse(time.RFC3339, body.LastTaskReceivedAt)
+			require.NotEmpty(t, attrs.LastTaskReceivedAt, "%s: last_task_received_at must be set", s.name)
+			_, err := time.Parse(time.RFC3339, attrs.LastTaskReceivedAt)
 			require.NoError(t, err, "%s: last_task_received_at must be RFC3339", s.name)
 		} else {
-			assert.Empty(t, body.LastTaskReceivedAt, "%s: last_task_received_at must be empty", s.name)
+			assert.Empty(t, attrs.LastTaskReceivedAt, "%s: last_task_received_at must be empty", s.name)
 		}
 	}
 }

--- a/pkg/privateactionrunner/opms/opms_test.go
+++ b/pkg/privateactionrunner/opms/opms_test.go
@@ -10,13 +10,13 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/DataDog/jsonapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -157,7 +157,7 @@ func TestDequeueTask_RequestBody(t *testing.T) {
 		raw, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		var body DequeueJSONRequest
-		require.NoError(t, json.Unmarshal(raw, &body))
+		require.NoError(t, jsonapi.Unmarshal(raw, &body))
 		bodies <- body
 		steps[i].respond(w)
 		i++
@@ -176,18 +176,14 @@ func TestDequeueTask_RequestBody(t *testing.T) {
 		}
 
 		body := <-bodies
-		require.NotNil(t, body.Data, "%s: data", s.name)
-		assert.Equal(t, "dequeue", body.Data.Type, "%s: data.type", s.name)
-		require.NotNil(t, body.Data.Attributes, "%s: data.attributes", s.name)
-		attrs := body.Data.Attributes
-		assert.Equal(t, runnerStartedAt, attrs.RunnerStartedAt, "%s: runner_started_at", s.name)
+		assert.Equal(t, runnerStartedAt, body.RunnerStartedAt, "%s: runner_started_at", s.name)
 
 		if s.wantLastTaskReceivedAt {
-			require.NotEmpty(t, attrs.LastTaskReceivedAt, "%s: last_task_received_at must be set", s.name)
-			_, err := time.Parse(time.RFC3339, attrs.LastTaskReceivedAt)
+			require.NotEmpty(t, body.LastTaskReceivedAt, "%s: last_task_received_at must be set", s.name)
+			_, err := time.Parse(time.RFC3339, body.LastTaskReceivedAt)
 			require.NoError(t, err, "%s: last_task_received_at must be RFC3339", s.name)
 		} else {
-			assert.Empty(t, attrs.LastTaskReceivedAt, "%s: last_task_received_at must be empty", s.name)
+			assert.Empty(t, body.LastTaskReceivedAt, "%s: last_task_received_at must be empty", s.name)
 		}
 	}
 }

--- a/pkg/privateactionrunner/opms/opms_test.go
+++ b/pkg/privateactionrunner/opms/opms_test.go
@@ -10,6 +10,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -44,6 +46,7 @@ func newTestClient(t *testing.T, srv *httptest.Server) *client {
 			RunnerId:           "test-runner",
 			PrivateKey:         newTestKey(t),
 		},
+		runnerStartedAt: time.Now().UTC(),
 	}
 }
 
@@ -119,6 +122,73 @@ func TestDequeueTask_RetryAfterMs_AbsentHeader(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, time.Duration(0), retryAfter)
 }
+
+// ---------- dequeue request body ----------
+
+// TestDequeueTask_RequestBody walks the runner through a scripted sequence of
+// server responses and asserts what each request body contains:
+//   - runner_started_at is on every request and stable
+//   - last_task_received_at is omitted until a non-empty dequeue succeeds, then
+//     populated, and not updated by empty or error responses.
+func TestDequeueTask_RequestBody(t *testing.T) {
+	empty := func(w http.ResponseWriter) { w.WriteHeader(http.StatusOK) }
+	fail := func(w http.ResponseWriter) { w.WriteHeader(http.StatusServiceUnavailable) }
+	task := func(w http.ResponseWriter) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"id":"task-1"}}`))
+	}
+
+	steps := []struct {
+		name                   string
+		respond                func(w http.ResponseWriter)
+		wantErr                bool
+		wantLastTaskReceivedAt bool
+	}{
+		{"first call, no prior task", empty, false, false},
+		{"error response does not record a timestamp", fail, true, false},
+		{"empty response does not record a timestamp", empty, false, false},
+		{"successful task: body sent before timestamp is recorded", task, false, false},
+		{"after a successful task, body carries the timestamp", empty, false, true},
+	}
+
+	bodies := make(chan DequeueJSONRequest, len(steps))
+	var i int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var body DequeueJSONRequest
+		require.NoError(t, json.Unmarshal(raw, &body))
+		bodies <- body
+		steps[i].respond(w)
+		i++
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	runnerStartedAt := c.runnerStartedAt.Format(time.RFC3339)
+
+	for _, s := range steps {
+		_, _, err := c.DequeueTask(context.Background())
+		if s.wantErr {
+			require.Error(t, err, s.name)
+		} else {
+			require.NoError(t, err, s.name)
+		}
+
+		body := <-bodies
+		assert.Equal(t, runnerStartedAt, body.RunnerStartedAt, "%s: runner_started_at", s.name)
+
+		if s.wantLastTaskReceivedAt {
+			require.NotEmpty(t, body.LastTaskReceivedAt, "%s: last_task_received_at must be set", s.name)
+			_, err := time.Parse(time.RFC3339, body.LastTaskReceivedAt)
+			require.NoError(t, err, "%s: last_task_received_at must be RFC3339", s.name)
+		} else {
+			assert.Empty(t, body.LastTaskReceivedAt, "%s: last_task_received_at must be empty", s.name)
+		}
+	}
+}
+
+// ---------- DequeueTask error handling ----------
 
 func TestDequeueTask_RetryAfterMs_OnErrorResponse(t *testing.T) {
 	// Server returns a 429 with a retry-after hint.


### PR DESCRIPTION
### What does this PR do?

Add `RunnerStartedAt` and `LastTaskReceivedAt` attributes to dequeue payload from PARs

### Motivation

ADRAP-31, configure adaptive polling from the backend

### Describe how you validated your changes

Ran locally

### Additional Notes
