### PR TITLE
Apply `testing/synctest` to `TestHighPriorityTransaction`

### DIFF
--- a/comp/forwarder/defaultforwarder/forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_test.go
@@ -824,13 +824,14 @@ func syncTestHighPriorityTransactionTendency(t *testing.T) {
 }
 
 func TestHighPriorityTransaction(t *testing.T) {
+	synctest.Test(t, syncTestHighPriorityTransaction)
+}
+
+func syncTestHighPriorityTransaction(t *testing.T) {
 	var receivedRequests = make(map[string]struct{})
-	var mutex sync.Mutex
 	var requestChan = make(chan (string))
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		mutex.Lock()
-		defer mutex.Unlock()
+	transport := handlerTransport(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
@@ -844,23 +845,21 @@ func TestHighPriorityTransaction(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			requestChan <- bodyStr
 		}
-	}))
+	})
 
 	mockConfig := mock.New(t)
 	mockConfig.SetWithoutSource("forwarder_backoff_max", 0.5)
 	mockConfig.SetWithoutSource("forwarder_max_concurrent_requests", 1)
 
-	oldFlushInterval := flushInterval
-	flushInterval = 500 * time.Millisecond
-	defer func() { flushInterval = oldFlushInterval }()
-
 	log := logmock.New(t)
-	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{ts.URL: {configUtils.NewAPIKeys("path", "api_key1")}})
+	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{"http://test.invalid": {configUtils.NewAPIKeys("path", "api_key1")}})
 	require.NoError(t, err)
 
 	secrets := secretsmock.New(t)
 	options := NewOptionsWithResolvers(mockConfig, log, r)
+	options.DisableAPIKeyChecking = true // Disable API key checking so no health check goroutine is started
 	options.Secrets = secrets
+	options.transport = transport
 	f := NewDefaultForwarder(mockConfig, log, options)
 
 	f.Start()


### PR DESCRIPTION
### What does this PR do?
Cuts Go unit test execution time by another ~9s:
- leverage the `handlerTransport` adapter and `Options.transport` injection introduced in #50180 to replace the `httptest.Server` with an in-process, channel-backed transport: channel operations are considered durably idle by `synctest`, whereas TCP syscalls are not,
- remove the `flushInterval` override (500ms -> production default 5s) since it only existed to limit wall-clock cost,
- set `DisableAPIKeyChecking = true` to suppress the health-check goroutine that makes real DNS lookups (not durably idle) and would deadlock the `synctest` "bubble",
- wrap `TestHighPriorityTransaction` in `synctest.Test` so the fake clock drives the retry flush ticker.

### Motivation
The test retried three transactions through a 500ms flush loop, spending 8-11s per run on real-time waits.
The `synctest` "bubble" advances the fake clock instantly once all goroutines are durably blocked.

### Describe how you validated your changes
Measured with:
```
go test -tags test -v -count 10 \
    -run TestHighPriorityTransaction$ \
    ./comp/forwarder/defaultforwarder/
```
```
before (10 samples): 9.53 10.52 11.02 7.54 8.52 10.03 9.03 8.02 8.52 11.05 s
                     avg 9.38 s
```
```
after  (10 samples): 0.05 0.05 0.05 0.05 0.04 0.05 0.04 0.05 0.05 0.05 s
                     avg 0.05 s
```

### Additional Notes
https://go.dev/blog/synctest