### PR TITLE
[ADP] bypass non-Linux OS gate via DD_DATA_PLANE_FORCE_ENABLE

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -683,7 +683,7 @@ func LoadDatadog(config pkgconfigmodel.Config, secretResolver secrets.Component,
 
 	sanitizeAPIKeyConfig(config, "api_key")
 	sanitizeAPIKeyConfig(config, "logs_config.api_key")
-	sanitizeDataPlaneConfig(config, runtime.GOOS)
+	sanitizeDataPlaneConfig(config, runtime.GOOS, os.Getenv)
 	setNumWorkers(config)
 
 	flareStrippedKeys := config.GetStringSlice("flare_stripped_keys")
@@ -1197,13 +1197,19 @@ func sanitizeAPIKeyConfig(config pkgconfigmodel.Config, key string) {
 // The goos parameter is the target OS string (normally runtime.GOOS). It is
 // exposed as a parameter so that tests can exercise both branches without
 // needing to cross-compile.
-func sanitizeDataPlaneConfig(config pkgconfigmodel.Config, goos string) {
-	if goos != "linux" {
-		if config.GetBool(DataPlaneEnabled) {
-			log.Warnf("%s is not supported on %s and will be ignored", DataPlaneEnabled, goos)
-		}
-		config.Set(DataPlaneEnabled, false, pkgconfigmodel.SourceAgentRuntime)
+//
+// The envLookup parameter is normally os.Getenv. It is exposed as a parameter
+// so tests can inject a stub without touching global state.
+// When DD_DATA_PLANE_FORCE_ENABLE=true the OS gate is skipped entirely; this
+// is intended for local development on macOS/Windows only.
+func sanitizeDataPlaneConfig(config pkgconfigmodel.Config, goos string, envLookup func(string) string) {
+	if goos == "linux" || envLookup("DD_DATA_PLANE_FORCE_ENABLE") == "true" {
+		return
 	}
+	if config.GetBool(DataPlaneEnabled) {
+		log.Warnf("%s is not supported on %s and will be ignored", DataPlaneEnabled, goos)
+	}
+	config.Set(DataPlaneEnabled, false, pkgconfigmodel.SourceAgentRuntime)
 }
 
 // sanitizeExternalMetricsProviderChunkSize ensures the value of `external_metrics_provider.chunk_size` is within an acceptable range

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1539,6 +1539,7 @@ func TestSanitizeDataPlaneConfig(t *testing.T) {
 	tests := []struct {
 		name         string
 		goos         string
+		forceEnable  string // value of DD_DATA_PLANE_FORCE_ENABLE
 		initialValue bool
 		wantValue    bool
 		wantSource   pkgconfigmodel.Source
@@ -1580,6 +1581,41 @@ func TestSanitizeDataPlaneConfig(t *testing.T) {
 			wantValue:    false,
 			wantSource:   pkgconfigmodel.SourceAgentRuntime,
 		},
+		{
+			name:         "darwin bypass: force-enable=true preserves true",
+			goos:         "darwin",
+			forceEnable:  "true",
+			initialValue: true,
+			wantValue:    true,
+			wantSource:   pkgconfigmodel.SourceFile,
+		},
+		{
+			name:         "windows bypass: force-enable=true preserves true",
+			goos:         "windows",
+			forceEnable:  "true",
+			initialValue: true,
+			wantValue:    true,
+			wantSource:   pkgconfigmodel.SourceFile,
+		},
+		{
+			// Garbage value in the env var does NOT bypass the gate.
+			name:         "darwin bypass: force-enable=yes is ignored (gate applies)",
+			goos:         "darwin",
+			forceEnable:  "yes",
+			initialValue: true,
+			wantValue:    false,
+			wantSource:   pkgconfigmodel.SourceAgentRuntime,
+		},
+		{
+			// When bypass is active and value is already false, gate is still skipped —
+			// SourceAgentRuntime override is not applied.
+			name:         "darwin bypass: force-enable=true preserves false",
+			goos:         "darwin",
+			forceEnable:  "true",
+			initialValue: false,
+			wantValue:    false,
+			wantSource:   pkgconfigmodel.SourceFile,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1587,7 +1623,13 @@ func TestSanitizeDataPlaneConfig(t *testing.T) {
 			cfg := newTestConf(t)
 			cfg.Set("data_plane.enabled", tt.initialValue, pkgconfigmodel.SourceFile)
 
-			sanitizeDataPlaneConfig(cfg, tt.goos)
+			envLookup := func(key string) string {
+				if key == "DD_DATA_PLANE_FORCE_ENABLE" {
+					return tt.forceEnable
+				}
+				return ""
+			}
+			sanitizeDataPlaneConfig(cfg, tt.goos, envLookup)
 
 			assert.Equal(t, tt.wantValue, cfg.GetBool("data_plane.enabled"))
 			assert.Equal(t, tt.wantSource, cfg.GetSource("data_plane.enabled"))


### PR DESCRIPTION
## Summary

Follows up on #50151. Adds `DD_DATA_PLANE_FORCE_ENABLE=true` as a developer escape hatch for the non-Linux OS gate in `sanitizeDataPlaneConfig`.

## Test plan

- [x] `dda inv test --targets=./pkg/config/setup/...` passes (295 tests, including 4 new bypass cases)
- [x] Verify on macOS: set `DD_DATA_PLANE_FORCE_ENABLE=true` in `datadog.yaml` env and confirm `data_plane.enabled` is honoured

🤖 Generated with [Claude Code](https://claude.com/claude-code)