### PR TITLE
[AD] Deduplicate process service templates against static configs

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -98,6 +98,7 @@ type AutoConfig struct {
 	filterStore              workloadfilter.Component
 	telemetryStore           *acTelemetry.Store
 	healthPlatform           option.Option[healthplatformdef.Component]
+	staticConfigIndex        *listeners.StaticConfigIndex
 
 	// m covers the `configPollers`, `listenerCandidates`, `listeners`, and `listenerRetryStop`, but
 	// not the values they point to.
@@ -204,7 +205,8 @@ func createNewAutoConfig(schedulerController *scheduler.Controller, secretResolv
 	} else {
 		log.Infof("Health platform component not available. Issue reporting disabled for config providers.")
 	}
-	cfgMgr := newReconcilingConfigManager(secretResolver, hpComp)
+	staticConfigIndex := listeners.NewStaticConfigIndex()
+	cfgMgr := newReconcilingConfigManager(secretResolver, hpComp, staticConfigIndex)
 	ac := &AutoConfig{
 		configPollers:            make([]*configPoller, 0, 9),
 		listenerCandidates:       make(map[string]*listenerCandidate),
@@ -225,6 +227,7 @@ func createNewAutoConfig(schedulerController *scheduler.Controller, secretResolv
 		filterStore:              filterStore,
 		telemetryStore:           acTelemetry.NewStore(telemetryComp),
 		healthPlatform:           hp,
+		staticConfigIndex:        staticConfigIndex,
 	}
 
 	secretResolver.SubscribeToChanges(func(_, origin string, _ []string, oldValue, _ any) {
@@ -565,11 +568,12 @@ func (ac *AutoConfig) addListenerCandidates(listenerConfigs []pkgconfigsetup.Lis
 		}
 		log.Debugf("Listener %s was registered", c.Name)
 		factoryOptions := listeners.ServiceListernerDeps{
-			Config:    &c,
-			Telemetry: ac.telemetryStore,
-			Filter:    ac.filterStore,
-			Tagger:    ac.taggerComp,
-			Wmeta:     ac.wmeta,
+			Config:            &c,
+			Telemetry:         ac.telemetryStore,
+			Filter:            ac.filterStore,
+			Tagger:            ac.taggerComp,
+			Wmeta:             ac.wmeta,
+			StaticConfigIndex: ac.staticConfigIndex,
 		}
 
 		ac.listenerCandidates[c.Name] = &listenerCandidate{factory: factory, options: factoryOptions}

--- a/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
@@ -108,6 +108,11 @@ type reconcilingConfigManager struct {
 	// methods correspond exactly to changes in this map.
 	scheduledConfigs map[string]integration.Config
 
+	// staticConfigIndex is a shared name set published to listeners so they
+	// can deduplicate templates against static configs (see ProcessService).
+	// May be nil; callers that don't need cross-listener dedup can omit it.
+	staticConfigIndex *listeners.StaticConfigIndex
+
 	secretResolver secrets.Component
 	healthPlatform healthplatformdef.Component
 }
@@ -115,7 +120,7 @@ type reconcilingConfigManager struct {
 var _ configManager = &reconcilingConfigManager{}
 
 // newReconcilingConfigManager creates a new, empty reconcilingConfigManager.
-func newReconcilingConfigManager(secretResolver secrets.Component, healthPlatform healthplatformdef.Component) configManager {
+func newReconcilingConfigManager(secretResolver secrets.Component, healthPlatform healthplatformdef.Component, staticConfigIndex *listeners.StaticConfigIndex) configManager {
 	return &reconcilingConfigManager{
 		activeConfigs:      map[string]integration.Config{},
 		activeServices:     map[string]serviceAndADIDs{},
@@ -123,6 +128,7 @@ func newReconcilingConfigManager(secretResolver secrets.Component, healthPlatfor
 		servicesByADID:     newMultimap(),
 		serviceResolutions: map[string]map[string]string{},
 		scheduledConfigs:   map[string]integration.Config{},
+		staticConfigIndex:  staticConfigIndex,
 		secretResolver:     secretResolver,
 		healthPlatform:     healthPlatform,
 	}
@@ -244,6 +250,16 @@ func (cm *reconcilingConfigManager) processNewConfig(config integration.Config) 
 		}
 
 		changes.ScheduleConfig(decryptedConfig)
+
+		// Publish to the cross-listener index so that subsequently
+		// reconciled services (e.g. ProcessService) can deduplicate
+		// templates against this static config.
+		//
+		// TODO: re-reconcile already-resolved services whose templates of
+		// this name would now be deduplicated. Without this, a static
+		// config that arrives after a dynamic process discovery leaves the
+		// duplicate scheduled until something else perturbs the service.
+		cm.staticConfigIndex.Add(config.Name)
 	}
 
 	//  4. update scheduledConfigs
@@ -295,6 +311,11 @@ func (cm *reconcilingConfigManager) processDelConfigs(configs []integration.Conf
 			}
 
 			changes.UnscheduleConfig(config)
+
+			// Update the cross-listener index. See processNewConfig for the
+			// TODO on runtime re-reconciliation of services whose templates
+			// of this name may now be (re)schedulable.
+			cm.staticConfigIndex.Remove(config.Name)
 		}
 
 		//  4. update scheduledConfigs

--- a/comp/core/autodiscovery/autodiscoveryimpl/configmgr_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/configmgr_test.go
@@ -545,7 +545,7 @@ func TestReconcilingConfigManagement(t *testing.T) {
 	mockResolver := MockSecretResolver{}
 	suite.Run(t, &ReconcilingConfigManagerSuite{
 		ConfigManagerSuite{factory: func() configManager {
-			return newReconcilingConfigManager(&mockResolver, nil)
+			return newReconcilingConfigManager(&mockResolver, nil, nil)
 		}},
 	})
 }
@@ -559,11 +559,93 @@ func (s *dummyServiceWithExtraConfigError) GetExtraConfig(key string) (string, e
 	return "", fmt.Errorf("extra config %q is not supported", key)
 }
 
+// A service whose FilterTemplates consults the shared StaticConfigIndex
+// (as ProcessService does) has its templates correctly deduped when its
+// reconciliation runs after a static config has already been published to
+// the index. This covers the common startup ordering: static configs from
+// conf.d are loaded before the process listener starts discovering
+// services.
+//
+// TODO: runtime ordering (static arrives after dynamic, or static leaves
+// while dynamic is scheduled) is not covered yet — see configmgr.go.
+func TestStaticConfigIndexDedupOnReconcile(t *testing.T) {
+	mockResolver := MockSecretResolver{}
+	idx := listeners.NewStaticConfigIndex()
+
+	cm := newReconcilingConfigManager(&mockResolver, nil, idx)
+
+	// A service whose FilterTemplates drops any template whose Name has a
+	// static config in the shared index — this is the contract ProcessService
+	// implements.
+	procSvc := &dummyService{
+		ID:            "process://1234",
+		ADIdentifiers: []string{"proc-redis"},
+		Hosts:         map[string]string{"main": "127.0.0.1"},
+	}
+	procSvc.filterTemplates = func(configs map[string]integration.Config) {
+		for digest, cfg := range configs {
+			if idx.Has(cfg.Name) {
+				delete(configs, digest)
+			}
+		}
+	}
+
+	redisTemplate := integration.Config{
+		Name:          "redis",
+		LogsConfig:    []byte("source: %%host%%"),
+		ADIdentifiers: []string{"proc-redis"},
+	}
+	staticRedis := integration.Config{Name: "redis"}
+
+	// Startup ordering: static config arrives first, then the template,
+	// then the matching service.
+	changes, _ := cm.processNewConfig(staticRedis)
+	assertConfigsMatch(t, changes.Schedule, matchName("redis"))
+	assertConfigsMatch(t, changes.Unschedule)
+	assert.True(t, idx.Has("redis"))
+
+	changes, _ = cm.processNewConfig(redisTemplate)
+	assertConfigsMatch(t, changes.Schedule)
+	assertConfigsMatch(t, changes.Unschedule)
+
+	// When the service arrives, reconciliation runs FilterTemplates and
+	// drops the redis template because the index reports a static config.
+	changes = cm.processNewService(procSvc)
+	assertConfigsMatch(t, changes.Schedule)
+	assertConfigsMatch(t, changes.Unschedule)
+	assertLoadedConfigsMatch(t, cm, matchAll(matchName("redis"), matchSvc("")))
+}
+
+// Static configs that share an integration name are refcounted in the
+// index, so Has stays true through partial removals and only flips false
+// when the last one goes away.
+func TestStaticConfigIndexRefcountThroughConfigMgr(t *testing.T) {
+	mockResolver := MockSecretResolver{}
+	idx := listeners.NewStaticConfigIndex()
+
+	cm := newReconcilingConfigManager(&mockResolver, nil, idx)
+
+	staticRedis1 := integration.Config{Name: "redis"}
+	staticRedis2 := integration.Config{Name: "redis", Instances: []integration.Data{integration.Data("port: 6380")}}
+
+	cm.processNewConfig(staticRedis1)
+	assert.True(t, idx.Has("redis"))
+
+	cm.processNewConfig(staticRedis2)
+	assert.True(t, idx.Has("redis"))
+
+	cm.processDelConfigs([]integration.Config{staticRedis1})
+	assert.True(t, idx.Has("redis"))
+
+	cm.processDelConfigs([]integration.Config{staticRedis2})
+	assert.False(t, idx.Has("redis"))
+}
+
 func TestResolveTemplateForService_ReportsToHealthPlatform(t *testing.T) {
 	mockResolver := MockSecretResolver{}
 	hp := healthplatformmock.Mock(t)
 
-	cm := newReconcilingConfigManager(&mockResolver, hp).(*reconcilingConfigManager)
+	cm := newReconcilingConfigManager(&mockResolver, hp, nil).(*reconcilingConfigManager)
 
 	tpl := integration.Config{
 		Name:          "postgres",
@@ -596,7 +678,7 @@ func TestResolveTemplateForService_ClearsHealthPlatformOnSuccess(t *testing.T) {
 	mockResolver := MockSecretResolver{}
 	hp := healthplatformmock.Mock(t)
 
-	cm := newReconcilingConfigManager(&mockResolver, hp).(*reconcilingConfigManager)
+	cm := newReconcilingConfigManager(&mockResolver, hp, nil).(*reconcilingConfigManager)
 
 	tpl := integration.Config{
 		Name:          "redis",

--- a/comp/core/autodiscovery/listeners/process.go
+++ b/comp/core/autodiscovery/listeners/process.go
@@ -29,16 +29,18 @@ import (
 // as services (i.e., processes with a non-nil Service property).
 type ProcessListener struct {
 	workloadmetaListener
-	tagger         tagger.Component
-	processFilters workloadfilter.FilterBundle
+	tagger            tagger.Component
+	processFilters    workloadfilter.FilterBundle
+	staticConfigIndex *StaticConfigIndex
 }
 
 // NewProcessListener returns a new ProcessListener.
 func NewProcessListener(options ServiceListernerDeps) (ServiceListener, error) {
 	const name = "ad-processlistener"
 	l := &ProcessListener{
-		tagger:         options.Tagger,
-		processFilters: options.Filter.GetProcessFilters([][]workloadfilter.ProcessFilter{{workloadfilter.ProcessCELGlobal}}),
+		tagger:            options.Tagger,
+		processFilters:    options.Filter.GetProcessFilters([][]workloadfilter.ProcessFilter{{workloadfilter.ProcessCELGlobal}}),
+		staticConfigIndex: options.StaticConfigIndex,
 	}
 	filter := workloadmeta.NewFilterBuilder().
 		SetSource(workloadmeta.SourceAll).
@@ -137,10 +139,11 @@ func (l *ProcessListener) createProcessService(entity workloadmeta.Entity) {
 		ports:    ports,
 		pid:      int(process.Pid),
 		// Host processes are accessible at localhost
-		hosts:  map[string]string{"host": "127.0.0.1"},
-		ready:  true,
-		tagger: l.tagger,
-		wmeta:  l.Store(),
+		hosts:             map[string]string{"host": "127.0.0.1"},
+		ready:             true,
+		tagger:            l.tagger,
+		wmeta:             l.Store(),
+		staticConfigIndex: l.staticConfigIndex,
 	}
 
 	svcID := buildSvcID(process.GetID())
@@ -149,14 +152,15 @@ func (l *ProcessListener) createProcessService(entity workloadmeta.Entity) {
 
 // ProcessService implements the Service interface for process entities.
 type ProcessService struct {
-	process  *workloadmeta.Process
-	tagsHash string
-	hosts    map[string]string
-	ports    []workloadmeta.ContainerPort
-	pid      int
-	ready    bool
-	tagger   tagger.Component
-	wmeta    workloadmeta.Component
+	process           *workloadmeta.Process
+	tagsHash          string
+	hosts             map[string]string
+	ports             []workloadmeta.ContainerPort
+	pid               int
+	ready             bool
+	tagger            tagger.Component
+	wmeta             workloadmeta.Component
+	staticConfigIndex *StaticConfigIndex
 }
 
 var _ Service = &ProcessService{}
@@ -234,8 +238,20 @@ func (s *ProcessService) HasFilter(_ workloadfilter.Scope) bool {
 }
 
 // FilterTemplates implements Service#FilterTemplates.
+//
+// In addition to the default AD-identifier matching filter, templates whose
+// integration name already has a scheduled non-template (static) config are
+// dropped so the static config wins. This dedup is intentionally scoped to
+// process services: users configure single-instance process integrations via
+// conf.d, and we don't want the dynamic process listener to schedule a second
+// instance behind their back.
 func (s *ProcessService) FilterTemplates(configs map[string]integration.Config) {
 	filterTemplatesMatched(s, configs)
+	for digest, cfg := range configs {
+		if s.staticConfigIndex.Has(cfg.Name) {
+			delete(configs, digest)
+		}
+	}
 }
 
 // GetExtraConfig returns extra configuration associated with the service.

--- a/comp/core/autodiscovery/listeners/process_test.go
+++ b/comp/core/autodiscovery/listeners/process_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 
+	adtypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
@@ -402,6 +404,76 @@ func TestProcessServiceEqual(t *testing.T) {
 
 	t.Run("different type", func(t *testing.T) {
 		assert.False(t, svc1.Equal(&WorkloadService{}))
+	})
+}
+
+func TestProcessServiceFilterTemplates_DedupesStaticConfigs(t *testing.T) {
+	process := &workloadmeta.Process{
+		EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindProcess, ID: "1234"},
+		Pid:      1234,
+		Service:  &workloadmeta.Service{GeneratedName: "redis"},
+	}
+
+	mkSvc := func(idx *StaticConfigIndex) *ProcessService {
+		return &ProcessService{
+			process:           process,
+			pid:               1234,
+			ready:             true,
+			staticConfigIndex: idx,
+		}
+	}
+
+	mkConfigs := func() map[string]integration.Config {
+		// Both templates carry the process AD identifier so the AD-identifier
+		// matching filter would keep them; the static-config filter is the
+		// only thing that should drop one of them.
+		return map[string]integration.Config{
+			"redis-digest": {
+				Name:          "redis",
+				ADIdentifiers: []string{string(adtypes.CelProcessIdentifier)},
+			},
+			"nginx-digest": {
+				Name:          "nginx",
+				ADIdentifiers: []string{string(adtypes.CelProcessIdentifier)},
+			},
+		}
+	}
+
+	t.Run("nil index keeps all templates", func(t *testing.T) {
+		configs := mkConfigs()
+		mkSvc(nil).FilterTemplates(configs)
+		assert.Contains(t, configs, "redis-digest")
+		assert.Contains(t, configs, "nginx-digest")
+	})
+
+	t.Run("empty index keeps all templates", func(t *testing.T) {
+		configs := mkConfigs()
+		mkSvc(NewStaticConfigIndex()).FilterTemplates(configs)
+		assert.Contains(t, configs, "redis-digest")
+		assert.Contains(t, configs, "nginx-digest")
+	})
+
+	t.Run("template is dropped when a static config of the same name exists", func(t *testing.T) {
+		idx := NewStaticConfigIndex()
+		idx.Add("redis")
+
+		configs := mkConfigs()
+		mkSvc(idx).FilterTemplates(configs)
+
+		assert.NotContains(t, configs, "redis-digest", "redis template should be deduplicated")
+		assert.Contains(t, configs, "nginx-digest", "nginx template should be preserved")
+	})
+
+	t.Run("template returns once the static config is removed", func(t *testing.T) {
+		idx := NewStaticConfigIndex()
+		idx.Add("redis")
+		idx.Remove("redis")
+
+		configs := mkConfigs()
+		mkSvc(idx).FilterTemplates(configs)
+
+		assert.Contains(t, configs, "redis-digest")
+		assert.Contains(t, configs, "nginx-digest")
 	})
 }
 

--- a/comp/core/autodiscovery/listeners/static_config_index.go
+++ b/comp/core/autodiscovery/listeners/static_config_index.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package listeners
+
+import "sync"
+
+// StaticConfigIndex is a refcounted set of integration names that currently
+// have at least one scheduled non-template (static) config. It is shared
+// between the autodiscovery config manager (writer) and listeners that need
+// to deduplicate against static configs (reader). Reads are safe to perform
+// while the writer holds its own mutex; the index has its own RWMutex and
+// must not be locked by any caller.
+//
+// A nil pointer is safe to use: Has always returns false, and Add/Remove are
+// no-ops.
+type StaticConfigIndex struct {
+	mu     sync.RWMutex
+	counts map[string]int
+}
+
+// NewStaticConfigIndex returns an empty index.
+func NewStaticConfigIndex() *StaticConfigIndex {
+	return &StaticConfigIndex{counts: map[string]int{}}
+}
+
+// Add increments the refcount for the given integration name. It returns true
+// if the name transitioned from absent to present so callers can trigger
+// reconciliation only on the meaningful edge.
+func (i *StaticConfigIndex) Add(name string) bool {
+	if i == nil {
+		return false
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.counts[name]++
+	return i.counts[name] == 1
+}
+
+// Remove decrements the refcount for the given integration name. It returns
+// true if the name transitioned from present to absent. Remove on an absent
+// name is a no-op and returns false.
+func (i *StaticConfigIndex) Remove(name string) bool {
+	if i == nil {
+		return false
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.counts[name] == 0 {
+		return false
+	}
+	i.counts[name]--
+	if i.counts[name] == 0 {
+		delete(i.counts, name)
+		return true
+	}
+	return false
+}
+
+// Has reports whether at least one static config with the given integration
+// name is currently scheduled.
+func (i *StaticConfigIndex) Has(name string) bool {
+	if i == nil {
+		return false
+	}
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.counts[name] > 0
+}

--- a/comp/core/autodiscovery/listeners/static_config_index_test.go
+++ b/comp/core/autodiscovery/listeners/static_config_index_test.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package listeners
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStaticConfigIndex_AddRemoveHas(t *testing.T) {
+	idx := NewStaticConfigIndex()
+
+	assert.False(t, idx.Has("redis"))
+
+	// First add transitions 0->1.
+	assert.True(t, idx.Add("redis"))
+	assert.True(t, idx.Has("redis"))
+
+	// Second add for the same name does not transition.
+	assert.False(t, idx.Add("redis"))
+	assert.True(t, idx.Has("redis"))
+
+	// First remove decrements but the name is still present.
+	assert.False(t, idx.Remove("redis"))
+	assert.True(t, idx.Has("redis"))
+
+	// Second remove transitions 1->0.
+	assert.True(t, idx.Remove("redis"))
+	assert.False(t, idx.Has("redis"))
+
+	// Remove on an absent name is a no-op.
+	assert.False(t, idx.Remove("redis"))
+	assert.False(t, idx.Remove("never-added"))
+}
+
+func TestStaticConfigIndex_NilSafe(t *testing.T) {
+	var idx *StaticConfigIndex
+	assert.False(t, idx.Has("anything"))
+	assert.False(t, idx.Add("anything"))
+	assert.False(t, idx.Remove("anything"))
+}
+
+func TestStaticConfigIndex_IndependentNames(t *testing.T) {
+	idx := NewStaticConfigIndex()
+
+	idx.Add("redis")
+	idx.Add("postgres")
+
+	assert.True(t, idx.Has("redis"))
+	assert.True(t, idx.Has("postgres"))
+	assert.False(t, idx.Has("mysql"))
+
+	assert.True(t, idx.Remove("redis"))
+	assert.False(t, idx.Has("redis"))
+	assert.True(t, idx.Has("postgres"))
+}

--- a/comp/core/autodiscovery/listeners/types.go
+++ b/comp/core/autodiscovery/listeners/types.go
@@ -70,11 +70,12 @@ type Config interface {
 
 // ServiceListernerDeps are the service listerner dependencies
 type ServiceListernerDeps struct {
-	Config    Config
-	Telemetry *telemetry.Store
-	Tagger    tagger.Component
-	Filter    workloadfilter.Component
-	Wmeta     option.Option[workloadmeta.Component]
+	Config            Config
+	Telemetry         *telemetry.Store
+	Tagger            tagger.Component
+	Filter            workloadfilter.Component
+	Wmeta             option.Option[workloadmeta.Component]
+	StaticConfigIndex *StaticConfigIndex
 }
 
 // ServiceListenerFactory builds a service listener


### PR DESCRIPTION
### What does this PR do?

Introduce a shared `StaticConfigIndex` that tracks integration names with a scheduled non-template (static) config. `ProcessService.FilterTemplates` consults the index and drops any dynamically discovered template whose name already has a static config, preventing duplicate checks against the same process. Scoped to `ProcessService` only, other listeners are unaffected.

### Motivation

A user-defined static check (e.g. `conf.d/redis.d/conf.yaml`) and a process discovered as the same integration would otherwise both schedule against the same target. With this change the static config wins.

### Describe how you validated your changes

Unit Tests

### Additional Notes

Covers the common startup ordering where static configs are loaded before the process listener begins.

Runtime ordering (static config arrives or leaves while a dynamic resolved template is already scheduled) is left for a follow-up,  a TODO in `configmgr.go` marks the spot; the index already has the state, only the re-reconciliation hook needs to be wired. Unsure how this interacts with remote-config received configs.

**Update**: By default `autoconf_config_files_poll` is false, only 0.3% of Agent's have this enabled. We can still consider this edge case for "static" configs arriving later for sources like RC. 