### PR TITLE
test/new-e2e/tests/autoscaling/spot: fix local CA image build script

### DIFF
--- a/test/new-e2e/tests/autoscaling/spot/README.md
+++ b/test/new-e2e/tests/autoscaling/spot/README.md
@@ -26,8 +26,14 @@ Run from the **repo root**. The test creates the kind cluster automatically and 
 DD_TEST_CLUSTER_AGENT_IMAGE=${USER}/cluster-agent:test \
   PULUMI_CONFIG_PASSPHRASE=dummy \
   dda inv new-e2e-tests.run --targets=./tests/autoscaling/spot/... \
+  --run "^TestSpotSchedulingKind$" \
   -e "-test.timeout 10m"
 ```
+
+The `--run "^TestSpotSchedulingKind$"` filter is required to exclude `TestSpotSchedulingKindCI`,
+which runs the same suite on an AWS-provisioned kind VM and is intended for CI pipelines only.
+Without the anchored filter, `dda inv` auto-detects the pipeline ID and the CI test runs
+locally, competing with the local kind cluster for the same Pulumi stack.
 
 If `DD_TEST_CLUSTER_AGENT_IMAGE` is not set, tests are skipped.
 
@@ -49,7 +55,8 @@ Use `E2E_DEV_MODE=true` to keep the kind cluster alive after test failures so yo
 DD_TEST_CLUSTER_AGENT_IMAGE=${USER}/cluster-agent:test \
   PULUMI_CONFIG_PASSPHRASE=dummy \
   E2E_DEV_MODE=true \
-  dda inv new-e2e-tests.run --targets=./tests/autoscaling/spot/...
+  dda inv new-e2e-tests.run --targets=./tests/autoscaling/spot/... \
+  --run "^TestSpotSchedulingKind$"
 ```
 
 After inspecting, destroy the stack — this deletes the kind cluster and removes all Pulumi state:

--- a/test/new-e2e/tests/autoscaling/spot/build-cluster-agent-image.sh
+++ b/test/new-e2e/tests/autoscaling/spot/build-cluster-agent-image.sh
@@ -15,6 +15,18 @@ DEVENV_IMAGE="registry.ddbuild.io/ci/datadog-agent-devenv:1-${DEVENV_ARCH}"
 
 echo "Building ${CLUSTER_AGENT_IMAGE} (linux/${DEVENV_ARCH}) from ${REPO_DIR}"
 
+# The Docker socket GID inside the Colima VM differs from the host GID
+# (typically 991 for the docker group in the VM vs 0 on macOS). Detect it
+# so --group-add can give the datadog user access to the socket.
+DOCKER_GID=$(docker run --rm --platform "linux/${DEVENV_ARCH}" \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    "${DEVENV_IMAGE}" stat -c '%g' /var/run/docker.sock 2>/dev/null || true)
+
+GROUP_FLAGS=()
+if [ -n "${DOCKER_GID}" ]; then
+    GROUP_FLAGS=(--group-add "${DOCKER_GID}")
+fi
+
 exec docker run --rm \
     --platform "linux/${DEVENV_ARCH}" \
     --cap-add=SYS_PTRACE \
@@ -25,6 +37,7 @@ exec docker run --rm \
     -v "${GOPATH:-${HOME}/go}/pkg/mod:/home/datadog/go/pkg/mod" \
     -v "${HOME}/.ssh:/home/datadog/.ssh" \
     --user datadog \
+    "${GROUP_FLAGS[@]}" \
     "${DEVENV_IMAGE}" \
     bash -xc "
         git config --global --add safe.directory /workspaces/datadog-agent && \


### PR DESCRIPTION
### What does this PR do?

- build-cluster-agent-image.sh: fix compatibility with Colima by mounting /var/run/docker.sock from inside the VM (works for both Docker Desktop and Colima) and detecting the docker socket GID via --group-add so the datadog user can access it (Colima's docker group GID differs from the macOS host)
- README: add anchored ^TestSpotSchedulingKind$ filter to both run examples to prevent TestSpotSchedulingKindCI (AWS provisioner) from running locally; dda inv auto-detects the pipeline ID which bypasses the E2E_PIPELINE_ID guard

### Motivation

Fix local e2e tests to work with Colima.

### Describe how you validated your changes

Ran the above locally.


