### PR TITLE
Raise default Bazel disk cache GC cap from 5G to 30G

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,7 +16,7 @@ startup --max_idle_secs=28800 # Keep the server alive for at most 8 hours of ina
 common --@rules_python//python/config_settings:bootstrap_impl=script # https://github.com/bazel-contrib/rules_python/blob/main/BZLMOD_SUPPORT.md
 common --check_direct_dependencies=error # Escalate any bypassed `bazel_dep` to a resolution failure
 common --enable_platform_specific_config # Supported OS identifiers are linux, macos, windows, freebsd, and openbsd
-common --experimental_disk_cache_gc_max_size=5G # Cap applied whenever --disk_cache is also set, no-op otherwise
+common --experimental_disk_cache_gc_max_size=30G # Cap applied whenever --disk_cache is also set, no-op otherwise. Override in user.bazelrc (50G good, 100G ideal)
 common --experimental_proto_descriptor_sets_include_source_info # Preserve comments in generated pb.go
 common --experimental_strict_repo_env # Do not leak uncontrolled environment variables into repository rules
 common --experimental_ui_max_stdouterr_bytes=1073741819 # why?


### PR DESCRIPTION
### What does this PR do?

Bumps the repo-wide default of `--experimental_disk_cache_gc_max_size` in `.bazelrc` from `5G` to `30G`.

### Motivation

A full `datadog-agent` build set (agent, system-probe, eBPF programs, Rust components, tests across configurations) easily exceeds 5 GB of compiled outputs. With the GC cap at 5 GB, blobs that an in-flight or follow-up action expects to read are evicted before they are consumed, forcing Bazel to re-run the action that produced the missing blob (and any prerequisites that were also evicted). The symptom is "the disk cache isn't helping" even when caching is configured correctly.

30 GB is the minimum value that empirically avoids this eviction loop on a single full `bazel build //...` / `bazel test //...` run, while still being modest enough not to surprise developers on disk-constrained machines. Larger values (50 GB / 100 GB) remain available as opt-in overrides via `user.bazelrc` and are documented on the [Bazel's cache configuration](https://datadoghq.atlassian.net/wiki/spaces/ABLD/pages/6471582772/Bazel+s+cache+configuration) Confluence page.

### Describe how you validated your changes

No code change — only a numeric default in the team-wide `.bazelrc`. Behavior change is purely "Bazel keeps more local cache before garbage-collecting"; the flag itself is unchanged and Bazel CI/dev workflows treat it identically.