### PR TITLE
Require client certification when using vsock

### DIFF
--- a/comp/api/grpcserver/impl-agent/grpc.go
+++ b/comp/api/grpcserver/impl-agent/grpc.go
@@ -87,7 +87,7 @@ func (s *server) BuildServer() http.Handler {
 	maxMessageSize := s.configComp.GetInt("cluster_agent.cluster_tagger.grpc_max_message_size")
 
 	// Use the convenience function that combines metrics and auth interceptors
-	var opts []googleGrpc.ServerOption = grpcutil.ServerOptionsWithMetricsAndAuth(
+	opts := grpcutil.ServerOptionsWithMetricsAndAuth(
 		grpcutil.RequireClientCert,
 		grpcutil.RequireClientCertStream,
 	)

--- a/comp/api/grpcserver/impl-agent/grpc.go
+++ b/comp/api/grpcserver/impl-agent/grpc.go
@@ -21,7 +21,7 @@ import (
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerserver "github.com/DataDog/datadog-agent/comp/core/tagger/server"
-	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadfilterServer "github.com/DataDog/datadog-agent/comp/core/workloadfilter/server"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -87,15 +87,10 @@ func (s *server) BuildServer() http.Handler {
 	maxMessageSize := s.configComp.GetInt("cluster_agent.cluster_tagger.grpc_max_message_size")
 
 	// Use the convenience function that combines metrics and auth interceptors
-	var opts []googleGrpc.ServerOption
-	if vsockAddr := s.configComp.GetString("vsock_addr"); vsockAddr == "" {
-		opts = append(opts,
-			grpcutil.ServerOptionsWithMetricsAndAuth(
-				grpcutil.RequireClientCert,
-				grpcutil.RequireClientCertStream,
-			)...,
-		)
-	}
+	var opts []googleGrpc.ServerOption = grpcutil.ServerOptionsWithMetricsAndAuth(
+		grpcutil.RequireClientCert,
+		grpcutil.RequireClientCertStream,
+	)
 
 	opts = append(opts,
 		googleGrpc.Creds(credentials.NewTLS(s.IPC.GetTLSServerConfig())),


### PR DESCRIPTION
### What does this PR do?

What does this PR do?
                                                                                                                                                         
Removes the vsock exception in the agent gRPC server that previously skipped mutual TLS client certificate authentication when vsock_addr was configured.
The gRPC server now consistently requires client certificates for all connections, regardless of whether they use TCP or vsock transport.                

### Motivation

When vsock support was originally added (#39478), authentication was skipped for vsock-based gRPC connections under the assumption that vsock provides   
sufficient transport-level isolation (vsock restricts communication to same-host or host/VM pairs). However, vsock isolation is not equivalent to
authentication — it restricts who can reach the socket, but does not verify who is connecting.                                                           
                
Requiring mutual TLS client certificates on vsock connections provides an additional layer of authentication, ensuring that only agents with valid       
certificates (i.e., trusted agents sharing the same IPC PKI) can interact with the gRPC server, even if an attacker gains access to the vsock namespace.

### Describe how you validated your changes

### Additional Notes
