### PR TITLE
Ignore enriched SBOMs if image is missing from workloadmeta

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
@@ -121,49 +121,35 @@ func workloadmetaEventFromSBOMEventSet(store workloadmeta.Component, event *sbom
 	log.Debugf("Container %s uses image %s, updating image SBOM", event.ID, imageID)
 
 	// Get existing image to merge SBOM data
-	var finalBom *cyclonedx_v1_4.Bom
-	var finalCompressedSBOM *workloadmeta.CompressedSBOM
-
 	existingImage, err := store.GetImage(imageID)
-	if err == nil && existingImage != nil && existingImage.SBOM != nil {
-		// Decompress existing image SBOM to get CycloneDXBOM
-		existingSBOM, err := sbomutil.UncompressSBOM(existingImage.SBOM)
-		if err == nil && existingSBOM != nil && existingSBOM.CycloneDXBOM != nil {
-			// Merge runtime properties from new BOM into existing image SBOM
-			finalBom = mergeRuntimeProperties(existingSBOM.CycloneDXBOM, &newBom)
-			log.Debugf("Merged runtime properties for image %s SBOM", imageID)
-		} else {
-			// Decompression failed or no CycloneDXBOM, use the new one directly
-			finalBom = &newBom
-			if err != nil {
-				log.Warnf("Failed to decompress existing SBOM for image %s: %v, using new SBOM", imageID, err)
-			} else {
-				log.Debugf("No existing CycloneDXBOM for image %s, using new SBOM", imageID)
-			}
-		}
-	} else {
-		// No existing SBOM on image, use the new one directly
-		finalBom = &newBom
-		if err != nil {
-			log.Debugf("Could not get image %s from store: %v, using new SBOM", imageID, err)
-		} else {
-			log.Debugf("No existing SBOM for image %s, using new SBOM", imageID)
-		}
+	if err != nil || existingImage == nil || existingImage.SBOM == nil ||
+		existingImage.SBOM.Status == workloadmeta.Pending || existingImage.SBOM.Status == "" {
+		log.Debugf("Ignoring system-probe SBOM for image %s: image not found or Trivy scan not yet complete", imageID)
+		return workloadmeta.Event{}, nil
 	}
+
+	// Decompress existing image SBOM to get CycloneDXBOM
+	existingSBOM, err := sbomutil.UncompressSBOM(existingImage.SBOM)
+	if err != nil || existingSBOM == nil || existingSBOM.CycloneDXBOM == nil {
+		return workloadmeta.Event{}, fmt.Errorf("Failed to decompress existing SBOM for image %s: %v, using new SBOM", imageID, err)
+	}
+
+	// Merge runtime properties from new BOM into existing image SBOM
+	finalBom := mergeRuntimeProperties(existingSBOM.CycloneDXBOM, &newBom)
+	log.Debugf("Merged runtime properties for image %s SBOM", imageID)
 
 	// Compress the final merged SBOM, preserving scan metadata from the existing
 	// SBOM so Status/GenerationTime/etc. survive the runtime-enrichment update.
 	sbomToCompress := &workloadmeta.SBOM{
-		CycloneDXBOM: finalBom,
+		CycloneDXBOM:       finalBom,
+		Status:             existingImage.SBOM.Status,
+		GenerationTime:     existingImage.SBOM.GenerationTime,
+		GenerationDuration: existingImage.SBOM.GenerationDuration,
+		GenerationMethod:   existingImage.SBOM.GenerationMethod,
+		Error:              existingImage.SBOM.Error,
 	}
-	if existingImage != nil && existingImage.SBOM != nil {
-		sbomToCompress.Status = existingImage.SBOM.Status
-		sbomToCompress.GenerationTime = existingImage.SBOM.GenerationTime
-		sbomToCompress.GenerationDuration = existingImage.SBOM.GenerationDuration
-		sbomToCompress.GenerationMethod = existingImage.SBOM.GenerationMethod
-		sbomToCompress.Error = existingImage.SBOM.Error
-	}
-	finalCompressedSBOM, err = sbomutil.CompressSBOM(sbomToCompress)
+
+	finalCompressedSBOM, err := sbomutil.CompressSBOM(sbomToCompress)
 	if err != nil {
 		return workloadmeta.Event{}, fmt.Errorf("failed to compress SBOM for image %s: %w", imageID, err)
 	}
@@ -412,6 +398,9 @@ func handleEvents(store workloadmeta.Component, collectorEvents []workloadmeta.C
 		workloadmetaEvent, err := convertFunc(store, protoEvent)
 		if err != nil {
 			log.Warnf("error converting workloadmeta event: %v", err)
+			continue
+		}
+		if workloadmetaEvent.Entity == nil {
 			continue
 		}
 

--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
@@ -122,10 +122,34 @@ func workloadmetaEventFromSBOMEventSet(store workloadmeta.Component, event *sbom
 
 	// Get existing image to merge SBOM data
 	existingImage, err := store.GetImage(imageID)
-	if err != nil || existingImage == nil || existingImage.SBOM == nil ||
-		existingImage.SBOM.Status == workloadmeta.Pending || existingImage.SBOM.Status == "" {
-		log.Debugf("Ignoring system-probe SBOM for image %s: image not found or Trivy scan not yet complete", imageID)
+	if err != nil || existingImage == nil {
+		// Kubelet reports Image.ID as the manifest/repo digest (e.g. "docker.io/foo@sha256:9fb3...")
+		// but images are stored by config digest. Fall back to a linear search on RepoDigests.
+		for _, img := range store.ListImages() {
+			for _, digest := range img.RepoDigests {
+				if digest == imageID {
+					existingImage = img
+					break
+				}
+			}
+			if existingImage != nil {
+				break
+			}
+		}
+	}
+	if existingImage == nil {
+		log.Debugf("Ignoring system-probe SBOM for image %s: image not found in workloadmeta", imageID)
 		return workloadmeta.Event{}, nil
+	}
+
+	if existingImage.SBOM == nil {
+		log.Debugf("Existing image %s has no SBOM, skipping", imageID)
+		return workloadmeta.Event{}, fmt.Errorf("existing image %s has no SBOM to merge with", imageID)
+	}
+
+	if existingImage.SBOM.Status == workloadmeta.Pending || existingImage.SBOM.Status == "" {
+		log.Debugf("Image %s SBOM is still in state '%s', skipping merge for now", imageID, existingImage.SBOM.Status)
+		return workloadmeta.Event{}, fmt.Errorf("image %s SBOM is still pending", imageID)
 	}
 
 	// Decompress existing image SBOM to get CycloneDXBOM

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -94,7 +94,10 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// CWS - SBOM
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.workloads_cache_size", 10)
+	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.enrichment_interval", "1m")
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.enrichment_ticker", "1m")
+	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.refresh_interval", "3s")
+	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.forward_interval", "20s")
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.host.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.generate_policies", false)
 

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -356,8 +356,14 @@ type RuntimeSecurityConfig struct {
 	SBOMResolverWorkloadsCacheSize int
 	// SBOMResolverHostEnabled defines if the SBOM resolver should compute the host's SBOM
 	SBOMResolverHostEnabled bool
+	// SBOMResolverEnrichmentInterval defines the minimum amount of time to wait before enriching an SBOM with runtime usage information
+	SBOMResolverEnrichmentInterval time.Duration
 	// SBOMResolverEnrichmentTicker defines the ticker for enriching SBOMs with runtime usage information
 	SBOMResolverEnrichmentTicker time.Duration
+	// SBOMResolverForwardInterval defines the interval for forwarding SBOMs
+	SBOMResolverForwardInterval time.Duration
+	// SBOMResolverRefreshInterval defines the interval for refreshing SBOMs
+	SBOMResolverRefreshInterval time.Duration
 	// SBOMResolverGeneratePolicies defines if the SBOM resolver should generate runtime security policies based on the computed SBOMs
 	SBOMResolverGeneratePolicies bool
 
@@ -589,6 +595,9 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		SBOMResolverEnabled:            pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sbom.enabled") || pkgconfigsetup.Datadog().GetBool("sbom.enrichment.usage.enabled"),
 		SBOMResolverWorkloadsCacheSize: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.sbom.workloads_cache_size"),
 		SBOMResolverEnrichmentTicker:   pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.sbom.enrichment_ticker"),
+		SBOMResolverEnrichmentInterval: pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.sbom.enrichment_interval"),
+		SBOMResolverRefreshInterval:    pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.sbom.refresh_interval"),
+		SBOMResolverForwardInterval:    pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.sbom.forward_interval"),
 		SBOMResolverHostEnabled:        pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sbom.host.enabled"),
 		SBOMResolverGeneratePolicies:   pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sbom.generate_policies"),
 

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -123,9 +123,6 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 	}
 
 	if config.RuntimeSecurity.SBOMResolverEnabled {
-		if err := cgroupsResolver.RegisterListener(cgroup.CGroupCreated, sbomResolver.OnCGroupCreatedEvent); err != nil {
-			return nil, err
-		}
 		if err := cgroupsResolver.RegisterListener(cgroup.CGroupDeleted, sbomResolver.OnCGroupDeletedEvent); err != nil {
 			return nil, err
 		}

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -299,7 +299,7 @@ func (r *Resolver) RefreshSBOM(containerID containerutils.ContainerID) error {
 		refresher = sbom.refresher
 		if refresher == nil {
 			refresher = debouncer.New(
-				3*time.Second, func() {
+				r.cfg.SBOMResolverRefreshInterval, func() {
 					// invalid cache data
 					r.removeSBOMData(sbom.workloadKey)
 
@@ -328,7 +328,7 @@ func (r *Resolver) triggerForwarding(sbom *SBOM) {
 	// Create forwarder debouncer on demand
 	if sbom.forwarder == nil {
 		sbom.forwarder = debouncer.New(
-			5*time.Second, func() {
+			r.cfg.SBOMResolverForwardInterval, func() {
 				// Forward current SBOM data with LastAccess to remote collector
 				sbom.Lock()
 				defer sbom.Unlock()
@@ -713,7 +713,7 @@ func (r *Resolver) ResolvePackage(pc *model.ProcessContext, file *model.FileEven
 		pkg.AccessedByRoot = pkg.AccessedByRoot || pc.UID == 0
 
 		// Trigger forwarding debouncer to send updated SBOM to remote collector
-		if pkg.LastAccess.Sub(oldLastAccess) > 1*time.Minute ||
+		if pkg.LastAccess.Sub(oldLastAccess) > r.cfg.SBOMResolverEnrichmentInterval ||
 			pkg.SuidBit != oldSuidBit || pkg.AccessedByRoot != oldAccessedByRoot {
 			sbom.invalidated = true
 		}
@@ -765,12 +765,13 @@ func (r *Resolver) processPendingFileEvents(sbom *SBOM) {
 
 	seclog.Debugf("processing %d pending file events for container '%s'", len(events), sbom.ContainerID)
 
+	now := time.Now()
 	for _, event := range events {
 		pkg := sbom.data.files.queryFile(event.filePath)
 		if pkg == nil {
 			continue
 		}
-		pkg.LastAccess = time.Now()
+		pkg.LastAccess = now
 		pkg.SuidBit = fs.FileMode(event.fileMode)&04000 != 0
 		pkg.AccessedByRoot = pkg.AccessedByRoot || event.uid == 0
 

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -53,6 +53,7 @@ const (
 	maxSBOMEntries           = 1024
 	scanQueueSize            = 100
 	maxPendingFileEvents     = 256
+	maxRetryForwarding       = 10
 )
 
 // pendingFileEvent holds the minimal information needed to re-process a file
@@ -94,8 +95,9 @@ type SBOM struct {
 	cgroup *cgroupModel.CacheEntry
 	state  *atomic.Int64
 
-	refresher *debouncer.Debouncer
-	forwarder *debouncer.Debouncer // Debouncer for forwarding SBOM updates
+	refresher         *debouncer.Debouncer
+	forwarder         *debouncer.Debouncer // Debouncer for forwarding SBOM updates
+	forwardRetryCount int
 
 	invalidated bool
 }
@@ -376,18 +378,20 @@ func (r *Resolver) triggerForwarding(sbom *SBOM) {
 				if sbom.status == workloadmeta.Pending || sbom.status == "" {
 					imageSBOM, err := r.getContainerSBOM(sbom.ContainerID)
 					if err != nil || imageSBOM == nil {
-						seclog.Warnf("Failed to get image SBOM for container '%s': %v", sbom.ContainerID, err)
-						sbom.forwarder.Call()
-						return
-					}
-
-					if imageSBOM.Status == workloadmeta.Pending || imageSBOM.Status == "" {
-						seclog.Warnf("Image SBOM for container '%s' is still pending, will retry forwarding later", sbom.ContainerID)
-						sbom.forwarder.Call()
-						return
+						seclog.Debugf("Failed to get image SBOM for container '%s': %v", sbom.ContainerID, err)
 					}
 
 					sbom.status = imageSBOM.Status
+				}
+
+				if sbom.status == workloadmeta.Pending || sbom.status == "" {
+					if sbom.forwardRetryCount++; sbom.forwardRetryCount > maxRetryForwarding {
+						seclog.Warnf("Max retries reached for forwarding SBOM of container '%s', giving up", sbom.ContainerID)
+					} else {
+						seclog.Debugf("Image SBOM for container '%s' is still in %s state, will retry forwarding later", sbom.status, sbom.ContainerID)
+						sbom.forwarder.Call()
+					}
+					return
 				}
 
 				if sbom.data == nil || len(sbom.data.packages) == 0 {

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -930,25 +930,6 @@ func (r *Resolver) GetWorkload(id containerutils.ContainerID) *SBOM {
 	return sbom
 }
 
-// OnCGroupCreatedEvent is used to handle a CGroupCreated event. It queues an SBOM scan for
-// the container as soon as the cgroup is known, without waiting for tag resolution.
-func (r *Resolver) OnCGroupCreatedEvent(cgroup *cgroupModel.CacheEntry) {
-	id := cgroup.GetContainerID()
-	if len(id) == 0 {
-		return
-	}
-
-	r.sbomsLock.Lock()
-	defer r.sbomsLock.Unlock()
-
-	if _, ok := r.sboms.Get(id); ok {
-		return
-	}
-
-	sbom := r.newSBOM(id, cgroup, workloadKey(id))
-	r.triggerScan(sbom)
-}
-
 // OnCGroupDeletedEvent is used to handle a CGroupDeleted event
 func (r *Resolver) OnCGroupDeletedEvent(cgroup *cgroupModel.CacheEntry) {
 	if !cgroup.IsContainerContextNull() {

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -89,6 +89,7 @@ type SBOM struct {
 	data *Data
 
 	workloadKey workloadKey
+	status      workloadmeta.SBOMStatus
 
 	cgroup *cgroupModel.CacheEntry
 	state  *atomic.Int64
@@ -322,6 +323,45 @@ func (r *Resolver) RefreshSBOM(containerID containerutils.ContainerID) error {
 	return fmt.Errorf("container %s not found", containerID)
 }
 
+func (r *Resolver) getContainerSBOM(containerID containerutils.ContainerID) (*workloadmeta.CompressedSBOM, error) {
+	container, err := r.wmeta.GetContainer(string(containerID))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get container metadata for '%s': %v", containerID, err)
+	}
+
+	imageID := container.Image.ID
+	if imageID == "" {
+		return nil, fmt.Errorf("Container '%s' has no image ID, cannot forward SBOM", containerID)
+	}
+
+	existingImage, err := r.wmeta.GetImage(imageID)
+	if err != nil || existingImage == nil {
+		// Kubelet reports Image.ID as the manifest/repo digest (e.g. "docker.io/foo@sha256:9fb3...")
+		// but images are stored by config digest. Fall back to a linear search on RepoDigests.
+		for _, img := range r.wmeta.ListImages() {
+			for _, digest := range img.RepoDigests {
+				if digest == imageID {
+					existingImage = img
+					break
+				}
+			}
+			if existingImage != nil {
+				break
+			}
+		}
+	}
+
+	if existingImage == nil {
+		return nil, fmt.Errorf("Image metadata for '%s' not found in workloadmeta, cannot forward SBOM for container '%s'", imageID, containerID)
+	}
+
+	if existingImage.SBOM == nil {
+		return nil, fmt.Errorf("Image '%s' has no SBOM, cannot forward SBOM for container '%s'", imageID, containerID)
+	}
+
+	return existingImage.SBOM, nil
+}
+
 // triggerForwarding triggers the forwarding debouncer to send updated SBOM with LastAccess to remote collector
 // This function assumes sbom is already locked by the caller
 func (r *Resolver) triggerForwarding(sbom *SBOM) {
@@ -332,6 +372,23 @@ func (r *Resolver) triggerForwarding(sbom *SBOM) {
 				// Forward current SBOM data with LastAccess to remote collector
 				sbom.Lock()
 				defer sbom.Unlock()
+
+				if sbom.status == workloadmeta.Pending || sbom.status == "" {
+					imageSBOM, err := r.getContainerSBOM(sbom.ContainerID)
+					if err != nil || imageSBOM == nil {
+						seclog.Warnf("Failed to get image SBOM for container '%s': %v", sbom.ContainerID, err)
+						sbom.forwarder.Call()
+						return
+					}
+
+					if imageSBOM.Status == workloadmeta.Pending || imageSBOM.Status == "" {
+						seclog.Warnf("Image SBOM for container '%s' is still pending, will retry forwarding later", sbom.ContainerID)
+						sbom.forwarder.Call()
+						return
+					}
+
+					sbom.status = imageSBOM.Status
+				}
 
 				if sbom.data == nil || len(sbom.data.packages) == 0 {
 					return
@@ -853,6 +910,9 @@ func (r *Resolver) OnWorkloadSelectorResolvedEvent(workload *tags.Workload) {
 	_, ok := r.sboms.Get(id)
 	if !ok {
 		sbom := r.newSBOM(id, workload.GCroupCacheEntry, workloadKey)
+		if imageSBOM, err := r.getContainerSBOM(id); err == nil && imageSBOM != nil {
+			sbom.status = imageSBOM.Status
+		}
 		r.queueWorkload(sbom)
 	}
 }

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -276,8 +276,7 @@ func (r *Resolver) Start(ctx context.Context) error {
 			case <-enrichTicker.C:
 				if r.wmeta != nil {
 					seclog.Debugf("Enriching SBOM with runtime usage")
-					_, err := r.enrichSBOMsWithUsage()
-					if err != nil {
+					if err := r.enrichSBOMsWithUsage(); err != nil {
 						seclog.Errorf("Couldn't enrich SBOMs with usage: %v", err)
 					}
 				}
@@ -302,7 +301,7 @@ func (r *Resolver) RefreshSBOM(containerID containerutils.ContainerID) error {
 			refresher = debouncer.New(
 				3*time.Second, func() {
 					// invalid cache data
-					r.removeSBOMData(workloadKey(sbom.ContainerID))
+					r.removeSBOMData(sbom.workloadKey)
 
 					r.sbomsLock.Lock()
 					sbom.Lock()
@@ -497,13 +496,12 @@ func (r *Resolver) removeSBOMData(key workloadKey) {
 	r.dataCacheLock.Unlock()
 }
 
-func (r *Resolver) enrichSBOMsWithUsage() (bool, error) {
+func (r *Resolver) enrichSBOMsWithUsage() error {
 	r.sbomsLock.RLock()
 	defer r.sbomsLock.RUnlock()
 
-	images := r.wmeta.ListImages()
 	enriched := false
-
+	images := r.wmeta.ListImages()
 	for _, image := range images {
 		uncompressedSBOM, err := sbomutil.UncompressSBOM(image.SBOM)
 		if err != nil {
@@ -517,14 +515,14 @@ func (r *Resolver) enrichSBOMsWithUsage() (bool, error) {
 
 		for _, sbom := range r.sboms.Values() {
 			sbom.Lock()
-			if sbom.data != nil && sbom.workloadKey == workloadKey(image.Name) {
+			if sbom.data != nil && (sbom.workloadKey == workloadKey(image.Name) || sbom.workloadKey == workloadKey(image.ID)) {
 				enriched = enriched || r.enrichSBOMWithUsage(uncompressedSBOM, sbom)
 			}
 			sbom.Unlock()
 		}
 	}
 
-	return enriched, nil
+	return nil
 }
 
 func (r *Resolver) enrichSBOMWithUsage(wsbom *workloadmeta.SBOM, sbom *SBOM) bool {
@@ -625,7 +623,7 @@ func (r *Resolver) analyzeWorkload(sb *SBOM) error {
 
 	// add to cache
 	r.dataCacheLock.Lock()
-	r.dataCache.Add(workloadKey(sb.ContainerID), data)
+	r.dataCache.Add(workloadKey(sb.workloadKey), data)
 	r.dataCacheLock.Unlock()
 
 	r.removePendingScan(sb.ContainerID)
@@ -803,7 +801,7 @@ func (r *Resolver) queueWorkload(sbom *SBOM) {
 	r.dataCacheLock.Lock()
 	defer r.dataCacheLock.Unlock()
 
-	if data, ok := r.dataCache.Get(workloadKey(sbom.ContainerID)); ok {
+	if data, ok := r.dataCache.Get(sbom.workloadKey); ok {
 		sbom.data = data
 
 		sbom.state.Store(computedState)
@@ -846,9 +844,13 @@ func (r *Resolver) OnWorkloadSelectorResolvedEvent(workload *tags.Workload) {
 		return
 	}
 
+	workloadKey := workloadKey(utils.GetTagValue("image_id", workload.Tags))
+	if workloadKey == "" {
+		workloadKey = getWorkloadKey(workload.Selector.Copy())
+	}
+
 	_, ok := r.sboms.Get(id)
 	if !ok {
-		workloadKey := getWorkloadKey(workload.Selector.Copy())
 		sbom := r.newSBOM(id, workload.GCroupCacheEntry, workloadKey)
 		r.queueWorkload(sbom)
 	}


### PR DESCRIPTION
### What does this PR do?

When the SBOM remote collector receives a runtime SBOM from system-probe, it now silently drops the event if the corresponding image is not yet present in
 workloadmeta or if its Trivy scan has not completed (Status is Pending or empty). Previously, the collector would fall back to storing the system-probe  
BOM directly in that case.
                                                                                                                                                          
In the success path (Trivy scan complete), the collector merges runtime properties from the system-probe BOM into the existing Trivy BOM and preserves the
 scan metadata (Status, GenerationTime, GenerationDuration, GenerationMethod, Error) from the existing image SBOM when compressing the merged result.
                                                                                                                                                          
A nil-entity guard is also added in handleEvents to safely skip empty events produced by the early-return path.                                           

### Motivation

Permanent Trivy scan skip. When system-probe sent its SBOM before Trivy finished scanning, the collector would store the system-probe BOM (reduced package
 set) as the remote_sbom_collector entity with no Status. The ContainerImageMetadata.Merge logic prefers remote_sbom_collector (alphabetically first), so
the merged image entity ended up with Status="". The image_sbom_trivy.go subscription loop skips images whose SBOM Status != Pending, so the Trivy scan   
was permanently skipped for that image.                   

### Describe how you validated your changes

### Additional Notes
