### PR TITLE
pkg/clusteragent/autoscaling/cluster/spot: use custom node selector for spot nodes

### DIFF
--- a/pkg/clusteragent/autoscaling/cluster/spot/README.md
+++ b/pkg/clusteragent/autoscaling/cluster/spot/README.md
@@ -34,10 +34,9 @@ Important:
   so Cluster Agent cannot directly fix spot-assigned pods that fail to schedule — it must evict them and let the workload to recreate them.
 - spot nodes carry a `NoSchedule` taint to repel unrelated workloads.
 
-The spot node label is currently Karpenter-specific [[2]](#karpenter-nodepool):
-- label: `karpenter.sh/capacity-type=spot`
-
-The spot node taint uses the Datadog namespace and must be configured separately on spot nodes:
+Both the nodeSelector and the taint use the same Datadog-namespaced key and must be configured on spot nodes
+(see the Karpenter NodePool example [[2]](#karpenter-nodepool) for how to set them automatically):
+- label: `autoscaling.datadoghq.com/capacity-type=interruptible`
 - taint: `autoscaling.datadoghq.com/capacity-type=interruptible:NoSchedule`
 
 When a pod is assigned to a spot instance at admission time, Cluster Agent begins tracking it.
@@ -60,6 +59,9 @@ metadata:
   name: spot
 spec:
   template:
+    metadata:
+      labels:
+        autoscaling.datadoghq.com/capacity-type: interruptible
     spec:
       requirements:
         - key: karpenter.sh/capacity-type

--- a/pkg/clusteragent/autoscaling/cluster/spot/cluster_test.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/cluster_test.go
@@ -109,7 +109,7 @@ func (c *fakeCluster) AddOnDemandNode(name string) {
 	})
 }
 
-// AddSpotNode adds a spot node with the Karpenter capacity-type label and NoSchedule taint.
+// AddSpotNode adds a spot node with the capacity-type node selector label and NoSchedule taint.
 func (c *fakeCluster) AddSpotNode(name string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/clusteragent/autoscaling/cluster/spot/const.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/const.go
@@ -27,3 +27,12 @@ const (
 	// SpotAssignedLabelValue is the SpotAssignedLabel value for pods assigned to spot instances.
 	SpotAssignedLabelValue = "true"
 )
+
+// Spot node label and taint.
+// Use our own namespace so we control it independently of the cluster autoscaler.
+const (
+	spotNodeLabelKey   = "autoscaling.datadoghq.com/capacity-type"
+	spotNodeLabelValue = "interruptible"
+	spotNodeTaintKey   = "autoscaling.datadoghq.com/capacity-type"
+	spotNodeTaintValue = "interruptible"
+)

--- a/pkg/clusteragent/autoscaling/cluster/spot/scheduler.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/scheduler.go
@@ -220,16 +220,6 @@ func (s *scheduler) spotEligibleFilter(entity workloadmeta.Entity) bool {
 	return ok
 }
 
-// Spot node label and taint.
-// The node label is Karpenter-specific; the taint uses our own namespace so we
-// control it independently of the cluster autoscaler.
-const (
-	spotNodeLabelKey   = "karpenter.sh/capacity-type"
-	spotNodeLabelValue = "spot"
-	spotNodeTaintKey   = "autoscaling.datadoghq.com/capacity-type"
-	spotNodeTaintValue = "interruptible"
-)
-
 func assignToSpot(pod *corev1.Pod) {
 	if pod.Spec.NodeSelector == nil {
 		pod.Spec.NodeSelector = map[string]string{}

--- a/test/new-e2e/tests/autoscaling/spot/README.md
+++ b/test/new-e2e/tests/autoscaling/spot/README.md
@@ -35,8 +35,8 @@ If `DD_TEST_CLUSTER_AGENT_IMAGE` is not set, tests are skipped.
 
 1. `localkubernetes.Provisioner` creates a 3-node kind cluster via Pulumi:
    - 1 control-plane node
-   - 1 worker labeled `karpenter.sh/capacity-type=on-demand`
-   - 1 worker labeled `karpenter.sh/capacity-type=spot` with a `autoscaling.datadoghq.com/capacity-type=interruptible:NoSchedule` taint
+   - 1 on-demand worker (no capacity-type label)
+   - 1 worker labeled `autoscaling.datadoghq.com/capacity-type=interruptible` with a `autoscaling.datadoghq.com/capacity-type=interruptible:NoSchedule` taint
 2. The cluster-agent image is loaded into kind via `WithKindLoadImage`.
 3. The cluster-agent is deployed via Helm with spot scheduling enabled and short timeouts.
 4. Tests create Deployments, observe pod placement via the k8s API, and verify spot/on-demand ratios.

--- a/test/new-e2e/tests/autoscaling/spot/suite_test.go
+++ b/test/new-e2e/tests/autoscaling/spot/suite_test.go
@@ -43,8 +43,8 @@ const (
 	spotAssignedLabel           = "autoscaling.datadoghq.com/spot-assigned"
 	spotConfigAnnotation        = "autoscaling.datadoghq.com/spot-config"
 	spotDisabledUntilAnnotation = "autoscaling.datadoghq.com/spot-disabled-until"
-	karpenterCapacityTypeLabel  = "karpenter.sh/capacity-type"
-	karpenterCapacityTypeSpot   = "spot"
+	spotCapacityTypeLabel       = "autoscaling.datadoghq.com/capacity-type"
+	spotCapacityTypeValue       = "interruptible"
 
 	// kindClusterName is the provisioner name; the kind cluster name is derived from it.
 	kindClusterName = "spot-test"
@@ -101,13 +101,11 @@ datadog:
 }
 
 // workerNodes defines the kind cluster topology required by the spot scheduling tests:
-// one on-demand worker and one spot worker with the interruptible taint.
+// one on-demand worker and one spot worker with the interruptible label and taint.
 var workerNodes = []kubeComp.KindWorkerNode{
+	{}, // on-demand
 	{
-		Labels: []kubeComp.Label{{Key: "karpenter.sh/capacity-type", Value: "on-demand"}},
-	},
-	{
-		Labels: []kubeComp.Label{{Key: "karpenter.sh/capacity-type", Value: "spot"}},
+		Labels: []kubeComp.Label{{Key: "autoscaling.datadoghq.com/capacity-type", Value: "interruptible"}},
 		Taints: []kubeComp.Taint{{Key: "autoscaling.datadoghq.com/capacity-type", Value: "interruptible", Effect: "NoSchedule"}},
 	},
 }
@@ -230,21 +228,21 @@ func (s *spotSchedulingSuite) expectRunningOnDemand(c *assert.CollectT, pods []c
 	require.Equal(c, count, actual, "expected %d running on-demand pods", count)
 }
 
-// identifyNodes finds the spot and on-demand worker nodes by karpenter.sh/capacity-type label.
+// identifyNodes finds the spot and on-demand worker nodes by autoscaling.datadoghq.com/capacity-type label.
 func (s *spotSchedulingSuite) identifyNodes() {
 	s.T().Helper()
 	nodes, err := s.kubeClient.CoreV1().Nodes().List(s.T().Context(), metav1.ListOptions{})
 	s.Require().NoError(err)
 	for _, node := range nodes.Items {
-		switch node.Labels[karpenterCapacityTypeLabel] {
-		case karpenterCapacityTypeSpot:
+		switch node.Labels[spotCapacityTypeLabel] {
+		case spotCapacityTypeValue:
 			s.spotNode = node.Name
 		default:
 			s.onDemandNode = node.Name
 		}
 	}
-	s.Require().NotEmpty(s.spotNode, "no node with %s=spot found; check WithKindWorkerNodes", karpenterCapacityTypeLabel)
-	s.Require().NotEmpty(s.onDemandNode, "no node without %s=spot found; check WithKindWorkerNodes", karpenterCapacityTypeLabel)
+	s.Require().NotEmpty(s.spotNode, "no node with %s=%s found; check WithKindWorkerNodes", spotCapacityTypeLabel, spotCapacityTypeValue)
+	s.Require().NotEmpty(s.onDemandNode, "no node without %s=%s found; check WithKindWorkerNodes", spotCapacityTypeLabel, spotCapacityTypeValue)
 }
 
 // waitForWebhook polls MutatingWebhookConfigurations until the spot scheduling webhook is registered.


### PR DESCRIPTION
### What does this PR do?

Replace the Karpenter-specific `karpenter.sh/capacity-type=spot` nodeSelector with `autoscaling.datadoghq.com/capacity-type=interruptible`, matching the existing spot node taint.

### Motivation

Using a Karpenter label would cause spot pods to land on any node that carries it — including spot nodes from unmanaged node pools. Using our own label ensures pods are only placed on nodes from the managed node pool where the label is explicitly configured.

### Describe how you validated your changes

Ran unit and local e2e spot scheduling tests.

### Additional Notes

Move the node label and taint constants from scheduler.go to const.go so all spot-related constants are in one place.

Updates https://datadoghq.atlassian.net/browse/CASCL-925
