### PR TITLE
[AGENTRUN-1270] corechecks/network: enable Go network check on AIX

### DIFF
--- a/cmd/agent/dist/core_checks.bzl
+++ b/cmd/agent/dist/core_checks.bzl
@@ -48,6 +48,7 @@ AIX_CORECHECKS = [
     "io",
     "load",
     "memory",
+    "network",
     "ntp",
     "oracle",
     "uptime",

--- a/pkg/collector/corechecks/net/network/netstat_tcpext_aix.go
+++ b/pkg/collector/corechecks/net/network/netstat_tcpext_aix.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build aix
+
+package network
+
+func netstatTCPExtCounters() (map[string]int64, error) {
+	return nil, nil
+}

--- a/pkg/collector/corechecks/net/network/netstat_tcpext_linux.go
+++ b/pkg/collector/corechecks/net/network/netstat_tcpext_linux.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package network
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func netstatTCPExtCounters() (map[string]int64, error) {
+	f, err := os.Open("/proc/net/netstat")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	counters := map[string]int64{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		i := strings.IndexRune(line, ':')
+		if i == -1 {
+			return nil, errors.New("/proc/net/netstat is not fomatted correctly, expected ':'")
+		}
+		proto := strings.ToLower(line[:i])
+		if proto != "tcpext" {
+			continue
+		}
+
+		counterNames := strings.Split(line[i+2:], " ")
+
+		if !scanner.Scan() {
+			return nil, errors.New("/proc/net/netstat is not fomatted correctly, not data line")
+		}
+		line = scanner.Text()
+
+		counterValues := strings.Split(line[i+2:], " ")
+		if len(counterNames) != len(counterValues) {
+			return nil, errors.New("/proc/net/netstat is not fomatted correctly, expected same number of columns")
+		}
+
+		for j := range counterNames {
+			value, err := strconv.ParseInt(counterValues[j], 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			counters[counterNames[j]] = value
+		}
+	}
+
+	return counters, nil
+}

--- a/pkg/collector/corechecks/net/network/network.go
+++ b/pkg/collector/corechecks/net/network/network.go
@@ -3,20 +3,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux || aix
 
 package network
 
 import (
-	"bufio"
-	"errors"
 	"fmt"
 	"maps"
-	"os"
 	"regexp"
+	"runtime"
 	"slices"
-	"strconv"
-	"strings"
 
 	"github.com/shirou/gopsutil/v4/net"
 	yaml "go.yaml.in/yaml/v2"
@@ -235,53 +231,12 @@ func submitConnectionsMetrics(sender sender.Sender, protocolName string, stateMe
 	}
 }
 
-func netstatTCPExtCounters() (map[string]int64, error) {
-	f, err := os.Open("/proc/net/netstat")
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	counters := map[string]int64{}
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		i := strings.IndexRune(line, ':')
-		if i == -1 {
-			return nil, errors.New("/proc/net/netstat is not fomatted correctly, expected ':'")
-		}
-		proto := strings.ToLower(line[:i])
-		if proto != "tcpext" {
-			continue
-		}
-
-		counterNames := strings.Split(line[i+2:], " ")
-
-		if !scanner.Scan() {
-			return nil, errors.New("/proc/net/netstat is not fomatted correctly, not data line")
-		}
-		line = scanner.Text()
-
-		counterValues := strings.Split(line[i+2:], " ")
-		if len(counterNames) != len(counterValues) {
-			return nil, errors.New("/proc/net/netstat is not fomatted correctly, expected same number of columns")
-		}
-
-		for j := range counterNames {
-			value, err := strconv.ParseInt(counterValues[j], 10, 64)
-			if err != nil {
-				return nil, err
-			}
-			counters[counterNames[j]] = value
-		}
-	}
-
-	return counters, nil
-}
-
 // Configure configures the network checks
 func (c *NetworkCheck) Configure(senderManager sender.SenderManager, _ uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string, provider string) error {
-	if flavor.GetFlavor() == flavor.DefaultAgent && !pkgconfigsetup.Datadog().GetBool("network_check.use_core_loader") {
+	// On Linux the Go network check coexists with the Python one; the flag
+	// selects which runs. On AIX there is no Python network check, so the
+	// Go check is unconditionally enabled.
+	if runtime.GOOS != "aix" && flavor.GetFlavor() == flavor.DefaultAgent && !pkgconfigsetup.Datadog().GetBool("network_check.use_core_loader") {
 		return fmt.Errorf("%w: network core check is disabled", check.ErrSkipCheckInstance)
 	}
 

--- a/pkg/collector/corechecks/net/network/network.go
+++ b/pkg/collector/corechecks/net/network/network.go
@@ -69,6 +69,9 @@ var (
 
 	udpStateMetricsSuffixMapping = map[string]string{
 		"NONE": "connections",
+		// AIX netstat output omits the state column for UDP rows; gopsutil
+		// leaves Status as "" in that case. Map it the same as "NONE".
+		"": "connections",
 	}
 )
 

--- a/pkg/collector/corechecks/net/network/stub.go
+++ b/pkg/collector/corechecks/net/network/stub.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux
+//go:build !linux && !aix
 
 package network
 

--- a/tasks/core_checks.py
+++ b/tasks/core_checks.py
@@ -48,6 +48,7 @@ AIX_CORECHECKS = [
     "io",
     "load",
     "memory",
+    "network",
     "ntp",
     "oracle",
     "uptime",


### PR DESCRIPTION
### What does this PR do?

Enables the Go network check on AIX by extending the build tag from `linux` to `linux || aix` and adding AIX to `AIX_CORECHECKS`.

`netstatTCPExtCounters()` (reads `/proc/net/netstat`) is extracted to a Linux-only file; the AIX stub returns `nil, nil`. The `network_check.use_core_loader` gate is bypassed on AIX since there is no Python network check to fall back to.

### Motivation

gopsutil v4.26.4 implements `ProtoCounters`, `IOCounters`, and `Connections` on AIX, providing everything the check needs. Metrics absent from AIX's `netstat -s` (e.g. `ListenOverflows`) are silently skipped.

### Describe how you validated your changes

Ran `agent check network` on AIX 7.2 — 34 metrics, status OK.

### Additional Notes

N/A