### PR TITLE
[CWS] Fix dpkg scanner missing installed files for multiarch packages

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3634,7 +3634,9 @@ func (p *EBPFProbe) newOpenEventFromReplay(entry *model.ProcessCacheEntry, snaps
 
 	event.Open.SyscallEvent.Retval = 0
 	event.Open.File.PathnameStr = snapshottedFile.Path
+	event.Open.File.IsPathnameStrResolved = true
 	event.Open.File.BasenameStr = filepath.Base(snapshottedFile.Path)
+	event.Open.File.IsBasenameStrResolved = true
 
 	// Try to stat the file to get basic metadata (best effort)
 	// This helps with file resolution and enrichment

--- a/pkg/security/resolvers/sbom/collectorv2/dpkg.go
+++ b/pkg/security/resolvers/sbom/collectorv2/dpkg.go
@@ -149,6 +149,11 @@ func (s *dpkgScanner) listInstalledFilesFromDir(root *os.Root, baseDir string) (
 				continue
 			}
 			pkgName := strings.TrimSuffix(fileName, md5sumsSuffix)
+			// dpkg info files for multiarch packages are named "pkg:arch.md5sums"
+			// but the Package: field in the status file is unqualified ("pkg"), so strip the arch suffix.
+			if i := strings.LastIndex(pkgName, ":"); i >= 0 {
+				pkgName = pkgName[:i]
+			}
 
 			installedFiles, err := s.parseInfoFile(root, filepath.Join(baseDir, fileName))
 			if err != nil {
@@ -158,7 +163,7 @@ func (s *dpkgScanner) listInstalledFilesFromDir(root *os.Root, baseDir string) (
 				continue
 			}
 
-			res[pkgName] = installedFiles
+			res[pkgName] = append(res[pkgName], installedFiles...)
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Strips the architecture qualifier (everything from the last : onward) from the filename stem when building the package-name to installed-files map. Non-multiarch packages (e.g. libc-bin) are unaffected since their filenames contain no colon.
                                                                        
Strip everything from the last colon onward when building the map key to
align it with the package name used at lookup time.                   

### Motivation

The dpkg SBOM scanner builds a map from package name → installed files by reading .md5sums files under /var/lib/dpkg/info/. On multiarch systems, dpkg    
  names those files <package>:<arch>.md5sums (e.g. libc6:amd64.md5sums), but the Package: field in /var/lib/dpkg/status is unqualified (libc6). Because the
  map was keyed on the raw filename stem (including the :amd64 suffix), lookups by pkg.Name always missed multiarch packages, silently returning an empty   
  file list. This affects a large share of packages on typical Debian/Ubuntu systems — anything installed with multiarch support (glibc, openssl, zlib, …).

### Describe how you validated your changes

### Additional Notes
