### PR TITLE
Fix consecutive Omnibus builds

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -77,13 +77,13 @@ build do
                 # SElinux policies aren't generated when system-probe isn't built
                 # Move SELinux policy
                 if debian_target? || redhat_target?
-                  move "#{install_dir}/etc/datadog-agent/selinux", "#{output_config_dir}/etc/datadog-agent/selinux"
+                  move "#{install_dir}/etc/datadog-agent/selinux", "#{output_config_dir}/etc/datadog-agent/selinux", :force=>true
                 end
               end
               move "#{install_dir}/etc/datadog-agent/security-agent.yaml.example", "#{output_config_dir}/etc/datadog-agent", :force=>true
               move "#{install_dir}/etc/datadog-agent/runtime-security.d", "#{output_config_dir}/etc/datadog-agent", :force=>true
-              move "#{install_dir}/etc/datadog-agent/compliance.d", "#{output_config_dir}/etc/datadog-agent"
-              move "#{install_dir}/etc/datadog-agent/private-action-runner", "#{output_config_dir}/etc/datadog-agent"
+              move "#{install_dir}/etc/datadog-agent/compliance.d", "#{output_config_dir}/etc/datadog-agent", :force=>true
+              move "#{install_dir}/etc/datadog-agent/private-action-runner", "#{output_config_dir}/etc/datadog-agent", :force=>true
             end
 
             # Create the installer symlink if the file doesn't already exist


### PR DESCRIPTION
### Motivation

Running `dda inv -- -e omnibus.build` after a previously-successful build produces the following error:

```
...
[Builder: datadog-agent-finalize] I | 2026-05-01T03:30:18+00:00 | mkdir `/etc/datadog-agent': 0.0002s
[Builder: datadog-agent-finalize] I | 2026-05-01T03:30:18+00:00 | move `/opt/datadog-agent/bin/agent/dd-agent' to `/usr/bin/dd-agent': 0.0004s
[Builder: datadog-agent-finalize] I | 2026-05-01T03:30:18+00:00 | move `/opt/datadog-agent/etc/datadog-agent/datadog.yaml.example' to `/etc/datadog-agent': 0.0004s
[Builder: datadog-agent-finalize] I | 2026-05-01T03:30:18+00:00 | move `/opt/datadog-agent/etc/datadog-agent/conf.d' to `/etc/datadog-agent': 0.0002s
[Builder: datadog-agent-finalize] I | 2026-05-01T03:30:18+00:00 | move `/opt/datadog-agent/etc/datadog-agent/application_monitoring.yaml.example' to `/etc/datadog-agent': 0.0003s
[Builder: datadog-agent-finalize] I | 2026-05-01T03:30:18+00:00 | move `/opt/datadog-agent/etc/datadog-agent/security-agent.yaml.example' to `/etc/datadog-agent': 0.0003s
[Builder: datadog-agent-finalize] I | 2026-05-01T03:30:18+00:00 | move `/opt/datadog-agent/etc/datadog-agent/runtime-security.d' to `/etc/datadog-agent': 0.0002s
[Builder: datadog-agent-finalize] I | 2026-05-01T03:30:18+00:00 | move `/opt/datadog-agent/etc/datadog-agent/compliance.d' to `/etc/datadog-agent': 0.0005s
[Builder: datadog-agent-finalize] I | 2026-05-01T03:30:18+00:00 | Build datadog-agent-finalize: 3.8031s
bundler: failed to load command: omnibus (/opt/dd/rvm/gems/ruby-2.7.2/bin/omnibus)
/opt/dd/rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/fileutils.rb:544:in `block in mv': File exists - /etc/datadog-agent/compliance.d (Errno::EEXIST)
```