### PR TITLE
Remove gorilla/mux from the observability middleware

### DIFF
--- a/comp/api/api/apiimpl/observability/BUILD.bazel
+++ b/comp/api/api/apiimpl/observability/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//comp/core/telemetry/def",
         "//pkg/util/log",
         "@com_github_benbjohnson_clock//:clock",
-        "@com_github_gorilla_mux//:mux",
         "@com_github_urfave_negroni//:negroni",
     ],
 )
@@ -32,7 +31,6 @@ go_test(
         "//comp/core/telemetry/mock",
         "//pkg/util/fxutil",
         "@com_github_benbjohnson_clock//:clock",
-        "@com_github_gorilla_mux//:mux",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/comp/api/api/apiimpl/observability/logging.go
+++ b/comp/api/api/apiimpl/observability/logging.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/gorilla/mux"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -32,12 +31,12 @@ func getLogFunc(code int) logFunc {
 }
 
 // LogResponseHandler is a middleware that logs the response code and other various information about the request
-func LogResponseHandler(servername string) mux.MiddlewareFunc {
+func LogResponseHandler(servername string) func(http.Handler) http.Handler {
 	return logResponseHandler(servername, getLogFunc, clock.New())
 }
 
 // logResponseHandler takes getLogFunc as a parameter to allow for testing
-func logResponseHandler(serverName string, getLogFunc func(int) logFunc, clock clock.Clock) mux.MiddlewareFunc {
+func logResponseHandler(serverName string, getLogFunc func(int) logFunc, clock clock.Clock) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var statusCode int

--- a/comp/api/api/apiimpl/observability/telemetry.go
+++ b/comp/api/api/apiimpl/observability/telemetry.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/gorilla/mux"
 
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 )
@@ -32,10 +31,10 @@ type telemetryMiddlewareFactory struct {
 
 // TelemetryMiddlewareFactory creates a telemetry middleware tagged with a given server name
 type TelemetryMiddlewareFactory interface {
-	Middleware(serverName string) mux.MiddlewareFunc
+	Middleware(serverName string) func(http.Handler) http.Handler
 }
 
-func (th *telemetryMiddlewareFactory) Middleware(serverName string) mux.MiddlewareFunc {
+func (th *telemetryMiddlewareFactory) Middleware(serverName string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var statusCode int
@@ -47,10 +46,9 @@ func (th *telemetryMiddlewareFactory) Middleware(serverName string) mux.Middlewa
 			var duration time.Duration
 			next = timeHandler(th.clock, &duration)(next)
 
-			// Plant a route capture in the context so that CaptureRouteTemplateMiddleware
-			// (registered inside the gorilla/mux router) can fill it with the matched route
-			// template. This avoids high-cardinality tags from user-provided path values such
-			// as /{component}/status where {component} varies per request.
+			// Plant a route capture in the context so that WrapWithRouteTemplate (called at
+			// handler registration) can fill it with the matched route template. This avoids
+			// high-cardinality metric tags from path variables such as /{component}/status.
 			r, capture := withRouteCapture(r)
 			next.ServeHTTP(w, r)
 

--- a/comp/api/api/apiimpl/observability/telemetry_test.go
+++ b/comp/api/api/apiimpl/observability/telemetry_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -65,12 +64,11 @@ func TestTelemetryMiddleware(t *testing.T) {
 				w.WriteHeader(tc.code)
 			}
 
-			// Use a gorilla/mux router with CaptureRouteTemplateMiddleware so the telemetry
-			// middleware can resolve route templates instead of raw user-provided paths.
-			router := mux.NewRouter()
-			router.Use(CaptureRouteTemplateMiddleware)
-			router.Handle(tc.path, tcHandler).Methods(tc.method)
-			server := httptest.NewServer(telemetryHandler(router))
+			// Use WrapWithRouteTemplate so the telemetry middleware resolves the route
+			// template instead of the raw request path for the metric tag.
+			mux := http.NewServeMux()
+			mux.Handle(tc.method+" "+tc.path, WrapWithRouteTemplate("", tc.path, tcHandler))
+			server := httptest.NewServer(telemetryHandler(mux))
 			defer server.Close()
 
 			url := url.URL{
@@ -113,10 +111,9 @@ func TestTelemetryMiddlewareUnmatchedRouteUsesUnknown(t *testing.T) {
 	tm := newTelemetryMiddlewareFactory(telemetry, clock.NewMock(), NoopAuthTagGetter)
 	telemetryHandler := tm.Middleware("test")
 
-	// No routes registered — any request will not match the capture middleware.
-	router := mux.NewRouter()
-	router.Use(CaptureRouteTemplateMiddleware)
-	server := httptest.NewServer(telemetryHandler(router))
+	// No routes registered — no WrapWithRouteTemplate wrapping, so template stays empty.
+	mux := http.NewServeMux()
+	server := httptest.NewServer(telemetryHandler(mux))
 	defer server.Close()
 
 	resp, err := server.Client().Get(server.URL + "/arbitrary/user/input")

--- a/comp/api/api/apiimpl/observability/utils.go
+++ b/comp/api/api/apiimpl/observability/utils.go
@@ -12,15 +12,14 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/gorilla/mux"
 	"github.com/urfave/negroni"
 )
 
-// routeCaptureKey is the context key used to share route template capture between
-// the outer telemetry middleware and the inner CaptureRouteTemplateMiddleware.
+// routeCaptureKey is the context key used to share the route template between
+// the outer telemetry middleware and the per-handler wrapper.
 type routeCaptureKey struct{}
 
-// routeCapture holds the matched route template filled in from inside gorilla/mux context.
+// routeCapture holds the matched route template.
 type routeCapture struct {
 	template string
 }
@@ -35,34 +34,29 @@ func extractPath(r *http.Request) string {
 	return reqURL.Path
 }
 
-// CaptureRouteTemplateMiddlewareWithPrefix returns a gorilla/mux middleware that captures the
-// matched route template and prepends prefix to it. Use this when the router is mounted via
-// http.StripPrefix so that the full request path is reflected in the metric tag.
-//
-// Must be registered via gorilla/mux Router.Use() so that it runs inside the routing context
-// where mux.CurrentRoute returns the matched route.
-func CaptureRouteTemplateMiddlewareWithPrefix(prefix string) mux.MiddlewareFunc {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if capture, ok := r.Context().Value(routeCaptureKey{}).(*routeCapture); ok {
-				if route := mux.CurrentRoute(r); route != nil {
-					if template, err := route.GetPathTemplate(); err == nil {
-						capture.template = prefix + template
-					}
-				}
-			}
-			next.ServeHTTP(w, r)
-		})
+// SetRouteTemplate stores template in the route capture context, if one is present.
+// Callers that know the matched route pattern call this after routing so the telemetry
+// middleware can use the template instead of the raw request path for metric tags.
+func SetRouteTemplate(r *http.Request, template string) {
+	if capture, ok := r.Context().Value(routeCaptureKey{}).(*routeCapture); ok {
+		capture.template = template
 	}
 }
 
-// When the router is mounted under http.StripPrefix, use CaptureRouteTemplateMiddlewareWithPrefix
-// instead to preserve the full path in the metric tag.
-var CaptureRouteTemplateMiddleware mux.MiddlewareFunc = CaptureRouteTemplateMiddlewareWithPrefix("")
+// WrapWithRouteTemplate wraps h, storing prefix+template in the capture context
+// so the telemetry middleware can use it for metric cardinality reduction instead of
+// the raw request path. Use this at handler registration time with net/http ServeMux.
+// Pass prefix="" when the handler is not mounted under http.StripPrefix.
+func WrapWithRouteTemplate(prefix, template string, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		SetRouteTemplate(r, prefix+template)
+		h.ServeHTTP(w, r)
+	})
+}
 
 // extractStatusCodeHandler is a middleware which extracts the status code from the response,
 // and stores it in the provided pointer.
-func extractStatusCodeHandler(status *int) mux.MiddlewareFunc {
+func extractStatusCodeHandler(status *int) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			lrw := negroni.NewResponseWriter(w)
@@ -74,7 +68,7 @@ func extractStatusCodeHandler(status *int) mux.MiddlewareFunc {
 
 // timeHandler is a middleware which measures the duration of the request,
 // and stores it in the provided pointer.
-func timeHandler(clock clock.Clock, duration *time.Duration) mux.MiddlewareFunc {
+func timeHandler(clock clock.Clock, duration *time.Duration) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := clock.Now()

--- a/comp/api/api/apiimpl/observability/utils_test.go
+++ b/comp/api/api/apiimpl/observability/utils_test.go
@@ -91,7 +91,7 @@ func TestSetRouteTemplate(t *testing.T) {
 		assert.Equal(t, "/foo/{id}", capture.template)
 	})
 
-	t.Run("no-op when no capture in context", func(t *testing.T) {
+	t.Run("no-op when no capture in context", func(_ *testing.T) {
 		r := httptest.NewRequest("GET", "/", nil)
 		// must not panic
 		SetRouteTemplate(r, "/foo/{id}")

--- a/comp/api/api/apiimpl/observability/utils_test.go
+++ b/comp/api/api/apiimpl/observability/utils_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,73 +41,60 @@ func TestExtractPath(t *testing.T) {
 	})
 }
 
-func TestCaptureRouteTemplateMiddleware(t *testing.T) {
+func TestWrapWithRouteTemplate(t *testing.T) {
 	testCases := []struct {
-		routeTemplate string
-		requestPath   string
-		expected      string
+		prefix   string
+		template string
+		expected string
 	}{
-		{"/test", "/test", "/test"},
-		{"/test/", "/test/", "/test/"},
-		// Path parameters are returned as the template, not the concrete values.
-		{"/test/{id}", "/test/1", "/test/{id}"},
-		{"/test/{id}", "/test/2?arg=value", "/test/{id}"},
+		{"", "/test", "/test"},
+		{"", "/test/", "/test/"},
+		{"", "/test/{id}", "/test/{id}"},
+		{"/agent", "/{component}/status", "/agent/{component}/status"},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.requestPath, func(t *testing.T) {
-			// Plant a capture in the context (normally done by telemetry middleware)
+		t.Run(tc.expected, func(t *testing.T) {
 			var capturedTemplate string
-			router := mux.NewRouter()
-			router.Use(CaptureRouteTemplateMiddleware)
-			router.HandleFunc(tc.routeTemplate, func(_ http.ResponseWriter, r *http.Request) {
+			handler := WrapWithRouteTemplate(tc.prefix, tc.template, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				if capture, ok := r.Context().Value(routeCaptureKey{}).(*routeCapture); ok {
 					capturedTemplate = capture.template
 				}
-			})
+			}))
 
-			r, capture := withRouteCapture(httptest.NewRequest("GET", "http://agent.host"+tc.requestPath, nil))
-			router.ServeHTTP(httptest.NewRecorder(), r)
+			r, capture := withRouteCapture(httptest.NewRequest("GET", "http://agent.host/test", nil))
+			handler.ServeHTTP(httptest.NewRecorder(), r)
 
 			assert.Equal(t, tc.expected, capture.template)
 			assert.Equal(t, tc.expected, capturedTemplate)
 		})
 	}
 
-	t.Run("with strip prefix - prefix is prepended to template", func(t *testing.T) {
-		// Simulate http.StripPrefix("/agent", router): the router only sees the path after the prefix,
-		// so the captured template must include the prefix to reflect the full request path.
-		router := mux.NewRouter()
-		router.Use(CaptureRouteTemplateMiddlewareWithPrefix("/agent"))
-		router.HandleFunc("/{component}/status", func(_ http.ResponseWriter, _ *http.Request) {})
-
-		// Mimic what http.StripPrefix does: strip "/agent" before handing off to the router.
-		strippedReq := httptest.NewRequest("GET", "http://agent.host/trace-agent/status", nil)
-		r, capture := withRouteCapture(strippedReq)
-		router.ServeHTTP(httptest.NewRecorder(), r)
-
-		assert.Equal(t, "/agent/{component}/status", capture.template)
-	})
-
-	t.Run("no matching route leaves capture empty", func(t *testing.T) {
-		router := mux.NewRouter()
-		router.Use(CaptureRouteTemplateMiddleware)
-		r, capture := withRouteCapture(httptest.NewRequest("GET", "http://agent.host/no-such-route", nil))
-		router.ServeHTTP(httptest.NewRecorder(), r)
-		assert.Equal(t, "", capture.template)
-	})
-
 	t.Run("no capture in context is a no-op", func(t *testing.T) {
-		// CaptureRouteTemplateMiddleware is safe to call without a capture in context
-		router := mux.NewRouter()
-		router.Use(CaptureRouteTemplateMiddleware)
-		router.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
+		called := false
+		handler := WrapWithRouteTemplate("", "/test", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			called = true
 			w.WriteHeader(http.StatusOK)
-		})
+		}))
 		req := httptest.NewRequest("GET", "http://agent.host/test", nil)
 		rr := httptest.NewRecorder()
-		router.ServeHTTP(rr, req)
+		handler.ServeHTTP(rr, req)
+		assert.True(t, called)
 		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
+func TestSetRouteTemplate(t *testing.T) {
+	t.Run("fills capture when present", func(t *testing.T) {
+		r, capture := withRouteCapture(httptest.NewRequest("GET", "/", nil))
+		SetRouteTemplate(r, "/foo/{id}")
+		assert.Equal(t, "/foo/{id}", capture.template)
+	})
+
+	t.Run("no-op when no capture in context", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		// must not panic
+		SetRouteTemplate(r, "/foo/{id}")
 	})
 }
 

--- a/comp/api/api/apiimpl/server_cmd.go
+++ b/comp/api/api/apiimpl/server_cmd.go
@@ -44,8 +44,17 @@ func (server *apiServer) startCMDServer(
 	// Validate token for every request
 	agentMux.Use(server.ipc.HTTPMiddleware)
 	// Fill route template captures for the telemetry middleware (reduces metric cardinality).
-	// Pass "/agent" to preserve the full path since agentMux is mounted via http.StripPrefix("/agent", ...).
-	agentMux.Use(observability.CaptureRouteTemplateMiddlewareWithPrefix("/agent"))
+	// Prepend "/agent" since agentMux is mounted via http.StripPrefix("/agent", ...).
+	agentMux.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if route := gorilla.CurrentRoute(r); route != nil {
+				if template, err := route.GetPathTemplate(); err == nil {
+					observability.SetRouteTemplate(r, "/agent"+template)
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	})
 
 	cmdMux := http.NewServeMux()
 	cmdMux.Handle(

--- a/comp/api/api/apiimpl/server_ipc.go
+++ b/comp/api/api/apiimpl/server_ipc.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"time"
 
+	gorilla "github.com/gorilla/mux"
+
 	configendpoint "github.com/DataDog/datadog-agent/comp/api/api/apiimpl/internal/config"
 	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl/listener"
 	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl/observability"
@@ -27,8 +29,18 @@ func (server *apiServer) startIPCServer(ipcServerAddr string, tmf observability.
 	server.ipcAddr = ipcListener.Addr()
 
 	configEndpointMux := configendpoint.GetConfigEndpointMuxCore(server.cfg)
-	// Pass "/config/v1" to preserve the full path since configEndpointMux is mounted via http.StripPrefix("/config/v1", ...).
-	configEndpointMux.Use(observability.CaptureRouteTemplateMiddlewareWithPrefix("/config/v1"))
+	// Fill route template captures for the telemetry middleware (reduces metric cardinality).
+	// Prepend "/config/v1" since configEndpointMux is mounted via http.StripPrefix("/config/v1", ...).
+	configEndpointMux.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if route := gorilla.CurrentRoute(r); route != nil {
+				if template, err := route.GetPathTemplate(); err == nil {
+					observability.SetRouteTemplate(r, "/config/v1"+template)
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	})
 
 	ipcMux := http.NewServeMux()
 	ipcMux.Handle(


### PR DESCRIPTION
### What does this PR do?

Removes `gorilla/mux` from the `comp/api/api/apiimpl/observability` package as a first step toward eliminating `gorilla/mux` from the agent entirely in favour of the standard library `net/http`.

**Bridge (temporary):** `server_cmd.go` and `server_ipc.go` still use a gorilla router. They now host a small inline gorilla middleware that reads `CurrentRoute` from gorilla's context and calls `observability.SetRouteTemplate` — keeping observability behaviour identical while the gorilla dependency is confined to files that already import it.

### Motivation

`gorilla/mux` is unmaintained (archived in 2023). The goal is to replace it with the standard library `net/http`, which since Go 1.22 supports method-based routing, path variables (`{name}`), and prefix matching — covering everything the agent uses gorilla for. This PR is the first step: it makes the observability middleware router-agnostic so it can work with both gorilla (bridge) and net/http (future).

### Describe how you validated your changes

- All 32 unit tests in the observability package pass (`dda inv test --targets=./comp/api/api/apiimpl/observability/...`)
- Full agent build passes (`dda inv agent.build`)
- All pre-push hooks pass (go-mod-tidy, go-linter, go-test)

### Additional Notes

The gorilla `router.Use()` call still accepts `func(http.Handler) http.Handler` values because `mux.MiddlewareFunc` has `func(http.Handler) http.Handler` as its underlying type — Go's assignability rules allow passing one for the other without explicit conversion, so no callers needed updating.