### PR TITLE
[SBOM] Merge additional properties at BOM level

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
@@ -37,22 +37,10 @@ import (
 
 const (
 	collectorID           = "sbom-collector"
-	LastAccessProperty    = "LastSeenRunning"
-	HasSetSuidBitProperty = "HasSetSuidBit"
-	RunningAsRootProperty = "RunningAsRoot"
+	LastAccessProperty    = workloadmeta.SBOMLastSeenRunningProperty
+	HasSetSuidBitProperty = workloadmeta.SBOMHasSetSuidBitProperty
+	RunningAsRootProperty = workloadmeta.SBOMRunningAsRootProperty
 )
-
-// normalizeVersion normalizes version strings to handle epoch differences
-// e.g., "1:4.4.36-4build1" and "4.4.36-4build1" should both map to "4.4.36-4build1"
-// Returns both the normalized version (without epoch) and the original version
-func normalizeVersion(version string) (normalized string, hasEpoch bool) {
-	// Check if version has epoch prefix (e.g., "1:4.4.36-4build1")
-	if idx := strings.Index(version, ":"); idx > 0 {
-		// Extract the part after the epoch
-		return version[idx+1:], true
-	}
-	return version, false
-}
 
 type client struct {
 	cl sbompb.SBOMCollectorClient
@@ -84,77 +72,47 @@ type streamHandler struct {
 	systemProbeConfig model.Reader
 }
 
-// workloadmetaEventFromSBOMEventSet converts the given SBOM message into a workloadmeta event
+// workloadmetaEventFromSBOMEventSet converts the given SBOM message into a workloadmeta event.
+// The raw system-probe BOM is stored as-is under the remote_sbom_collector source; merging
+// its runtime properties into the Trivy BOM happens in ContainerImageMetadata.Merge via
+// mergeCompressedSBOMs, so the correct result is produced regardless of arrival order.
 func workloadmetaEventFromSBOMEventSet(store workloadmeta.Component, event *sbompb.SBOMMessage) (workloadmeta.Event, error) {
 	if event == nil {
 		return workloadmeta.Event{}, nil
 	}
 
-	var newBom cyclonedx_v1_4.Bom
-	err := proto.Unmarshal(event.Data, &newBom)
-	if err != nil {
+	var finalBom cyclonedx_v1_4.Bom
+	if err := proto.Unmarshal(event.Data, &finalBom); err != nil {
 		return workloadmeta.Event{}, fmt.Errorf("failed to unmarshal SBOM: %w", err)
 	}
 
 	if event.Kind != string(workloadmeta.KindContainer) {
 		return workloadmeta.Event{}, fmt.Errorf("expected KindContainer, got %s", event.Kind)
 	}
-
 	if event.ID == "" {
 		return workloadmeta.Event{}, errors.New("expected container ID, got empty")
 	}
 
 	log.Debugf("Received forwarded SBOM for container %s", event.ID)
 
-	// Get container to find its image
 	container, err := store.GetContainer(event.ID)
 	if err != nil || container == nil {
 		return workloadmeta.Event{}, fmt.Errorf("container %s not found in workloadmeta: %w", event.ID, err)
 	}
-
-	// Get the image ID from the container
 	imageID := container.Image.ID
 	if imageID == "" {
 		return workloadmeta.Event{}, fmt.Errorf("container %s has no image ID", event.ID)
 	}
 
-	log.Debugf("Container %s uses image %s, updating image SBOM", event.ID, imageID)
-
-	// Get existing image to merge SBOM data
-	var finalBom *cyclonedx_v1_4.Bom
-	var finalCompressedSBOM *workloadmeta.CompressedSBOM
-
 	existingImage, err := store.GetImage(imageID)
-	if err == nil && existingImage != nil && existingImage.SBOM != nil {
-		// Decompress existing image SBOM to get CycloneDXBOM
-		existingSBOM, err := sbomutil.UncompressSBOM(existingImage.SBOM)
-		if err == nil && existingSBOM != nil && existingSBOM.CycloneDXBOM != nil {
-			// Merge runtime properties from new BOM into existing image SBOM
-			finalBom = mergeRuntimeProperties(existingSBOM.CycloneDXBOM, &newBom)
-			log.Debugf("Merged runtime properties for image %s SBOM", imageID)
-		} else {
-			// Decompression failed or no CycloneDXBOM, use the new one directly
-			finalBom = &newBom
-			if err != nil {
-				log.Warnf("Failed to decompress existing SBOM for image %s: %v, using new SBOM", imageID, err)
-			} else {
-				log.Debugf("No existing CycloneDXBOM for image %s, using new SBOM", imageID)
-			}
-		}
-	} else {
-		// No existing SBOM on image, use the new one directly
-		finalBom = &newBom
-		if err != nil {
-			log.Debugf("Could not get image %s from store: %v, using new SBOM", imageID, err)
-		} else {
-			log.Debugf("No existing SBOM for image %s, using new SBOM", imageID)
-		}
+	if err != nil || existingImage == nil {
+		log.Infof("Image %s not found in workloadmeta, will create new entity with SBOM", imageID)
 	}
 
 	// Compress the final merged SBOM, preserving scan metadata from the existing
 	// SBOM so Status/GenerationTime/etc. survive the runtime-enrichment update.
 	sbomToCompress := &workloadmeta.SBOM{
-		CycloneDXBOM: finalBom,
+		CycloneDXBOM: &finalBom,
 	}
 	if existingImage != nil && existingImage.SBOM != nil {
 		sbomToCompress.Status = existingImage.SBOM.Status
@@ -163,7 +121,7 @@ func workloadmetaEventFromSBOMEventSet(store workloadmeta.Component, event *sbom
 		sbomToCompress.GenerationMethod = existingImage.SBOM.GenerationMethod
 		sbomToCompress.Error = existingImage.SBOM.Error
 	}
-	finalCompressedSBOM, err = sbomutil.CompressSBOM(sbomToCompress)
+	finalCompressedSBOM, err := sbomutil.CompressSBOM(sbomToCompress)
 	if err != nil {
 		return workloadmeta.Event{}, fmt.Errorf("failed to compress SBOM for image %s: %w", imageID, err)
 	}
@@ -179,147 +137,6 @@ func workloadmetaEventFromSBOMEventSet(store workloadmeta.Component, event *sbom
 			SBOM: finalCompressedSBOM,
 		},
 	}, nil
-}
-
-// mergeRuntimeProperties merges runtime properties from newBom into existingBom.
-// Returns a new BOM whose component list is deduplicated (by name+normalised version) and
-// enriched with runtime properties (LastSeenRunning / HasSetSuidBit / RunningAsRoot) taken
-// from newBom.  Deduplication is necessary because a previously-merged SBOM stored in the
-// image entity may already carry both an original Trivy entry and a runtime-enriched copy of
-// the same package; without it every merge round would re-emit both copies.
-func mergeRuntimeProperties(existingBom, newBom *cyclonedx_v1_4.Bom) *cyclonedx_v1_4.Bom {
-	if newBom == nil || len(newBom.Components) == 0 {
-		return existingBom
-	}
-
-	// Build a lookup map from newBom (system-probe) components by name+normalised version.
-	// We normalise versions to handle epoch differences (e.g. "1:4.4.36" vs "4.4.36").
-	newComponentsMap := make(map[string]*cyclonedx_v1_4.Component)
-	for _, comp := range newBom.Components {
-		if comp != nil {
-			normalizedVersion, _ := normalizeVersion(comp.Version)
-			key := comp.Name + "@" + normalizedVersion
-			newComponentsMap[key] = comp
-		}
-	}
-
-	// Shallow-copy the BOM envelope; Components is rebuilt below.
-	mergedBom := &cyclonedx_v1_4.Bom{
-		SpecVersion:        existingBom.SpecVersion,
-		Version:            existingBom.Version,
-		SerialNumber:       existingBom.SerialNumber,
-		Metadata:           existingBom.Metadata,
-		Services:           existingBom.Services,
-		ExternalReferences: existingBom.ExternalReferences,
-		Dependencies:       existingBom.Dependencies,
-		Compositions:       existingBom.Compositions,
-		Vulnerabilities:    existingBom.Vulnerabilities,
-	}
-
-	// seen tracks which name@version keys have already been emitted so that duplicate
-	// entries for the same package (which can accumulate across merge rounds) are dropped.
-	seen := make(map[string]struct{}, len(existingBom.Components))
-
-	for _, existingComp := range existingBom.Components {
-		if existingComp == nil {
-			continue
-		}
-
-		normalizedVersion, _ := normalizeVersion(existingComp.Version)
-		key := existingComp.Name + "@" + normalizedVersion
-
-		// Emit only the first occurrence of each package.
-		if _, already := seen[key]; already {
-			continue
-		}
-		seen[key] = struct{}{}
-
-		// Copy all fields so we do not mutate the original BOM.
-		mergedComp := &cyclonedx_v1_4.Component{
-			Type:               existingComp.Type,
-			MimeType:           existingComp.MimeType,
-			BomRef:             existingComp.BomRef,
-			Supplier:           existingComp.Supplier,
-			Author:             existingComp.Author,
-			Publisher:          existingComp.Publisher,
-			Group:              existingComp.Group,
-			Name:               existingComp.Name,
-			Version:            existingComp.Version,
-			Description:        existingComp.Description,
-			Scope:              existingComp.Scope,
-			Hashes:             existingComp.Hashes,
-			Licenses:           existingComp.Licenses,
-			Copyright:          existingComp.Copyright,
-			Cpe:                existingComp.Cpe,
-			Purl:               existingComp.Purl,
-			Swid:               existingComp.Swid,
-			Modified:           existingComp.Modified,
-			Pedigree:           existingComp.Pedigree,
-			ExternalReferences: existingComp.ExternalReferences,
-			Components:         existingComp.Components,
-			Properties:         existingComp.Properties,
-			Evidence:           existingComp.Evidence,
-			ReleaseNotes:       existingComp.ReleaseNotes,
-		}
-
-		// Add or update runtime properties from newBom.
-		if newComp, exists := newComponentsMap[key]; exists && newComp.Properties != nil {
-			updateProperty := func(propertyName string) {
-				var newProp *cyclonedx_v1_4.Property
-				for _, prop := range newComp.Properties {
-					if prop != nil && prop.Name == propertyName {
-						newProp = prop
-						break
-					}
-				}
-				if newProp == nil {
-					return
-				}
-				if mergedComp.Properties == nil {
-					mergedComp.Properties = []*cyclonedx_v1_4.Property{}
-				}
-				for j, prop := range mergedComp.Properties {
-					if prop != nil && prop.Name == propertyName {
-						mergedComp.Properties[j] = newProp
-						log.Tracef("Updated %s for component %s@%s", propertyName, existingComp.Name, existingComp.Version)
-						return
-					}
-				}
-				mergedComp.Properties = append(mergedComp.Properties, newProp)
-				log.Tracef("Added %s for component %s@%s", propertyName, existingComp.Name, existingComp.Version)
-			}
-
-			updateProperty(LastAccessProperty)
-			updateProperty(HasSetSuidBitProperty)
-			updateProperty(RunningAsRootProperty)
-		}
-
-		// If LastAccessProperty is not present in the merged component (neither from
-		// existingBom nor from newBom), set it to zero so downstream consumers can
-		// distinguish "never seen running" from "unknown".
-		hasLastAccess := false
-		for _, prop := range mergedComp.Properties {
-			if prop != nil && prop.Name == LastAccessProperty {
-				hasLastAccess = true
-				break
-			}
-		}
-		if !hasLastAccess {
-			if mergedComp.Properties == nil {
-				mergedComp.Properties = []*cyclonedx_v1_4.Property{}
-			}
-			zeroValue := "0"
-			mergedComp.Properties = append(mergedComp.Properties, &cyclonedx_v1_4.Property{
-				Name:  LastAccessProperty,
-				Value: &zeroValue,
-			})
-			log.Tracef("Set %s to zero for component %s@%s", LastAccessProperty, existingComp.Name, existingComp.Version)
-		}
-
-		mergedBom.Components = append(mergedBom.Components, mergedComp)
-	}
-
-	return mergedBom
 }
 
 // NewCollector returns a remote process collector for workloadmeta if any

--- a/comp/core/workloadmeta/def/BUILD.bazel
+++ b/comp/core/workloadmeta/def/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/discovery/tracermetadata/model",
         "//pkg/languagedetection/languagemodels",
         "//pkg/util/containers/image",
+        "//pkg/util/log",
         "//pkg/util/scrubber",
         "@com_github_datadog_agent_payload_v5//cyclonedx_v1_4",
         "@com_github_fatih_color//:color",
@@ -27,6 +28,7 @@ go_library(
         "@com_github_opencontainers_image_spec//specs-go/v1:specs-go",
         "@io_k8s_apimachinery//pkg/runtime/schema",
         "@io_k8s_apimachinery//pkg/version",
+        "@org_golang_google_protobuf//proto",
         "@org_uber_go_fx//:fx",
     ],
 )
@@ -47,6 +49,7 @@ go_test(
         "//pkg/discovery/tracermetadata/model",
         "//pkg/languagedetection/languagemodels",
         "//pkg/util/pointer",
+        "@com_github_datadog_agent_payload_v5//cyclonedx_v1_4",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_k8s_apimachinery//pkg/runtime/schema",

--- a/comp/core/workloadmeta/def/merge_test.go
+++ b/comp/core/workloadmeta/def/merge_test.go
@@ -9,11 +9,48 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
+
+// makeProp builds a cyclonedx Property pointer for use in tests.
+func makeProp(name, value string) *cyclonedx_v1_4.Property {
+	return &cyclonedx_v1_4.Property{Name: name, Value: &value}
+}
+
+// makeComp builds a cyclonedx Component for use in tests.
+func makeComp(name, version string, props ...*cyclonedx_v1_4.Property) *cyclonedx_v1_4.Component {
+	return &cyclonedx_v1_4.Component{Name: name, Version: version, Properties: props}
+}
+
+// makeBOMBytes compresses the given components into a valid gzip+proto BOM.
+func makeBOMBytes(t *testing.T, comps ...*cyclonedx_v1_4.Component) []byte {
+	t.Helper()
+	data, err := compressSBOMBom(&cyclonedx_v1_4.Bom{Components: comps})
+	require.NoError(t, err)
+	return data
+}
+
+// propValue returns the string value of a Property, or "" if nil.
+func propValue(p *cyclonedx_v1_4.Property) string {
+	if p == nil || p.Value == nil {
+		return ""
+	}
+	return *p.Value
+}
+
+// findProp returns the first property with the given name, or nil.
+func findProp(props []*cyclonedx_v1_4.Property, name string) *cyclonedx_v1_4.Property {
+	for _, p := range props {
+		if p != nil && p.Name == name {
+			return p
+		}
+	}
+	return nil
+}
 
 func container1(testTime time.Time) Container {
 	return Container{
@@ -193,24 +230,177 @@ func TestMerge(t *testing.T) {
 	assert.ElementsMatch(t, container1(testTime).Ports, fromSource2.Ports)
 }
 
-// TestContainerImageMetadataMergeSBOM verifies that merging two ContainerImageMetadata
-// entities that both carry a CompressedSBOM does NOT concatenate the Bom []byte fields.
-// Byte-level concatenation of two gzip streams produces a valid multistream gzip; when
-// decoded the inner protobuf repeated-field (Components) would be duplicated.
-func TestContainerImageMetadataMergeSBOM(t *testing.T) {
+// TestMergeCompressedSBOMs verifies the BOM-level merge logic used by
+// ContainerImageMetadata.Merge.
+//
+// computeCache() always merges sources alphabetically: remote_sbom_collector
+// (dst) before runtime/Trivy (src). mergeCompressedSBOMs must therefore:
+//   - Select scan metadata (Status, GenerationMethod, …) from the strictly
+//     higher-priority source; dst wins on a tie.
+//   - Build the component list from the primary BOM, enriched with runtime
+//     properties (e.g. LastSeenRunning) from matching secondary components.
+func TestMergeCompressedSBOMs(t *testing.T) {
+	t.Run("nil handling", func(t *testing.T) {
+		assert.Nil(t, mergeCompressedSBOMs(nil, nil))
+
+		src := &CompressedSBOM{Bom: makeBOMBytes(t), Status: Success}
+		assert.Same(t, src, mergeCompressedSBOMs(nil, src), "dst nil: src returned as-is")
+
+		dst := &CompressedSBOM{Bom: makeBOMBytes(t), Status: Success}
+		assert.Same(t, dst, mergeCompressedSBOMs(dst, nil), "src nil: dst returned as-is")
+	})
+
+	t.Run("src strictly higher status wins metadata", func(t *testing.T) {
+		// Mirrors the "system-probe fires first" scenario:
+		// dst=remote_sbom_collector (Status=""), src=runtime/Trivy (Status=Success).
+		dst := &CompressedSBOM{Bom: makeBOMBytes(t), Status: ""}
+		src := &CompressedSBOM{
+			Bom:              makeBOMBytes(t),
+			Status:           Success,
+			GenerationMethod: "trivy",
+		}
+		result := mergeCompressedSBOMs(dst, src)
+		require.NotNil(t, result)
+		assert.Equal(t, Success, result.Status)
+		assert.Equal(t, "trivy", result.GenerationMethod)
+	})
+
+	t.Run("dst wins on equal status", func(t *testing.T) {
+		// Both sources at Success — dst is the alphabetically-first source and
+		// already holds the previously-merged result; it must keep its metadata.
+		dst := &CompressedSBOM{
+			Bom:              makeBOMBytes(t),
+			Status:           Success,
+			GenerationMethod: "dst-method",
+		}
+		src := &CompressedSBOM{
+			Bom:              makeBOMBytes(t),
+			Status:           Success,
+			GenerationMethod: "src-method",
+		}
+		result := mergeCompressedSBOMs(dst, src)
+		require.NotNil(t, result)
+		assert.Equal(t, "dst-method", result.GenerationMethod)
+	})
+
+	t.Run("runtime properties merged into primary component list", func(t *testing.T) {
+		// Primary (Trivy, Status=Success): libc@2.31 — no runtime props.
+		// Secondary (system-probe, Status=""): libc@2.31 — has LastSeenRunning.
+		// dst = remote_sbom_collector (system-probe), src = runtime (Trivy).
+		// src priority > dst priority, so src is primary and dst is secondary.
+		libcTrivy := makeComp("libc", "2.31")
+		libcRuntime := makeComp("libc", "2.31", makeProp("LastSeenRunning", "1234567890"))
+
+		dst := &CompressedSBOM{Bom: makeBOMBytes(t, libcRuntime), Status: ""}
+		src := &CompressedSBOM{Bom: makeBOMBytes(t, libcTrivy), Status: Success}
+
+		result := mergeCompressedSBOMs(dst, src)
+		require.NotNil(t, result)
+		assert.Equal(t, Success, result.Status)
+
+		resultBOM, err := decompressSBOMBom(result.Bom)
+		require.NoError(t, err)
+		require.Len(t, resultBOM.Components, 1)
+		assert.Equal(t, "1234567890", propValue(findProp(resultBOM.Components[0].Properties, "LastSeenRunning")))
+	})
+
+	t.Run("epoch-prefixed version normalised for matching", func(t *testing.T) {
+		// Primary has libc@2.31, secondary has libc@1:2.31.
+		// normalizeComponentVersion must strip the epoch so they match.
+		libcTrivy := makeComp("libc", "2.31")
+		libcRuntime := makeComp("libc", "1:2.31", makeProp("LastSeenRunning", "999"))
+
+		dst := &CompressedSBOM{Bom: makeBOMBytes(t, libcRuntime), Status: ""}
+		src := &CompressedSBOM{Bom: makeBOMBytes(t, libcTrivy), Status: Success}
+
+		result := mergeCompressedSBOMs(dst, src)
+		require.NotNil(t, result)
+		resultBOM, err := decompressSBOMBom(result.Bom)
+		require.NoError(t, err)
+		require.Len(t, resultBOM.Components, 1)
+		assert.Equal(t, "999", propValue(findProp(resultBOM.Components[0].Properties, "LastSeenRunning")),
+			"epoch normalisation should allow version matching")
+	})
+
+	t.Run("secondary-only components not added to result", func(t *testing.T) {
+		// Primary has only libc; secondary has libc + bash.
+		// Result must only contain primary's component set.
+		libcTrivy := makeComp("libc", "2.31")
+		libcRuntime := makeComp("libc", "2.31")
+		bashRuntime := makeComp("bash", "5.0")
+
+		dst := &CompressedSBOM{Bom: makeBOMBytes(t, libcRuntime, bashRuntime), Status: ""}
+		src := &CompressedSBOM{Bom: makeBOMBytes(t, libcTrivy), Status: Success}
+
+		result := mergeCompressedSBOMs(dst, src)
+		require.NotNil(t, result)
+		resultBOM, err := decompressSBOMBom(result.Bom)
+		require.NoError(t, err)
+		require.Len(t, resultBOM.Components, 1, "secondary-only components must not be added")
+		assert.Equal(t, "libc", resultBOM.Components[0].Name)
+	})
+
+	t.Run("existing non-runtime primary property not overridden by secondary", func(t *testing.T) {
+		libcWithPrimary := makeComp("libc", "2.31", makeProp("CustomProp", "primary-value"))
+		libcWithSecondary := makeComp("libc", "2.31", makeProp("CustomProp", "secondary-value"))
+
+		dst := &CompressedSBOM{Bom: makeBOMBytes(t, libcWithSecondary), Status: ""}
+		src := &CompressedSBOM{Bom: makeBOMBytes(t, libcWithPrimary), Status: Success}
+
+		result := mergeCompressedSBOMs(dst, src)
+		require.NotNil(t, result)
+		resultBOM, err := decompressSBOMBom(result.Bom)
+		require.NoError(t, err)
+		assert.Equal(t, "primary-value", propValue(findProp(resultBOM.Components[0].Properties, "CustomProp")),
+			"non-runtime primary property must not be overridden by secondary")
+	})
+
+	t.Run("runtime properties always overridden by secondary", func(t *testing.T) {
+		// Simulate a stale merged SBOM reused as the primary (docker/runtime source):
+		// primary already carries LastSeenRunning from a previous merge, but system-probe
+		// has sent a newer value. The secondary (system-probe) must win for runtime props.
+		libcStale := makeComp("libc", "2.31",
+			makeProp(SBOMLastSeenRunningProperty, "old-timestamp"),
+			makeProp(SBOMRunningAsRootProperty, "false"),
+			makeProp(SBOMHasSetSuidBitProperty, "false"),
+		)
+		libcUpdated := makeComp("libc", "2.31",
+			makeProp(SBOMLastSeenRunningProperty, "new-timestamp"),
+			makeProp(SBOMRunningAsRootProperty, "true"),
+			makeProp(SBOMHasSetSuidBitProperty, "true"),
+		)
+
+		dst := &CompressedSBOM{Bom: makeBOMBytes(t, libcUpdated), Status: ""}
+		src := &CompressedSBOM{Bom: makeBOMBytes(t, libcStale), Status: Success}
+
+		result := mergeCompressedSBOMs(dst, src)
+		require.NotNil(t, result)
+		resultBOM, err := decompressSBOMBom(result.Bom)
+		require.NoError(t, err)
+		require.Len(t, resultBOM.Components, 1)
+		props := resultBOM.Components[0].Properties
+		assert.Equal(t, "new-timestamp", propValue(findProp(props, SBOMLastSeenRunningProperty)),
+			"secondary LastSeenRunning must override stale primary value")
+		assert.Equal(t, "true", propValue(findProp(props, SBOMRunningAsRootProperty)),
+			"secondary RunningAsRoot must override stale primary value")
+		assert.Equal(t, "true", propValue(findProp(props, SBOMHasSetSuidBitProperty)),
+			"secondary HasSetSuidBit must override stale primary value")
+	})
+}
+
+// TestContainerImageMetadataMerge_SBOM verifies that ContainerImageMetadata.Merge
+// correctly delegates SBOM merging and preserves shallow-copy safety.
+func TestContainerImageMetadataMerge_SBOM(t *testing.T) {
 	trivySBOM := &CompressedSBOM{
-		Bom:              []byte("trivy-sbom-bytes"),
+		Bom:              makeBOMBytes(t, makeComp("libc", "2.31")),
+		Status:           Success,
 		GenerationMethod: "trivy",
 	}
-	enrichedSBOM := &CompressedSBOM{
-		Bom:              []byte("enriched-sbom-bytes"),
-		GenerationMethod: "runtime",
-	}
 
-	// dst has enriched SBOM, src has Trivy SBOM — dst must win.
+	// dst has no SBOM — src metadata must propagate.
 	dst := &ContainerImageMetadata{
 		EntityID: EntityID{Kind: KindContainerImageMetadata, ID: "img1"},
-		SBOM:     enrichedSBOM,
+		SBOM:     nil,
 	}
 	src := &ContainerImageMetadata{
 		EntityID: EntityID{Kind: KindContainerImageMetadata, ID: "img1"},
@@ -218,22 +408,10 @@ func TestContainerImageMetadataMergeSBOM(t *testing.T) {
 	}
 	err := dst.Merge(src)
 	require.NoError(t, err)
-	assert.Equal(t, enrichedSBOM, dst.SBOM, "dst SBOM should not be overwritten by src SBOM")
-	assert.Equal(t, enrichedSBOM.Bom, dst.SBOM.Bom, "Bom bytes must not be concatenated")
+	require.NotNil(t, dst.SBOM)
+	assert.Equal(t, Success, dst.SBOM.Status)
+	assert.Equal(t, "trivy", dst.SBOM.GenerationMethod)
 
-	// dst has no SBOM, src has Trivy SBOM — src must propagate.
-	dst2 := &ContainerImageMetadata{
-		EntityID: EntityID{Kind: KindContainerImageMetadata, ID: "img2"},
-		SBOM:     nil,
-	}
-	src2 := &ContainerImageMetadata{
-		EntityID: EntityID{Kind: KindContainerImageMetadata, ID: "img2"},
-		SBOM:     trivySBOM,
-	}
-	err = dst2.Merge(src2)
-	require.NoError(t, err)
-	assert.Equal(t, trivySBOM, dst2.SBOM, "src SBOM should be copied when dst has none")
-
-	// src mutation does not affect the original entity (shallow-copy safety).
+	// src must not be modified by the merge (shallow-copy safety).
 	assert.Equal(t, trivySBOM, src.SBOM, "src SBOM must not be modified by merge")
 }

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -6,6 +6,8 @@
 package workloadmeta
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -15,6 +17,7 @@ import (
 
 	"github.com/mohae/deepcopy"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
 
@@ -24,6 +27,7 @@ import (
 	tracermetadata "github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata/model"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	pkgcontainersimage "github.com/DataDog/datadog-agent/pkg/util/containers/image"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // TODO(component): it might make more sense to move the store into its own
@@ -118,6 +122,15 @@ const (
 
 	// SourceKubeAPIServer represents metadata collected from the Kubernetes API Server
 	SourceKubeAPIServer Source = "kubeapiserver"
+)
+
+// Runtime SBOM property names injected by system-probe via the remote SBOM collector.
+// These properties are always overwritten by the secondary (system-probe) source during
+// SBOM merges so that updates from system-probe are never silently dropped.
+const (
+	SBOMLastSeenRunningProperty = "LastSeenRunning"
+	SBOMHasSetSuidBitProperty   = "HasSetSuidBit"
+	SBOMRunningAsRootProperty   = "RunningAsRoot"
 )
 
 // ContainerRuntime is the container runtime used by a container.
@@ -1570,6 +1583,211 @@ func (i ContainerImageMetadata) GetID() EntityID {
 	return i.EntityID
 }
 
+// sbomStatusPriority returns a numeric rank for a CompressedSBOM's Status,
+// used to decide which SBOM provides the authoritative scan metadata when
+// merging two sources.
+func sbomStatusPriority(s *CompressedSBOM) int {
+	if s == nil {
+		return -1
+	}
+	switch s.Status {
+	case Success:
+		return 3
+	case Failed:
+		return 2
+	case Pending:
+		return 1
+	default: // "" — remote_sbom_collector fired before the scan completed
+		return 0
+	}
+}
+
+// normalizeComponentVersion strips the epoch prefix from a package version
+// (e.g. "1:4.4.36-4build1" → "4.4.36-4build1") for component key matching.
+func normalizeComponentVersion(v string) string {
+	if idx := strings.Index(v, ":"); idx > 0 {
+		return v[idx+1:]
+	}
+	return v
+}
+
+func decompressSBOMBom(data []byte) (*cyclonedx_v1_4.Bom, error) {
+	if len(data) == 0 {
+		return &cyclonedx_v1_4.Bom{}, nil
+	}
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	var bom cyclonedx_v1_4.Bom
+	if err := proto.Unmarshal(raw, &bom); err != nil {
+		return nil, err
+	}
+	return &bom, nil
+}
+
+func compressSBOMBom(bom *cyclonedx_v1_4.Bom) ([]byte, error) {
+	raw, err := proto.Marshal(bom)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(raw); err != nil {
+		return nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func copyComponentForMerge(c *cyclonedx_v1_4.Component) *cyclonedx_v1_4.Component {
+	return &cyclonedx_v1_4.Component{
+		Type:               c.Type,
+		MimeType:           c.MimeType,
+		BomRef:             c.BomRef,
+		Supplier:           c.Supplier,
+		Author:             c.Author,
+		Publisher:          c.Publisher,
+		Group:              c.Group,
+		Name:               c.Name,
+		Version:            c.Version,
+		Description:        c.Description,
+		Scope:              c.Scope,
+		Hashes:             c.Hashes,
+		Licenses:           c.Licenses,
+		Copyright:          c.Copyright,
+		Cpe:                c.Cpe,
+		Purl:               c.Purl,
+		Swid:               c.Swid,
+		Modified:           c.Modified,
+		Pedigree:           c.Pedigree,
+		ExternalReferences: c.ExternalReferences,
+		Components:         c.Components,
+		Properties:         append([]*cyclonedx_v1_4.Property(nil), c.Properties...),
+		Evidence:           c.Evidence,
+		ReleaseNotes:       c.ReleaseNotes,
+	}
+}
+
+func isRuntimeSBOMProperty(name string) bool {
+	return name == SBOMLastSeenRunningProperty ||
+		name == SBOMHasSetSuidBitProperty ||
+		name == SBOMRunningAsRootProperty
+}
+
+// mergeCompressedSBOMs combines two CompressedSBOM values into one:
+//   - scan metadata (Status, GenerationTime, …) comes from whichever input has
+//     the strictly higher status; when equal, dst wins (it is the alphabetically
+//     first source in computeCache and already holds any previously-merged result);
+//   - the component list is built from the primary BOM's components, enriched with
+//     properties from matching secondary components; runtime properties
+//     (LastSeenRunning, HasSetSuidBit, RunningAsRoot) are always overwritten by the
+//     secondary so that system-probe updates are never silently dropped even when the
+//     primary already carries a stale copy from a previous merge.
+//
+// This lets Trivy's package list and scan metadata coexist with system-probe's
+// runtime properties regardless of which source fires first.
+func mergeCompressedSBOMs(dst, src *CompressedSBOM) *CompressedSBOM {
+	if dst == nil {
+		return src
+	}
+	if src == nil {
+		return dst
+	}
+
+	primary, secondary := dst, src
+	if sbomStatusPriority(src) > sbomStatusPriority(dst) {
+		primary, secondary = src, dst
+	}
+
+	primaryBOM, err := decompressSBOMBom(primary.Bom)
+	if err != nil {
+		log.Warnf("workloadmeta: SBOM merge: failed to decompress primary BOM: %v", err)
+		return primary
+	}
+
+	secondaryBOM, err := decompressSBOMBom(secondary.Bom)
+	if err != nil || len(secondaryBOM.GetComponents()) == 0 {
+		return primary
+	}
+
+	secondaryIndex := make(map[string]*cyclonedx_v1_4.Component, len(secondaryBOM.Components))
+	for _, c := range secondaryBOM.Components {
+		if c != nil {
+			secondaryIndex[c.Name+"@"+normalizeComponentVersion(c.Version)] = c
+		}
+	}
+
+	mergedBOM := &cyclonedx_v1_4.Bom{
+		SpecVersion:        primaryBOM.SpecVersion,
+		Version:            primaryBOM.Version,
+		SerialNumber:       primaryBOM.SerialNumber,
+		Metadata:           primaryBOM.Metadata,
+		Services:           primaryBOM.Services,
+		ExternalReferences: primaryBOM.ExternalReferences,
+		Dependencies:       primaryBOM.Dependencies,
+		Compositions:       primaryBOM.Compositions,
+		Vulnerabilities:    primaryBOM.Vulnerabilities,
+		Components:         make([]*cyclonedx_v1_4.Component, 0, len(primaryBOM.Components)),
+	}
+
+	seen := make(map[string]struct{}, len(primaryBOM.Components))
+	for _, pc := range primaryBOM.Components {
+		if pc == nil {
+			continue
+		}
+		key := pc.Name + "@" + normalizeComponentVersion(pc.Version)
+		if _, already := seen[key]; already {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		mc := copyComponentForMerge(pc)
+		if sc, ok := secondaryIndex[key]; ok {
+			for _, sp := range sc.Properties {
+				if sp == nil {
+					continue
+				}
+				existingIdx := -1
+				for i, pp := range mc.Properties {
+					if pp != nil && pp.Name == sp.Name {
+						existingIdx = i
+						break
+					}
+				}
+				if existingIdx == -1 {
+					mc.Properties = append(mc.Properties, sp)
+				} else if isRuntimeSBOMProperty(sp.Name) {
+					mc.Properties[existingIdx] = sp
+				}
+			}
+		}
+		mergedBOM.Components = append(mergedBOM.Components, mc)
+	}
+
+	compressedBOM, err := compressSBOMBom(mergedBOM)
+	if err != nil {
+		log.Warnf("workloadmeta: SBOM merge: failed to recompress merged BOM: %v", err)
+		return primary
+	}
+
+	return &CompressedSBOM{
+		Bom:                compressedBOM,
+		Status:             primary.Status,
+		GenerationTime:     primary.GenerationTime,
+		GenerationDuration: primary.GenerationDuration,
+		GenerationMethod:   primary.GenerationMethod,
+		Error:              primary.Error,
+	}
+}
+
 // Merge implements Entity#Merge.
 func (i *ContainerImageMetadata) Merge(e Entity) error {
 	otherImage, ok := e.(*ContainerImageMetadata)
@@ -1578,12 +1796,9 @@ func (i *ContainerImageMetadata) Merge(e Entity) error {
 	}
 
 	// Save SBOM pointers before the generic merge to prevent mergo from
-	// concatenating the compressed Bom []byte fields across sources. Two
-	// gzip-encoded protobufs appended byte-for-byte form a valid multistream
-	// gzip that decodes to a concatenated protobuf, which duplicates all
-	// repeated Components.  We apply our own "prefer dst if non-nil" rule
-	// instead: the remote SBOM collector (alphabetically first) always
-	// produces an already-enriched SBOM that supersedes the raw Trivy SBOM.
+	// touching the compressed Bom []byte fields. We rebuild the SBOM ourselves
+	// via mergeCompressedSBOMs, which decompresses both sides, unions runtime
+	// properties into the higher-status BOM's component list, and recompresses.
 	dstSBOM := i.SBOM
 	srcSBOM := otherImage.SBOM
 
@@ -1594,12 +1809,7 @@ func (i *ContainerImageMetadata) Merge(e Entity) error {
 
 	err := merge(i, &otherImageCopy)
 
-	// Restore SBOM: keep dst's enriched SBOM when available, else fall back to src.
-	if dstSBOM != nil {
-		i.SBOM = dstSBOM
-	} else {
-		i.SBOM = srcSBOM
-	}
+	i.SBOM = mergeCompressedSBOMs(dstSBOM, srcSBOM)
 
 	return err
 }

--- a/pkg/security/resolvers/sbom/report.go
+++ b/pkg/security/resolvers/sbom/report.go
@@ -12,15 +12,16 @@ import (
 	"strconv"
 
 	cyclonedx_v1_4 "github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	sbomtypes "github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/types"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 const (
-	LastAccessProperty    = "LastSeenRunning"
-	HasSetSuidBitProperty = "HasSetSuidBit"
-	RunningAsRootProperty = "RunningAsRoot"
+	LastAccessProperty    = workloadmeta.SBOMLastSeenRunningProperty
+	HasSetSuidBitProperty = workloadmeta.SBOMHasSetSuidBitProperty
+	RunningAsRootProperty = workloadmeta.SBOMRunningAsRootProperty
 )
 
 // PackagesReport wraps package data and implements the sbom.Report interface


### PR DESCRIPTION
### What does this PR do?

Merge SBOM runtime properties at BOM level in workloadmeta

Instead of picking one whole CompressedSBOM when merging two sources,
decompress both, take scan metadata (Status, GenerationTime, …) from the
higher-priority source (dst wins on a tie), and union component properties
from the secondary source into the primary component list.

This makes both arrival orders correct:
- Trivy first: remote_sbom_collector (dst, Status="") + runtime (src,
  Status=Success) → src is primary, LastSeenRunning props from dst are
  merged into each matching component.
- system-probe first: same merge path, same result — no property is
  permanently lost because it was written to the "wrong" source first.

normalizeComponentVersion (epoch stripping) and mergeCompressedSBOMs are
now inlined into workloadmeta/def/types.go so the def package owns the
merge policy; sbomcollector is simplified to just forwarding the raw BOM.

### Motivation

There are cases where system-probe forwards the SBOM before the core agent
had time to generate a SBOM for it, such as hosts where there are a larger number
of containers. In this case system-probe, scans multiple container at the same time,
sends a SBOM with runtime attributes but with others missing such as layer info.
With the current logic, when the core agent eventually computes the SBOM, it
was overwriting the runtime attributes sent by system-probe.

### Describe how you validated your changes

Unit tests and manual validation by having testing the happy path (core agent
computes the SBOM first)  and the other one (system-probe computes it first).

### Additional Notes
