### PR TITLE
Allow Bucket Counts <= Explicit Bound Counts

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/metrics/default_mapper.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/default_mapper.go
@@ -340,12 +340,12 @@ func (m *defaultMapper) getSketchBuckets(
 
 	bucketCounts := p.BucketCounts()
 	explicitBounds := p.ExplicitBounds()
-	// Validate the OTel invariant: N bucket counts require exactly N-1 explicit bounds.
-	// Malformed senders can violate this; guard before the loop to prevent an index panic.
-	if bucketCounts.Len() > 0 && bucketCounts.Len() != explicitBounds.Len()+1 {
-		return fmt.Errorf("histogram %q has %d bucket counts but %d explicit bounds (expected counts == bounds+1)",
+	// Having more bucket counts than explicit bounds can cause a panic
+	if bucketCounts.Len() > explicitBounds.Len()+1 {
+		return fmt.Errorf("histogram %q has %d bucket counts but %d explicit bounds (expected counts <= bounds+1)",
 			pointDims.name, bucketCounts.Len(), explicitBounds.Len())
 	}
+
 	// From the spec (https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/data-model.md#histogram):
 	// > A Histogram without buckets conveys a population in terms of only the sum and count,
 	// > and may be interpreted as a histogram with single bucket covering (-Inf, +Inf).
@@ -479,8 +479,8 @@ func (m *defaultMapper) getLegacyBuckets(
 	ts := uint64(p.Timestamp())
 	// We have a single metric, 'bucket', which is tagged with the bucket bounds. See:
 	// https://github.com/DataDog/integrations-core/blob/7.30.1/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transformers/histogram.py
-	if p.BucketCounts().Len() > 0 && p.BucketCounts().Len() != p.ExplicitBounds().Len()+1 {
-		return fmt.Errorf("histogram %q has %d bucket counts but %d explicit bounds (expected counts == bounds+1)",
+	if p.BucketCounts().Len() > p.ExplicitBounds().Len()+1 {
+		return fmt.Errorf("histogram %q has %d bucket counts but %d explicit bounds (expected counts <= bounds+1)",
 			pointDims.name, p.BucketCounts().Len(), p.ExplicitBounds().Len())
 	}
 	baseBucketDims := pointDims.WithSuffix("bucket")

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go
@@ -2222,11 +2222,10 @@ func TestLegacyBucketsTags(t *testing.T) {
 	assert.ElementsMatch(t, seriesTwo[0].tags, []string{"lower_bound:-inf", "upper_bound:1.0"})
 }
 
-// TestMalformedHistogramNoPanic verifies that histograms violating the OTel
-// invariant (counts == bounds+1) are rejected without panicking, covering both
-// the counts > bounds+1 case (which would panic in getBounds) and the
-// counts < bounds+1 case.
-func TestMalformedHistogramNoPanic(t *testing.T) {
+// TestMalformedHistogram verifies that histograms with bucket counts
+// greater than bounds+1 are rejected without panicking. Histograms
+// with bucket counts less than bounds+1 and greater than 0 are accepted.
+func TestMalformedHistogram(t *testing.T) {
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
 	mapper := tr.getMapper().(*defaultMapper)
@@ -2236,16 +2235,31 @@ func TestMalformedHistogramNoPanic(t *testing.T) {
 		name         string
 		bucketCounts []uint64
 		bounds       []float64
+		expectError  bool
 	}{
 		{
 			name:         "counts > bounds+1",
 			bucketCounts: []uint64{1, 2},
 			bounds:       []float64{},
+			expectError:  true,
+		},
+		{
+			name:         "counts == bounds+1",
+			bucketCounts: []uint64{1, 2},
+			bounds:       []float64{1},
+			expectError:  false,
 		},
 		{
 			name:         "counts < bounds+1",
+			bucketCounts: []uint64{1, 2},
+			bounds:       []float64{0.5, 1.0},
+			expectError:  false,
+		},
+		{
+			name:         "counts < bounds",
 			bucketCounts: []uint64{1},
 			bounds:       []float64{0.5, 1.0},
+			expectError:  false,
 		},
 	}
 
@@ -2261,16 +2275,26 @@ func TestMalformedHistogramNoPanic(t *testing.T) {
 			assert.NotPanics(t, func() {
 				legacyErr = mapper.getLegacyBuckets(ctx, consumer, dims, p, true)
 			})
-			assert.Error(t, legacyErr)
-			assert.Empty(t, consumer.metrics)
+			if tc.expectError {
+				assert.Error(t, legacyErr)
+				assert.Empty(t, consumer.metrics)
+			} else {
+				assert.NoError(t, legacyErr)
+				assert.NotEmpty(t, consumer.metrics)
+			}
 
 			fullConsumer := &mockFullConsumer{}
 			var sketchErr error
 			assert.NotPanics(t, func() {
 				sketchErr = mapper.getSketchBuckets(ctx, fullConsumer, dims, p, histogramInfo{ok: false}, true)
 			})
-			assert.Error(t, sketchErr)
-			assert.Empty(t, fullConsumer.sketches)
+			if tc.expectError {
+				assert.Error(t, sketchErr)
+				assert.Empty(t, fullConsumer.sketches)
+			} else {
+				assert.NoError(t, sketchErr)
+				assert.NotEmpty(t, fullConsumer.sketches)
+			}
 		})
 	}
 }


### PR DESCRIPTION
TODO: fill in PR details

### What does this PR do?
Fix errors sending metrics that will not panic, but are being unnecessarily blocked:
```
error: histogram "jobrunr.jobs.active" has 28 bucket counts but 28 explicit bounds (expected counts == bounds+1)
```

### Motivation

### Describe how you validated your changes

### Additional Notes
