### PR TITLE
Fix configuring more than one Omnibus CLI override

### DIFF
--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -32,17 +32,23 @@ from tasks.libs.dependencies import get_effective_dependencies_env
 from tasks.libs.releasing.version import get_version
 
 
+def _format_omnibus_overrides(**overrides):
+    override_values = [f"{key}:{value}" for key, value in overrides.items() if value]
+    if not override_values:
+        return ""
+
+    return f"--override={' '.join(override_values)}"
+
+
 def omnibus_run_task(
     ctx, task, target_project, base_dir, env, log_level="info", host_distribution=None, cache_dir=None
 ):
     with ctx.cd("omnibus"):
-        overrides = []
-        if base_dir:
-            overrides.append(f"--override=base_dir:{base_dir}")
-        if cache_dir:
-            overrides.append(f"--override=cache_dir:{cache_dir}")
-        if host_distribution:
-            overrides.append(f"--override=host_distribution:{host_distribution}")
+        overrides = _format_omnibus_overrides(
+            base_dir=base_dir,
+            cache_dir=cache_dir,
+            host_distribution=host_distribution,
+        )
 
         omnibus = f"bundle exec {'omnibus.bat' if sys.platform == 'win32' else 'omnibus'}"
         cmd = "{omnibus} {task} {project_name} --log-level={log_level} {overrides}"
@@ -51,7 +57,7 @@ def omnibus_run_task(
             "task": task,
             "project_name": target_project,
             "log_level": log_level,
-            "overrides": " ".join(overrides),
+            "overrides": overrides,
         }
 
         with gitlab_section(f"Running omnibus task {task}", collapsed=True):

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -232,6 +232,30 @@ class TestOmnibusCache(unittest.TestCase):
         )
 
 
+class TestOmnibusRunTask(unittest.TestCase):
+    def setUp(self):
+        self.mock_ctx = MockContextRaising(run={})
+        self.mock_ctx.set_result_for('run', re.compile(r'bundle exec omnibus build agent .*'), Result())
+
+    def test_formats_overrides_as_single_hash_option(self):
+        omnibus.omnibus_run_task(
+            self.mock_ctx,
+            task="build",
+            target_project="agent",
+            base_dir="/opt/dd/omnibus",
+            env={},
+            host_distribution="ubuntu",
+            cache_dir="/var/cache/dd/omnibus/cache",
+        )
+
+        command = self.mock_ctx.run.mock_calls[0].args[0]
+        self.assertIn(
+            "--override=base_dir:/opt/dd/omnibus cache_dir:/var/cache/dd/omnibus/cache host_distribution:ubuntu",
+            command,
+        )
+        self.assertEqual(command.count("--override="), 1)
+
+
 class TestOmnibusInstall(unittest.TestCase):
     def setUp(self):
         self.mock_ctx = MockContextRaising(run={})


### PR DESCRIPTION
### Motivation

When testing https://github.com/DataDog/datadog-agent-buildimages/pull/1089 I encountered the following error and discovered that the cause was the concurrent use of both `OMNIBUS_BASE_DIR` and `OMNIBUS_CACHE_DIR` variables.

```
$ dda inv -- -e omnibus.build --skip-deps
...
We are building omnibus with flavor: base
cd omnibus && bundle exec omnibus build agent --log-level=info --override=base_dir:/opt/dd/omnibus --override=cache_dir:/var/cache/dd/omnibus/cache
...
[NullFetcher: datadog-agent-prepare] I | 2026-04-30T23:05:46+00:00 | Fetching `datadog-agent-prepare' (nothing to fetch)
#<Thread:0x00005f3bdb172a98 /opt/dd/rvm/gems/ruby-2.7.2/bundler/gems/omnibus-ruby-8548f93c51d5/lib/omnibus/thread_pool.rb:56 run> terminated with exception (report_on_exception is true):
/opt/dd/rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/fileutils.rb:250:in `mkdir': Permission denied @ dir_s_mkdir - /var/cache/omnibus (Errno::EACCES)
```

Omnibus [defines](https://github.com/DataDog/omnibus-ruby/blob/7.57.x/lib/omnibus/cli/base.rb#L95-L99) `--override` as a [Thor](https://github.com/rails/thor) `type: :hash` [option](https://github.com/rails/thor/wiki/Method-Options#types-for-method_options). Thor hash options are meant to receive multiple `key:value` pairs as one option value, for example:

```sh
--override=base_dir:/opt/dd/omnibus cache_dir:/var/cache/dd/omnibus/cache
```

Our Invoke task was instead emitting one `--override=...` flag per setting:

```sh
--override=base_dir:/opt/dd/omnibus --override=cache_dir:/var/cache/dd/omnibus/cache
```

Because `--override` is not marked [repeatable](https://github.com/rails/thor/wiki/Method-Options#repeatable-options) in Omnibus, Thor does not merge repeated occurrences. Each occurrence [assigns](https://github.com/rails/thor/blob/6a680f2f929cc24d61b81197e113066aa18c8fbb/lib/thor/parser/options.rb#L117) a new hash to the same option, so the later `cache_dir` override [replaced](https://github.com/rails/thor/blob/6a680f2f929cc24d61b81197e113066aa18c8fbb/lib/thor/parser/options.rb#L195) the earlier `base_dir` override. As a result, Omnibus accepted `cache_dir` but silently fell back to its default `base_dir` (`/var/cache/omnibus` on Linux), which caused permission errors in the dev environment.

Although this particular combination of overrides was made possible by https://github.com/DataDog/datadog-agent/pull/49135, it was already possible to trigger the issue since we supported more than one override even before that PR.