### PR TITLE
Otel Agent: Disable IPC when in standalone

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -204,12 +204,20 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 
 	pkgconfig.Set("apm_config.receiver_enabled", false, pkgconfigmodel.SourceDefault) // disable HTTP receiver
 	pkgconfig.Set("apm_config.ignore_resources", ddc.Traces.IgnoreResources, pkgconfigmodel.SourceFile)
-	pkgconfig.Set("apm_config.skip_ssl_validation", ddc.ClientConfig.TLS.InsecureSkipVerify, pkgconfigmodel.SourceFile)
 	if v := ddc.Traces.TraceBuffer; v > 0 {
 		pkgconfig.Set("apm_config.trace_buffer", v, pkgconfigmodel.SourceFile)
 	}
 	if addr := ddc.Traces.Endpoint; addr != "" {
 		pkgconfig.Set("apm_config.apm_dd_url", addr, pkgconfigmodel.SourceFile)
+	}
+	// Standalone mode runs without a core Datadog Agent on the same host, so
+	// every client that would otherwise contact it over IPC (trace-agent
+	// hostname acquisition, remote tagger, remote workloadmeta, ...) must be
+	// disabled. cmd_port=-1 is the conventional way to express "no core agent
+	// IPC" and is honored by those callers; forcing it here means users only
+	// have to set DD_OTEL_STANDALONE=true.
+	if pkgconfig.GetBool("otel_standalone") {
+		pkgconfig.Set("cmd_port", -1, pkgconfigmodel.SourceAgentRuntime)
 	}
 	if pkgconfig.GetInt("cmd_port") <= 0 {
 		pkgconfig.Set("remote_configuration.enabled", false, pkgconfigmodel.SourceFile)

--- a/comp/otelcol/converter/impl/testdata/extensions/standalone/dogtel-injected/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/extensions/standalone/dogtel-injected/config-result.yaml
@@ -29,5 +29,3 @@ service:
     logs:
       receivers: [nop]
       exporters: [nop]
-
-

--- a/releasenotes/notes/otel-agent-standalone-disable-ipc-18e451bdb47a9020.yaml
+++ b/releasenotes/notes/otel-agent-standalone-disable-ipc-18e451bdb47a9020.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    The OTel Agent standalone mode now automatically disables IPC with a core
+    Datadog Agent. When ``DD_OTEL_STANDALONE`` is enabled, ``DD_CMD_PORT`` is forced
+    to ``-1``, so users no longer need to set it manually when running DDOT without
+    a core Agent.


### PR DESCRIPTION
### What does this PR do?

Automatically set `CMD_PORT` to -1 to prevent the OTel agent from attempting to contact the core agent

### Motivation

Improve the user experience when using standalone DDOT

### Describe how you validated your changes

Running the agent locally, with and without this patch, looking at the logs for errors

