### PR TITLE
[AGENTRUN-1271] packaging/aix: drop --rebuild from trace-agent build

### DIFF
--- a/packaging/aix/stages/04-agent.sh
+++ b/packaging/aix/stages/04-agent.sh
@@ -122,7 +122,7 @@ log "agent binary build complete: $STAGING/opt/datadog-agent/bin/agent/agent"
 
 log "Building trace-agent binary via inv trace-agent.build"
 cd /opt/datadog-agent
-python3.12 -m invoke trace-agent.build --rebuild
+python3.12 -m invoke trace-agent.build
 mkdir -p "$STAGING/opt/datadog-agent/embedded/bin"
 rm -f "$STAGING/opt/datadog-agent/embedded/bin/trace-agent"
 cp /opt/datadog-agent/bin/trace-agent/trace-agent "$STAGING/opt/datadog-agent/embedded/bin/trace-agent"


### PR DESCRIPTION
### What does this PR do?

Removes `--rebuild` from the `inv trace-agent.build` invocation in `04-agent.sh`.

### Motivation

`--rebuild` maps to `go build -a`, which forces recompilation of every package regardless of the Go build cache. On AIX POWER8, a full rebuild takes 30–60 minutes. The build cache at `$GOCACHE` (`/opt/dd-build/gocache`) already persists across runs, so incremental builds only recompile changed packages. The agent build doesn't use `--rebuild` for the same reason.

### Describe how you validated your changes

N/A — one-line removal of a flag; the change to incremental builds is the intended behaviour.

### Additional Notes

N/A