### PR TITLE
Apply `testing/synctest` to `TestTransactionEventHandlersOnRetry`

### DIFF
--- a/comp/forwarder/defaultforwarder/forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_test.go
@@ -590,13 +590,13 @@ func TestTransactionEventHandlers(t *testing.T) {
 }
 
 func TestTransactionEventHandlersOnRetry(t *testing.T) {
+	synctest.Test(t, syncTestTransactionEventHandlersOnRetry)
+}
+
+func syncTestTransactionEventHandlersOnRetry(t *testing.T) {
 	requests := atomic.NewInt64(0)
 
-	mux := http.NewServeMux()
-	mux.HandleFunc(endpoints.V1ValidateEndpoint.Route, func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	mux.HandleFunc(endpoints.SeriesEndpoint.Route, func(w http.ResponseWriter, _ *http.Request) {
+	transport := handlerTransport(func(w http.ResponseWriter, _ *http.Request) {
 		if v := requests.Inc(); v == 1 {
 			w.WriteHeader(http.StatusInternalServerError)
 		} else {
@@ -604,18 +604,15 @@ func TestTransactionEventHandlersOnRetry(t *testing.T) {
 		}
 	})
 
-	ts := httptest.NewServer(mux)
-	defer ts.Close()
-
 	mockConfig := mock.New(t)
-	mockConfig.SetWithoutSource("dd_url", ts.URL)
-
 	log := logmock.New(t)
-	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{ts.URL: {configUtils.NewAPIKeys("path", "api_key1")}})
+	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{"http://test.invalid": {configUtils.NewAPIKeys("path", "api_key1")}})
 	require.NoError(t, err)
 	secrets := secretsmock.New(t)
 	options := NewOptionsWithResolvers(mockConfig, log, r)
+	options.DisableAPIKeyChecking = true // Disable API key checking so no health check goroutine is started
 	options.Secrets = secrets
+	options.transport = transport
 	f := NewDefaultForwarder(mockConfig, log, options)
 
 	_ = f.Start()


### PR DESCRIPTION
### What does this PR do?
Cuts Go unit test execution time by another ~5s:
- leverage the `handlerTransport` adapter and `Options.transport` injection introduced in #50180 to replace the `httptest.Server` with an in-process, channel-backed transport: channel operations are considered durably idle by `synctest`, whereas TCP syscalls are not,
- set `DisableAPIKeyChecking = true` to suppress the health-check goroutine that makes real DNS lookups (not durably idle) and would deadlock the `synctest` 'bubble' => this also eliminates the need for the separate validate-endpoint handler the original test served,
- wrap `TestTransactionEventHandlersOnRetry` in `synctest.Test` so the fake clock drives the retry backoff timer.

### Motivation
The test blocked on a 5s retry backoff waiting for a failed transaction to be retried.
The `synctest` "bubble" advances the fake clock instantly once all goroutines are durably blocked.

### Describe how you validated your changes
Measured with:
```
go test -tags test -v -count 10 \
    -run TestTransactionEventHandlersOnRetry$ \
    ./comp/forwarder/defaultforwarder/
```
```
before (10 samples): 5.08 5.12 5.04 5.08 5.08 5.06 5.03 5.11 5.05 5.03 s
                     avg 5.07 s
```
```
after  (10 samples): 0.04 0.04 0.04 0.04 0.04 0.04 0.04 0.04 0.04 0.05 s
                     avg 0.04 s
```

### Additional Notes
https://go.dev/blog/synctest