### PR TITLE
[CWS] skip rule evaluation for internal events

### DIFF
--- a/pkg/security/ebpf/c/include/constants/enums.h
+++ b/pkg/security/ebpf/c/include/constants/enums.h
@@ -89,6 +89,7 @@ enum
     EVENT_FLAGS_ACTIVITY_DUMP_SAMPLE = 1 << 2, // event is a AD sample
     // EventFlagsSecurityProfileInProfile = 1<<3 isn't used in kernel space
     EVENT_FLAGS_ANOMALY_DETECTION_EVENT = 1 << 4, // event is an anomaly detection event
+    EVENT_FLAGS_INTERNAL = 1 << 5, // event used to keep track of internal caches & resources
 };
 
 enum file_flags

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -243,7 +243,8 @@ int __attribute__((always_inline)) _sys_open_ret(void *ctx, struct syscall_cache
         .syscall_ctx.id = syscall->ctx_id,
         .event.flags = (syscall->async ? EVENT_FLAGS_ASYNC : 0) |
                        (syscall->resolver.flags & SAVED_BY_ACTIVITY_DUMP ? EVENT_FLAGS_SAVED_BY_AD : 0) |
-                       (syscall->resolver.flags & ACTIVITY_DUMP_RUNNING ? EVENT_FLAGS_ACTIVITY_DUMP_SAMPLE : 0),
+                       (syscall->resolver.flags & ACTIVITY_DUMP_RUNNING ? EVENT_FLAGS_ACTIVITY_DUMP_SAMPLE : 0) |
+                       (syscall->state == INTERNAL ? EVENT_FLAGS_INTERNAL : 0),
         .file = syscall->open.file,
         .flags = syscall->open.flags,
         .mode = syscall->open.mode,

--- a/pkg/security/ebpf/c/include/hooks/rmdir.h
+++ b/pkg/security/ebpf/c/include/hooks/rmdir.h
@@ -64,18 +64,19 @@ int hook_security_inode_rmdir(ctx_t *ctx) {
         syscall->rmdir.dentry = dentry;
         syscall->policy = fetch_policy(EVENT_RMDIR);
 
-        // let the cgroup event being forwarded as it is used userspace side to track the cgroups
-        if (is_cgroup2fs(syscall->rmdir.dentry) && S_ISDIR(syscall->rmdir.file.metadata.mode)) {
-            syscall->state = ACCEPTED;
-            break;
-        }
+        approve_syscall(syscall, rmdir_approvers);
 
-        if (approve_syscall(syscall, rmdir_approvers) == DISCARDED) {
-            // do not pop, we want to invalidate the inode even if the syscall is discarded
-            return 0;
-        }
         if (is_auid_discarder(EVENT_RMDIR)) {
             syscall->state = DISCARDED;
+        }
+
+        // let the cgroup event being forwarded as it is used userspace side to track the cgroups
+        if (is_cgroup2fs(syscall->rmdir.dentry) && S_ISDIR(syscall->rmdir.file.metadata.mode)) {
+            syscall->state = INTERNAL;
+        }
+
+        // do not pop, we want to invalidate the inode even if the syscall is discarded
+        if (syscall->state == DISCARDED) {
             return 0;
         }
 
@@ -98,14 +99,15 @@ int hook_security_inode_rmdir(ctx_t *ctx) {
         // fake rmdir event as we will generate and rmdir event at the end
         syscall->policy = fetch_policy(EVENT_RMDIR);
 
+        approve_syscall(syscall, rmdir_approvers);
+
         // let the cgroup event being forwarded as it is used userspace side to track the cgroups
         if (is_cgroup2fs(syscall->unlink.dentry) && S_ISDIR(syscall->unlink.file.metadata.mode)) {
-            syscall->state = ACCEPTED;
-            break;
+            syscall->state = INTERNAL;
         }
 
-        if (approve_syscall(syscall, rmdir_approvers) == DISCARDED) {
-            // do not pop, we want to invalidate the inode even if the syscall is discarded
+        // do not pop, we want to invalidate the inode even if the syscall is discarded
+        if (syscall->state == DISCARDED) {
             return 0;
         }
 
@@ -136,7 +138,7 @@ TAIL_CALL_FNC(dr_security_inode_rmdir_callback, ctx_t *ctx) {
         return 0;
     }
 
-    if (syscall->resolver.ret == DENTRY_DISCARDED) {
+    if (syscall->resolver.ret == DENTRY_DISCARDED && syscall->state != INTERNAL) {
         monitor_discarded(syscall->type);
         // do not pop, we want to invalidate the inode even if the syscall is discarded
         syscall->state = DISCARDED;
@@ -158,7 +160,8 @@ int __attribute__((always_inline)) sys_rmdir_ret(void *ctx, int retval) {
         struct rmdir_event_t event = {
             .syscall.retval = retval,
             .syscall_ctx.id = syscall->ctx_id,
-            .event.flags = syscall->async ? EVENT_FLAGS_ASYNC : 0,
+            .event.flags = (syscall->async ? EVENT_FLAGS_ASYNC : 0) |
+                           (syscall->state == INTERNAL ? EVENT_FLAGS_INTERNAL : 0),
             .file = syscall->rmdir.file,
         };
 

--- a/pkg/security/ebpf/c/include/hooks/unlink.h
+++ b/pkg/security/ebpf/c/include/hooks/unlink.h
@@ -126,12 +126,12 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
         return 0;
     }
 
-    u64 enabled_events = get_enabled_events();
-    if (syscall->state != DISCARDED && (mask_has_event(enabled_events, EVENT_UNLINK) || mask_has_event(enabled_events, EVENT_RMDIR))) {
+    if (syscall->state != DISCARDED) {
         if (syscall->unlink.flags & AT_REMOVEDIR) {
             struct rmdir_event_t event = {
                 .syscall.retval = retval,
-                .event.flags = syscall->async ? EVENT_FLAGS_ASYNC : 0,
+                .event.flags = (syscall->async ? EVENT_FLAGS_ASYNC : 0) |
+                               (syscall->state == INTERNAL ? EVENT_FLAGS_INTERNAL : 0),
                 .file = syscall->unlink.file,
             };
 
@@ -144,7 +144,8 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
             struct unlink_event_t event = {
                 .syscall.retval = retval,
                 .syscall_ctx.id = syscall->ctx_id,
-                .event.flags = syscall->async ? EVENT_FLAGS_ASYNC : 0,
+                .event.flags = (syscall->async ? EVENT_FLAGS_ASYNC : 0) |
+                               (syscall->state == INTERNAL ? EVENT_FLAGS_INTERNAL : 0),
                 .file = syscall->unlink.file,
                 .flags = syscall->unlink.flags,
             };
@@ -156,7 +157,7 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
             send_event(ctx, EVENT_UNLINK, event);
         }
     } else {
-        if (mask_has_event(enabled_events, EVENT_RMDIR)) {
+        if (syscall->unlink.flags & AT_REMOVEDIR) {
             monitor_discarded(EVENT_RMDIR);
         } else {
             monitor_discarded(EVENT_UNLINK);

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1364,6 +1364,13 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 			}
 			p.Resolvers.CGroupResolver.Add(cgroupContext)
 		}
+
+		// internal open events are emitted only to populate the cgroup
+		// resolver above; they don't reflect a user action so skip rule
+		// evaluation
+		if event.IsEventInternal() {
+			return false
+		}
 	case model.FileMkdirEventType:
 		if !p.regularUnmarshalEvent(&event.Mkdir, eventType, offset, dataLen, data) {
 			return false

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1385,6 +1385,13 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		if fs == "cgroup2" && event.Rmdir.File.PathKey.Inode != 0 && event.Rmdir.File.IsDir() && event.Rmdir.Retval == 0 {
 			p.Resolvers.CGroupResolver.Delete(event.Rmdir.File.PathKey.Inode)
 		}
+
+		// internal rmdir events are emitted only to update the cgroup
+		// resolver above; they don't reflect a user action so skip rule
+		// evaluation
+		if event.IsEventInternal() {
+			return false
+		}
 	case model.FileUnlinkEventType:
 		if !p.regularUnmarshalEvent(&event.Unlink, eventType, offset, dataLen, data) {
 			return false
@@ -1392,8 +1399,15 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 
 		// handle cgroup v2 deletion
 		fs := p.fieldHandlers.ResolveFileFilesystem(event, &event.Unlink.File)
-		if fs == "cgroup2" && event.Unlink.File.PathKey.Inode != 0 && event.Unlink.File.IsDir() {
+		if fs == "cgroup2" && event.Unlink.File.PathKey.Inode != 0 && event.Unlink.File.IsDir() && event.Unlink.Retval == 0 {
 			p.Resolvers.CGroupResolver.Delete(event.Unlink.File.PathKey.Inode)
+		}
+
+		// internal unlink events are emitted only to update the cgroup
+		// resolver above; they don't reflect a user action so skip rule
+		// evaluation
+		if event.IsEventInternal() {
+			return false
 		}
 	case model.FileRenameEventType:
 		if !p.regularUnmarshalEvent(&event.Rename, eventType, offset, dataLen, data) {

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -47,6 +47,8 @@ const (
 )
 
 const (
+	// the following flags have to be kept in sync with their kernel counterparts in pkg/security/ebpf/c/include/constants/enums.h
+
 	// EventFlagsAsync async event
 	EventFlagsAsync = 1 << iota
 
@@ -61,6 +63,11 @@ const (
 
 	// EventFlagsAnomalyDetectionEvent true if the event is marked as being an anomaly
 	EventFlagsAnomalyDetectionEvent
+
+	// EventFlagsInternal true if the event is an internal event used to keep caches & internal resources up-to-date
+	EventFlagsInternal
+
+	// non kernel flags
 
 	// EventFlagsHasActiveActivityDump true if the event has an active activity dump associated to it
 	EventFlagsHasActiveActivityDump

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -322,6 +322,14 @@ func (e *Event) IsEventFromReplay() bool {
 	return e.Flags&EventFlagsFromReplay > 0
 }
 
+// IsEventInternal returns true if this is an internal event.
+// Internal events are emitted by the kernel side to keep userspace caches and
+// resources in sync; they don't reflect a user-visible action and rule
+// evaluation can be skipped for them.
+func (e *Event) IsEventInternal() bool {
+	return e.Flags&EventFlagsInternal > 0
+}
+
 // AddToFlags adds a flag to the event
 func (e *Event) AddToFlags(flag uint32) {
 	e.Flags |= flag

--- a/pkg/security/seclwin/model/consts_common.go
+++ b/pkg/security/seclwin/model/consts_common.go
@@ -47,6 +47,8 @@ const (
 )
 
 const (
+	// the following flags have to be kept in sync with their kernel counterparts in pkg/security/ebpf/c/include/constants/enums.h
+
 	// EventFlagsAsync async event
 	EventFlagsAsync = 1 << iota
 
@@ -61,6 +63,11 @@ const (
 
 	// EventFlagsAnomalyDetectionEvent true if the event is marked as being an anomaly
 	EventFlagsAnomalyDetectionEvent
+
+	// EventFlagsInternal true if the event is an internal event used to keep caches & internal resources up-to-date
+	EventFlagsInternal
+
+	// non kernel flags
 
 	// EventFlagsHasActiveActivityDump true if the event has an active activity dump associated to it
 	EventFlagsHasActiveActivityDump

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -322,6 +322,14 @@ func (e *Event) IsEventFromReplay() bool {
 	return e.Flags&EventFlagsFromReplay > 0
 }
 
+// IsEventInternal returns true if this is an internal event.
+// Internal events are emitted by the kernel side to keep userspace caches and
+// resources in sync; they don't reflect a user-visible action and rule
+// evaluation can be skipped for them.
+func (e *Event) IsEventInternal() bool {
+	return e.Flags&EventFlagsInternal > 0
+}
+
 // AddToFlags adds a flag to the event
 func (e *Event) AddToFlags(flag uint32) {
 	e.Flags |= flag


### PR DESCRIPTION
The kernel emits synthetic open events for cgroup v2 directories so that userspace can populate the cgroup resolver. These events don't reflect a user action and should not be matched against rules.

Tag them at the source with a new EVENT_FLAGS_INTERNAL bit (set when syscall->state == INTERNAL in the open ret hook) and have the userspace probe early-return after refreshing the cgroup resolver, so the rule engine never sees them.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
