### PR TITLE
chore(deps): disable Renovate auto-updates for github.com/prometheus/prometheus

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -81,6 +81,7 @@
           "golang.org/x/**",
           "go.opentelemetry.io/**",
           "github.com/open-telemetry/opentelemetry-collector-contrib/**",
+          "github.com/prometheus/prometheus",
           "github.com/spf13/cast",
           "github.com/mailru/easyjson"
         ],


### PR DESCRIPTION
### What does this PR do?

Adds `github.com/prometheus/prometheus` to the list of Go dependencies that Renovate will not auto-update.

### Motivation

`github.com/prometheus/prometheus` must be upgraded in lockstep with `github.com/open-telemetry/opentelemetry-collector-contrib` (already disabled in Renovate). Renovate [opened a PR bumping](https://github.com/DataDog/datadog-agent/pull/50148) `v0.311.2-0.20260410083055-07c6232d159b` (a pre-release pseudo-version pinned to a specific commit) to the actual `v0.311.2` tag. The two commits have incompatible APIs: between the pinned commit and the `v0.311.2` tag, `discovery.DiscovererMetrics` changed from a struct (with `RefreshManager`/`MechanismMetrics` fields) to a `map[string]DiscovererMetrics`, breaking `opentelemetry-collector-contrib/receiver/prometheusreceiver@v0.150.0`.

Disabling unilateral prometheus bumps prevents this class of breakage until both libraries can be upgraded together in a coordinated PR.

### Describe how you validated your changes

Config-only change; no code was modified.