### PR TITLE
Netflow: add netflow template exporter for flares

### DIFF
--- a/comp/netflow/server/impl/FLARE_TEMPLATES.md
+++ b/comp/netflow/server/impl/FLARE_TEMPLATES.md
@@ -1,0 +1,132 @@
+# NetFlow Template Export in Flares
+
+## Overview
+
+The NetFlow component now automatically exports template information when a flare is created. This helps debug issues where customers send packet captures without the necessary templates.
+
+## What Gets Exported
+
+When a flare is generated, the following files are created in the `netflow/` directory:
+
+### 1. Human-Readable Format (`templates_readable.txt`)
+
+A text file containing all templates with:
+- Template metadata (exporter IP, version, observation domain ID, template ID)
+- Field definitions with human-readable names
+- Field types and lengths
+- Support for NetFlow v9, IPFIX, and Options templates
+
+Example:
+```
+Template Key: 192.168.1.1-9-0-256
+Listener: 0.0.0.0:2055
+Exporter IP: 192.168.1.1
+Version: 9 (NetFlow v9)
+Observation Domain ID: 0
+Template ID: 256
+
+Type: Data Template
+Field Count: 8
+
+Fields:
+   1. IPV4_SRC_ADDR                     (Type:     8, Length:   4)
+   2. IPV4_DST_ADDR                     (Type:    12, Length:   4)
+   3. L4_SRC_PORT                       (Type:     7, Length:   2)
+   4. L4_DST_PORT                       (Type:    11, Length:   2)
+   ...
+```
+
+### 2. JSON Format (`templates.json`)
+
+A machine-readable JSON file containing all template data. Useful for:
+- Automated analysis
+- Template comparison
+- Integration with other tools
+
+### 3. Pcap Format (`templates_*.pcap`)
+
+A pcap file per exporter/observation domain combination, containing one
+synthesized Ethernet/IPv4/UDP frame whose payload is the cached NetFlow v9
+or IPFIX template packet. The synthetic source IP matches the recorded
+exporter address and the destination port matches the protocol default
+(2055 for v9, 4739 for IPFIX), so Wireshark's NetFlow dissector caches the
+templates against the same key as data records seen in a real capture.
+
+File naming: `templates_{IP}_v{version}_obs{obsdomainid}.pcap`
+
+Example:
+- `templates_192.168.1.1_v9_obs0.pcap`
+- `templates_10.0.0.5_v10_obs123.pcap`
+
+Each pcap is accompanied by a `*_README.txt` documenting the synthetic
+framing and the recommended merge command.
+
+## Use Cases
+
+### 1. Debugging Missing Templates
+When customers send Wireshark captures of data flows but don't include the
+template packets, merge the template pcap with their capture so Wireshark
+can dissect the otherwise-orphan data records:
+
+```
+mergecap -a -w merged.pcap templates_<IP>_v<N>_obs<N>.pcap customer.pcap
+wireshark merged.pcap
+```
+
+`mergecap -a` (append) preserves source order so the synthetic templates
+are dissected before the customer's data records regardless of timestamps.
+
+### 2. Template Verification
+Check if the agent is receiving and storing templates correctly by inspecting the human-readable format.
+
+### 3. Template Comparison
+Compare templates between different environments or time periods using the JSON format.
+
+## Implementation Details
+
+- Templates are collected from all active NetFlow/IPFIX listeners
+- sFlow listeners are skipped (they don't use templates)
+- Collection has a 5-second timeout per listener
+- Pcap frames use synthetic Ethernet/IPv4/UDP headers; only IPv4 exporters
+  are exported today (IPv6 exporters are skipped with a warning)
+- All formats include the same template data for consistency
+
+## Technical Notes
+
+### Template Sources
+Templates are stored in the GoFlow2 in-memory template system and accessed via the `TemplateInterface`:
+- `ListTemplates()` - Enumerate all stored templates
+- `GetTemplate()` - Retrieve specific template data
+
+### Pcap Format Details
+Each pcap contains a single synthesized frame:
+- **Link layer**: Ethernet, with locally-administered placeholder MACs
+- **Network layer**: IPv4, source = recorded exporter IP, destination =
+  127.0.0.1 (synthetic; not a real receiver)
+- **Transport layer**: UDP, destination port = 2055 (v9) or 4739 (IPFIX),
+  source port = 49152, checksum = 0 (legal in IPv4)
+- **Payload**: a complete NetFlow/IPFIX packet
+  - **NetFlow v9**: Version 9 header + template FlowSets (ID=0) or options template FlowSets (ID=1)
+  - **IPFIX**: Version 10 header + template Sets (ID=2) or options template Sets (ID=3)
+  - Both formats include proper headers, padding, and length fields
+
+### Performance Impact
+- Templates are collected asynchronously when a flare is generated
+- No impact on normal flow processing
+- Minimal memory overhead (templates are already in memory)
+- Collection continues even if individual templates fail
+
+## Limitations
+
+1. Only active listeners are queried (stopped listeners won't have their templates exported)
+2. Templates that have expired from the cache won't be included
+3. Only IPv4 exporters produce a pcap today; IPv6 exporters are skipped with a log warning
+4. Templates the customer's collector observed but the agent did not (different
+   vantage point, NAT rewrites, etc.) cannot be reconstructed from this export
+
+## Future Enhancements
+
+Potential improvements:
+- IPv6 exporter support in the pcap path
+- Include template statistics (first seen, last seen, usage count)
+- Export template history if available

--- a/comp/netflow/server/impl/flare.go
+++ b/comp/netflow/server/impl/flare.go
@@ -1,0 +1,827 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package serverimpl
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net"
+	"path/filepath"
+	"time"
+
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
+	"github.com/DataDog/datadog-agent/comp/netflow/goflowlib/netflowstate"
+	"github.com/netsampler/goflow2/decoders/netflow"
+	"github.com/netsampler/goflow2/decoders/netflow/templates"
+)
+
+const (
+	pcapMagicMicro    = 0xa1b2c3d4
+	pcapLinkEthernet  = 1
+	pcapSnapLen       = 65535
+	ethTypeIPv4       = 0x0800
+	ipProtoUDP        = 17
+	netflowV9DstPort  = 2055
+	ipfixDstPort      = 4739
+	syntheticSrcPort  = 49152
+)
+
+// fillFlare adds netflow template information to the flare
+func (s *Server) fillFlare(parentCtx context.Context, fb flaretypes.FlareBuilder) error {
+	if !s.running {
+		s.logger.Debug("NetFlow server not running, skipping template export for flare")
+		return nil
+	}
+
+	s.logger.Debug("Collecting NetFlow templates for flare")
+
+	// Collect templates from all listeners
+	allTemplates := make(map[string]*TemplateInfo)
+
+	for _, listener := range s.listeners {
+		if listener == nil || listener.flowState == nil {
+			continue
+		}
+
+		// Check if this is a NetFlow/IPFIX listener (not sFlow)
+		state, ok := listener.flowState.State.(*netflowstate.StateNetFlow)
+		if !ok {
+			s.logger.Debugf("Skipping non-NetFlow listener on %s", listener.config.Addr())
+			continue
+		}
+
+		s.logger.Debugf("Collecting templates from listener on %s", listener.config.Addr())
+
+		// Get templates from this listener
+		ctx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
+		templatesChan := make(chan *templates.TemplateKey, 100)
+
+		// Start collecting templates
+		go func() {
+			defer close(templatesChan)
+			if err := state.TemplateSystem.ListTemplates(ctx, templatesChan); err != nil {
+				s.logger.Errorf("Error listing templates: %v", err)
+			}
+		}()
+
+		for key := range templatesChan {
+			if key == nil {
+				// goflow2's memory driver signals end-of-stream with a nil key.
+				break
+			}
+			templateData, err := state.TemplateSystem.GetTemplate(ctx, key)
+			if err != nil {
+				s.logger.Warnf("Error getting template %s: %v", key.String(), err)
+				continue
+			}
+
+			// Store template info
+			allTemplates[key.String()] = &TemplateInfo{
+				Key:          key,
+				TemplateData: templateData,
+				ListenerAddr: listener.config.Addr(),
+			}
+		}
+
+		cancel()
+	}
+
+	if len(allTemplates) == 0 {
+		s.logger.Info("No NetFlow templates found to export")
+		return fb.AddFile("netflow/templates_summary.txt", []byte("No NetFlow templates found.\n"))
+	}
+
+	s.logger.Infof("Found %d NetFlow templates to export", len(allTemplates))
+
+	// Export human-readable format
+	if err := s.exportHumanReadableTemplates(fb, allTemplates); err != nil {
+		s.logger.Errorf("Error exporting human-readable templates: %v", err)
+	}
+
+	// Export JSON format
+	if err := s.exportJSONTemplates(fb, allTemplates); err != nil {
+		s.logger.Errorf("Error exporting JSON templates: %v", err)
+	}
+
+	// Export pcap format (mergeable with customer pcaps for offline decoding)
+	if err := s.exportPcapTemplates(fb, allTemplates); err != nil {
+		s.logger.Errorf("Error exporting pcap templates: %v", err)
+	}
+
+	return nil
+}
+
+// TemplateInfo holds information about a single template
+type TemplateInfo struct {
+	Key          *templates.TemplateKey
+	TemplateData interface{}
+	ListenerAddr string
+}
+
+// exportHumanReadableTemplates exports templates in a human-readable text format
+func (s *Server) exportHumanReadableTemplates(fb flaretypes.FlareBuilder, allTemplates map[string]*TemplateInfo) error {
+	var buf bytes.Buffer
+
+	buf.WriteString("NetFlow Template Export\n")
+	buf.WriteString("=======================\n\n")
+	buf.WriteString(fmt.Sprintf("Generated: %s\n", time.Now().UTC().Format(time.RFC3339)))
+	buf.WriteString(fmt.Sprintf("Total Templates: %d\n\n", len(allTemplates)))
+
+	for keyStr, info := range allTemplates {
+		buf.WriteString("----------------------------------------\n")
+		buf.WriteString(fmt.Sprintf("Template Key: %s\n", keyStr))
+		buf.WriteString(fmt.Sprintf("Listener: %s\n", info.ListenerAddr))
+		buf.WriteString(fmt.Sprintf("Exporter IP: %s\n", info.Key.TemplateKey))
+		buf.WriteString(fmt.Sprintf("Version: %d (", info.Key.Version))
+		if info.Key.Version == 9 {
+			buf.WriteString("NetFlow v9)\n")
+		} else if info.Key.Version == 10 {
+			buf.WriteString("IPFIX)\n")
+		} else {
+			buf.WriteString("Unknown)\n")
+		}
+		buf.WriteString(fmt.Sprintf("Observation Domain ID: %d\n", info.Key.ObsDomainId))
+		buf.WriteString(fmt.Sprintf("Template ID: %d\n\n", info.Key.TemplateId))
+
+		// Format the template data based on its type
+		switch tmpl := info.TemplateData.(type) {
+		case netflow.TemplateRecord:
+			buf.WriteString("Type: Data Template\n")
+			buf.WriteString(fmt.Sprintf("Field Count: %d\n\n", tmpl.FieldCount))
+			buf.WriteString("Fields:\n")
+			for i, field := range tmpl.Fields {
+				fieldName := getFieldName(field.Type, info.Key.Version)
+				buf.WriteString(fmt.Sprintf("  %2d. %-35s (Type: %5d, Length: %3d", i+1, fieldName, field.Type, field.Length))
+				if field.PenProvided {
+					buf.WriteString(fmt.Sprintf(", PEN: %d", field.Pen))
+				}
+				buf.WriteString(")\n")
+			}
+
+		case netflow.NFv9OptionsTemplateRecord:
+			buf.WriteString("Type: NetFlow v9 Options Template\n")
+			buf.WriteString(fmt.Sprintf("Scope Length: %d\n", tmpl.ScopeLength))
+			buf.WriteString(fmt.Sprintf("Option Length: %d\n\n", tmpl.OptionLength))
+
+			buf.WriteString("Scope Fields:\n")
+			for i, field := range tmpl.Scopes {
+				fieldName := getFieldName(field.Type, info.Key.Version)
+				buf.WriteString(fmt.Sprintf("  %2d. %-35s (Type: %5d, Length: %3d)\n", i+1, fieldName, field.Type, field.Length))
+			}
+
+			buf.WriteString("\nOption Fields:\n")
+			for i, field := range tmpl.Options {
+				fieldName := getFieldName(field.Type, info.Key.Version)
+				buf.WriteString(fmt.Sprintf("  %2d. %-35s (Type: %5d, Length: %3d)\n", i+1, fieldName, field.Type, field.Length))
+			}
+
+		case netflow.IPFIXOptionsTemplateRecord:
+			buf.WriteString("Type: IPFIX Options Template\n")
+			buf.WriteString(fmt.Sprintf("Field Count: %d\n", tmpl.FieldCount))
+			buf.WriteString(fmt.Sprintf("Scope Field Count: %d\n\n", tmpl.ScopeFieldCount))
+
+			buf.WriteString("Scope Fields:\n")
+			for i, field := range tmpl.Scopes {
+				fieldName := getFieldName(field.Type, info.Key.Version)
+				buf.WriteString(fmt.Sprintf("  %2d. %-35s (Type: %5d, Length: %3d", i+1, fieldName, field.Type, field.Length))
+				if field.PenProvided {
+					buf.WriteString(fmt.Sprintf(", PEN: %d", field.Pen))
+				}
+				buf.WriteString(")\n")
+			}
+
+			buf.WriteString("\nOption Fields:\n")
+			for i, field := range tmpl.Options {
+				fieldName := getFieldName(field.Type, info.Key.Version)
+				buf.WriteString(fmt.Sprintf("  %2d. %-35s (Type: %5d, Length: %3d", i+1, fieldName, field.Type, field.Length))
+				if field.PenProvided {
+					buf.WriteString(fmt.Sprintf(", PEN: %d", field.Pen))
+				}
+				buf.WriteString(")\n")
+			}
+
+		default:
+			buf.WriteString(fmt.Sprintf("Type: Unknown (%T)\n", tmpl))
+		}
+
+		buf.WriteString("\n")
+	}
+
+	return fb.AddFile("netflow/templates_readable.txt", buf.Bytes())
+}
+
+// exportJSONTemplates exports templates in JSON format for programmatic access
+func (s *Server) exportJSONTemplates(fb flaretypes.FlareBuilder, allTemplates map[string]*TemplateInfo) error {
+	jsonData := make([]map[string]interface{}, 0, len(allTemplates))
+
+	for keyStr, info := range allTemplates {
+		entry := map[string]interface{}{
+			"template_key":          keyStr,
+			"listener_addr":         info.ListenerAddr,
+			"exporter_ip":           info.Key.TemplateKey,
+			"version":               info.Key.Version,
+			"observation_domain_id": info.Key.ObsDomainId,
+			"template_id":           info.Key.TemplateId,
+		}
+
+		// Add template-specific data
+		switch tmpl := info.TemplateData.(type) {
+		case netflow.TemplateRecord:
+			entry["template_type"] = "data"
+			entry["field_count"] = tmpl.FieldCount
+			fields := make([]map[string]interface{}, len(tmpl.Fields))
+			for i, field := range tmpl.Fields {
+				fields[i] = map[string]interface{}{
+					"type":         field.Type,
+					"name":         getFieldName(field.Type, info.Key.Version),
+					"length":       field.Length,
+					"pen_provided": field.PenProvided,
+					"pen":          field.Pen,
+				}
+			}
+			entry["fields"] = fields
+
+		case netflow.NFv9OptionsTemplateRecord:
+			entry["template_type"] = "nfv9_options"
+			entry["scope_length"] = tmpl.ScopeLength
+			entry["option_length"] = tmpl.OptionLength
+
+			scopes := make([]map[string]interface{}, len(tmpl.Scopes))
+			for i, field := range tmpl.Scopes {
+				scopes[i] = map[string]interface{}{
+					"type":   field.Type,
+					"name":   getFieldName(field.Type, info.Key.Version),
+					"length": field.Length,
+				}
+			}
+			entry["scope_fields"] = scopes
+
+			options := make([]map[string]interface{}, len(tmpl.Options))
+			for i, field := range tmpl.Options {
+				options[i] = map[string]interface{}{
+					"type":   field.Type,
+					"name":   getFieldName(field.Type, info.Key.Version),
+					"length": field.Length,
+				}
+			}
+			entry["option_fields"] = options
+
+		case netflow.IPFIXOptionsTemplateRecord:
+			entry["template_type"] = "ipfix_options"
+			entry["field_count"] = tmpl.FieldCount
+			entry["scope_field_count"] = tmpl.ScopeFieldCount
+
+			scopes := make([]map[string]interface{}, len(tmpl.Scopes))
+			for i, field := range tmpl.Scopes {
+				scopes[i] = map[string]interface{}{
+					"type":         field.Type,
+					"name":         getFieldName(field.Type, info.Key.Version),
+					"length":       field.Length,
+					"pen_provided": field.PenProvided,
+					"pen":          field.Pen,
+				}
+			}
+			entry["scope_fields"] = scopes
+
+			options := make([]map[string]interface{}, len(tmpl.Options))
+			for i, field := range tmpl.Options {
+				options[i] = map[string]interface{}{
+					"type":         field.Type,
+					"name":         getFieldName(field.Type, info.Key.Version),
+					"length":       field.Length,
+					"pen_provided": field.PenProvided,
+					"pen":          field.Pen,
+				}
+			}
+			entry["option_fields"] = options
+		}
+
+		jsonData = append(jsonData, entry)
+	}
+
+	jsonBytes, err := json.MarshalIndent(jsonData, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal templates to JSON: %w", err)
+	}
+
+	return fb.AddFile("netflow/templates.json", jsonBytes)
+}
+
+// exportPcapTemplates exports templates as pcap files containing synthesized
+// UDP/IP/Ethernet frames carrying NetFlow/IPFIX template packets. The synthetic
+// packets use the recorded exporter IP as the source address, so the resulting
+// pcap can be merged with a customer capture via `mergecap` to populate
+// Wireshark's per-exporter template cache and decode otherwise-orphan data
+// records.
+func (s *Server) exportPcapTemplates(fb flaretypes.FlareBuilder, allTemplates map[string]*TemplateInfo) error {
+	// Group templates by exporter and version
+	type exporterKey struct {
+		ExporterIP  string
+		Version     uint16
+		ObsDomainID uint32
+	}
+
+	exporters := make(map[exporterKey][]*TemplateInfo)
+	for _, info := range allTemplates {
+		key := exporterKey{
+			ExporterIP:  info.Key.TemplateKey,
+			Version:     info.Key.Version,
+			ObsDomainID: info.Key.ObsDomainId,
+		}
+		exporters[key] = append(exporters[key], info)
+	}
+
+	for expKey, templates := range exporters {
+		srcIP := net.ParseIP(expKey.ExporterIP)
+		if srcIP == nil {
+			s.logger.Warnf("Skipping pcap export: exporter address %q is not a parseable IP", expKey.ExporterIP)
+			continue
+		}
+		if srcIP.To4() == nil {
+			// IPv4-only for now; IPv6 would require an IPv6 header path.
+			s.logger.Warnf("Skipping pcap export for non-IPv4 exporter %s (IPv6 templates pcap not yet supported)", expKey.ExporterIP)
+			continue
+		}
+
+		var payload bytes.Buffer
+		var dstPort uint16
+		var err error
+		switch expKey.Version {
+		case 9:
+			err = encodeNetFlowV9Templates(&payload, expKey.ObsDomainID, templates)
+			dstPort = netflowV9DstPort
+		case 10:
+			err = encodeIPFIXTemplates(&payload, expKey.ObsDomainID, templates)
+			dstPort = ipfixDstPort
+		default:
+			s.logger.Warnf("Unknown NetFlow version %d for exporter %s", expKey.Version, expKey.ExporterIP)
+			continue
+		}
+		if err != nil {
+			s.logger.Errorf("Error encoding templates for %s: %v", expKey.ExporterIP, err)
+			continue
+		}
+
+		pcapBytes, err := buildTemplatesPcap(payload.Bytes(), srcIP.To4(), dstPort, time.Now())
+		if err != nil {
+			s.logger.Errorf("Error building pcap for %s: %v", expKey.ExporterIP, err)
+			continue
+		}
+
+		sanitizedIP := filepath.Base(expKey.ExporterIP)
+		filename := fmt.Sprintf("netflow/templates_%s_v%d_obs%d.pcap", sanitizedIP, expKey.Version, expKey.ObsDomainID)
+		if err := fb.AddFileWithoutScrubbing(filename, pcapBytes); err != nil {
+			return err
+		}
+
+		readmePath := fmt.Sprintf("netflow/templates_%s_v%d_obs%d_README.txt", sanitizedIP, expKey.Version, expKey.ObsDomainID)
+		readme := fmt.Sprintf(`NetFlow Template Pcap
+======================
+
+Exporter IP: %s
+Version: %d (%s)
+Observation Domain ID: %d
+Template Count: %d
+
+This pcap contains one synthesized UDP packet carrying the templates the
+agent had cached for this exporter at flare-collection time. It is NOT a
+real capture; the Ethernet/IPv4/UDP framing is synthetic. The source IP
+matches the exporter so Wireshark's NetFlow dissector caches the templates
+against the same key as data records seen in a real capture.
+
+Decoding a customer pcap that lacks templates:
+
+  mergecap -a -w merged.pcap %s customer.pcap
+  wireshark merged.pcap
+
+Use -a (append) so the synthetic templates are dissected before the
+customer's data records regardless of timestamps.
+
+Caveats:
+- Only templates the agent observed are included. Templates the customer's
+  collector saw but the agent did not (different vantage point, NAT, etc.)
+  cannot be reconstructed here.
+- If the customer's exporter address differs from the one above (e.g. NAT
+  rewrites between agent and customer's collector), Wireshark will not
+  match the templates against the customer's data records.
+`, expKey.ExporterIP, expKey.Version, versionName(expKey.Version), expKey.ObsDomainID, len(templates), filepath.Base(filename))
+
+		if err := fb.AddFile(readmePath, []byte(readme)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// maxIPv4UDPPayload is the largest UDP payload that fits in a single IPv4
+// datagram (65535 - 20 IP header - 8 UDP header). NetFlow exporters fragment
+// large template sets across packets in real life; we don't, so a wildly
+// over-sized template set has to be reported instead of silently truncated by
+// the uint16 length fields.
+const maxIPv4UDPPayload = 65535 - 20 - 8
+
+// buildTemplatesPcap returns a complete pcap byte slice containing one
+// Ethernet/IPv4/UDP frame whose UDP payload is the supplied NetFlow/IPFIX
+// template packet. srcIP must be a 4-byte IPv4 address.
+func buildTemplatesPcap(payload []byte, srcIP net.IP, dstPort uint16, ts time.Time) ([]byte, error) {
+	if len(srcIP) != net.IPv4len {
+		return nil, fmt.Errorf("srcIP must be IPv4 (got %d bytes)", len(srcIP))
+	}
+	if len(payload) > maxIPv4UDPPayload {
+		return nil, fmt.Errorf("template payload %d bytes exceeds max IPv4 UDP payload %d", len(payload), maxIPv4UDPPayload)
+	}
+
+	frame := buildEthernetIPv4UDP(payload, srcIP, dstPort)
+
+	var buf bytes.Buffer
+	// pcap global header
+	if err := binary.Write(&buf, binary.LittleEndian, struct {
+		Magic    uint32
+		Major    uint16
+		Minor    uint16
+		ThisZone int32
+		SigFigs  uint32
+		SnapLen  uint32
+		LinkType uint32
+	}{
+		Magic: pcapMagicMicro, Major: 2, Minor: 4,
+		SnapLen: pcapSnapLen, LinkType: pcapLinkEthernet,
+	}); err != nil {
+		return nil, err
+	}
+
+	// pcap record header + frame
+	if err := binary.Write(&buf, binary.LittleEndian, struct {
+		TsSec   uint32
+		TsUsec  uint32
+		InclLen uint32
+		OrigLen uint32
+	}{
+		TsSec:   uint32(ts.Unix()),
+		TsUsec:  uint32(ts.Nanosecond() / 1000),
+		InclLen: uint32(len(frame)),
+		OrigLen: uint32(len(frame)),
+	}); err != nil {
+		return nil, err
+	}
+	buf.Write(frame)
+	return buf.Bytes(), nil
+}
+
+// buildEthernetIPv4UDP returns a complete frame: Ethernet | IPv4 | UDP | payload.
+// Destination address is loopback (127.0.0.1); MAC addresses are locally
+// administered placeholders. The UDP checksum is left zero (legal for IPv4).
+func buildEthernetIPv4UDP(payload []byte, srcIP net.IP, dstPort uint16) []byte {
+	const ethLen, ipLen, udpLen = 14, 20, 8
+	frame := make([]byte, ethLen+ipLen+udpLen+len(payload))
+
+	// Ethernet
+	copy(frame[0:6], []byte{0x02, 0x00, 0x00, 0x00, 0x00, 0x02})  // dst MAC
+	copy(frame[6:12], []byte{0x02, 0x00, 0x00, 0x00, 0x00, 0x01}) // src MAC
+	binary.BigEndian.PutUint16(frame[12:14], ethTypeIPv4)
+
+	ip := frame[ethLen : ethLen+ipLen]
+	udp := frame[ethLen+ipLen : ethLen+ipLen+udpLen]
+	udpAndPayload := frame[ethLen+ipLen:]
+
+	// IPv4
+	ip[0] = 0x45 // version 4, IHL 5
+	ip[1] = 0    // DSCP/ECN
+	binary.BigEndian.PutUint16(ip[2:4], uint16(ipLen+udpLen+len(payload))) // total length
+	binary.BigEndian.PutUint16(ip[4:6], 0)                                 // identification
+	binary.BigEndian.PutUint16(ip[6:8], 0x4000)                            // flags=DF, fragment offset 0
+	ip[8] = 64                                                             // TTL
+	ip[9] = ipProtoUDP                                                     // protocol
+	binary.BigEndian.PutUint16(ip[10:12], 0)                               // checksum (computed below)
+	copy(ip[12:16], srcIP)
+	copy(ip[16:20], net.IPv4(127, 0, 0, 1).To4())
+	binary.BigEndian.PutUint16(ip[10:12], onesComplementChecksum(ip))
+
+	// UDP
+	binary.BigEndian.PutUint16(udp[0:2], syntheticSrcPort)
+	binary.BigEndian.PutUint16(udp[2:4], dstPort)
+	binary.BigEndian.PutUint16(udp[4:6], uint16(udpLen+len(payload)))
+	binary.BigEndian.PutUint16(udp[6:8], 0) // checksum: 0 = "not computed", legal in IPv4
+
+	copy(udpAndPayload[udpLen:], payload)
+	return frame
+}
+
+// onesComplementChecksum is the standard 16-bit one's-complement sum used by IPv4.
+func onesComplementChecksum(b []byte) uint16 {
+	var sum uint32
+	for i := 0; i+1 < len(b); i += 2 {
+		sum += uint32(b[i])<<8 | uint32(b[i+1])
+	}
+	if len(b)%2 == 1 {
+		sum += uint32(b[len(b)-1]) << 8
+	}
+	for sum>>16 != 0 {
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+	return ^uint16(sum)
+}
+
+// writeBinary is a helper to write binary data and check errors
+func writeBinary(buf *bytes.Buffer, data interface{}) error {
+	return binary.Write(buf, binary.BigEndian, data)
+}
+
+// encodeNetFlowV9Templates encodes NetFlow v9 templates into a binary packet
+func encodeNetFlowV9Templates(buf *bytes.Buffer, obsDomainID uint32, templates []*TemplateInfo) error {
+	// NetFlow v9 packet header
+	if err := writeBinary(buf, uint16(9)); err != nil {
+		return err
+	}
+	if err := writeBinary(buf, uint16(len(templates))); err != nil {
+		return err
+	}
+	if err := writeBinary(buf, uint32(time.Now().Unix())); err != nil {
+		return err
+	}
+	if err := writeBinary(buf, uint32(time.Now().Unix())); err != nil {
+		return err
+	}
+	if err := writeBinary(buf, uint32(0)); err != nil {
+		return err
+	}
+	if err := writeBinary(buf, uint32(obsDomainID)); err != nil {
+		return err
+	}
+
+	for _, info := range templates {
+		switch tmpl := info.TemplateData.(type) {
+		case netflow.TemplateRecord:
+			// Template FlowSet header
+			flowSetStart := buf.Len()
+			if err := writeBinary(buf, uint16(0)); err != nil {
+				return err
+			}
+			lengthPos := buf.Len()
+			if err := writeBinary(buf, uint16(0)); err != nil {
+				return err
+			}
+
+			// Template Record
+			if err := writeBinary(buf, tmpl.TemplateId); err != nil {
+				return err
+			}
+			if err := writeBinary(buf, tmpl.FieldCount); err != nil {
+				return err
+			}
+
+			for _, field := range tmpl.Fields {
+				if err := writeBinary(buf, field.Type); err != nil {
+					return err
+				}
+				if err := writeBinary(buf, field.Length); err != nil {
+					return err
+				}
+			}
+
+			// Update length
+			flowSetLen := buf.Len() - flowSetStart
+			// Pad to 4-byte boundary
+			for flowSetLen%4 != 0 {
+				buf.WriteByte(0)
+				flowSetLen++
+			}
+
+			// Write the actual length
+			oldBytes := buf.Bytes()
+			binary.BigEndian.PutUint16(oldBytes[lengthPos:], uint16(flowSetLen))
+
+		case netflow.NFv9OptionsTemplateRecord:
+			// Options Template FlowSet header
+			flowSetStart := buf.Len()
+			if err := writeBinary(buf, uint16(1)); err != nil {
+				return err
+			}
+			lengthPos := buf.Len()
+			if err := writeBinary(buf, uint16(0)); err != nil {
+				return err
+			}
+
+			// Options Template Record
+			if err := writeBinary(buf, tmpl.TemplateId); err != nil {
+				return err
+			}
+			if err := writeBinary(buf, tmpl.ScopeLength); err != nil {
+				return err
+			}
+			if err := writeBinary(buf, tmpl.OptionLength); err != nil {
+				return err
+			}
+
+			for _, field := range tmpl.Scopes {
+				if err := writeBinary(buf, field.Type); err != nil {
+					return err
+				}
+				if err := writeBinary(buf, field.Length); err != nil {
+					return err
+				}
+			}
+
+			for _, field := range tmpl.Options {
+				if err := writeBinary(buf, field.Type); err != nil {
+					return err
+				}
+				if err := writeBinary(buf, field.Length); err != nil {
+					return err
+				}
+			}
+
+			// Update length
+			flowSetLen := buf.Len() - flowSetStart
+			// Pad to 4-byte boundary
+			for flowSetLen%4 != 0 {
+				buf.WriteByte(0)
+				flowSetLen++
+			}
+
+			oldBytes := buf.Bytes()
+			binary.BigEndian.PutUint16(oldBytes[lengthPos:], uint16(flowSetLen))
+		}
+	}
+
+	return nil
+}
+
+// encodeIPFIXTemplates encodes IPFIX templates into a binary packet
+func encodeIPFIXTemplates(buf *bytes.Buffer, obsDomainID uint32, templates []*TemplateInfo) error {
+	// IPFIX packet header
+	if err := writeBinary(buf, uint16(10)); err != nil {
+		return err
+	}
+	lengthPos := buf.Len()
+	if err := writeBinary(buf, uint16(0)); err != nil {
+		return err
+	}
+	if err := writeBinary(buf, uint32(time.Now().Unix())); err != nil {
+		return err
+	}
+	if err := writeBinary(buf, uint32(0)); err != nil {
+		return err
+	}
+	if err := writeBinary(buf, uint32(obsDomainID)); err != nil {
+		return err
+	}
+
+	bufStart := buf.Len() - 16 // start of the IPFIX header we just wrote
+
+	for _, info := range templates {
+		switch tmpl := info.TemplateData.(type) {
+		case netflow.TemplateRecord:
+			// Template Set header
+			setStart := buf.Len()
+			if err := writeBinary(buf, uint16(2)); err != nil {
+				return err
+			}
+			setLengthPos := buf.Len()
+			if err := writeBinary(buf, uint16(0)); err != nil {
+				return err
+			}
+
+			// Template Record
+			if err := writeBinary(buf, tmpl.TemplateId); err != nil {
+				return err
+			}
+			if err := writeBinary(buf, tmpl.FieldCount); err != nil {
+				return err
+			}
+
+			for _, field := range tmpl.Fields {
+				fieldType := field.Type
+				if field.PenProvided {
+					fieldType |= 0x8000 // Set enterprise bit
+				}
+				if err := writeBinary(buf, fieldType); err != nil {
+					return err
+				}
+				if err := writeBinary(buf, field.Length); err != nil {
+					return err
+				}
+				if field.PenProvided {
+					if err := writeBinary(buf, field.Pen); err != nil {
+						return err
+					}
+				}
+			}
+
+			// Update set length
+			setLen := buf.Len() - setStart
+			// Pad to 4-byte boundary
+			for setLen%4 != 0 {
+				buf.WriteByte(0)
+				setLen++
+			}
+
+			oldBytes := buf.Bytes()
+			binary.BigEndian.PutUint16(oldBytes[setLengthPos:], uint16(setLen))
+
+		case netflow.IPFIXOptionsTemplateRecord:
+			// Options Template Set header
+			setStart := buf.Len()
+			if err := writeBinary(buf, uint16(3)); err != nil {
+				return err
+			}
+			setLengthPos := buf.Len()
+			if err := writeBinary(buf, uint16(0)); err != nil {
+				return err
+			}
+
+			// Options Template Record
+			if err := writeBinary(buf, tmpl.TemplateId); err != nil {
+				return err
+			}
+			if err := writeBinary(buf, tmpl.FieldCount); err != nil {
+				return err
+			}
+			if err := writeBinary(buf, tmpl.ScopeFieldCount); err != nil {
+				return err
+			}
+
+			// Write scope fields
+			for _, field := range tmpl.Scopes {
+				fieldType := field.Type
+				if field.PenProvided {
+					fieldType |= 0x8000
+				}
+				if err := writeBinary(buf, fieldType); err != nil {
+					return err
+				}
+				if err := writeBinary(buf, field.Length); err != nil {
+					return err
+				}
+				if field.PenProvided {
+					if err := writeBinary(buf, field.Pen); err != nil {
+						return err
+					}
+				}
+			}
+
+			// Write option fields
+			for _, field := range tmpl.Options {
+				fieldType := field.Type
+				if field.PenProvided {
+					fieldType |= 0x8000
+				}
+				if err := writeBinary(buf, fieldType); err != nil {
+					return err
+				}
+				if err := writeBinary(buf, field.Length); err != nil {
+					return err
+				}
+				if field.PenProvided {
+					if err := writeBinary(buf, field.Pen); err != nil {
+						return err
+					}
+				}
+			}
+
+			// Update set length
+			setLen := buf.Len() - setStart
+			// Pad to 4-byte boundary
+			for setLen%4 != 0 {
+				buf.WriteByte(0)
+				setLen++
+			}
+
+			oldBytes := buf.Bytes()
+			binary.BigEndian.PutUint16(oldBytes[setLengthPos:], uint16(setLen))
+		}
+	}
+
+	totalLen := buf.Len() - bufStart
+	oldBytes := buf.Bytes()
+	binary.BigEndian.PutUint16(oldBytes[lengthPos:], uint16(totalLen))
+
+	return nil
+}
+
+// getFieldName returns a human-readable name for a field type
+func getFieldName(fieldType uint16, version uint16) string {
+	if version == 9 {
+		return netflow.NFv9TypeToString(fieldType)
+	} else if version == 10 {
+		return netflow.IPFIXTypeToString(fieldType)
+	}
+	return fmt.Sprintf("UNKNOWN_%d", fieldType)
+}
+
+// versionName returns a human-readable version name
+func versionName(version uint16) string {
+	if version == 9 {
+		return "NetFlow v9"
+	} else if version == 10 {
+		return "IPFIX"
+	}
+	return "Unknown"
+}

--- a/comp/netflow/server/impl/flare_test.go
+++ b/comp/netflow/server/impl/flare_test.go
@@ -1,0 +1,163 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package serverimpl
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcapgo"
+	"github.com/netsampler/goflow2/decoders/netflow"
+	"github.com/netsampler/goflow2/decoders/netflow/templates"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
+	forwardermock "github.com/DataDog/datadog-agent/comp/ndmtmp/forwarder/mock"
+	server "github.com/DataDog/datadog-agent/comp/netflow/server/def"
+	"github.com/DataDog/datadog-agent/comp/netflow/testutil"
+	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// TestFillFlare_NetFlow9 starts a real NetFlow v9 listener, sends a packet
+// containing template + data records, waits for the agent to decode and flush
+// the flows (which proves templates were cached), and then exercises
+// fillFlare end-to-end. It validates the human-readable, JSON, and pcap
+// outputs — including round-tripping the pcap through gopacket to confirm the
+// synthetic Ethernet/IPv4/UDP framing matches the recorded exporter.
+func TestFillFlare_NetFlow9(t *testing.T) {
+	port, err := ndmtestutils.GetFreePort()
+	require.NoError(t, err)
+
+	var epForwarder forwardermock.MockComponent
+	srv := fxutil.Test[server.Component](t, fx.Options(
+		testOptions,
+		fx.Populate(&epForwarder),
+		fx.Replace(singleListenerConfig("netflow9", port)),
+		setTimeNow,
+	)).(*Server)
+
+	// We don't care about exact event counts here — only that decoding
+	// happened (which is what populates the template cache).
+	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), eventplatform.EventTypeNetworkDevicesNetFlow).Return(nil).AnyTimes()
+	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), "network-devices-metadata").Return(nil).AnyTimes()
+
+	packet, err := testutil.GetNetFlow9Packet()
+	require.NoError(t, err, "error getting netflow9 packet")
+
+	// Sending the packet and waiting for flushed flows guarantees the
+	// listener fully decoded the data records, which in turn requires that
+	// templates were cached first.
+	require.True(t, assertFlowEventsCount(t, port, srv, packet, 29))
+
+	fb := helpers.NewFlareBuilderMock(t, false)
+	require.NoError(t, srv.fillFlare(context.Background(), fb.FlareBuilder))
+
+	// Text + JSON exports.
+	fb.AssertFileExists("netflow", "templates_readable.txt")
+	fb.AssertFileExists("netflow", "templates.json")
+	fb.AssertFileContentMatch("(?s)NetFlow Template Export", "netflow", "templates_readable.txt")
+
+	rawJSON, err := os.ReadFile(filepath.Join(fb.Root, "netflow", "templates.json"))
+	require.NoError(t, err)
+	var entries []map[string]any
+	require.NoError(t, json.Unmarshal(rawJSON, &entries))
+	require.NotEmpty(t, entries, "expected at least one exported template")
+	foundLoopbackV9 := false
+	for _, e := range entries {
+		if e["exporter_ip"] == "127.0.0.1" {
+			assert.EqualValues(t, 9, e["version"])
+			foundLoopbackV9 = true
+		}
+	}
+	require.True(t, foundLoopbackV9, "expected templates from 127.0.0.1 in JSON, got: %v", entries)
+
+	// Locate the pcap regardless of observation domain id.
+	pcapMatches, err := filepath.Glob(filepath.Join(fb.Root, "netflow", "templates_127.0.0.1_v9_obs*.pcap"))
+	require.NoError(t, err)
+	require.NotEmpty(t, pcapMatches, "expected a templates pcap for 127.0.0.1")
+
+	pcapPath := pcapMatches[0]
+	pf, err := os.Open(pcapPath)
+	require.NoError(t, err)
+	defer pf.Close()
+
+	r, err := pcapgo.NewReader(pf)
+	require.NoError(t, err)
+	require.EqualValues(t, layers.LinkTypeEthernet, r.LinkType())
+
+	data, _, err := r.ReadPacketData()
+	require.NoError(t, err, "pcap should contain at least one frame")
+
+	pkt := gopacket.NewPacket(data, layers.LayerTypeEthernet, gopacket.Default)
+	if errLayer := pkt.ErrorLayer(); errLayer != nil {
+		t.Fatalf("gopacket failed to dissect synthetic frame: %v", errLayer.Error())
+	}
+	require.NotNil(t, pkt.Layer(layers.LayerTypeEthernet), "expected Ethernet layer")
+
+	ipLayer := pkt.Layer(layers.LayerTypeIPv4)
+	require.NotNil(t, ipLayer, "expected IPv4 layer")
+	ip := ipLayer.(*layers.IPv4)
+	require.Equal(t, "127.0.0.1", ip.SrcIP.String(), "src IP must match recorded exporter")
+	require.EqualValues(t, ipProtoUDP, ip.Protocol)
+
+	udpLayer := pkt.Layer(layers.LayerTypeUDP)
+	require.NotNil(t, udpLayer, "expected UDP layer")
+	udp := udpLayer.(*layers.UDP)
+	require.EqualValues(t, netflowV9DstPort, udp.DstPort, "dst port should be NetFlow v9 default")
+
+	// Payload begins with NetFlow v9 version field (big-endian uint16 = 9).
+	require.GreaterOrEqual(t, len(udp.Payload), 2, "UDP payload too short")
+	require.Equal(t, byte(0x00), udp.Payload[0])
+	require.Equal(t, byte(0x09), udp.Payload[1])
+
+	// README accompanies the pcap.
+	readme := strings.TrimSuffix(filepath.Base(pcapPath), ".pcap") + "_README.txt"
+	fb.AssertFileExists("netflow", readme)
+	fb.AssertFileContentMatch("mergecap -a", "netflow", readme)
+
+	// Round-trip the synthesized UDP payload through goflow2's NetFlow
+	// decoder against a fresh in-memory template cache. This guards against
+	// regressions in the NetFlow v9 / IPFIX encoding helpers — any malformed
+	// header, flowset, or template record would surface here, even if the
+	// outer pcap framing is fine.
+	ctx := context.Background()
+	freshTS, err := templates.FindTemplateSystem(ctx, "memory")
+	require.NoError(t, err)
+	defer freshTS.Close(ctx)
+
+	decoderKey := ip.SrcIP.String()
+	_, err = netflow.DecodeMessageContext(ctx, bytes.NewBuffer(udp.Payload), decoderKey,
+		netflow.TemplateWrapper{Ctx: ctx, Key: decoderKey, Inner: freshTS})
+	require.NoError(t, err, "synthetic NetFlow payload failed to decode")
+
+	roundTripChan := make(chan *templates.TemplateKey, 64)
+	go func() {
+		defer close(roundTripChan)
+		require.NoError(t, freshTS.ListTemplates(ctx, roundTripChan))
+	}()
+	var roundTripCount int
+	for k := range roundTripChan {
+		if k == nil {
+			break
+		}
+		roundTripCount++
+	}
+	require.Greater(t, roundTripCount, 0, "expected at least one template to be re-decodable from the synthesized pcap")
+}

--- a/comp/netflow/server/impl/server.go
+++ b/comp/netflow/server/impl/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/status"
@@ -45,6 +46,7 @@ type Provides struct {
 
 	Comp           server.Component
 	StatusProvider status.InformationProvider
+	FlareProvider  flaretypes.Provider
 }
 
 // NewComponent configures a netflow server.
@@ -98,6 +100,7 @@ func NewComponent(deps Requires) (Provides, error) {
 	return Provides{
 		Comp:           srv,
 		StatusProvider: status.NewInformationProvider(statusProvider),
+		FlareProvider:  flaretypes.NewProvider(srv.fillFlare),
 	}, nil
 }
 

--- a/releasenotes/notes/netflow-flare-updates-14e97b2c757b12bf.yaml
+++ b/releasenotes/notes/netflow-flare-updates-14e97b2c757b12bf.yaml
@@ -1,0 +1,5 @@
+other:
+  - |
+    NetFlow: Flares now include NetFlow9/IPFIX templates cached on the agent. This allows for easier
+    support when using PCAP files that do not include the template records, as well as providing more context for the
+    data being processed


### PR DESCRIPTION
### What does this PR do?
This PR adds a flare collector to the NetFlow module. It reads the cached templates from memory and puts them in a pcap format for easy import into WireShark.

### Motivation
A common challenge we have with NetFlow support tickets is that pcaps often don't include the templates for v9 or IPFIX data. The templates define how the data should be parsed, with out them we can't make sense of the capture the customer took time to collect.

This PR updates our flare logic to also export the templates that are on the agent at the time of export, which we can use `mergecap` to join with a customer's pcap.

### Describe how you validated your changes
Integration tests verifies the whole flow from incoming packet -> flare

Trying out a flare locally

### Additional Notes
