### PR TITLE
[observer/logssource] register kubelet journald source after launchers start

### DIFF
--- a/comp/observer/impl/log_tagged_pattern_clusterer.go
+++ b/comp/observer/impl/log_tagged_pattern_clusterer.go
@@ -216,15 +216,32 @@ func (tc *TaggedPatternClusterer) Process(tags []string, message string, unixSec
 
 	sub, exists := tc.subClusterers[groupHash]
 	if !exists {
-		tc.evictLRUTagGroupIfOverCap(groupHash)
+		// Two-phase create: build a transient sub-clusterer but do NOT
+		// commit it (insert into tc.subClusterers, possibly evicting the
+		// LRU group to make room) until sub.Process actually accepts the
+		// message. Otherwise an empty/whitespace-only first message from
+		// a new tag group — which PatternClusterer rejects when IgnoreEmpty
+		// is on — would steal a slot from an active group while leaving an
+		// empty sub-clusterer behind to count against MaxTagGroups. A burst
+		// of empty logs from new containers could then evict real pattern
+		// state and suppress later anomalies.
 		sub = tc.newPatternClusterer()
 		sub.MaxClusters = tc.MaxClustersPerGroup
-		tc.subClusterers[groupHash] = sub
 	}
 
 	cluster, ok := sub.Process(message, unixSec)
 	if !ok {
+		// Transient sub-clusterer (when !exists) is dropped on the floor
+		// here — nothing was ever inserted into tc.subClusterers, so no
+		// eviction or LRU bookkeeping is needed.
 		return 0, nil, false
+	}
+
+	// Process accepted the message; only now do we commit the new
+	// sub-clusterer (and evict the LRU group if we've hit the cap).
+	if !exists {
+		tc.evictLRUTagGroupIfOverCap(groupHash)
+		tc.subClusterers[groupHash] = sub
 	}
 
 	// Drain layer-1 LRU evictions from this sub-clusterer and tag them with groupHash.

--- a/comp/observer/impl/log_tagged_pattern_clusterer_test.go
+++ b/comp/observer/impl/log_tagged_pattern_clusterer_test.go
@@ -251,6 +251,51 @@ func TestTaggedPatternClusterer_MaxTagGroupsEvictsLRUGroup(t *testing.T) {
 	}
 }
 
+// TestTaggedPatternClusterer_EmptyMessageFromNewGroupDoesNotEvict regresses
+// the bug where an empty (or whitespace-only) first message from a brand-new
+// tag group, while at MaxTagGroups capacity, would trigger eviction of an
+// active group BEFORE the inner PatternClusterer.Process rejected the empty
+// message. The active group's clusters were lost, an empty sub-clusterer
+// stayed wedged into tc.subClusterers counting against the cap, and a stream
+// of empty logs from new containers could evict real pattern state and
+// suppress later anomalies.
+//
+// The fix is two-phase create in Process: build a transient sub-clusterer
+// without committing it; only insert + evict-LRU after sub.Process returns
+// ok. This test confirms an empty message from a new group at-cap is a
+// no-op for both the existing groups and the eviction queue.
+func TestTaggedPatternClusterer_EmptyMessageFromNewGroupDoesNotEvict(t *testing.T) {
+	tc := NewTaggedPatternClusterer(NewTagGroupByKeyRegistry())
+	tc.MaxTagGroups = 2
+
+	tagsA := []string{"service:a"}
+	tagsB := []string{"service:b"}
+	tagsC := []string{"service:c"} // would be the new “third” group at-cap
+
+	hashA, _, okA := tc.Process(tagsA, "alpha", 1000)
+	require.True(t, okA)
+	hashB, _, okB := tc.Process(tagsB, "beta", 1100)
+	require.True(t, okB)
+	require.Equal(t, 2, tc.NumSubClusterers(), "both groups resident at cap")
+	require.Empty(t, tc.DrainLRUEvictions())
+
+	for _, msg := range []string{"", "   ", "\t\n"} {
+		hashC, _, okC := tc.Process(tagsC, msg, 1200)
+		require.False(t, okC, "empty/whitespace messages must be rejected by inner Process")
+		require.Equal(t, uint64(0), hashC, "rejected calls return zero hash")
+		require.Equal(t, 2, tc.NumSubClusterers(),
+			"empty msg from new group at-cap must NOT create a sub-clusterer (would steal a slot from A or B)")
+		require.Empty(t, tc.DrainLRUEvictions(),
+			"empty msg from new group at-cap must NOT evict an existing group")
+	}
+
+	// Both original groups must still be reachable after the empty stream.
+	gotA, _, _ := tc.Process(tagsA, "alpha", 1300)
+	require.Equal(t, hashA, gotA, "group A must survive a stream of empty new-group messages")
+	gotB, _, _ := tc.Process(tagsB, "beta", 1301)
+	require.Equal(t, hashB, gotB, "group B must survive a stream of empty new-group messages")
+}
+
 func TestTaggedPatternClusterer_DrainLRUEvictionsIsOneShot(t *testing.T) {
 	tc := NewTaggedPatternClusterer(NewTagGroupByKeyRegistry())
 	tc.MaxClustersPerGroup = 1
@@ -268,7 +313,7 @@ func TestTaggedPatternClusterer_ResetClearsLRUState(t *testing.T) {
 	tc.MaxClustersPerGroup = 1
 	tc.MaxTagGroups = 1
 	tc.Process([]string{"service:a"}, "alpha", 1000)
-	tc.Process([]string{"service:b"}, "beta", 1001)  // evicts service:a's group
+	tc.Process([]string{"service:b"}, "beta", 1001) // evicts service:a's group
 	tc.Reset()
 	require.Empty(t, tc.DrainLRUEvictions(), "Reset must clear pending evictions")
 	require.Equal(t, 0, tc.NumSubClusterers())

--- a/comp/observer/logssource/impl/logssource.go
+++ b/comp/observer/logssource/impl/logssource.go
@@ -128,8 +128,6 @@ func NewComponent(deps Requires) (Provides, error) {
 	launchersMgr.AddLauncher(launcher)
 	launchersMgr.AddLauncher(journaldlauncher.NewLauncher(flare.NewFlareController(), deps.Tagger))
 
-	registerKubeletJournaldSource(logSources, deps.Log)
-
 	sp := newSourceProvider(wmeta, logSources, pauseFilter)
 
 	services := service.NewServices()
@@ -152,6 +150,7 @@ func NewComponent(deps Requires) (Provides, error) {
 			// Launchers must be ready before schedulers add sources so that tailers
 			// can be created immediately when the first AD config arrives.
 			launchersMgr.Start()
+			registerKubeletJournaldSource(logSources, deps.Log)
 			if adScheduler != nil {
 				adScheduler.Start(adMgr)
 			}


### PR DESCRIPTION
## Summary

`sources.go`'s subscribe methods (`SubscribeAll`, `SubscribeForType`, `GetAddedForType`) spawn an uncontrolled goroutine to deliver pre-existing sources to new subscribers. That goroutine has no context and no cancellation: if the launcher stops reading before delivery completes (e.g. fast shutdown in tests), it blocks permanently.

The main logs agent never hits this because `LogSources` is always empty at subscribe time — sources arrive via the AD scheduler which starts after launchers. The logssource component broke this invariant by calling `registerKubeletJournaldSource` in `NewComponent`, before `OnStart`.

**Fix:** move the call into `OnStart`, after `launchersMgr.Start()`. `LogSources` is now empty when launchers subscribe. The kubelet source is added via the normal synchronous `AddSource` path into already-running launchers.