### PR TITLE
[draft] agent check: auto-create IPC artifacts so checks work without a running daemon

### DIFF
--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -215,7 +215,10 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 				getPlatformModules(),
 				jmxloggerimpl.Module(jmxloggerimpl.NewCliParams("")),
 				haagentfx.Module(),
-				ipcfx.ModuleReadOnly(),
+				// ModuleReadWrite creates auth_token / ipc_cert.pem if they don't
+				// exist yet, so `agent check` works without a running daemon.
+				// The API server (needed for JMX checks) requires valid TLS certs.
+				ipcfx.ModuleReadWrite(),
 				remotetraceroute.Module(),
 			)
 		},


### PR DESCRIPTION
### What does this PR do?

Switches `agent check`'s IPC fx module from `ipcfx.ModuleReadOnly()` to `ipcfx.ModuleReadWrite()` in `pkg/cli/subcommands/check/command.go`, so the subcommand auto-creates `auth_token` and `ipc_cert.pem` if they do not yet exist on disk. One-line change with three lines of comment.

```go
// Before
ipcfx.ModuleReadOnly(),

// After
// ModuleReadWrite creates auth_token / ipc_cert.pem if they don't
// exist yet, so `agent check` works without a running daemon.
// The API server (needed for JMX checks) requires valid TLS certs.
ipcfx.ModuleReadWrite(),
```

### Motivation

`agent check <name>` currently fails on a fresh build with no running agent:

```
touch: cannot touch 'bin/agent/dist/auth_token': No such file or directory
Error: error while fetching IPC cert: ...
```

`ModuleReadOnly()` requires `auth_token` and `ipc_cert.pem` to already exist — they're normally created by `agent run`. The subcommand also pulls in `apiimpl.Module()` (needed for JMX check communication, which starts a TLS server), so simply skipping IPC via `ModuleInsecure()` is not sufficient — the API server requires valid TLS certs.

`ModuleReadWrite()` solves both: it reads existing artifacts when present and creates them when missing. The created files are local IPC artifacts (a random auth token and a self-signed cert); if a running agent already created them, the read path takes over.

### Scope

- Affects every invocation of `agent check <name>`, not a single check.
- Does **not** change behavior when a running agent has already created the artifacts (`ModuleReadWrite` reads existing files in that case).
- Does **not** affect any other subcommand — `agent run`, `agent status`, `agent diagnose`, etc. continue to use whatever IPC mode they already have.

### Describe how you validated your changes

- On a fresh build with no running agent, `agent check <core-check-name>` now succeeds and produces output.
- With a running agent (`agent run`) holding existing `auth_token` / `ipc_cert.pem`, `agent check` reuses those artifacts (the read path).
- The corresponding integration tests in `pkg/gpu/integrationtests` and `pkg/collector/corechecks/gpu/integrationtests` (added in #49685) rely on this fix to drive the full check pipeline — those tests pass against the rebuilt agent.

### Additional Notes

This change was originally part of #49685 (the fake-NVML library PR) where it was needed for the new GPU check integration tests to work without a running daemon. Splitting it out for cleaner ownership review since it's a behavior change for `agent check` across all check types, not just GPU.
