### PR TITLE
Prevent `polkit` password prompts in Bazel tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,6 +42,7 @@ common:lint --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=
 # Linux config ---------------------------------------------------------------------------------------------------------
 common:linux --credential_helper=buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog=%workspace%/bazel/tools/credential-helper
 common:linux --strategy=sandboxed
+common:linux --test_env=DBUS_SYSTEM_BUS_ADDRESS= # cut off D-Bus so polkit cannot prompt for passwords in tests
 
 # macOS config ---------------------------------------------------------------------------------------------------------
 common:macos --credential_helper=buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog=%workspace%/bazel/tools/credential-helper


### PR DESCRIPTION
### What does this PR do?
Set `DBUS_SYSTEM_BUS_ADDRESS=` for all Linux test actions via `--test_env`, cutting off access to the D-Bus system bus so that tools like `systemctl` cannot trigger `polkit` authentication prompts during test runs.

### Motivation
On secure developer machines where `kernel.unprivileged_userns_clone=0`, the Bazel `linux-sandbox` is unavailable (it requires `CLONE_NEWUSER`), so tests run with full host filesystem access.
Any test that exercises code invoking `systemctl` would prompt for a password up to N times per run via `polkit`, e.g.,
<img width="411" height="388" alt="Screenshot from 2026-05-04 17-19-09" src="https://github.com/user-attachments/assets/1a3aab10-76a3-4853-a2ad-54215213ab8c" />

The `--test_env` approach is tool-agnostic: any tool that reaches polkit via D-Bus is silenced without per-tool flags or code changes.

### Describe how you validated your changes
Ran
```
bazel test --nocache_test_results //pkg/fleet/installer/packages/apminject:apminject_test
```
... without any single password prompt (instead of 4).

### Additional Notes
Approaches considered and rejected:
- `--no-ask-password` on each `systemctl` call: tool-specific, would not cover future password-prompting tools,
- `SysProcAttr{Setsid: true}` in `telemetry/cmd_wrapper.go`: detaches subprocesses from the controlling terminal, preventing `polkit`'s TTY agent from prompting: scoped to the fleet installer's `exec` wrapper,
- `--experimental_use_hermetic_linux_sandbox` would isolate the filesystem (`pivot_root`) and network (`CLONE_NEWNET`), making both the D-Bus socket and `systemctl` itself unreachable: blocked by `kernel.unprivileged_userns_clone=0` because `linux-sandbox` requires `CLONE_NEWUSER` and silently falls back to `ProcessWrapperSandboxedSpawnRunner`, which has no filesystem isolation,
- `--sandbox_block_path`: same prerequisite as hermetic sandbox, same failure.